### PR TITLE
Sync from internal

### DIFF
--- a/internal/privateusage/privateusage.go
+++ b/internal/privateusage/privateusage.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 )
@@ -31,7 +32,7 @@ func init() {
 func check() error {
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		if !strings.HasSuffix(os.Args[0], ".test") {
+		if !strings.HasSuffix(os.Args[0], testSuffix) && filepath.Base(os.Args[0]) != debugBin {
 			return errors.New("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects")
 		}
 		return nil

--- a/internal/privateusage/privateusage_unix.go
+++ b/internal/privateusage/privateusage_unix.go
@@ -1,0 +1,23 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
+
+package privateusage
+
+const (
+	testSuffix = ".test"
+	debugBin   = "__debug_bin"
+)

--- a/internal/privateusage/privateusage_windows.go
+++ b/internal/privateusage/privateusage_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package privateusage
+
+const (
+	testSuffix = ".test.exe"
+	debugBin   = "__debug_bin.exe"
+)


### PR DESCRIPTION
- Only include imports in exactly one CodeGeneratorRequest created by bufimage.ImagesToCodeGeneratorRequests
- Allow private packages in the context of a Golang debugger.