### PR TITLE
Add git, openssh-client, tzdata to docker images

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -9,7 +9,7 @@ RUN go build -o /go/bin/buf ./cmd/buf
 FROM alpine:3.10
 
 RUN apk add --update --no-cache \
-    ca-certificates && \
+    ca-certificates tzdata git openssh-client && \
   rm -rf /var/cache/apk/*
 
 COPY --from=builder /go/bin/buf /usr/local/bin/buf

--- a/Dockerfile.workspace
+++ b/Dockerfile.workspace
@@ -17,6 +17,8 @@ RUN apk add --update --no-cache \
     bash \
     build-base \
     ca-certificates \
+    tzdata \
+    openssh-client \
     curl \
     git \
     unzip \


### PR DESCRIPTION
The missing git binary results in failures when running the `check
breaking` feature from within a container because it relies on git to
clone branches/versions. This patch enables use of `check breaking` from
the public container.

Adding openssh-client enables cloning over SSH and enables Linux and WSL
users to forward/mount the local SSH agent. This enables cloning private
repositories over SSH through the docker image.

The tzdata dependency is required for Go binaries that manage time.
There doesn't appear to be any current use case where timezone data are
manipulated but this will prevent broken builds and panics should a
timezone operation make its way into buf.