### PR TITLE
Use stringutil.ToPascalCase in Image modifiers

### DIFF
--- a/private/bufpkg/bufimage/bufimagemodify/php_namespace.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_namespace.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -179,11 +180,12 @@ func phpNamespaceValue(imageFile bufimage.ImageFile) string {
 	}
 	packageParts := strings.Split(pkg, ".")
 	for i, part := range packageParts {
-		// Append _ to the package part if it is a reserved keyword.
+		packagePart := stringutil.ToPascalCase(part)
 		if _, ok := phpReservedKeywords[strings.ToLower(part)]; ok {
-			part += "_"
+			// Append _ to the package part if it is a reserved keyword.
+			packagePart += "_"
 		}
-		packageParts[i] = strings.Title(part)
+		packageParts[i] = packagePart
 	}
 	return strings.Join(packageParts, `\`)
 }

--- a/private/bufpkg/bufimage/bufimagemodify/php_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_namespace_test.go
@@ -197,6 +197,7 @@ func TestPhpNamespaceOptions(t *testing.T) {
 	testPhpNamespaceOptions(t, filepath.Join("testdata", "phpoptions", "double"), `Acme\Weather\V1`)
 	testPhpNamespaceOptions(t, filepath.Join("testdata", "phpoptions", "triple"), `Acme\Weather\Data\V1`)
 	testPhpNamespaceOptions(t, filepath.Join("testdata", "phpoptions", "reserved"), `Acme\Error_\V1`)
+	testPhpNamespaceOptions(t, filepath.Join("testdata", "phpoptions", "underscore"), `Acme\Weather\FooBar\V1`)
 }
 
 func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {

--- a/private/bufpkg/bufimage/bufimagemodify/ruby_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/ruby_package.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -79,7 +80,7 @@ func rubyPackageValue(imageFile bufimage.ImageFile) string {
 	}
 	packageParts := strings.Split(pkg, ".")
 	for i, part := range packageParts {
-		packageParts[i] = strings.Title(part)
+		packageParts[i] = stringutil.ToPascalCase(part)
 	}
 	return strings.Join(packageParts, "::")
 }

--- a/private/bufpkg/bufimage/bufimagemodify/ruby_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/ruby_package_test.go
@@ -196,6 +196,7 @@ func TestRubyPackageOptions(t *testing.T) {
 	testRubyPackageOptions(t, filepath.Join("testdata", "rubyoptions", "single"), `Acme::V1`)
 	testRubyPackageOptions(t, filepath.Join("testdata", "rubyoptions", "double"), `Acme::Weather::V1`)
 	testRubyPackageOptions(t, filepath.Join("testdata", "rubyoptions", "triple"), `Acme::Weather::Data::V1`)
+	testRubyPackageOptions(t, filepath.Join("testdata", "rubyoptions", "underscore"), `Acme::Weather::FooBar::V1`)
 }
 
 func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {

--- a/private/bufpkg/bufimage/bufimagemodify/testdata/phpoptions/underscore/php.proto
+++ b/private/bufpkg/bufimage/bufimagemodify/testdata/phpoptions/underscore/php.proto
@@ -1,0 +1,3 @@
+package acme.weather.foo_bar.v1;
+
+option php_namespace = "foo";

--- a/private/bufpkg/bufimage/bufimagemodify/testdata/rubyoptions/underscore/ruby.proto
+++ b/private/bufpkg/bufimage/bufimagemodify/testdata/rubyoptions/underscore/ruby.proto
@@ -1,0 +1,3 @@
+package acme.weather.foo_bar.v1;
+
+option ruby_package = "foo";


### PR DESCRIPTION
Similar in spirit to #472, but for `php_namespace` and `ruby_package`.