### PR TITLE
Fix make bufrelease

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -41,6 +41,7 @@ BUF_BREAKING_AGAINST_INPUT ?= .git\#branch=main
 
 include make/go/bootstrap.mk
 include make/go/dep_buf.mk
+include make/go/dep_minisign.mk
 include make/go/dep_protoc.mk
 include make/go/dep_protoc_gen_go.mk
 include make/go/dep_protoc_gen_go_grpc.mk
@@ -115,7 +116,7 @@ bufgeneratesteps:: \
 	bufgenerateprotogoclient
 
 .PHONY: bufrelease
-bufrelease:
+bufrelease: $(MINISIGN)
 	DOCKER_IMAGE=golang:1.17.0-buster bash make/buf/scripts/release.bash
 
 # We have to manually set the Homebrew version on the Homebrew badge as there

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -145,3 +145,5 @@ mkdir -p assets
 for file in $(find . -maxdepth 1 -type f | sed 's/^\.\///' | sort | uniq); do
   mv "${file}" "assets/${file}"
 done
+
+echo Upload all the files in this directory to GitHub: open "${RELEASE_DIR}/assets"

--- a/make/go/dep_minisign.mk
+++ b/make/go/dep_minisign.mk
@@ -1,0 +1,22 @@
+# Managed by makego. DO NOT EDIT.
+
+# Must be set
+$(call _assert_var,MAKEGO)
+$(call _conditional_include,$(MAKEGO)/base.mk)
+$(call _assert_var,CACHE_VERSIONS)
+$(call _assert_var,CACHE_BIN)
+
+# Settable
+# https://github.com/aead/minisign/commit/4b0a1d5cec55046cced3e84526660c7820b8f58c 11082021 checked 11082021
+# Contains fix for https://github.com/aead/minisign/issues/11
+MINISIGN_VERSION ?= 4b0a1d5cec55046cced3e84526660c7820b8f58c
+
+MINISIGN := $(CACHE_VERSIONS)/MINISIGN/$(MINISIGN_VERSION)
+$(MINISIGN):
+	@rm -f $(CACHE_BIN)/minisign
+	GOBIN=$(CACHE_BIN) go install aead.dev/minisign/cmd/minisign@$(MINISIGN_VERSION)
+	@rm -rf $(dir $(MINISIGN))
+	@mkdir -p $(dir $(MINISIGN))
+	@touch $(MINISIGN)
+
+deps:: $(MINISIGN)


### PR DESCRIPTION
- Add `minisign` as a dependency.
- Print out the directory that assets are located in, along with an `open` string that can be copy/pasted into the terminal.