### PR TITLE
Fix double-dot missing flag errors

### DIFF
--- a/internal/buf/bufcli/errors.go
+++ b/internal/buf/bufcli/errors.go
@@ -110,7 +110,7 @@ func NewTooManyEmptyAnswersError(attempts int) error {
 
 // NewFlagIsRequiredError informs the user that a given flag is required.
 func NewFlagIsRequiredError(flagName string) error {
-	return appcmd.NewInvalidArgumentErrorf("--%s is required.", flagName)
+	return appcmd.NewInvalidArgumentErrorf("--%s is required", flagName)
 }
 
 // NewOrganizationNameAlreadyExistsError informs the user that an organization with

--- a/internal/buf/cmd/buf/command/beta/mod/modexport/modexport.go
+++ b/internal/buf/cmd/buf/command/beta/mod/modexport/modexport.go
@@ -80,7 +80,7 @@ func run(
 	moduleResolverReaderProvider bufcli.ModuleResolverReaderProvider,
 ) error {
 	if flags.Output == "" {
-		return appcmd.NewInvalidArgumentErrorf("--%s is required", outputFlagName)
+		return bufcli.NewFlagIsRequiredError(outputFlagName)
 	}
 	moduleRef, err := buffetch.NewModuleRefParser(
 		container.Logger(),

--- a/internal/buf/cmd/buf/command/beta/mod/modinit/modinit.go
+++ b/internal/buf/cmd/buf/command/beta/mod/modinit/modinit.go
@@ -117,7 +117,7 @@ func run(
 	flags *flags,
 ) error {
 	if flags.OutDirPath == "" {
-		return appcmd.NewInvalidArgumentErrorf("Flag --%s is required.", outDirPathFlagName)
+		return bufcli.NewFlagIsRequiredError(outDirPathFlagName)
 	}
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	readWriteBucket, err := storageosProvider.NewReadWriteBucket(

--- a/internal/buf/cmd/buf/command/breaking/breaking.go
+++ b/internal/buf/cmd/buf/command/breaking/breaking.go
@@ -252,7 +252,7 @@ func run(
 		return err
 	}
 	if againstInput == "" {
-		return appcmd.NewInvalidArgumentErrorf("Flag --%s is required.", againstFlagName)
+		return bufcli.NewFlagIsRequiredError(againstFlagName)
 	}
 	paths, err := bufcli.GetStringSliceFlagOrDeprecatedFlag(
 		flags.Paths,

--- a/internal/buf/cmd/buf/command/build/build.go
+++ b/internal/buf/cmd/buf/command/build/build.go
@@ -166,7 +166,7 @@ func run(
 	moduleResolverReaderProvider bufcli.ModuleResolverReaderProvider,
 ) error {
 	if flags.Output == "" {
-		return appcmd.NewInvalidArgumentErrorf("Flag --%s is required.", outputFlagName)
+		return bufcli.NewFlagIsRequiredError(outputFlagName)
 	}
 	input, err := bufcli.GetInputValue(container, flags.InputHashtag, flags.Source, sourceFlagName, ".")
 	if err != nil {

--- a/internal/buf/cmd/buf/command/convert/convert.go
+++ b/internal/buf/cmd/buf/command/convert/convert.go
@@ -111,7 +111,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 
 func run(ctx context.Context, container appflag.Container, flags *flags) (retErr error) {
 	if flags.Output == "" {
-		return appcmd.NewInvalidArgumentErrorf("--%s is required", outputFlagName)
+		return bufcli.NewFlagIsRequiredError(outputFlagName)
 	}
 	paths, err := bufcli.GetStringSliceFlagOrDeprecatedFlag(
 		flags.Paths,

--- a/internal/buf/cmd/buf/command/protoc/protoc.go
+++ b/internal/buf/cmd/buf/command/protoc/protoc.go
@@ -192,7 +192,7 @@ func run(
 		return nil
 	}
 	if env.Output == "" {
-		return appcmd.NewInvalidArgumentErrorf("--%s is required", outputFlagName)
+		return bufcli.NewFlagIsRequiredError(outputFlagName)
 	}
 	imageRef, err := buffetch.NewImageRefParser(container.Logger()).GetImageRef(ctx, env.Output)
 	if err != nil {

--- a/internal/pkg/licenseheader/cmd/license-header/main.go
+++ b/internal/pkg/licenseheader/cmd/license-header/main.go
@@ -152,5 +152,5 @@ func run(ctx context.Context, container app.Container, flags *flags) error {
 }
 
 func newRequiredFlagError(flagName string) error {
-	return appcmd.NewInvalidArgumentErrorf("--%s is required.", flagName)
+	return appcmd.NewInvalidArgumentErrorf("--%s is required", flagName)
 }

--- a/internal/pkg/spdx/cmd/spdx-go-data/main.go
+++ b/internal/pkg/spdx/cmd/spdx-go-data/main.go
@@ -201,7 +201,7 @@ func (l *licenseInfo) ID() string {
 }
 
 func newRequiredFlagError(flagName string) error {
-	return appcmd.NewInvalidArgumentErrorf("--%s is required.", flagName)
+	return appcmd.NewInvalidArgumentErrorf("--%s is required", flagName)
 }
 
 type licenseInfoList struct {


### PR DESCRIPTION
Fixes #317

This updates some errors like this:

```
Failed to "breaking": Flag --against is required..
```

to be this:

```
Failed to "breaking": --against is required.
```

This includes some refactors to use bufcli.NewFlagIsRequiredError rather
than appcmd.NewInvalidArgumentErrorf, but only in those instances where
bufcli was already imported. I wasn't sure if adding that import in e.g.
`internal/pkg/spdx/cmd/spdx-go-data` was desired, so I left those
changes out.


