### PR TITLE
Support arbitrary git refs in input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.2
 	github.com/jhump/protoreflect v1.6.2-0.20200602154950-9a9113f80b57
-	github.com/klauspost/compress v1.10.8
+	github.com/klauspost/compress v1.10.9
 	github.com/klauspost/pgzip v1.2.4
 	github.com/pkg/profile v1.5.0
 	github.com/spf13/cobra v1.0.0
@@ -15,7 +15,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0
-	google.golang.org/genproto v0.0.0-20200616192300-fc83d8c00726 // indirect
+	google.golang.org/genproto v0.0.0-20200617032506-f1bdc9086088 // indirect
 	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.10.8 h1:eLeJ3dr/Y9+XRfJT4l+8ZjmtB5RPJhucH2HeCV5+IZY=
-github.com/klauspost/compress v1.10.8/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.9 h1:pPRt1Z78crspaHISkpSSHjDlx+Tt9suHe519dsI0vF4=
+github.com/klauspost/compress v1.10.9/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/pgzip v1.2.4 h1:TQ7CNpYKovDOmqzRHKxJh0BeaBI7UdQZYc6p7pMQh1A=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -211,8 +211,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200616192300-fc83d8c00726 h1:lMcDmvQ6vt1yLOlu+nQLw6GpCy3JFPCvLb24pDfbtk4=
-google.golang.org/genproto v0.0.0-20200616192300-fc83d8c00726/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
+google.golang.org/genproto v0.0.0-20200617032506-f1bdc9086088 h1:XXo4PvhJkaWYIkwn7bX7mcdB8RdcOvn12HbaUUAwX3E=
+google.golang.org/genproto v0.0.0-20200617032506-f1bdc9086088/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/internal/pkg/fetch/errors.go
+++ b/internal/pkg/fetch/errors.go
@@ -44,12 +44,20 @@ func newFormatCannotBeDeterminedError(value string) error {
 	return fmt.Errorf("format cannot be determined from %q", value)
 }
 
-func newMustSpecifyGitRepositoryRefNameError(path string) error {
-	return fmt.Errorf(`must specify git reference (example: "%s#branch=master" or "%s#tag=v1.0.0")`, path, path)
+func newCannotSpecifyGitBranchAndTagError() error {
+	return fmt.Errorf(`must specify only one of "branch", "tag"`)
 }
 
-func newCannotSpecifyMultipleGitRepositoryRefNamesError() error {
-	return fmt.Errorf(`must specify only one of "branch", "tag"`)
+func newCannotSpecifyTagWithRefError() error {
+	return fmt.Errorf(`cannot specify "tag" with "ref"`)
+}
+
+func newDepthParseError(s string) error {
+	return fmt.Errorf(`could not parse "depth" value %q`, s)
+}
+
+func newDepthZeroError() error {
+	return fmt.Errorf(`"depth" must be >0 if specified`)
 }
 
 func newPathUnknownGzError(path string) error {

--- a/internal/pkg/fetch/fetch.go
+++ b/internal/pkg/fetch/fetch.go
@@ -149,7 +149,10 @@ func NewDirRef(path string) (DirRef, error) {
 type GitRef interface {
 	BucketRef
 	GitScheme() GitScheme
-	GitRefName() git.RefName
+	// Optional. May be nil, in which case clone the default branch.
+	GitName() git.Name
+	// Will always be >= 1
+	Depth() uint32
 	RecurseSubmodules() bool
 	gitRef()
 }
@@ -157,10 +160,11 @@ type GitRef interface {
 // NewGitRef returns a new GitRef.
 func NewGitRef(
 	path string,
-	gitRefName git.RefName,
+	gitName git.Name,
+	depth uint32,
 	recurseSubmodules bool,
 ) (GitRef, error) {
-	return newGitRef("", path, gitRefName, recurseSubmodules)
+	return newGitRef("", path, gitName, depth, recurseSubmodules)
 }
 
 // HasFormat is an object that has a format.
@@ -301,7 +305,16 @@ type RawRef struct {
 	// Only one of GitBranch and GitTag will be set
 	GitTag string
 	// Only set for git formats
+	// Specifies an exact git reference to use with git checkout.
+	// Can be used on its own or with GitBranch. Not allowed with GitTag.
+	// This is defined as anything that can be given to git checkout.
+	GitRef string
+	// Only set for git formats
 	GitRecurseSubmodules bool
+	// Only set for git formats.
+	// The depth to use when cloning a repository. Only allowed when GitRef
+	// is set. Defaults to 50 if unset.
+	GitDepth uint32
 	// Only set for archive formats
 	ArchiveStripComponents uint32
 }

--- a/internal/pkg/fetch/git_ref.go
+++ b/internal/pkg/fetch/git_ref.go
@@ -37,26 +37,32 @@ type gitRef struct {
 	format            string
 	path              string
 	gitScheme         GitScheme
-	gitRefName        git.RefName
+	gitName           git.Name
+	depth             uint32
 	recurseSubmodules bool
 }
 
 func newGitRef(
 	format string,
 	path string,
-	gitRefName git.RefName,
+	gitName git.Name,
+	depth uint32,
 	recurseSubmodules bool,
 ) (*gitRef, error) {
 	gitScheme, path, err := getGitSchemeAndPath(path)
 	if err != nil {
 		return nil, err
 	}
+	if depth == 0 {
+		return nil, newDepthZeroError()
+	}
 	return buildGitRef(
 		format,
 		path,
 		gitScheme,
-		gitRefName,
+		gitName,
 		recurseSubmodules,
+		depth,
 	), nil
 }
 
@@ -64,14 +70,16 @@ func buildGitRef(
 	format string,
 	path string,
 	gitScheme GitScheme,
-	gitRefName git.RefName,
+	gitName git.Name,
 	recurseSubmodules bool,
+	depth uint32,
 ) *gitRef {
 	return &gitRef{
 		format:            format,
 		path:              path,
 		gitScheme:         gitScheme,
-		gitRefName:        gitRefName,
+		gitName:           gitName,
+		depth:             depth,
 		recurseSubmodules: recurseSubmodules,
 	}
 }
@@ -88,8 +96,12 @@ func (r *gitRef) GitScheme() GitScheme {
 	return r.gitScheme
 }
 
-func (r *gitRef) GitRefName() git.RefName {
-	return r.gitRefName
+func (r *gitRef) GitName() git.Name {
+	return r.gitName
+}
+
+func (r *gitRef) Depth() uint32 {
+	return r.depth
 }
 
 func (r *gitRef) RecurseSubmodules() bool {

--- a/internal/pkg/fetch/reader.go
+++ b/internal/pkg/fetch/reader.go
@@ -127,6 +127,7 @@ func (r *reader) GetBucket(
 			ctx,
 			container,
 			t,
+			t.Depth(),
 			getBucketOptions.transformerOptions,
 		)
 	default:
@@ -236,6 +237,7 @@ func (r *reader) getGitBucket(
 	ctx context.Context,
 	container app.EnvStdinContainer,
 	gitRef GitRef,
+	depth uint32,
 	transformerOptions []normalpath.TransformerOption,
 ) (_ storage.ReadBucketCloser, retErr error) {
 	if !r.gitEnabled {
@@ -255,9 +257,10 @@ func (r *reader) getGitBucket(
 		ctx,
 		container,
 		gitURL,
-		gitRef.GitRefName(),
+		depth,
 		readWriteBucketCloser,
 		git.CloneToBucketOptions{
+			Name:               gitRef.GitName(),
 			RecurseSubmodules:  gitRef.RecurseSubmodules(),
 			TransformerOptions: transformerOptions,
 		},

--- a/internal/pkg/fetch/ref_parser_test.go
+++ b/internal/pkg/fetch/ref_parser_test.go
@@ -254,8 +254,33 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"path/to/dir.git",
 			GitSchemeLocal,
-			git.NewBranchRefName("master"),
+			nil,
 			false,
+			1,
+		),
+		"path/to/dir.git",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"path/to/dir.git",
+			GitSchemeLocal,
+			nil,
+			false,
+			40,
+		),
+		"path/to/dir.git#depth=40",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"path/to/dir.git",
+			GitSchemeLocal,
+			git.NewBranchName("master"),
+			false,
+			1,
 		),
 		"path/to/dir.git#branch=master",
 	)
@@ -265,8 +290,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"/path/to/dir.git",
 			GitSchemeLocal,
-			git.NewBranchRefName("master"),
+			git.NewBranchName("master"),
 			false,
+			1,
 		),
 		"file:///path/to/dir.git#branch=master",
 	)
@@ -276,8 +302,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"path/to/dir.git",
 			GitSchemeLocal,
-			git.NewTagRefName("v1.0.0"),
+			git.NewTagName("v1.0.0"),
 			false,
+			1,
 		),
 		"path/to/dir.git#tag=v1.0.0",
 	)
@@ -287,8 +314,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"hello.com/path/to/dir.git",
 			GitSchemeHTTP,
-			git.NewBranchRefName("master"),
+			git.NewBranchName("master"),
 			false,
+			1,
 		),
 		"http://hello.com/path/to/dir.git#branch=master",
 	)
@@ -298,8 +326,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"hello.com/path/to/dir.git",
 			GitSchemeHTTPS,
-			git.NewBranchRefName("master"),
+			git.NewBranchName("master"),
 			false,
+			1,
 		),
 		"https://hello.com/path/to/dir.git#branch=master",
 	)
@@ -309,10 +338,59 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"user@hello.com:path/to/dir.git",
 			GitSchemeSSH,
-			git.NewBranchRefName("master"),
+			git.NewBranchName("master"),
 			false,
+			1,
 		),
 		"ssh://user@hello.com:path/to/dir.git#branch=master",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"user@hello.com:path/to/dir.git",
+			GitSchemeSSH,
+			git.NewRefName("refs/remotes/origin/HEAD"),
+			false,
+			50,
+		),
+		"ssh://user@hello.com:path/to/dir.git#ref=refs/remotes/origin/HEAD",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"user@hello.com:path/to/dir.git",
+			GitSchemeSSH,
+			git.NewRefNameWithBranch("refs/remotes/origin/HEAD", "master"),
+			false,
+			50,
+		),
+		"ssh://user@hello.com:path/to/dir.git#ref=refs/remotes/origin/HEAD,branch=master",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"user@hello.com:path/to/dir.git",
+			GitSchemeSSH,
+			git.NewRefName("refs/remotes/origin/HEAD"),
+			false,
+			10,
+		),
+		"ssh://user@hello.com:path/to/dir.git#ref=refs/remotes/origin/HEAD,depth=10",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"user@hello.com:path/to/dir.git",
+			GitSchemeSSH,
+			git.NewRefNameWithBranch("refs/remotes/origin/HEAD", "master"),
+			false,
+			10,
+		),
+		"ssh://user@hello.com:path/to/dir.git#ref=refs/remotes/origin/HEAD,branch=master,depth=10",
 	)
 	testGetParsedRefSuccess(
 		t,
@@ -440,8 +518,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"/path/to/dir",
 			GitSchemeLocal,
-			git.NewBranchRefName("master"),
+			git.NewBranchName("master"),
 			false,
+			1,
 		),
 		"/path/to/dir#branch=master,format=git",
 	)
@@ -451,8 +530,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"/path/to/dir",
 			GitSchemeLocal,
-			git.NewBranchRefName("master/foo"),
+			git.NewBranchName("master/foo"),
 			false,
+			1,
 		),
 		"/path/to/dir#format=git,branch=master/foo",
 	)
@@ -462,8 +542,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"path/to/dir",
 			GitSchemeLocal,
-			git.NewTagRefName("master/foo"),
+			git.NewTagName("master/foo"),
 			false,
+			1,
 		),
 		"path/to/dir#tag=master/foo,format=git",
 	)
@@ -473,8 +554,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"path/to/dir",
 			GitSchemeLocal,
-			git.NewTagRefName("master/foo"),
+			git.NewTagName("master/foo"),
 			false,
+			1,
 		),
 		"path/to/dir#format=git,tag=master/foo",
 	)
@@ -484,8 +566,9 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"path/to/dir",
 			GitSchemeLocal,
-			git.NewTagRefName("master/foo"),
+			git.NewTagName("master/foo"),
 			true,
+			1,
 		),
 		"path/to/dir#format=git,tag=master/foo,recurse_submodules=true",
 	)
@@ -495,10 +578,35 @@ func TestGetParsedRefSuccess(t *testing.T) {
 			testFormatGit,
 			"path/to/dir",
 			GitSchemeLocal,
-			git.NewTagRefName("master/foo"),
+			git.NewTagName("master/foo"),
 			false,
+			1,
 		),
 		"path/to/dir#format=git,tag=master/foo,recurse_submodules=false",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"path/to/dir",
+			GitSchemeLocal,
+			git.NewRefName("refs/remotes/origin/HEAD"),
+			false,
+			50,
+		),
+		"path/to/dir#format=git,ref=refs/remotes/origin/HEAD",
+	)
+	testGetParsedRefSuccess(
+		t,
+		buildGitRef(
+			testFormatGit,
+			"path/to/dir",
+			GitSchemeLocal,
+			git.NewRefName("refs/remotes/origin/HEAD"),
+			false,
+			10,
+		),
+		"path/to/dir#format=git,ref=refs/remotes/origin/HEAD,depth=10",
 	)
 	testGetParsedRefSuccess(
 		t,
@@ -651,18 +759,28 @@ func TestGetParsedRefError(t *testing.T) {
 	)
 	testGetParsedRefError(
 		t,
-		newMustSpecifyGitRepositoryRefNameError("path/to/foo.git"),
-		"path/to/foo.git",
-	)
-	testGetParsedRefError(
-		t,
-		newMustSpecifyGitRepositoryRefNameError("path/to/foo"),
-		"path/to/foo#format=git",
-	)
-	testGetParsedRefError(
-		t,
-		newCannotSpecifyMultipleGitRepositoryRefNamesError(),
+		newCannotSpecifyGitBranchAndTagError(),
 		"path/to/foo#format=git,branch=foo,tag=bar",
+	)
+	testGetParsedRefError(
+		t,
+		newCannotSpecifyGitBranchAndTagError(),
+		"path/to/foo#format=git,branch=foo,tag=bar,ref=baz",
+	)
+	testGetParsedRefError(
+		t,
+		newCannotSpecifyTagWithRefError(),
+		"path/to/foo#format=git,tag=foo,ref=bar",
+	)
+	testGetParsedRefError(
+		t,
+		newDepthParseError("bar"),
+		"path/to/foo#format=git,depth=bar",
+	)
+	testGetParsedRefError(
+		t,
+		newDepthZeroError(),
+		"path/to/foo#format=git,ref=foor,depth=0",
 	)
 	testGetParsedRefError(
 		t,

--- a/internal/pkg/git/branch.go
+++ b/internal/pkg/git/branch.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+type branch struct {
+	branch string
+}
+
+func newBranch(name string) *branch {
+	return &branch{
+		branch: name,
+	}
+}
+
+func (r *branch) cloneBranch() string {
+	if r == nil {
+		return ""
+	}
+	return r.branch
+}
+
+func (r branch) checkout() string {
+	return ""
+}
+
+// Used for logging
+func (r *branch) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + r.cloneBranch() + `"`), nil
+}
+
+func (r *branch) String() string {
+	return r.cloneBranch()
+}

--- a/internal/pkg/git/git_test.go
+++ b/internal/pkg/git/git_test.go
@@ -15,9 +15,12 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bufbuild/buf/internal/pkg/app"
@@ -29,7 +32,9 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestCloneToBucket(t *testing.T) {
+// TODO: refactor this into common logic shared by tests
+
+func TestCloneBranchToBucket(t *testing.T) {
 	t.Parallel()
 	absGitPath, err := filepath.Abs("../../../.git")
 	require.NoError(t, err)
@@ -56,7 +61,145 @@ func TestCloneToBucket(t *testing.T) {
 		context.Background(),
 		envContainer,
 		"file://"+absGitPath,
-		NewBranchRefName("master"),
+		1,
+		readWriteBucketCloser,
+		CloneToBucketOptions{
+			Name: NewBranchName("master"),
+			TransformerOptions: []normalpath.TransformerOption{
+				normalpath.WithExt(".go"),
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = readWriteBucketCloser.Stat(context.Background(), relFilePathSuccess1)
+	assert.NoError(t, err)
+	_, err = readWriteBucketCloser.Stat(context.Background(), relFilePathError1)
+	assert.True(t, storage.IsNotExist(err))
+
+	assert.NoError(t, readWriteBucketCloser.Close())
+}
+
+func TestCloneRefToBucket(t *testing.T) {
+	t.Parallel()
+	absGitPath, err := filepath.Abs("../../../.git")
+	require.NoError(t, err)
+	_, err = os.Stat(absGitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skip("no .git repository")
+			return
+		}
+		require.NoError(t, err)
+	}
+
+	absFilePathSuccess1, err := filepath.Abs("../app/app.go")
+	require.NoError(t, err)
+	relFilePathSuccess1, err := filepath.Rel(filepath.Dir(absGitPath), absFilePathSuccess1)
+	require.NoError(t, err)
+	relFilePathError1 := "Makefile"
+
+	cloner := NewCloner(zap.NewNop(), ClonerOptions{})
+	envContainer, err := app.NewEnvContainerForOS()
+	require.NoError(t, err)
+	readWriteBucketCloser := storagemem.NewReadWriteBucketCloser()
+	err = cloner.CloneToBucket(
+		context.Background(),
+		envContainer,
+		"file://"+absGitPath,
+		1,
+		readWriteBucketCloser,
+		CloneToBucketOptions{
+			Name: NewRefName(testGetLastGitCommit(t)),
+			TransformerOptions: []normalpath.TransformerOption{
+				normalpath.WithExt(".go"),
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = readWriteBucketCloser.Stat(context.Background(), relFilePathSuccess1)
+	assert.NoError(t, err)
+	_, err = readWriteBucketCloser.Stat(context.Background(), relFilePathError1)
+	assert.True(t, storage.IsNotExist(err))
+
+	assert.NoError(t, readWriteBucketCloser.Close())
+}
+
+func TestCloneBranchAndRefToBucket(t *testing.T) {
+	t.Parallel()
+	absGitPath, err := filepath.Abs("../../../.git")
+	require.NoError(t, err)
+	_, err = os.Stat(absGitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skip("no .git repository")
+			return
+		}
+		require.NoError(t, err)
+	}
+
+	absFilePathSuccess1, err := filepath.Abs("../app/app.go")
+	require.NoError(t, err)
+	relFilePathSuccess1, err := filepath.Rel(filepath.Dir(absGitPath), absFilePathSuccess1)
+	require.NoError(t, err)
+	relFilePathError1 := "Makefile"
+
+	cloner := NewCloner(zap.NewNop(), ClonerOptions{})
+	envContainer, err := app.NewEnvContainerForOS()
+	require.NoError(t, err)
+	readWriteBucketCloser := storagemem.NewReadWriteBucketCloser()
+	err = cloner.CloneToBucket(
+		context.Background(),
+		envContainer,
+		"file://"+absGitPath,
+		50,
+		readWriteBucketCloser,
+		CloneToBucketOptions{
+			Name: newRefWithBranch("refs/remotes/origin/master", "master"), // Should hopefully always exist
+			TransformerOptions: []normalpath.TransformerOption{
+				normalpath.WithExt(".go"),
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = readWriteBucketCloser.Stat(context.Background(), relFilePathSuccess1)
+	assert.NoError(t, err)
+	_, err = readWriteBucketCloser.Stat(context.Background(), relFilePathError1)
+	assert.True(t, storage.IsNotExist(err))
+
+	assert.NoError(t, readWriteBucketCloser.Close())
+}
+
+func TestCloneDefault(t *testing.T) {
+	t.Parallel()
+	absGitPath, err := filepath.Abs("../../../.git")
+	require.NoError(t, err)
+	_, err = os.Stat(absGitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skip("no .git repository")
+			return
+		}
+		require.NoError(t, err)
+	}
+
+	absFilePathSuccess1, err := filepath.Abs("../app/app.go")
+	require.NoError(t, err)
+	relFilePathSuccess1, err := filepath.Rel(filepath.Dir(absGitPath), absFilePathSuccess1)
+	require.NoError(t, err)
+	relFilePathError1 := "Makefile"
+
+	cloner := NewCloner(zap.NewNop(), ClonerOptions{})
+	envContainer, err := app.NewEnvContainerForOS()
+	require.NoError(t, err)
+	readWriteBucketCloser := storagemem.NewReadWriteBucketCloser()
+	err = cloner.CloneToBucket(
+		context.Background(),
+		envContainer,
+		"file://"+absGitPath,
+		1,
 		readWriteBucketCloser,
 		CloneToBucketOptions{
 			TransformerOptions: []normalpath.TransformerOption{
@@ -72,4 +215,15 @@ func TestCloneToBucket(t *testing.T) {
 	assert.True(t, storage.IsNotExist(err))
 
 	assert.NoError(t, readWriteBucketCloser.Close())
+}
+
+func testGetLastGitCommit(t *testing.T) string {
+	envContainer, err := app.NewEnvContainerForOS()
+	require.NoError(t, err)
+	buffer := bytes.NewBuffer(nil)
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Env = app.Environ(envContainer)
+	cmd.Stdout = buffer
+	require.NoError(t, cmd.Run())
+	return strings.TrimSpace(buffer.String())
 }

--- a/internal/pkg/git/ref.go
+++ b/internal/pkg/git/ref.go
@@ -14,29 +14,32 @@
 
 package git
 
-type refName struct {
-	branchValue string
-	isTag       bool
+type ref struct {
+	ref string
 }
 
-func newRefName(branchValue string, isTag bool) *refName {
-	return &refName{
-		branchValue: branchValue,
-		isTag:       isTag,
+func newRef(name string) *ref {
+	return &ref{
+		ref: name,
 	}
 }
 
-func (r *refName) branch() string {
+func (r *ref) cloneBranch() string {
+	return ""
+}
+
+func (r *ref) checkout() string {
 	if r == nil {
 		return ""
 	}
-	return r.branchValue
+	return r.ref
 }
 
-func (r *refName) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + r.branch() + `"`), nil
+// Used for logging
+func (r *ref) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + r.checkout() + `"`), nil
 }
 
-func (r *refName) String() string {
-	return r.branch()
+func (r *ref) String() string {
+	return r.checkout()
 }

--- a/internal/pkg/git/ref_branch.go
+++ b/internal/pkg/git/ref_branch.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import "encoding/json"
+
+type refWithBranch struct {
+	ref    string
+	branch string
+}
+
+func newRefWithBranch(ref string, branch string) *refWithBranch {
+	return &refWithBranch{
+		ref:    ref,
+		branch: branch,
+	}
+}
+
+func (r *refWithBranch) cloneBranch() string {
+	if r == nil {
+		return ""
+	}
+	return r.branch
+}
+
+func (r *refWithBranch) checkout() string {
+	if r == nil {
+		return ""
+	}
+	return r.ref
+}
+
+// Used for logging
+func (r *refWithBranch) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Ref    string
+		Branch string
+	}{
+		Ref:    r.checkout(),
+		Branch: r.cloneBranch(),
+	})
+}
+
+func (r *refWithBranch) String() string {
+	return r.checkout()
+}

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -49,6 +49,9 @@ if [ -z "${INSIDE_DOCKER}" ]; then
     -e INSIDE_DOCKER=1 \
     "${DOCKER_IMAGE}" \
     bash -x make/buf/scripts/release.bash
+  if [ "$(uname -s)" == "Linux" ]; then
+    sudo chown -R "$(whoami):$(whoami)" .build
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
A valid ref is defined as anything accepted by "git checkout". Depth can further be configured by specifying the depth option. It defaults to 50 when ref is used, or 1 otherwise.