### PR TITLE
Add buf generate --include-imports

### DIFF
--- a/internal/buf/bufgen/bufgen.go
+++ b/internal/buf/bufgen/bufgen.go
@@ -127,6 +127,15 @@ func GenerateWithBaseOutDirPath(baseOutDirPath string) GenerateOption {
 	}
 }
 
+// GenerateWithIncludeImports says to also generate imports.
+//
+// Note that this does NOT result in the Well-Known Types being generated.
+func GenerateWithIncludeImports() GenerateOption {
+	return func(generateOptions *generateOptions) {
+		generateOptions.includeImports = true
+	}
+}
+
 // Config is a configuration.
 type Config struct {
 	// Required

--- a/internal/buf/bufgen/generator.go
+++ b/internal/buf/bufgen/generator.go
@@ -65,6 +65,7 @@ func (g *generator) Generate(
 		config,
 		image,
 		generateOptions.baseOutDirPath,
+		generateOptions.includeImports,
 	)
 }
 
@@ -74,6 +75,7 @@ func (g *generator) generate(
 	config *Config,
 	image bufimage.Image,
 	baseOutDirPath string,
+	includeImports bool,
 ) error {
 	if err := modifyImage(ctx, config, image); err != nil {
 		return err
@@ -107,7 +109,12 @@ func (g *generator) generate(
 			container,
 			pluginConfig.Name,
 			out,
-			bufimage.ImagesToCodeGeneratorRequests(pluginImages, pluginConfig.Opt, appprotoexec.DefaultVersion),
+			bufimage.ImagesToCodeGeneratorRequests(
+				pluginImages,
+				pluginConfig.Opt,
+				appprotoexec.DefaultVersion,
+				includeImports,
+			),
 			appprotoos.GenerateWithPluginPath(pluginConfig.Path),
 			appprotoos.GenerateWithCreateOutDirIfNotExists(),
 		); err != nil {
@@ -215,6 +222,7 @@ func defaultManagedModeModifier(sweeper bufimagemodify.Sweeper) (bufimagemodify.
 
 type generateOptions struct {
 	baseOutDirPath string
+	includeImports bool
 }
 
 func newGenerateOptions() *generateOptions {

--- a/internal/buf/bufimage/bufimagetesting/bufimagetesting_test.go
+++ b/internal/buf/bufimage/bufimagetesting/bufimagetesting_test.go
@@ -454,7 +454,7 @@ func TestBasic(t *testing.T) {
 	require.Equal(
 		t,
 		codeGeneratorRequest,
-		bufimage.ImageToCodeGeneratorRequest(image, "foo", nil),
+		bufimage.ImageToCodeGeneratorRequest(image, "foo", nil, false),
 	)
 	newImage, err = bufimage.NewImageForCodeGeneratorRequest(codeGeneratorRequest)
 	require.NoError(t, err)

--- a/internal/buf/cmd/buf/command/protoc/plugin.go
+++ b/internal/buf/cmd/buf/command/protoc/plugin.go
@@ -58,6 +58,7 @@ func executePlugin(
 			images,
 			strings.Join(pluginInfo.Opt, ","),
 			appprotoexec.DefaultVersion,
+			false,
 		),
 		appprotoos.GenerateWithPluginPath(pluginInfo.Path),
 	); err != nil {

--- a/internal/buf/cmd/protoc-gen-buf-lint/lint_test.go
+++ b/internal/buf/cmd/protoc-gen-buf-lint/lint_test.go
@@ -286,5 +286,5 @@ func testBuildCodeGeneratorRequest(
 	}
 	image, err := bufimage.NewImage(imageFiles)
 	require.NoError(t, err)
-	return bufimage.ImageToCodeGeneratorRequest(image, parameter, nil)
+	return bufimage.ImageToCodeGeneratorRequest(image, parameter, nil, false)
 }


### PR DESCRIPTION
This adds `buf generate --include-imports`, which will generate all imports except for the Well-Known Types. For example, if you import `google/type.date.proto` from googleapis, this will generate just that. If there is later a use case to also generate the Well-Known Types, we can add a `--include-wkt` flag.