### PR TITLE
Error on all usage of protoc-gen-buf-check-breaking and protoc-gen-buf-check-lint

### DIFF
--- a/cmd/protoc-gen-buf-check-breaking/main.go
+++ b/cmd/protoc-gen-buf-check-breaking/main.go
@@ -14,13 +14,32 @@
 
 package main
 
-import breaking "github.com/bufbuild/buf/internal/buf/cmd/protoc-gen-buf-breaking"
+import (
+	"fmt"
+	"os"
+)
+
+const deprecationMessage = `protoc-gen-buf-check-breaking has been moved to protoc-gen-buf-breaking.
+Use protoc-gen-buf-breaking instead.
+
+As one of the few changes buf will ever make, protoc-gen-buf-check-breaking was deprecated and
+scheduled for removal for v1.0 in January 2021. In preparation for v1.0, instead of just printing
+out a message notifying users of this, this command now returns an error for every invocation
+and will be completely removed when v1.0 is released.
+
+The only migration necessary is to change your installation and invocation
+from protoc-gen-buf-check-breaking to protoc-gen-buf-breaking.
+protoc-gen-buf-breaking can be installed in the exact same manner, whether
+from GitHub Releases, Homebrew, AUR, or direct Go installation:
+
+# instead of go get github.com/bufbuild/buf/cmd/protoc-gen-buf-check-breaking
+go get github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking
+# instead of curl -sSL https://github.com/bufbuild/buf/releases/download/v0.51.1/protoc-gen-buf-check-breaking-Linux-x86_64
+curl -sSL https://github.com/bufbuild/buf/releases/download/v0.51.1/protoc-gen-buf-breaking-Linux-x86_64
+
+There is no change in functionality.`
 
 func main() {
-	breaking.Main(
-		breaking.WithDeprecatedBinaryName(
-			"protoc-gen-buf-check-breaking",
-			"protoc-gen-buf-breaking",
-		),
-	)
+	fmt.Fprintln(os.Stderr, deprecationMessage)
+	os.Exit(1)
 }

--- a/cmd/protoc-gen-buf-check-lint/main.go
+++ b/cmd/protoc-gen-buf-check-lint/main.go
@@ -14,13 +14,32 @@
 
 package main
 
-import lint "github.com/bufbuild/buf/internal/buf/cmd/protoc-gen-buf-lint"
+import (
+	"fmt"
+	"os"
+)
+
+const deprecationMessage = `protoc-gen-buf-check-lint has been moved to protoc-gen-buf-lint.
+Use protoc-gen-buf-lint instead.
+
+As one of the few changes buf will ever make, protoc-gen-buf-check-lint was deprecated and
+scheduled for removal for v1.0 in January 2021. In preparation for v1.0, instead of just printing
+out a message notifying users of this, this command now returns an error for every invocation
+and will be completely removed when v1.0 is released.
+
+The only migration necessary is to change your installation and invocation
+from protoc-gen-buf-check-lint to protoc-gen-buf-lint.
+protoc-gen-buf-lint can be installed in the exact same manner, whether
+from GitHub Releases, Homebrew, AUR, or direct Go installation:
+
+# instead of go get github.com/bufbuild/buf/cmd/protoc-gen-buf-check-lint
+go get github.com/bufbuild/buf/cmd/protoc-gen-buf-lint
+# instead of curl -sSL https://github.com/bufbuild/buf/releases/download/v0.51.1/protoc-gen-buf-check-lint-Linux-x86_64
+curl -sSL https://github.com/bufbuild/buf/releases/download/v0.51.1/protoc-gen-buf-lint-Linux-x86_64
+
+There is no change in functionality.`
 
 func main() {
-	lint.Main(
-		lint.WithDeprecatedBinaryName(
-			"protoc-gen-buf-check-lint",
-			"protoc-gen-buf-lint",
-		),
-	)
+	fmt.Fprintln(os.Stderr, deprecationMessage)
+	os.Exit(1)
 }

--- a/internal/buf/cmd/protoc-gen-buf-lint/lint.go
+++ b/internal/buf/cmd/protoc-gen-buf-lint/lint.go
@@ -35,11 +35,7 @@ import (
 const defaultTimeout = 10 * time.Second
 
 // Main is the main.
-func Main(options ...MainOption) {
-	mainOptions := newMainOptions()
-	for _, option := range options {
-		option(mainOptions)
-	}
+func Main() {
 	appproto.Main(
 		context.Background(),
 		appproto.HandlerFunc(
@@ -54,24 +50,10 @@ func Main(options ...MainOption) {
 					container,
 					responseWriter,
 					request,
-					mainOptions.oldBinaryName,
-					mainOptions.newBinaryName,
 				)
 			},
 		),
 	)
-}
-
-// MainOption is an option for Main.
-type MainOption func(*mainOptions)
-
-// WithDeprecatedBinaryName returns a new MainOption that marks this binary
-// as deprecated and points from the old binary name to the new binary name.
-func WithDeprecatedBinaryName(oldBinaryName string, newBinaryName string) MainOption {
-	return func(mainOptions *mainOptions) {
-		mainOptions.oldBinaryName = oldBinaryName
-		mainOptions.newBinaryName = newBinaryName
-	}
 }
 
 func handle(
@@ -79,8 +61,6 @@ func handle(
 	container app.EnvStderrContainer,
 	responseWriter appproto.ResponseWriter,
 	request *pluginpb.CodeGeneratorRequest,
-	oldBinaryName string,
-	newBinaryName string,
 ) error {
 	responseWriter.SetFeatureProto3Optional()
 	externalConfig := &externalConfig{}
@@ -99,16 +79,6 @@ func handle(
 	logger, err := applog.NewLogger(container.Stderr(), externalConfig.LogLevel, externalConfig.LogFormat)
 	if err != nil {
 		return err
-	}
-	if oldBinaryName != "" && newBinaryName != "" {
-		logger.Sugar().Warnf(
-			"%s is deprecated. Use %s instead. %s can be installed in the same manner as %s, whether from GitHub Releases, Homebrew, AUR, or direct Go installation. %s will be deleted as a release artifact before v1.0.",
-			oldBinaryName,
-			newBinaryName,
-			newBinaryName,
-			oldBinaryName,
-			oldBinaryName,
-		)
 	}
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	readWriteBucket, err := storageosProvider.NewReadWriteBucket(
@@ -158,13 +128,4 @@ type externalConfig struct {
 	LogFormat   string          `json:"log_format,omitempty" yaml:"log_format,omitempty"`
 	ErrorFormat string          `json:"error_format,omitempty" yaml:"error_format,omitempty"`
 	Timeout     time.Duration   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-}
-
-type mainOptions struct {
-	oldBinaryName string
-	newBinaryName string
-}
-
-func newMainOptions() *mainOptions {
-	return &mainOptions{}
 }

--- a/internal/buf/cmd/protoc-gen-buf-lint/lint_test.go
+++ b/internal/buf/cmd/protoc-gen-buf-lint/lint_test.go
@@ -197,8 +197,6 @@ func testRunLint(
 					container,
 					responseWriter,
 					request,
-					"",
-					"",
 				)
 			},
 		),


### PR DESCRIPTION
We have been notifying users of this via a message since January 2021. This now upgrades to making each of these plugins exit with code 1. Maintaining these binaries is having a cost, both in clutter of the releases, and just plain build time, and will only get worse when we add Windows support and releases.

The message printed:

```
protoc-gen-buf-check-breaking has been moved to protoc-gen-buf-breaking.
Use protoc-gen-buf-breaking instead.

As one of the few changes buf will ever make, protoc-gen-buf-check-breaking was deprecated and
scheduled for removal for v1.0 in January 2021. In preparation for v1.0, instead of just printing
out a message notifying users of this, this command now returns an error for every invocation
and will be completely removed when v1.0 is released.

The only migration necessary is to change your installation and invocation
from protoc-gen-buf-check-breaking to protoc-gen-buf-breaking.
protoc-gen-buf-breaking can be installed in the exact same manner, whether
from GitHub Releases, Homebrew, AUR, or direct Go installation:

# instead of go get github.com/bufbuild/buf/cmd/protoc-gen-buf-check-breaking
go get github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking
# instead of curl -sSL https://github.com/bufbuild/buf/releases/download/v0.51.1/protoc-gen-buf-check-breaking-Linux-x86_64
curl -sSL https://github.com/bufbuild/buf/releases/download/v0.51.1/protoc-gen-buf-breaking-Linux-x86_64

There is no change in functionality.
```