### PR TITLE
Support multi-architecture Docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,13 +32,46 @@ jobs:
           BUF_BREAKING_PROTO_INPUT: 'https://github.com/bufbuild/buf.git#branch=master,subdir=proto'
           BUF_INPUT_HTTPS_USERNAME: ${{ github.actor }}
           BUF_INPUT_HTTPS_PASSWORD: ${{ github.token }}
-      - name: docker
-        if: success()
-        run: bash .github/scripts/docker.bash
-        env:
-          DOCKER_BUILD_MAKE_TARGET: dockerbuildbuf
-          DOCKER_IMAGE: bufbuild/buf
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-          DOCKER_LATEST_BRANCH: master
-          DOCKER_VERSION_TAG_PREFIX: v
+  docker:
+    runs-on: ubuntu-20.04
+    needs: build
+    # This job only runs when
+    # 1. When the previous `build` job has completed successfully
+    # 2. When the repository is not a fork, i.e. it will only run on the official bufbuild/buf
+    # 3. When the workflow run is trigged by master branch OR a tag with v prefix
+    # See https://github.com/bufbuild/buf/pull/289/files#r596207623 for the discussion
+    if:  ${{ success() && github.repository == 'bufbuild/buf' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/v')) }}
+    steps:
+      - name: setup-qemu
+        uses: docker/setup-qemu-action@v1
+        id: qemu
+        with:
+          # alpine image doesn't support linux/riscv64
+          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
+      - name: setup-docker-buildx
+        uses: docker/setup-buildx-action@v1
+      - name: login-docker
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: set-tag
+        # See the following links for setting job outputs
+        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs
+        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
+        id: tag
+        run: |
+          if echo "${GITHUB_REF}" | grep ^refs/heads/master$ >/dev/null; then
+            echo ::set-output name=tag::latest
+          elif echo "${GITHUB_REF}" | grep ^refs/tags/v >/dev/null; then
+            echo ::set-output name=tag::"$(echo "${GITHUB_REF}" | sed "s/refs\/tags\/v//")"
+          fi
+      - name: docker-build-push
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile.buf
+          platforms: ${{ steps.qemu.outputs.platforms }}
+          push: true
+          tags: |
+            bufbuild/buf:latest
+            bufbuild/buf:${{ steps.tag.outputs.tag }}

--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -1,4 +1,4 @@
-FROM golang:1.16.2-alpine3.12 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.16.2-alpine3.12 as builder
 
 WORKDIR /workspace
 
@@ -7,9 +7,13 @@ RUN go mod download
 
 COPY cmd /workspace/cmd
 COPY internal /workspace/internal
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o /go/bin/buf ./cmd/buf
 
-FROM alpine:3.12.4
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+  go build -ldflags "-s -w" -trimpath -o /go/bin/buf ./cmd/buf
+
+FROM --platform=${TARGETPLATFORM} alpine:3.12.4
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
As per #288, I have made this PR to make GitHub Actions supports building multi-architecture Docker image by using [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action), [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action), and [docker/build-push-action](https://github.com/docker/build-push-action).

I have tested the GitHub Actions workflow in my fork. The `docker` job depends on `build` job, and `docker` job will be run if and only if it is on `master` branch or a tag is pushed.

EDIT: This PR will make `.github/scripts/docker.bash` redundant, the maintainers can consider to remove it.