### PR TITLE
Move `TestCompareGoogleapis` to unix-only

### DIFF
--- a/private/bufpkg/bufimage/bufimagebuild/builder_test.go
+++ b/private/bufpkg/bufimage/bufimagebuild/builder_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 var buftestingDirPath = filepath.Join(
@@ -173,21 +172,6 @@ func TestGoogleapis(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCompareGoogleapis(t *testing.T) {
-	testingextended.SkipIfShort(t)
-	// Don't run in parallel as it allocates a lot of memory
-	// cannot directly compare with source code info as buf protoc creates additional source
-	// code infos that protoc does not
-	image := testBuildGoogleapis(t, false)
-	fileDescriptorSet := bufimage.ImageToFileDescriptorSet(image)
-	actualProtocFileDescriptorSet := testBuildActualProtocGoogleapis(t, false)
-	prototesting.AssertFileDescriptorSetsEqual(
-		t,
-		fileDescriptorSet,
-		actualProtocFileDescriptorSet,
-	)
-}
-
 func TestCompareCustomOptions1(t *testing.T) {
 	t.Parallel()
 	testCompare(t, "customoptions1")
@@ -259,15 +243,6 @@ func testBuildGoogleapis(t *testing.T, includeSourceInfo bool) bufimage.Image {
 	image, fileAnnotations := testBuild(t, includeSourceInfo, googleapisDirPath)
 	require.Equal(t, 0, len(fileAnnotations), fileAnnotations)
 	return image
-}
-
-func testBuildActualProtocGoogleapis(t *testing.T, includeSourceInfo bool) *descriptorpb.FileDescriptorSet {
-	googleapisDirPath := buftesting.GetGoogleapisDirPath(t, buftestingDirPath)
-	filePaths := buftesting.GetProtocFilePaths(t, googleapisDirPath, 0)
-	fileDescriptorSet := buftesting.GetActualProtocFileDescriptorSet(t, true, includeSourceInfo, googleapisDirPath, filePaths)
-	assert.Equal(t, buftesting.NumGoogleapisFilesWithImports, len(fileDescriptorSet.GetFile()))
-
-	return fileDescriptorSet
 }
 
 func testBuild(t *testing.T, includeSourceInfo bool, dirPath string) (bufimage.Image, []bufanalysis.FileAnnotation) {

--- a/private/bufpkg/bufimage/bufimagebuild/builder_unix_test.go
+++ b/private/bufpkg/bufimage/bufimagebuild/builder_unix_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
+
+package bufimagebuild
+
+import (
+	"testing"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/bufpkg/buftesting"
+	"github.com/bufbuild/buf/private/pkg/prototesting"
+	"github.com/bufbuild/buf/private/pkg/testingextended"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func TestCompareGoogleapis(t *testing.T) {
+	testingextended.SkipIfShort(t)
+	// Don't run in parallel as it allocates a lot of memory
+	// cannot directly compare with source code info as buf protoc creates additional source
+	// code infos that protoc does not
+	image := testBuildGoogleapis(t, false)
+	fileDescriptorSet := bufimage.ImageToFileDescriptorSet(image)
+	actualProtocFileDescriptorSet := testBuildActualProtocGoogleapis(t, false)
+	prototesting.AssertFileDescriptorSetsEqual(
+		t,
+		fileDescriptorSet,
+		actualProtocFileDescriptorSet,
+	)
+}
+
+func testBuildActualProtocGoogleapis(t *testing.T, includeSourceInfo bool) *descriptorpb.FileDescriptorSet {
+	googleapisDirPath := buftesting.GetGoogleapisDirPath(t, buftestingDirPath)
+	filePaths := buftesting.GetProtocFilePaths(t, googleapisDirPath, 0)
+	fileDescriptorSet := buftesting.GetActualProtocFileDescriptorSet(t, true, includeSourceInfo, googleapisDirPath, filePaths)
+	assert.Equal(t, buftesting.NumGoogleapisFilesWithImports, len(fileDescriptorSet.GetFile()))
+
+	return fileDescriptorSet
+}


### PR DESCRIPTION
Move this test to a unix-only test file.
Using `protoc` to build the file descriptor set on Windows creates a command-line invocation that exceeds the Windows limits.

Output from `dlv` when calling https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/syscall/exec_windows.go;l=297:

```
len(cmdline)
140219
cmdline
"C:\\ProgramData\\chocolatey\\bin\\protoc.exe -I C:\\ProgramData\\chocolatey\\lib\\protoc\\tools\\include -I ..\\..\\buftesting\\cache\\googleapis --include_imports --descriptor_set_out=C:\\Users\\dkeung\\AppData\\Local\\Temp\\2359832949 ..\\..\\buftesting\\cache\\googleapis\\google\\ads\\googleads\\v1\\common\\ad_asset.proto
..."
```

As the comment states in the `syscall` package, the Windows command line takes everything as a single string, and the limit is [`8191` characters](https://docs.microsoft.com/en-US/troubleshoot/windows-client/shell-experience/command-line-string-limitation). In the future we can consider augmenting this test or testing the `protoc` behaviour with a smaller proto repository, but we currently have other tests to validate the behaviour of `buf` on Windows.
