### PR TITLE
Expand build tags in app packages

### DIFF
--- a/internal/pkg/app/app_unix.go
+++ b/internal/pkg/app/app_unix.go
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+//
+// We expanded this to all unix-like platforms, including those we don't support, as most
+// of this should work without issue, and there are bigger problems with supporting i.e. js,wasm
+// that are outside the scope of these build tags. Being able to build buf on i.e. openbsd
+// was a blocker, see https://github.com/bufbuild/buf/issues/362 and the linked discussions.
+// We still only officially support linux and darwin for buf as a whole.
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package app
 

--- a/internal/pkg/app/appname/appname_unix_test.go
+++ b/internal/pkg/app/appname/appname_unix_test.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin linux
+// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
+
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package appname
 


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/362.
Supplants https://github.com/bufbuild/buf/pull/363.
See https://github.com/cockroachdb/cockroach/issues/67216.

This doesn't certify that `app` features will actually work with all unix-like platforms, but on balance, allowing these builds seems better than blocking the builds, or actually setting up testing for each platform. If there is an issue down the road for an unsupported platform, we can fix it when we add support.