### PR TITLE
Fix C# namespace transformation

### DIFF
--- a/private/bufpkg/bufimage/bufimagemodify/csharp_namespace.go
+++ b/private/bufpkg/bufimage/bufimagemodify/csharp_namespace.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -72,7 +73,7 @@ func csharpNamespaceValue(imageFile bufimage.ImageFile) string {
 	}
 	packageParts := strings.Split(pkg, ".")
 	for i, part := range packageParts {
-		packageParts[i] = strings.Title(part)
+		packageParts[i] = stringutil.ToPascalCase(part)
 	}
 	return strings.Join(packageParts, ".")
 }

--- a/private/bufpkg/bufimage/bufimagemodify/csharp_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/csharp_namespace_test.go
@@ -110,6 +110,7 @@ func TestCsharpNamespaceOptions(t *testing.T) {
 	testCsharpNamespaceOptions(t, filepath.Join("testdata", "csharpoptions", "single"), "Acme.V1")
 	testCsharpNamespaceOptions(t, filepath.Join("testdata", "csharpoptions", "double"), "Acme.Weather.V1")
 	testCsharpNamespaceOptions(t, filepath.Join("testdata", "csharpoptions", "triple"), "Acme.Weather.Data.V1")
+	testCsharpNamespaceOptions(t, filepath.Join("testdata", "csharpoptions", "underscore"), "Acme.Weather.FooBar.V1")
 }
 
 func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {

--- a/private/bufpkg/bufimage/bufimagemodify/testdata/csharpoptions/underscore/csharp.proto
+++ b/private/bufpkg/bufimage/bufimagemodify/testdata/csharpoptions/underscore/csharp.proto
@@ -1,0 +1,3 @@
+package acme.weather.foo_bar.v1;
+
+option csharp_namespace = "foo";

--- a/private/pkg/stringutil/stringutil.go
+++ b/private/pkg/stringutil/stringutil.go
@@ -232,7 +232,7 @@ func ToPascalCase(s string) string {
 	return output
 }
 
-// IsAlpha returns true for [0-9a-zA-Z].
+// IsAlphanumeric returns true for [0-9a-zA-Z].
 func IsAlphanumeric(r rune) bool {
 	return IsNumeric(r) || IsAlpha(r)
 }


### PR DESCRIPTION
Fixes #445 

This updates the `csharp_namespace` transformation in **Managed Mode** to use `stringutil.ToPascalCase` so that we use an idiomatic C# namespace in the generated code. Previously package elements like `foo_bar` were translated to `Foo_bar` instead of `FooBar`.