### PR TITLE
Update Dockerfile.buf

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -11,7 +11,7 @@ COPY cmd /workspace/cmd
 COPY internal /workspace/internal
 RUN CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o /go/bin/buf ./cmd/buf
 
-FROM alpine:3.12.0
+FROM alpine:3.12.4
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
Fixes several issues with OpenSSL in alpine 3.12.0

https://snyk.io/vuln/SNYK-ALPINE312-OPENSSL-1050745
https://snyk.io/vuln/SNYK-ALPINE312-MUSL-1042762
https://snyk.io/vuln/SNYK-ALPINE312-OPENSSL-1075734
https://snyk.io/vuln/SNYK-ALPINE312-OPENSSL-1075735
https://snyk.io/vuln/SNYK-ALPINE312-OPENSSL-1075736