### PR TITLE
Add java_package_prefix option

### DIFF
--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -163,6 +163,7 @@ type ManagedConfig struct {
 	CcEnableArenas        *bool
 	JavaMultipleFiles     *bool
 	JavaStringCheckUtf8   *bool
+	JavaPackagePrefix     string
 	OptimizeFor           *descriptorpb.FileOptions_OptimizeMode
 	GoPackagePrefixConfig *GoPackagePrefixConfig
 }
@@ -237,6 +238,7 @@ type ExternalManagedConfigV1 struct {
 	CcEnableArenas      *bool                           `json:"cc_enable_arenas,omitempty" yaml:"cc_enable_arenas,omitempty"`
 	JavaMultipleFiles   *bool                           `json:"java_multiple_files,omitempty" yaml:"java_multiple_files,omitempty"`
 	JavaStringCheckUtf8 *bool                           `json:"java_string_check_utf8,omitempty" yaml:"java_string_check_utf8,omitempty"`
+	JavaPackagePrefix   string                          `json:"java_package_prefix,omitempty" yaml:"java_package_prefix,omitempty"`
 	OptimizeFor         string                          `json:"optimize_for,omitempty" yaml:"optimize_for,omitempty"`
 	GoPackagePrefix     ExternalGoPackagePrefixConfigV1 `json:"go_package_prefix,omitempty" yaml:"go_package_prefix,omitempty"`
 }
@@ -245,6 +247,8 @@ type ExternalManagedConfigV1 struct {
 func (e ExternalManagedConfigV1) IsEmpty() bool {
 	return e.CcEnableArenas == nil &&
 		e.JavaMultipleFiles == nil &&
+		e.JavaStringCheckUtf8 == nil &&
+		e.JavaPackagePrefix == "" &&
 		e.OptimizeFor == "" &&
 		e.GoPackagePrefix.IsEmpty()
 }

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -193,6 +193,7 @@ func newManagedConfigV1(externalManagedConfig ExternalManagedConfigV1) (*Managed
 		CcEnableArenas:        externalManagedConfig.CcEnableArenas,
 		JavaMultipleFiles:     externalManagedConfig.JavaMultipleFiles,
 		JavaStringCheckUtf8:   externalManagedConfig.JavaStringCheckUtf8,
+		JavaPackagePrefix:     externalManagedConfig.JavaPackagePrefix,
 		OptimizeFor:           optimizeFor,
 		GoPackagePrefixConfig: goPackagePrefixConfig,
 	}, nil

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -157,6 +157,7 @@ func TestReadConfigV1(t *testing.T) {
 			CcEnableArenas:      &truth,
 			JavaMultipleFiles:   &truth,
 			JavaStringCheckUtf8: &truth,
+			JavaPackagePrefix:   "org.",
 			OptimizeFor:         optimizeModePtr(descriptorpb.FileOptions_CODE_SIZE),
 		},
 	}

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -157,7 +157,7 @@ func TestReadConfigV1(t *testing.T) {
 			CcEnableArenas:      &truth,
 			JavaMultipleFiles:   &truth,
 			JavaStringCheckUtf8: &truth,
-			JavaPackagePrefix:   "org.",
+			JavaPackagePrefix:   "org",
 			OptimizeFor:         optimizeModePtr(descriptorpb.FileOptions_CODE_SIZE),
 		},
 	}

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// defaultJavaPackagePrefix is the default java_package prefix used in the JavaPackage modifier.
-	defaultJavaPackagePrefix = "com."
+	defaultJavaPackagePrefix = "com"
 )
 
 type generator struct {

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	// javaPackagePrefix is the default java_package prefix used in the JavaPackage modifier.
-	javaPackagePrefix = "com."
+	// defaultJavaPackagePrefix is the default java_package prefix used in the JavaPackage modifier.
+	defaultJavaPackagePrefix = "com."
 )
 
 type generator struct {
@@ -142,7 +142,7 @@ func modifyImage(
 		return err
 	}
 	// Apply the user-specified modifiers, which may override the defaults.
-	// E.g. JavaMultipleFiles, etc.
+	// E.g. JavaMultipleFiles, JavaPackage, etc.
 	configModifier, err := managedConfigModifier(config.ManagedConfig, sweeper)
 	if err != nil {
 		return err
@@ -179,6 +179,16 @@ func managedConfigModifier(managedConfig *ManagedConfig, sweeper bufimagemodify.
 			bufimagemodify.JavaStringCheckUtf8(sweeper, *managedConfig.JavaStringCheckUtf8),
 		)
 	}
+	if managedConfig.JavaPackagePrefix != "" {
+		javaPackage, err := bufimagemodify.JavaPackage(sweeper, managedConfig.JavaPackagePrefix)
+		if err != nil {
+			return nil, err
+		}
+		modifier = bufimagemodify.Merge(
+			modifier,
+			javaPackage,
+		)
+	}
 	if managedConfig.OptimizeFor != nil {
 		modifier = bufimagemodify.Merge(
 			modifier,
@@ -211,9 +221,10 @@ func defaultManagedModeModifier(sweeper bufimagemodify.Sweeper) (bufimagemodify.
 		bufimagemodify.PhpNamespace(sweeper),
 		bufimagemodify.PhpMetadataNamespace(sweeper),
 		bufimagemodify.RubyPackage(sweeper),
-		bufimagemodify.JavaMultipleFiles(sweeper, true),
+		bufimagemodify.JavaMultipleFiles(sweeper, true), // JavaMultipleFiles can be overridden by configuration.
 	)
-	javaPackageModifier, err := bufimagemodify.JavaPackage(sweeper, javaPackagePrefix)
+	// JavaPackage can be overridden by configuration.
+	javaPackageModifier, err := bufimagemodify.JavaPackage(sweeper, defaultJavaPackagePrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/private/buf/bufgen/testdata/v1/gen_success1.json
+++ b/private/buf/bufgen/testdata/v1/gen_success1.json
@@ -5,7 +5,7 @@
     "cc_enable_arenas": true,
     "java_multiple_files": true,
     "java_string_check_utf8": true,
-    "java_package_prefix": "org.",
+    "java_package_prefix": "org",
     "optimize_for": "CODE_SIZE"
   },
   "plugins": [

--- a/private/buf/bufgen/testdata/v1/gen_success1.json
+++ b/private/buf/bufgen/testdata/v1/gen_success1.json
@@ -5,6 +5,7 @@
     "cc_enable_arenas": true,
     "java_multiple_files": true,
     "java_string_check_utf8": true,
+    "java_package_prefix": "org.",
     "optimize_for": "CODE_SIZE"
   },
   "plugins": [

--- a/private/buf/bufgen/testdata/v1/gen_success1.yaml
+++ b/private/buf/bufgen/testdata/v1/gen_success1.yaml
@@ -4,6 +4,7 @@ managed:
   cc_enable_arenas: true
   java_multiple_files: true
   java_string_check_utf8: true
+  java_package_prefix: org.
   optimize_for: CODE_SIZE
 plugins:
   - name: go

--- a/private/buf/bufgen/testdata/v1/gen_success1.yaml
+++ b/private/buf/bufgen/testdata/v1/gen_success1.yaml
@@ -4,7 +4,7 @@ managed:
   cc_enable_arenas: true
   java_multiple_files: true
   java_string_check_utf8: true
-  java_package_prefix: org.
+  java_package_prefix: org
   optimize_for: CODE_SIZE
 plugins:
   - name: go

--- a/private/bufpkg/bufimage/bufimagemodify/java_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_package.go
@@ -74,7 +74,7 @@ func javaPackageForFile(
 // empty string is returned.
 func javaPackageValue(imageFile bufimage.ImageFile, packagePrefix string) string {
 	if pkg := imageFile.Proto().GetPackage(); pkg != "" {
-		return packagePrefix + pkg
+		return packagePrefix + "." + pkg
 	}
 	return ""
 }

--- a/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testJavaPackagePrefix = "com."
+const testJavaPackagePrefix = "com"
 
 func TestJavaPackageError(t *testing.T) {
 	t.Parallel()
@@ -171,7 +171,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 func TestJavaPackageWellKnownTypes(t *testing.T) {
 	t.Parallel()
 	dirPath := filepath.Join("testdata", "wktimport")
-	javaPackagePrefix := "org."
+	javaPackagePrefix := "org"
 	modifiedJavaPackage := "org.acme.weather.v1alpha1"
 	t.Run("with SourceCodeInfo", func(t *testing.T) {
 		t.Parallel()

--- a/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
@@ -171,13 +171,14 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 func TestJavaPackageWellKnownTypes(t *testing.T) {
 	t.Parallel()
 	dirPath := filepath.Join("testdata", "wktimport")
-	modifiedJavaPackage := "com.acme.weather.v1alpha1"
+	javaPackagePrefix := "org."
+	modifiedJavaPackage := "org.acme.weather.v1alpha1"
 	t.Run("with SourceCodeInfo", func(t *testing.T) {
 		t.Parallel()
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix)
+		javaPackageModifier, err := JavaPackage(sweeper, javaPackagePrefix)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -206,7 +207,7 @@ func TestJavaPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix)
+		modifier, err := JavaPackage(sweeper, javaPackagePrefix)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),


### PR DESCRIPTION
Re: https://github.com/bufbuild/buf/issues/465#issuecomment-907779934

This proposes a `java_package_prefix` option so that users can customize what prefix is used to generate the `java_package` value in **Managed Mode**.

This idea was originally suggested in Slack, with the following context:

```
It's not a super big deal for us if the package path changes as part of adopting Managed Mode,
but it's still a breaking change that affects all our current generated code. It'll make Managed
Mode a little tougher sell.

...

The issue right now is that it's not just the generated code that has a custom TLD as package prefix,
but also our Maven artifacts. E.g:

  <groupId>tech.einride</groupId>
  <artifactId>proto</artifactId>

This is a bit of a hurdle for smooth adoption.
```