### PR TITLE
Add a warn-level log if the module cacher has a sum mismatch

### DIFF
--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -50,7 +50,7 @@ func TestReaderBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	delegateDataReadWriteBucket, delegateSumReadWriteBucket, delegateFileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(delegateDataReadWriteBucket, delegateSumReadWriteBucket, delegateFileLocker)
+	moduleCacher := newModuleCacher(zap.NewNop(), delegateDataReadWriteBucket, delegateSumReadWriteBucket, delegateFileLocker)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,
@@ -181,7 +181,7 @@ func TestCacherBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	dataReadWriteBucket, sumReadWriteBucket, fileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(dataReadWriteBucket, sumReadWriteBucket, fileLocker)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, fileLocker)
 	_, err = moduleCacher.GetModule(ctx, modulePin)
 	require.True(t, storage.IsNotExist(err))
 
@@ -223,7 +223,7 @@ func TestModuleReaderCacherWithDocumentation(t *testing.T) {
 	require.NoError(t, err)
 
 	dataReadWriteBucket, sumReadWriteBucket, fileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(dataReadWriteBucket, sumReadWriteBucket, fileLocker)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, fileLocker)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,

--- a/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -74,7 +74,7 @@ func (m *moduleCacher) GetModule(
 	}
 	if digest != storedDigest {
 		m.logger.Sugar().Warnf(
-			"Module %q has invalid cache state: calculated digest %q does not match stored digest %q. The cache will attemp to self-correct.",
+			"Module %q has invalid cache state: calculated digest %q does not match stored digest %q. The cache will attempt to self-correct.",
 			modulePin.String(),
 			digest,
 			storedDigest,

--- a/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
@@ -53,6 +53,7 @@ func newModuleReader(
 		option(moduleReader)
 	}
 	moduleReader.cache = newModuleCacher(
+		logger,
 		dataReadWriteBucket,
 		sumReadWriteBucket,
 		moduleReader.fileLocker,
@@ -66,6 +67,8 @@ func (m *moduleReader) GetModule(
 ) (bufmodule.Module, error) {
 	module, err := m.cache.GetModule(ctx, modulePin)
 	if err != nil {
+		// Note that IsNotExist will happen if there was a checksum mismatch as well, in which case
+		// we want to overwrite whatever is actually in the cache and self-correct the issue
 		if storage.IsNotExist(err) {
 			m.logger.Debug(
 				"cache_miss",


### PR DESCRIPTION
This adds a log message if we have a sum mismatch in the module cacher. This makes future diagnostics slightly better.

This also uses `storage.ReadPath` in one place.