### PR TITLE
Dogfood buf, propagate stderr for protoc plugins, and re-add SourceCodeInfo comparison testing

### DIFF
--- a/internal/buf/cmd/buf/buf.go
+++ b/internal/buf/cmd/buf/buf.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is the version of buf.
-const Version = "0.19.0"
+const Version = "0.20.0-dev"
 
 // Main is the main.
 func Main(use string, options ...RootCommandOption) {

--- a/internal/buf/cmd/buf/internal/protoc/protoc_test.go
+++ b/internal/buf/cmd/buf/internal/protoc/protoc_test.go
@@ -82,7 +82,7 @@ func TestComparePrintFreeFieldNumbersGoogleapis(t *testing.T) {
 	)
 }
 
-func TestCompareOutputJSONGoogleapis(t *testing.T) {
+func TestCompareOutputGoogleapis(t *testing.T) {
 	t.Parallel()
 	googleapisDirPath := buftesting.GetGoogleapisDirPath(t, buftestingDirPath)
 	filePaths := buftesting.GetProtocFilePaths(t, googleapisDirPath, 1000)
@@ -94,9 +94,7 @@ func TestCompareOutputJSONGoogleapis(t *testing.T) {
 		filePaths,
 	)
 	bufProtocFileDescriptorSet := testGetBufProtocFileDescriptorSet(t, googleapisDirPath)
-	diffOne, err := prototesting.DiffFileDescriptorSetsJSON(bufProtocFileDescriptorSet, actualProtocFileDescriptorSet, "buf", "protoc")
-	assert.NoError(t, err)
-	assert.Equal(t, "", diffOne, "JSON diff:\n%s", diffOne)
+	prototesting.AssertFileDescriptorSetsEqual(t, bufProtocFileDescriptorSet, actualProtocFileDescriptorSet)
 }
 
 func TestCompareGeneratedStubsGoogleapisGo(t *testing.T) {

--- a/internal/pkg/diff/diff.go
+++ b/internal/pkg/diff/diff.go
@@ -54,7 +54,7 @@ func Diff(
 	if len(data) > 0 {
 		// diff exits with a non-zero status when the files don't match.
 		// Ignore that failure as long as we get output.
-		return modifyHeader(data, filename1, filename2, keepTimestamps)
+		return tryModifyHeader(data, filename1, filename2, keepTimestamps), nil
 	}
 	return nil, err
 }
@@ -75,15 +75,15 @@ func writeTempFile(dir, prefix string, data []byte) (string, error) {
 	return file.Name(), nil
 }
 
-func modifyHeader(
+func tryModifyHeader(
 	diff []byte,
 	filename1 string,
 	filename2 string,
 	keepTimestamps bool,
-) ([]byte, error) {
+) []byte {
 	bs := bytes.SplitN(diff, []byte{'\n'}, 3)
 	if len(bs) < 3 {
-		return nil, fmt.Errorf("got unexpected diff for %s-%s", filename1, filename2)
+		return diff
 	}
 	// Preserve timestamps.
 	var t0, t1 []byte
@@ -103,5 +103,5 @@ func modifyHeader(
 	}
 	bs[0] = []byte(fmt.Sprintf("--- %s%s", filename1, t0))
 	bs[1] = []byte(fmt.Sprintf("+++ %s%s", filename2, t1))
-	return bytes.Join(bs, []byte{'\n'}), nil
+	return bytes.Join(bs, []byte{'\n'})
 }

--- a/make/buf/base.mk
+++ b/make/buf/base.mk
@@ -17,6 +17,7 @@ FILE_IGNORES := $(FILE_IGNORES) \
 	internal/buf/internal/buftesting/cache/ \
 	internal/pkg/storage/storageos/tmp/
 
+PROTOC_USE_BUF := true
 
 include make/go/bootstrap.mk
 include make/go/go.mk
@@ -25,6 +26,8 @@ include make/go/dep_protoc.mk
 include make/go/docker.mk
 include make/go/protoc_gen_go.mk
 include make/go/dep_go_fuzz.mk
+
+protocpreinstall:: installbuf
 
 .PHONY: wkt
 wkt: installstorage-go-binary-data $(PROTOC)

--- a/make/go/base.mk
+++ b/make/go/base.mk
@@ -99,6 +99,9 @@ dockerdeps::
 .PHONY: deps
 deps:: dockerdeps
 
+.PHONY: preinstallgenerate
+preinstallgenerate::
+
 .PHONY: pregenerate
 pregenerate::
 
@@ -110,6 +113,7 @@ licensegenerate::
 
 .PHONY: generate
 generate:
+	@$(MAKE) preinstallgenerate
 	@$(MAKE) pregenerate
 	@$(MAKE) postgenerate
 	@$(MAKE) licensegenerate

--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -38,5 +38,17 @@ $(PROTOC):
 
 dockerdeps:: $(PROTOC)
 
-.PHONY: protocpre
-protocpre::
+.PHONY: protocpreinstall
+protocpreinstall::
+
+.PHONY: protocgenerate
+protocgenerate::
+
+preinstallgenerate:: protocpreinstall
+
+pregenerate:: protocgenerate
+
+.PHONY: protoc
+protoc:
+	$(MAKE) protocpreinstall
+	$(MAKE) protocgenerate

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -42,6 +42,11 @@ all:
 	@$(MAKE) lint
 	@$(MAKE) test
 
+.PHONY: shortall
+shortall:
+	@$(MAKE) lint
+	@$(MAKE) shorttest
+
 .PHONY: ci
 ci:
 	@$(MAKE) deps
@@ -110,6 +115,10 @@ pretest::
 .PHONY: test
 test: pretest
 	go test $(GO_TEST_FLAGS) $(GOPKGS)
+
+.PHONY: shorttest
+shorttest: pretest
+	go test -test.short $(GO_TEST_FLAGS) $(GOPKGS)
 
 .PHONY: deppkgs
 deppkgs:

--- a/make/go/protoc_gen_go.mk
+++ b/make/go/protoc_gen_go.mk
@@ -18,13 +18,18 @@ PROTOC_GEN_GO_OPT ?=
 
 EXTRA_MAKEGO_FILES := $(EXTRA_MAKEGO_FILES) scripts/protoc_gen_plugin.bash
 
+PROTOC_GEN_GO_EXTRA_FLAGS :=
+ifdef PROTOC_USE_BUF
+PROTOC_GEN_GO_EXTRA_FLAGS := --use-buf
+endif
+
 .PHONY: protocgengoclean
 protocgengoclean:
 	rm -rf "$(PROTOC_GEN_GO_OUT)"
 
 .PHONY: protocgengo
-protocgengo: protocpre protocgengoclean $(PROTOC) $(PROTOC_GEN_GO)
-	bash $(MAKEGO)/scripts/protoc_gen_plugin.bash \
+protocgengo: protocgengoclean $(PROTOC) $(PROTOC_GEN_GO)
+	bash $(MAKEGO)/scripts/protoc_gen_plugin.bash $(PROTOC_GEN_GO_EXTRA_FLAGS) \
 		"--proto_path=$(PROTO_PATH)" \
 		"--proto_include_path=$(CACHE_INCLUDE)" \
 		$(patsubst %,--proto_include_path=%,$(PROTO_INCLUDE_PATHS)) \
@@ -32,4 +37,4 @@ protocgengo: protocpre protocgengoclean $(PROTOC) $(PROTOC_GEN_GO)
 		"--plugin_out=$(PROTOC_GEN_GO_OUT)" \
 		"--plugin_opt=$(PROTOC_GEN_GO_OPT)"
 
-pregenerate:: protocgengo
+protocgenerate:: protocgengo

--- a/make/go/scripts/protoc_gen_plugin.bash
+++ b/make/go/scripts/protoc_gen_plugin.bash
@@ -32,6 +32,7 @@ PROTO_INCLUDE_PATHS=()
 PLUGIN_NAME=
 PLUGIN_OUT=
 PLUGIN_OPT=
+USE_BUF=
 while test $# -gt 0; do
   case "${1}" in
     -h|--help)
@@ -56,6 +57,10 @@ while test $# -gt 0; do
       ;;
     --plugin_opt*)
       PLUGIN_OPT="$(echo ${1} | sed -e 's/^[^=]*=//g')"
+      shift
+      ;;
+    --use-buf)
+      USE_BUF=1
       shift
       ;;
     *)
@@ -84,7 +89,12 @@ fi
 mkdir -p "${PLUGIN_OUT}"
 for proto_path in "${PROTO_PATHS[@]}"; do
   for dir in $(find "${proto_path}" -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq); do
-    echo protoc "${PROTOC_FLAGS[@]}" $(find "${dir}" -name '*.proto')
-    protoc --experimental_allow_proto3_optional "${PROTOC_FLAGS[@]}" $(find "${dir}" -name '*.proto')
+    if [ -n "${USE_BUF}" ]; then
+      echo buf protoc "${PROTOC_FLAGS[@]}" $(find "${dir}" -name '*.proto')
+      buf protoc "${PROTOC_FLAGS[@]}" $(find "${dir}" -name '*.proto')
+    else
+      echo protoc --experimental_allow_proto3_optional "${PROTOC_FLAGS[@]}" $(find "${dir}" -name '*.proto')
+      protoc --experimental_allow_proto3_optional "${PROTOC_FLAGS[@]}" $(find "${dir}" -name '*.proto')
+    fi
   done
 done


### PR DESCRIPTION
This does the following:

- Uses `buf protoc` instead of `protoc` for buf.
- Fixes an issue where stderr was not propagated for protoc plugins on the CLI side.
- Re-adds `SourceCodeInfo` comparison testing, as that now works.