### PR TITLE
Clean up Windows Github Action

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,14 +7,30 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: cache-chocolatey-deps
+        if: success()
+        uses: actions/cache@v2
+        with:
+          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey
+          key: ${{ runner.os }}-chocolatey-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-chocolatey-
+      - name: cache-go-installs
+        if: success()
+        uses: actions/cache@v2
+        with:
+          path: C:\Users\runneradmin\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: setup-go
         if: success()
         uses: actions/setup-go@v2.1.4 # this contains a fix for Windows file extraction
         with:
           go-version: 1.17.0
-      - name: setup-deps
+      - name: install-protoc
         if: success()
-        run: ./windows/setupDeps.ps1
+        run: choco install --confirm protoc
       - name: setup-external-plugins
         if: success()
         run: ./windows/setupExternalPlugins.ps1

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/bufbuild/buf/private/pkg/storage"
@@ -1025,10 +1024,6 @@ func RunTestSuite(
 		diff2 := `@@ -1 +0,0 @@
 -dddd
 `
-		if runtime.GOOS == "windows" {
-			diff1 = strings.ReplaceAll(diff1, "\n", "\r\n")
-			diff2 = strings.ReplaceAll(diff2, "\n", "\r\n")
-		}
 		expectDiff := fmt.Sprintf(
 			`diff -u %s %s
 --- %s

--- a/windows/setupDeps.ps1
+++ b/windows/setupDeps.ps1
@@ -1,9 +1,0 @@
-$installedApps = choco list --localonly | Out-String
-
-$apps = @('diffutils', 'golang', 'protoc')
-$apps | ForEach-Object {
-    if (-Not $installedApps.Contains($PSItem)) {
-        Write-Host "Installing $PSItem"
-        choco install --confirm $PSItem
-    }
-}


### PR DESCRIPTION
This PR adds a cache for both Chocolatey and Go dependencies for faster builds and removes the `setupDeps.ps1` script, since we are using the `setup-go` action, and only need to install `protoc` using Chocolatey.

Refs: #478