### PR TITLE
Make linter not consider directives to be valid comments

### DIFF
--- a/internal/buf/bufcheck/buflint/buflint_test.go
+++ b/internal/buf/bufcheck/buflint/buflint_test.go
@@ -36,8 +36,10 @@ import (
 )
 
 // Hint on how to get these:
-// 1. cd into the specific diriectory
-// 2. buf lint --error-format=json | jq '[.path, ".", .start_line, .start_column, .end_line, .end_column, .type] | @csv' --raw-output
+// 1. cd into the specific directory
+// 2. buf lint --error-format=json | jq '[.path, .start_line, .start_column, .end_line, .end_column, .type] | @csv' --raw-output
+//      or
+//    buf lint --error-format=json | jq -r '"bufanalysistesting.NewFileAnnotation(t, \"\(.path)\", \(.start_line|tostring), \(.start_column|tostring), \(.end_line|tostring), \(.end_column|tostring), \"\(.type)\"),"'
 
 func TestRunComments(t *testing.T) {
 	testLint(
@@ -140,6 +142,7 @@ func TestRunComments(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 260, 3, 260, 72, "COMMENT_RPC"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 263, 1, 265, 2, "COMMENT_MESSAGE"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 264, 3, 264, 30, "COMMENT_FIELD"),
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 274, 3, 274, 72, "COMMENT_RPC"),
 	)
 }
 

--- a/internal/buf/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
+++ b/internal/buf/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
@@ -85,7 +85,7 @@ func checkCommentNamedDescriptor(
 		// this will magically skip map entry fields as well as a side-effect, although originally unintended
 		return nil
 	}
-	if strings.TrimSpace(location.LeadingComments()) == "" {
+	if !validLeadingComment(location.LeadingComments()) {
 		add(namedDescriptor, location, nil, "%s %q should have a non-empty comment for documentation.", typeName, namedDescriptor.Name())
 	}
 	return nil

--- a/internal/buf/bufcheck/buflint/internal/buflintcheck/util.go
+++ b/internal/buf/bufcheck/buflint/internal/buflintcheck/util.go
@@ -15,6 +15,8 @@
 package buflintcheck
 
 import (
+	"strings"
+
 	"github.com/bufbuild/buf/internal/buf/bufanalysis"
 	"github.com/bufbuild/buf/internal/buf/bufcheck/internal"
 	"github.com/bufbuild/buf/internal/pkg/protosource"
@@ -38,6 +40,18 @@ func fieldToUpperSnakeCase(s string) string {
 	// We allow both effectively by not passing the option
 	//return stringutil.ToUpperSnakeCase(s, stringutil.SnakeCaseWithNewWordOnDigits())
 	return stringutil.ToUpperSnakeCase(s)
+}
+
+// validLeadingComment returns true if comment has at least one line that isn't empty and doesn't start with
+// "buf:lint:ignore"
+func validLeadingComment(comment string) bool {
+	for _, line := range strings.Split(comment, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "buf:lint:ignore") {
+			return true
+		}
+	}
+	return false
 }
 
 func newFilesCheckFunc(

--- a/internal/buf/bufcheck/buflint/testdata/comments/a.proto
+++ b/internal/buf/bufcheck/buflint/testdata/comments/a.proto
@@ -263,3 +263,13 @@ service ServiceFoo5 {
 message Baz {
   map<int64, string> one = 1;
 }
+
+// comment
+service ServiceFoo6 {
+  // comment
+  rpc MethodFoo(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  //buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_REQUEST_STANDARD_NAME
+  //
+  rpc MethodBar(google.protobuf.Empty) returns (google.protobuf.Empty);
+}


### PR DESCRIPTION
This makes COMMENT_* checks stop considering buf:lint:ignore directives to be valid comments.

fixes #297
