### PR TITLE
Add plugin generation strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,9 @@ require (
 	go.opencensus.io v0.22.5
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
-	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d // indirect
+	golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc // indirect
+	google.golang.org/genproto v0.0.0-20201211151036-40ec1c210f7a // indirect
 	google.golang.org/protobuf v1.25.1-0.20201020201750-d3470999428b
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f h1:QdHQnPce6K4XQewki9WNbG5KOROuDzqO3NaYjI1cXJ0=
+golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -367,8 +367,8 @@ google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBr
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc h1:BgQmMjmd7K1zov8j8lYULHW0WnmBGUIMp6+VDwlGErc=
-google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201211151036-40ec1c210f7a h1:GnJAhasbD8HiT8DZMvsEx3QLVy/X0icq/MGr0MqRJ2M=
+google.golang.org/genproto v0.0.0-20201211151036-40ec1c210f7a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/internal/buf/bufgen/bufgen.go
+++ b/internal/buf/bufgen/bufgen.go
@@ -19,12 +19,52 @@ package bufgen
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/bufbuild/buf/internal/buf/bufcore/bufimage"
 	"github.com/bufbuild/buf/internal/pkg/app"
 	"github.com/bufbuild/buf/internal/pkg/storage/storageos"
 	"go.uber.org/zap"
 )
+
+const (
+	// StrategyDirectory is the strategy that says to generate per directory.
+	//
+	// This is the default value.
+	StrategyDirectory Strategy = 1
+	// StrategyAll is the strategy that says to generate with all files at once.
+	StrategyAll Strategy = 2
+)
+
+// Strategy is a generation stategy.
+type Strategy int
+
+// ParseStrategy parses the Strategy.
+//
+// If the empty string is provided, this is interpreted as StrategyDirectory.
+func ParseStrategy(s string) (Strategy, error) {
+	switch s {
+	case "", "directory":
+		return StrategyDirectory, nil
+	case "all":
+		return StrategyAll, nil
+	default:
+		return 0, fmt.Errorf("unknown strategy: %s", s)
+	}
+}
+
+// String implements fmt.Stringer.
+func (s Strategy) String() string {
+	switch s {
+	case StrategyDirectory:
+		return "directory"
+	case StrategyAll:
+		return "all"
+	default:
+		return strconv.Itoa(int(s))
+	}
+}
 
 // Generator generates Protobuf stubs based on configurations.
 type Generator interface {
@@ -78,6 +118,8 @@ type PluginConfig struct {
 	Opt string
 	// Optional
 	Path string
+	// Required
+	Strategy Strategy
 }
 
 // ReadConfig reads the configuration from the OS.
@@ -103,10 +145,11 @@ type ExternalConfigV1Beta1 struct {
 //
 // Only use outside of this package for testing.
 type ExternalPluginConfigV1Beta1 struct {
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
-	Out  string `json:"out,omitempty" yaml:"out,omitempty"`
-	Opt  string `json:"opt,omitempty" yaml:"opt,omitempty"`
-	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	Name     string `json:"name,omitempty" yaml:"name,omitempty"`
+	Out      string `json:"out,omitempty" yaml:"out,omitempty"`
+	Opt      string `json:"opt,omitempty" yaml:"opt,omitempty"`
+	Path     string `json:"path,omitempty" yaml:"path,omitempty"`
+	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }
 
 type externalConfigVersion struct {

--- a/internal/buf/bufgen/config.go
+++ b/internal/buf/bufgen/config.go
@@ -113,13 +113,18 @@ func validateExternalConfigV1Beta1(externalConfig ExternalConfigV1Beta1, id stri
 func newConfigV1Beta1(externalConfig ExternalConfigV1Beta1) (*Config, error) {
 	config := &Config{}
 	for _, plugin := range externalConfig.Plugins {
+		strategy, err := ParseStrategy(plugin.Strategy)
+		if err != nil {
+			return nil, err
+		}
 		config.PluginConfigs = append(
 			config.PluginConfigs,
 			&PluginConfig{
-				Name: plugin.Name,
-				Out:  plugin.Out,
-				Opt:  plugin.Opt,
-				Path: plugin.Path,
+				Name:     plugin.Name,
+				Out:      plugin.Out,
+				Opt:      plugin.Opt,
+				Path:     plugin.Path,
+				Strategy: strategy,
 			},
 		)
 	}

--- a/internal/buf/bufgen/config_test.go
+++ b/internal/buf/bufgen/config_test.go
@@ -26,10 +26,11 @@ func TestReadConfig(t *testing.T) {
 	successConfig := &Config{
 		PluginConfigs: []*PluginConfig{
 			{
-				Name: "go",
-				Out:  "gen/go",
-				Opt:  "plugins=grpc",
-				Path: "/path/to/foo",
+				Name:     "go",
+				Out:      "gen/go",
+				Opt:      "plugins=grpc",
+				Path:     "/path/to/foo",
+				Strategy: StrategyAll,
 			},
 		},
 	}

--- a/internal/buf/bufgen/testdata/gen_success1.json
+++ b/internal/buf/bufgen/testdata/gen_success1.json
@@ -5,7 +5,8 @@
       "name": "go",
       "out": "gen/go",
       "opt": "plugins=grpc",
-      "path": "/path/to/foo"
+      "path": "/path/to/foo",
+      "strategy": "all"
     }
   ]
 }

--- a/internal/buf/bufgen/testdata/gen_success1.yaml
+++ b/internal/buf/bufgen/testdata/gen_success1.yaml
@@ -4,3 +4,4 @@ plugins:
     out: gen/go
     opt: plugins=grpc
     path: /path/to/foo
+    strategy: all


### PR DESCRIPTION
Fixes #208.

This adds the `plugins.strategy` option for `buf.gen.yaml` configuration files. You can choose either `directory` or `all`:

```yaml
version: v1beta1
plugins:
  - name: doc
    out: doc
    strategy: all
```

The default is `directory`.
