### PR TITLE
Add unix-like build tags in locations other than app package

### DIFF
--- a/internal/buf/cmd/buf/command/protoc/const_unix.go
+++ b/internal/buf/cmd/buf/command/protoc/const_unix.go
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package protoc
 
 // https://github.com/protocolbuffers/protobuf/blob/336ed1820a4f2649c9aa3953d5059b03b7a77100/src/google/protobuf/compiler/command_line_interface.cc#L892-L896
+//
+// This will be ":" for all unix-like platforms including darwin.
+// This will be ";" for windows.
 const includeDirPathSeparator = ":"

--- a/internal/buf/cmd/buf/command/protoc/const_windows.go
+++ b/internal/buf/cmd/buf/command/protoc/const_windows.go
@@ -17,4 +17,7 @@
 package protoc
 
 // https://github.com/protocolbuffers/protobuf/blob/336ed1820a4f2649c9aa3953d5059b03b7a77100/src/google/protobuf/compiler/command_line_interface.cc#L892-L896
+//
+// This will be ":" for all unix-like platforms including darwin.
+// This will be ";" for windows.
 const includeDirPathSeparator = ";"

--- a/internal/pkg/filepathextended/filepathextended_unix_test.go
+++ b/internal/pkg/filepathextended/filepathextended_unix_test.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package filepathextended
 

--- a/internal/pkg/interrupt/interrupt.go
+++ b/internal/pkg/interrupt/interrupt.go
@@ -20,6 +20,13 @@ import (
 	"os/signal"
 )
 
+var signals = append(
+	[]os.Signal{
+		os.Interrupt,
+	},
+	extraSignals...,
+)
+
 // WithCancel returns a context that is cancelled if interrupt signals are sent.
 func WithCancel(ctx context.Context) (context.Context, context.CancelFunc) {
 	signalC, closer := NewSignalChannel()

--- a/internal/pkg/interrupt/interrupt_unix.go
+++ b/internal/pkg/interrupt/interrupt_unix.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package interrupt
 
@@ -21,7 +23,12 @@ import (
 	"syscall"
 )
 
-var signals = []os.Signal{
-	syscall.SIGINT,
+// extraSignals are signals beyond os.Interrupt that we want to be handled
+// as interrupts.
+//
+// For unix-like platforms, this adds syscall.SIGTERM, although this is only
+// tested on darwin and linux, which buf officially supports. Other unix-like
+// platforms should have this as well, however.
+var extraSignals = []os.Signal{
 	syscall.SIGTERM,
 }

--- a/internal/pkg/interrupt/interrupt_windows.go
+++ b/internal/pkg/interrupt/interrupt_windows.go
@@ -18,6 +18,10 @@ package interrupt
 
 import "os"
 
-var signals = []os.Signal{
-	os.Interrupt,
-}
+// extraSignals are signals beyond os.Interrupt that we want to be handled
+// as interrupts.
+//
+// For unix-like platforms, this adds syscall.SIGTERM, although this is only
+// tested on darwin and linux, which buf officially supports. Other unix-like
+// platforms should have this as well, however.
+var extraSignals = []os.Signal{}

--- a/internal/pkg/netrc/netrc_unix.go
+++ b/internal/pkg/netrc/netrc_unix.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package netrc
 
 // netrcFilename is the netrc filename.
 //
-// This will be .netrc for darwin and linux.
+// This will be .netrc for unix-like platforms including darwin.
 // This will be _netrc for windows.
 const netrcFilename = ".netrc"

--- a/internal/pkg/netrc/netrc_unix_test.go
+++ b/internal/pkg/netrc/netrc_unix_test.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package netrc
 


### PR DESCRIPTION
Starts to address https://github.com/bufbuild/buf/issues/362.
Starts to supplant https://github.com/bufbuild/buf/pull/363.
See https://github.com/cockroachdb/cockroach/issues/67216.

We will deal with the `app` package in a separate PR - the solution for now might be to allow the build to process with similar opt-in to unix-like system build tags, but document what the issues could be for unsupported platforms.