### PR TITLE
Fix Environment Variables for Windows

### DIFF
--- a/internal/pkg/app/app_windows.go
+++ b/internal/pkg/app/app_windows.go
@@ -67,7 +67,7 @@ func HomeDirPath(envContainer EnvContainer) (string, error) {
 //
 // Users cannot assume that CacheDirPath, ConfigDirPath, and DataDirPath are unique.
 func CacheDirPath(envContainer EnvContainer) (string, error) {
-	if value := envContainer.Env("LocalAppData"); value != "" {
+	if value := envContainer.Env("LOCALAPPDATA"); value != "" {
 		return value, nil
 	}
 	return "", errors.New("%LocalAppData% is not set")
@@ -85,7 +85,7 @@ func CacheDirPath(envContainer EnvContainer) (string, error) {
 //
 // Users cannot assume that CacheDirPath, ConfigDirPath, and DataDirPath are unique.
 func ConfigDirPath(envContainer EnvContainer) (string, error) {
-	if value := envContainer.Env("AppData"); value != "" {
+	if value := envContainer.Env("APPDATA"); value != "" {
 		return value, nil
 	}
 	return "", errors.New("%AppData% is not set")
@@ -103,7 +103,7 @@ func ConfigDirPath(envContainer EnvContainer) (string, error) {
 //
 // Users cannot assume that CacheDirPath, ConfigDirPath, and DataDirPath are unique.
 func DataDirPath(envContainer EnvContainer) (string, error) {
-	if value := envContainer.Env("LocalAppData"); value != "" {
+	if value := envContainer.Env("LOCALAPPDATA"); value != "" {
 		return value, nil
 	}
 	return "", errors.New("%LocalAppData% is not set")


### PR DESCRIPTION
Fixes #385 

Update the environment variables from camel case to all caps for windows to get correct cache, config and data directory paths