### PR TITLE
To allow pre-built binaries use, switch Docker builds to Debian-based

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -1,19 +1,36 @@
-ARG DOCKER_WORKSPACE_IMAGE
+# syntax=docker/dockerfile:1.0.0-experimental
 
+ARG DOCKER_WORKSPACE_IMAGE
 FROM $DOCKER_WORKSPACE_IMAGE as builder
 
 COPY cmd ./cmd
 COPY internal ./internal
 RUN go build -ldflags "-s -w" -trimpath -o /go/bin/buf ./cmd/buf
 
-FROM alpine:3.12.0
+ENV PROTOC_VERSION=3.13.0
+RUN wget \
+        https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
+        -O /tmp/protoc.zip \
+    && unzip /tmp/protoc.zip -d /opt/protoc \
+    && chmod 755 /opt/protoc/bin/protoc
 
-RUN apk add --update --no-cache \
-    ca-certificates \
-    git \
-    openssh-client && \
-  rm -rf /var/cache/apk/*
+
+# Production image
+# TODO: rethink using python as base. Need to add NodeJS (for typescript) and Java plugins for protoc.
+FROM python:3.8-buster
+
+RUN --mount=target=/var/lib/apt/lists,type=cache \
+    --mount=target=/var/cache/apt,type=cache \
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git
 
 COPY --from=builder /go/bin/buf /usr/local/bin/buf
+COPY --from=builder /opt/protoc /usr/local/
+
+RUN pip install \
+    --no-cache-dir \
+    "betterproto[compiler]" \
+    mypy-protobuf
 
 ENTRYPOINT ["/usr/local/bin/buf"]

--- a/Dockerfile.workspace
+++ b/Dockerfile.workspace
@@ -1,4 +1,6 @@
-FROM golang:1.15.0-alpine3.12
+# syntax=docker/dockerfile:1.0.0-experimental
+
+FROM golang:1.15.0
 
 ARG PROJECT
 ARG GO_MODULE
@@ -13,21 +15,11 @@ ENV \
 
 WORKDIR /workspace
 
-RUN apk add --update --no-cache \
-    bash \
-    build-base \
-    ca-certificates \
-    curl \
-    git \
-    openssh-client \
-    unzip \
-    wget && \
-  rm -rf /var/cache/apk/*
-
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
-  apk add --no-cache glibc-2.31-r0.apk && \
-  rm -rf /var/cache/apk/*
+RUN --mount=target=/var/lib/apt/lists,type=cache \
+    --mount=target=/var/cache/apt,type=cache \
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        unzip
 
 COPY go.mod go.sum /workspace/
 RUN go mod download

--- a/make/go/docker.mk
+++ b/make/go/docker.mk
@@ -24,7 +24,7 @@ DOCKERMAKETARGET ?= all
 
 .PHONY: dockerbuildworkspace
 dockerbuildworkspace:
-	docker build \
+	DOCKER_BUILDKIT=1 docker build \
 		--build-arg PROJECT=$(PROJECT) \
 		--build-arg GO_MODULE=$(GO_MODULE) \
 		-t $(DOCKER_WORKSPACE_IMAGE) \
@@ -41,7 +41,7 @@ dockerbuild::
 define dockerbinfunc
 .PHONY: dockerbuild$(1)
 dockerbuild$(1): dockerbuildworkspace
-	docker build \
+	DOCKER_BUILDKIT=1 docker build \
 		--build-arg DOCKER_WORKSPACE_IMAGE=$(DOCKER_WORKSPACE_IMAGE) \
 		-t $(DOCKER_ORG)/$(1):latest \
 		-f Dockerfile.$(1) \


### PR DESCRIPTION
Just dropping `protoc` binary into Alpine-based `bufbuild/buf` docker image did NOT work. 
One of libc dependencies were missing (`ldd /path/to/protoc`) and attempts to run `protoc` resulted in ` 'protoc' not found  ` errors.

This PR:
- adds `protoc` from latest release AND
- switches base image from Alpine to Debian where libc and friends are friendly to having vendor-compiled binaries to be just dropped in.


Same problem is anticipated for multitude of other vendor-pre-compiled binaries. Recompiling all of them just to package them on top of Alpine is unjustified pain.

What's most annoying with current Alpine-based image is that I cannot just use it as base image, just add `protoc` plugins / tools and move on. I literally have to rebuild entire `buf` image from different base.

While rebasing on top of Debian slim adds a few megabytes to the image, it saves so much labor costs and trade off is very much worth it, considering Debian Buster Slim already sits in cache on every Docker host at this point.

Obviously don't need to merge my PR, but contemplate switching like that to a sensible docker base which we can just extend without having to rebuild from scratch