### PR TITLE
Change successful command output target to container.Stdout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/buf
 
-go 1.14
+go 1.15
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d

--- a/internal/pkg/app/appcmd/appcmd.go
+++ b/internal/pkg/app/appcmd/appcmd.go
@@ -119,7 +119,7 @@ func run(
 	}
 
 	cobraCommand.SetArgs(app.Args(container)[1:])
-	cobraCommand.SetOut(container.Stderr())
+	cobraCommand.SetOut(container.Stdout())
 	cobraCommand.SetErr(container.Stderr())
 
 	if err := cobraCommand.Execute(); err != nil {


### PR DESCRIPTION
I'm not sure this was intended or not, successful command output is piped to `stderr`, not `stdout`.

I think piping successful command output to `stdout` is more reasonable, so I'd like to suggest changing successful command output target to `container.Stdout`.