### PR TITLE
Simplify bufmodule

### DIFF
--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -135,15 +135,7 @@ func run(
 			return bufcli.NewInternalError(err)
 		}
 	}
-	module, err = bufmodule.NewModuleForBucketWithDependencyModulePins(
-		ctx,
-		readWriteBucket,
-		dependencyModulePins,
-	)
-	if err != nil {
-		return err
-	}
-	if err := bufmodule.PutModuleDependencyModulePinsToBucket(ctx, readWriteBucket, module.DependencyModulePins()); err != nil {
+	if err := bufmodule.PutDependencyModulePinsToBucket(ctx, readWriteBucket, dependencyModulePins); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Make it so that `newModuleForBucket` and `newModuleForProto` are more independent.
- Do not always read the `documentation` from the `ReadBucket`, instead pass it as a parameter to `newModule`.
- Delete `NewModuleWithDependencyModulePins`.
- Add `DependencyModulePinsForBucket` and expand `PutDependencyModulePinsToBucket`.
- Replace unnecessary creates of `bufmodule.Modules` in `mod prune` and `mod update`.