### PR TITLE
Sync from internal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
+	github.com/gofrs/flock v0.8.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.3
@@ -18,6 +19,7 @@ require (
 	go.opencensus.io v0.22.5
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/sys v0.0.0-20201118182958-a01c418693c7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20201117123952-62d171c70ae1 // indirect
 	google.golang.org/protobuf v1.25.1-0.20201020201750-d3470999428b

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
+github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -305,6 +307,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201118182958-a01c418693c7 h1:Z991aAXPjz0tLnj74pVXW3eWJ5lHMIBvbRfMq4M2jHA=
+golang.org/x/sys v0.0.0-20201118182958-a01c418693c7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/buf/bufcore/bufimage/bufimage.go
+++ b/internal/buf/bufcore/bufimage/bufimage.go
@@ -78,6 +78,7 @@ type Image interface {
 //
 // The input ImageFiles are expected to be in correct DAG order!
 // TODO: Consider checking the above, and if not, reordering the Files.
+// If imageFiles is empty, returns error
 func NewImage(imageFiles []ImageFile) (Image, error) {
 	return newImage(imageFiles, false)
 }

--- a/internal/buf/bufcore/bufimage/bufimagebuild/builder_test.go
+++ b/internal/buf/bufcore/bufimage/bufimagebuild/builder_test.go
@@ -155,7 +155,7 @@ func TestGoogleapis(t *testing.T) {
 			"google/foo/nonsense.proto",
 		},
 	)
-	assert.Equal(t, errors.New("google/foo/nonsense.proto has no matching file in the image"), err)
+	assert.Equal(t, errors.New(`path "google/foo/nonsense.proto" has no matching file in the image`), err)
 	_, err = bufimage.ImageWithOnlyPaths(
 		image,
 		[]string{
@@ -165,7 +165,7 @@ func TestGoogleapis(t *testing.T) {
 			"google/foo",
 		},
 	)
-	assert.Equal(t, errors.New("google/foo has no matching file in the image"), err)
+	assert.Equal(t, errors.New(`path "google/foo" has no matching file in the image`), err)
 
 	assert.Equal(t, buftesting.NumGoogleapisFilesWithImports, len(image.Files()))
 	// basic check to make sure there is no error at this scale

--- a/internal/buf/bufcore/bufimage/image.go
+++ b/internal/buf/bufcore/bufimage/image.go
@@ -15,6 +15,7 @@
 package bufimage
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -26,6 +27,9 @@ type image struct {
 }
 
 func newImage(files []ImageFile, reorder bool) (*image, error) {
+	if len(files) == 0 {
+		return nil, errors.New("image contains no files")
+	}
 	pathToImageFile := make(map[string]ImageFile, len(files))
 	for _, file := range files {
 		path := file.Path()

--- a/internal/buf/bufcore/bufimage/util.go
+++ b/internal/buf/bufcore/bufimage/util.go
@@ -56,6 +56,10 @@ func imageWithOnlyPaths(image Image, fileOrDirPaths []string, allowNotExist bool
 	// that itself contains ImageFiles, i.e. a/b.proto/c.proto is valid if not dumb
 	var potentialDirPaths []string
 	for _, fileOrDirPath := range fileOrDirPaths {
+		// this is not allowed, this is the equivalent of a root
+		if fileOrDirPath == "." {
+			return nil, errors.New(`"." is not a valid path value`)
+		}
 		if normalpath.Ext(fileOrDirPath) != ".proto" {
 			// not a .proto file, therefore must be a directory
 			potentialDirPaths = append(potentialDirPaths, fileOrDirPath)
@@ -119,7 +123,7 @@ func imageWithOnlyPaths(image Image, fileOrDirPaths []string, allowNotExist bool
 		for potentialDirPath := range potentialDirPathMap {
 			if _, ok := matchingPotentialDirPathMap[potentialDirPath]; !ok {
 				// no match, this is an error given that allowNotExist is false
-				return nil, fmt.Errorf("%s has no matching file in the image", potentialDirPath)
+				return nil, fmt.Errorf("path %q has no matching file in the image", potentialDirPath)
 			}
 		}
 	}

--- a/internal/buf/bufcore/bufimage/validate.go
+++ b/internal/buf/bufcore/bufimage/validate.go
@@ -24,10 +24,10 @@ import (
 // we validate the FileDescriptorProtos as part of NewFile
 func validateProtoImageExceptFileDescriptorProtos(protoImage *imagev1.Image) error {
 	if protoImage == nil {
-		return errors.New("nil Image")
+		return errors.New("nil image")
 	}
 	if len(protoImage.File) == 0 {
-		return errors.New("empty Image Files")
+		return errors.New("image contains no files")
 	}
 	if protoImage.BufbuildImageExtension != nil {
 		return validateProtoImageExtension(protoImage.BufbuildImageExtension, uint32(len(protoImage.File)))
@@ -49,10 +49,10 @@ func validateProtoImageExtension(
 		}
 		fileIndex := *imageImportRef.FileIndex
 		if fileIndex >= numFiles {
-			return fmt.Errorf("invalid file index: %d", fileIndex)
+			return fmt.Errorf("invalid ImageImportRef file index: %d", fileIndex)
 		}
 		if _, ok := seenFileIndexes[fileIndex]; ok {
-			return fmt.Errorf("duplicate file index: %d", fileIndex)
+			return fmt.Errorf("duplicate ImageImportRef file index: %d", fileIndex)
 		}
 		seenFileIndexes[fileIndex] = struct{}{}
 	}

--- a/internal/buf/bufcore/bufmodule/bufmodulebuild/util.go
+++ b/internal/buf/bufcore/bufmodule/bufmodulebuild/util.go
@@ -64,14 +64,14 @@ func pathsToTargetPaths(roots []string, paths []string, pathType normalpath.Path
 func pathToTargetPath(roots []string, path string, pathType normalpath.PathType) (string, error) {
 	var matchingRoots []string
 	for _, root := range roots {
-		if normalpath.EqualsOrContainsPath(root, path, pathType) {
+		if normalpath.ContainsPath(root, path, pathType) {
 			matchingRoots = append(matchingRoots, root)
 		}
 	}
 	switch len(matchingRoots) {
 	case 0:
 		// this is a user error and will likely happen often
-		return "", fmt.Errorf("%s is not contained within any of %s", path, strings.Join(roots, ", "))
+		return "", fmt.Errorf("path %q is not contained within any of roots %q - note that specified paths cannot be roots, but must be contained within roots", path, strings.Join(roots, ", "))
 	case 1:
 		targetPath, err := normalpath.Rel(matchingRoots[0], path)
 		if err != nil {
@@ -81,7 +81,7 @@ func pathToTargetPath(roots []string, path string, pathType normalpath.PathType)
 		return normalpath.NormalizeAndValidate(targetPath)
 	default:
 		// this should never happen
-		return "", fmt.Errorf("%q is contained in multiple roots %v", path, roots)
+		return "", fmt.Errorf("%q is contained in multiple roots %q", path, strings.Join(roots, ", "))
 	}
 }
 
@@ -135,13 +135,13 @@ func sortAndCheckDuplicatePaths(outputs []string, name string, pathType normalpa
 			output2 := outputs[j]
 
 			if output1 == output2 {
-				return nil, fmt.Errorf("duplicate %s %s", name, output1)
+				return nil, fmt.Errorf("duplicate %s %q", name, output1)
 			}
 			if normalpath.EqualsOrContainsPath(output2, output1, pathType) {
-				return nil, fmt.Errorf("%s %s is within %s %s which is not allowed", name, output1, name, output2)
+				return nil, fmt.Errorf("%s %q is within %s %q which is not allowed", name, output1, name, output2)
 			}
 			if normalpath.EqualsOrContainsPath(output1, output2, pathType) {
-				return nil, fmt.Errorf("%s %s is within %s %s which is not allowed", name, output2, name, output1)
+				return nil, fmt.Errorf("%s %q is within %s %q which is not allowed", name, output2, name, output1)
 			}
 		}
 	}
@@ -159,10 +159,10 @@ func sortAndCheckDuplicatePaths(outputs []string, name string, pathType normalpa
 	}
 	if hasTerminateDir {
 		if len(notTerminateDir) == 1 {
-			return nil, fmt.Errorf("%s %s is within %s %s which is not allowed", name, notTerminateDir[0], name, pathType.Separator())
+			return nil, fmt.Errorf("%s %q is within %s %q which is not allowed", name, notTerminateDir[0], name, pathType.Separator())
 		}
 		if len(notTerminateDir) > 1 {
-			return nil, fmt.Errorf("%ss %v are within %s %s which is not allowed", name, notTerminateDir, name, pathType.Separator())
+			return nil, fmt.Errorf("%ss %q are within %s %q which is not allowed", name, strings.Join(notTerminateDir, ", "), name, pathType.Separator())
 		}
 	}
 

--- a/internal/buf/bufcore/bufmodule/targeting_module.go
+++ b/internal/buf/bufcore/bufmodule/targeting_module.go
@@ -141,7 +141,7 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufc
 		for potentialDirPath := range potentialDirPathMap {
 			if _, ok := matchingPotentialDirPathMap[potentialDirPath]; !ok {
 				// no match, this is an error given that allowNotExist is false
-				return nil, fmt.Errorf("%s has no matching file in the module", potentialDirPath)
+				return nil, fmt.Errorf("path %q has no matching file in the module", potentialDirPath)
 			}
 		}
 	}

--- a/internal/buf/bufwire/image_reader.go
+++ b/internal/buf/bufwire/image_reader.go
@@ -74,7 +74,7 @@ func (i *imageReader) GetImage(
 		firstProtoImage := &imagev1.Image{}
 		_, span := trace.StartSpan(ctx, "first_wire_unmarshal")
 		if err := protoencoding.NewWireUnmarshaler(nil).Unmarshal(data, firstProtoImage); err != nil {
-			return nil, fmt.Errorf("could not unmarshal Image: %v", err)
+			return nil, fmt.Errorf("could not unmarshal image: %v", err)
 		}
 		span.End()
 		_, span = trace.StartSpan(ctx, "new_resolver")
@@ -89,14 +89,14 @@ func (i *imageReader) GetImage(
 		span.End()
 		_, span = trace.StartSpan(ctx, "second_wire_unmarshal")
 		if err := protoencoding.NewWireUnmarshaler(resolver).Unmarshal(data, protoImage); err != nil {
-			return nil, fmt.Errorf("could not unmarshal Image: %v", err)
+			return nil, fmt.Errorf("could not unmarshal image: %v", err)
 		}
 		span.End()
 	case buffetch.ImageEncodingJSON:
 		firstProtoImage := &imagev1.Image{}
 		_, span := trace.StartSpan(ctx, "first_json_unmarshal")
 		if err := protoencoding.NewJSONUnmarshaler(nil).Unmarshal(data, firstProtoImage); err != nil {
-			return nil, fmt.Errorf("could not unmarshal Image: %v", err)
+			return nil, fmt.Errorf("could not unmarshal image: %v", err)
 		}
 		// TODO right now, NewResolver sets AllowUnresolvable to true all the time
 		// we want to make this into a check, and we verify if we need this for the individual command
@@ -111,7 +111,7 @@ func (i *imageReader) GetImage(
 		span.End()
 		_, span = trace.StartSpan(ctx, "second_json_unmarshal")
 		if err := protoencoding.NewJSONUnmarshaler(resolver).Unmarshal(data, protoImage); err != nil {
-			return nil, fmt.Errorf("could not unmarshal Image: %v", err)
+			return nil, fmt.Errorf("could not unmarshal image: %v", err)
 		}
 		span.End()
 	default:

--- a/internal/buf/cmd/buf/command/generate/generate.go
+++ b/internal/buf/cmd/buf/command/generate/generate.go
@@ -118,6 +118,10 @@ $ buf generate --path proto/foo/foo.proto --path proto/foo/bar.proto
 # Only generate for the files in the directory proto/foo on your GitHub repository
 $ buf generate --template buf.gen.yaml https://github.com/foo/bar.git --path proto/foo
 
+Note that all paths must be contained within a root. For example, if you have the single
+root "proto", you cannot specify "--path proto", however "--path proto/foo" is allowed
+as "proto/foo" is contained within "proto".
+
 Plugins are invoked in the order they are specified in the template, but each plugin
 has a per-directory parallel invocation, with results from each invocation combined
 before writing the result. This is equivalent behavior to "buf protoc --by_dir".

--- a/internal/pkg/github/githubtesting/githubtesting.go
+++ b/internal/pkg/github/githubtesting/githubtesting.go
@@ -29,6 +29,10 @@ type ArchiveReader interface {
 	// The root directory within the tarball is stripped.
 	// If the directory already exists, this is a no-op.
 	//
+	// Uses file locking to make sure the no-op works properly across multiple process invocations,
+	// which is needed for example with go test.
+	// This is also thread-safe.
+	//
 	// Only use for testing.
 	GetArchive(
 		ctx context.Context,


### PR DESCRIPTION
- Adds file locking for testing
- Updates some error messages
- Clarifies that `--path` values must be fully contained within roots