### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/internal/buf/cmd/buf/command/login/login.go
+++ b/internal/buf/cmd/buf/command/login/login.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/bufbuild/buf/internal/buf/bufcli"
 	"github.com/bufbuild/buf/internal/bufpkg/bufrpc"
@@ -107,7 +107,7 @@ func run(
 	}
 	var token string
 	if flags.TokenStdin {
-		data, err := ioutil.ReadAll(container.Stdin())
+		data, err := io.ReadAll(container.Stdin())
 		if err != nil {
 			return err
 		}

--- a/internal/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/internal/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -16,7 +16,7 @@ package bufmodulecache
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/bufbuild/buf/internal/bufpkg/buflock"
 	"github.com/bufbuild/buf/internal/bufpkg/bufmodule"
@@ -172,7 +172,7 @@ func (m *moduleCacher) getModuleAndStoredDigest(
 	defer func() {
 		retErr = multierr.Append(retErr, digestReadObjectCloser.Close())
 	}()
-	digestData, err := ioutil.ReadAll(digestReadObjectCloser)
+	digestData, err := io.ReadAll(digestReadObjectCloser)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/pkg/storage/storagetesting/storagetesting.go
+++ b/internal/pkg/storage/storagetesting/storagetesting.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1431,7 +1430,7 @@ func RunTestSuite(
 		isEmpty, err = storage.IsEmpty(ctx, readBucket, "")
 		require.NoError(t, err)
 		require.True(t, isEmpty)
-		err = ioutil.WriteFile(filepath.Join(tmpDir.AbsPath(), "foo.txt"), []byte("foo"), 0600)
+		err = os.WriteFile(filepath.Join(tmpDir.AbsPath(), "foo.txt"), []byte("foo"), 0600)
 		require.NoError(t, err)
 		// need to make a new readBucket since the old one won't necessarily have the foo.txt
 		// file in it, ie in-memory buckets


### PR DESCRIPTION
The io/ioutil package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since PR #430 had already upgraded the project to Go 1.17, we can replace all usage of `io/ioutil` to `io` and `os` package.

I did not create an issue beforehand because this is a small PR and does not introduce any breaking change. I hope the maintainers don't mind