### PR TITLE
Add missing `--` to protoc proxy handler opt flag

### DIFF
--- a/internal/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
+++ b/internal/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
@@ -92,7 +92,7 @@ func (h *protocProxyHandler) Handle(
 	if parameter := request.GetParameter(); parameter != "" {
 		args = append(
 			args,
-			fmt.Sprintf("%s_opt=%s", h.pluginName, parameter),
+			fmt.Sprintf("--%s_opt=%s", h.pluginName, parameter),
 		)
 	}
 	args = append(


### PR DESCRIPTION
Fixes issue where the opt flag is interpreted as a file to generate,
causing the compilation to fail.