### PR TITLE
Only export files from dependencies that are imported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.18.1
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67 // indirect
 	google.golang.org/grpc v1.40.0-dev.0.20210708170655-30dfb4b933a5

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraCFObP8S1v6PRp0bLrtU=
+golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/internal/buf/cmd/buf/buf_test.go
+++ b/internal/buf/cmd/buf/buf_test.go
@@ -1133,6 +1133,55 @@ breaking:
 	)
 }
 
+func TestExportProto(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	testRunStdout(
+		t,
+		nil,
+		0,
+		``,
+		"export",
+		"-o",
+		tempDir,
+		filepath.Join("testdata", "export", "proto"),
+	)
+	readWriteBucket, err := storageos.NewProvider().NewReadWriteBucket(tempDir)
+	require.NoError(t, err)
+	// This should NOT include unimported.proto
+	storagetesting.AssertPaths(
+		t,
+		readWriteBucket,
+		"",
+		"request.proto",
+		"rpc.proto",
+	)
+}
+
+func TestExportOtherProto(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	testRunStdout(
+		t,
+		nil,
+		0,
+		``,
+		"export",
+		"-o",
+		tempDir,
+		filepath.Join("testdata", "export", "other", "proto"),
+	)
+	readWriteBucket, err := storageos.NewProvider().NewReadWriteBucket(tempDir)
+	require.NoError(t, err)
+	storagetesting.AssertPaths(
+		t,
+		readWriteBucket,
+		"",
+		"request.proto",
+		"unimported.proto",
+	)
+}
+
 func TestExportAll(t *testing.T) {
 	t.Parallel()
 	tempDir := t.TempDir()
@@ -1144,7 +1193,7 @@ func TestExportAll(t *testing.T) {
 		"export",
 		"-o",
 		tempDir,
-		filepath.Join("testdata", "workspace", "success", "dir", "proto"),
+		filepath.Join("testdata", "export"),
 	)
 	readWriteBucket, err := storageos.NewProvider().NewReadWriteBucket(tempDir)
 	require.NoError(t, err)
@@ -1152,8 +1201,10 @@ func TestExportAll(t *testing.T) {
 		t,
 		readWriteBucket,
 		"",
+		"another.proto",
 		"request.proto",
 		"rpc.proto",
+		"unimported.proto",
 	)
 }
 
@@ -1169,7 +1220,7 @@ func TestExportExcludeImports(t *testing.T) {
 		"--exclude-imports",
 		"-o",
 		tempDir,
-		filepath.Join("testdata", "workspace", "success", "dir", "proto"),
+		filepath.Join("testdata", "export", "proto"),
 	)
 	readWriteBucket, err := storageos.NewProvider().NewReadWriteBucket(tempDir)
 	require.NoError(t, err)
@@ -1191,10 +1242,10 @@ func TestExportPaths(t *testing.T) {
 		``,
 		"export",
 		"--path",
-		filepath.Join("testdata", "workspace", "success", "dir", "other", "proto", "request.proto"),
+		filepath.Join("testdata", "export", "other", "proto", "request.proto"),
 		"-o",
 		tempDir,
-		filepath.Join("testdata", "workspace", "success", "dir"),
+		filepath.Join("testdata", "export"),
 	)
 	readWriteBucket, err := storageos.NewProvider().NewReadWriteBucket(tempDir)
 	require.NoError(t, err)

--- a/internal/buf/cmd/buf/testdata/export/another/proto/another.proto
+++ b/internal/buf/cmd/buf/testdata/export/another/proto/another.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package another;
+
+message Request {
+  string name = 1;
+}

--- a/internal/buf/cmd/buf/testdata/export/another/proto/buf.yaml
+++ b/internal/buf/cmd/buf/testdata/export/another/proto/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: bufbuild.test/workspace/another

--- a/internal/buf/cmd/buf/testdata/export/buf.work.yaml
+++ b/internal/buf/cmd/buf/testdata/export/buf.work.yaml
@@ -1,0 +1,5 @@
+version: v1
+directories:
+  - another/proto
+  - other/proto
+  - proto

--- a/internal/buf/cmd/buf/testdata/export/other/proto/buf.yaml
+++ b/internal/buf/cmd/buf/testdata/export/other/proto/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: bufbuild.test/workspace/request

--- a/internal/buf/cmd/buf/testdata/export/other/proto/request.proto
+++ b/internal/buf/cmd/buf/testdata/export/other/proto/request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package request;
+
+message Request {
+  string name = 1;
+}

--- a/internal/buf/cmd/buf/testdata/export/other/proto/unimported.proto
+++ b/internal/buf/cmd/buf/testdata/export/other/proto/unimported.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+// This file isn't imported so if we just export proto/ it should not appear.
+
+package request;
+
+message NotImported {
+  string name = 1;
+}

--- a/internal/buf/cmd/buf/testdata/export/proto/buf.yaml
+++ b/internal/buf/cmd/buf/testdata/export/proto/buf.yaml
@@ -1,0 +1,4 @@
+version: v1
+name: bufbuild.test/workspace/rpc
+deps:
+  - bufbuild.test/workspace/request

--- a/internal/buf/cmd/buf/testdata/export/proto/rpc.proto
+++ b/internal/buf/cmd/buf/testdata/export/proto/rpc.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package example;
+
+import "request.proto";
+
+message RPC {
+    request.Request req = 1;
+}

--- a/make/buf/scripts/brew.sh
+++ b/make/buf/scripts/brew.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR="$(cd "$(dirname "${0}")/../../.." && pwd)"
+DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
 cd "${DIR}"
 
 if [ -z "${1}" ]; then

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -3,7 +3,7 @@
 set -eo pipefail
 set -x
 
-DIR="$(cd "$(dirname "${0}")/../../.." && pwd)"
+DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
 cd "${DIR}"
 
 fail() {


### PR DESCRIPTION
When we do `buf export`, we export all files from dependencies, even if they are not used as imports. This means, for example, that if you depend on googleapis, you get all 4000 files exported, even if you only import 1 file. This caused an OOM error for a customer.

If you are not excluding imports, this changes `buf export` so that you only export those files that you import. This is accomplished by building a merged image, and if you are going to export an import, checking if the file is in the merged image.