### PR TITLE
Fix typo in generate command sample YAML

### DIFF
--- a/internal/buf/cmd/buf/command/generate/generate.go
+++ b/internal/buf/cmd/buf/command/generate/generate.go
@@ -104,7 +104,7 @@ plugins:
     #
     # Optional. If omitted, "directory" is used. Most users should not need to set this option.
     strategy: directory
-  - name java
+  - name: java
     out: gen/java
 
 As an example, here's a typical "buf.gen.yaml" go and grpc, assuming


### PR DESCRIPTION
Currently the sample YAML file has a typo that results in an invalid file, this PR fixes it.
There is no existing linked issue filed for this, please let me know if one is needed.