### PR TITLE
Add recurse_submodules input option

### DIFF
--- a/internal/buf/bufos/env_reader.go
+++ b/internal/buf/bufos/env_reader.go
@@ -518,6 +518,7 @@ func (e *envReader) getReadBucketCloser(
 			getenv,
 			inputRef.Path,
 			inputRef.GitRefName,
+			inputRef.GitRecurseSubmodules,
 		)
 	default:
 		return nil, fmt.Errorf("unknown format outside of parse: %v", inputRef.Format)
@@ -597,6 +598,7 @@ func (e *envReader) getReadBucketCloserFromGitRepo(
 	getenv func(string) string,
 	gitRepo string,
 	gitRefName storagegitplumbing.RefName,
+	gitRecurseSubmodules bool,
 ) (_ storage.ReadBucketCloser, retErr error) {
 	defer utillog.Defer(e.logger, "get_git_bucket_memory")()
 
@@ -612,6 +614,7 @@ func (e *envReader) getReadBucketCloserFromGitRepo(
 		homeDirPath,
 		gitRepo,
 		gitRefName,
+		gitRecurseSubmodules,
 		e.httpsUsernameEnvKey,
 		e.httpsPasswordEnvKey,
 		e.sshKeyFileEnvKey,

--- a/internal/buf/bufos/internal/input_ref_parser_test.go
+++ b/internal/buf/bufos/internal/input_ref_parser_test.go
@@ -192,6 +192,25 @@ func TestParseInputRefSuccess(t *testing.T) {
 	testParseInputRefSuccess(
 		t,
 		&InputRef{
+			Format:               FormatGit,
+			Path:                 "path/to/dir",
+			GitRefName:           storagegitplumbing.NewTagRefName("master/foo"),
+			GitRecurseSubmodules: true,
+		},
+		"path/to/dir#format=git,tag=master/foo,recurse_submodules=true",
+	)
+	testParseInputRefSuccess(
+		t,
+		&InputRef{
+			Format:     FormatGit,
+			Path:       "path/to/dir",
+			GitRefName: storagegitplumbing.NewTagRefName("master/foo"),
+		},
+		"path/to/dir#format=git,tag=master/foo,recurse_submodules=false",
+	)
+	testParseInputRefSuccess(
+		t,
+		&InputRef{
 			Format:          FormatTarGz,
 			Path:            "path/to/file",
 			StripComponents: 1,
@@ -262,7 +281,7 @@ func TestParseInputRefError(t *testing.T) {
 	)
 	testParseInputRefErrorBasic(
 		t,
-		newCannotSpecifyMultipleGitRefNamesError(testValueFlagName),
+		newOptionsDuplicateKeyError(testValueFlagName, "branch"),
 		"path/to/foo#format=git,branch=foo,branch=bar",
 	)
 	testParseInputRefErrorBasic(
@@ -324,6 +343,11 @@ func TestParseInputRefError(t *testing.T) {
 		t,
 		newOptionsInvalidForFormatError(testValueFlagName, FormatDir, "strip_components=1"),
 		"path/to/foo#strip_components=1",
+	)
+	testParseInputRefErrorBasic(
+		t,
+		newOptionsDuplicateKeyError(testValueFlagName, "strip_components"),
+		"path/to/foo.tar#strip_components=0,strip_components=1",
 	)
 }
 

--- a/internal/buf/bufos/internal/internal.go
+++ b/internal/buf/bufos/internal/internal.go
@@ -23,6 +23,9 @@ type InputRef struct {
 	// GitRefName is the git reference name.
 	// This will only and always be set if Format == FormatGit.
 	GitRefName storagegitplumbing.RefName
+	// GitRecurseSubmodules says to check out submodules recursively.
+	// This will only be set if Format == FormatGit.
+	GitRecurseSubmodules bool
 }
 
 // InputRefParser parses InputRefs.

--- a/internal/pkg/storage/internal/storagetesting/storagetesting_test.go
+++ b/internal/pkg/storage/internal/storagetesting/storagetesting_test.go
@@ -198,6 +198,7 @@ func TestGitClone(t *testing.T) {
 		"",
 		absGitPath,
 		storagegitplumbing.NewBranchRefName("master"),
+		false,
 		"",
 		"",
 		"",

--- a/internal/pkg/storage/storagegit/storagegit.go
+++ b/internal/pkg/storage/storagegit/storagegit.go
@@ -54,6 +54,7 @@ func Clone(
 	homeDirPath string,
 	gitURL string,
 	refName storagegitplumbing.RefName,
+	recurseSubmodules bool,
 	httpsUsernameEnvKey string,
 	httpsPasswordEnvKey string,
 	sshKeyFileEnvKey string,
@@ -86,12 +87,18 @@ func Clone(
 	if err != nil {
 		return err
 	}
+	submoduleRecursivity := git.NoRecurseSubmodules
+	if recurseSubmodules {
+		// TODO: this only does 10 depth, compare to git
+		submoduleRecursivity = git.DefaultSubmoduleRecursionDepth
+	}
 	cloneOptions := &git.CloneOptions{
-		URL:           gitURL,
-		Auth:          authMethod,
-		ReferenceName: refName.ReferenceName(),
-		SingleBranch:  true,
-		Depth:         1,
+		URL:               gitURL,
+		Auth:              authMethod,
+		ReferenceName:     refName.ReferenceName(),
+		RecurseSubmodules: submoduleRecursivity,
+		SingleBranch:      true,
+		Depth:             1,
 	}
 	filesystem := memfs.New()
 	if _, err := git.CloneContext(ctx, memory.NewStorage(), filesystem, cloneOptions); err != nil {


### PR DESCRIPTION
Fixes #42.

Example:

```
$ buf check lint --input https://github.com/foo/bar.git#branch=master,recurse_submodules=true
```