### PR TITLE
Fix module caching

### DIFF
--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -50,7 +50,7 @@ func TestReaderBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	delegateDataReadWriteBucket, delegateSumReadWriteBucket, delegateFileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), delegateDataReadWriteBucket, delegateSumReadWriteBucket, delegateFileLocker)
+	moduleCacher := newModuleCacher(zap.NewNop(), delegateDataReadWriteBucket, delegateSumReadWriteBucket)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,
@@ -180,8 +180,8 @@ func TestCacherBasic(t *testing.T) {
 	module, err := bufmodule.NewModuleForBucket(ctx, readBucket)
 	require.NoError(t, err)
 
-	dataReadWriteBucket, sumReadWriteBucket, fileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, fileLocker)
+	dataReadWriteBucket, sumReadWriteBucket, _ := newTestDataSumBucketsAndLocker(t)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket)
 	_, err = moduleCacher.GetModule(ctx, modulePin)
 	require.True(t, storage.IsNotExist(err))
 
@@ -222,8 +222,8 @@ func TestModuleReaderCacherWithDocumentation(t *testing.T) {
 	module, err := bufmodule.NewModuleForBucket(ctx, readBucket)
 	require.NoError(t, err)
 
-	dataReadWriteBucket, sumReadWriteBucket, fileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, fileLocker)
+	dataReadWriteBucket, sumReadWriteBucket, _ := newTestDataSumBucketsAndLocker(t)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,

--- a/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -79,7 +79,7 @@ func (m *moduleCacher) GetModule(
 				modulePin.String(),
 			)
 			// We want to return ErrNotExist so that the ModuleReader can re-download
-			return nil, storage.NewErrNotExist(newCacheKey(modulePin))
+			return nil, storage.NewErrNotExist(modulePath)
 		}
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (m *moduleCacher) GetModule(
 		)
 		// We want to return ErrNotExist so that the ModuleReader can re-download
 		// Note that we deal with invalid data in the cache at the ModuleReader level by overwriting via PutModule
-		return nil, storage.NewErrNotExist(newCacheKey(modulePin))
+		return nil, storage.NewErrNotExist(modulePath)
 	}
 	digest, err := bufmodule.ModuleDigestB2(ctx, module)
 	if err != nil {
@@ -108,7 +108,7 @@ func (m *moduleCacher) GetModule(
 		)
 		// We want to return ErrNotExist so that the ModuleReader can re-download
 		// Note that we deal with invalid data in the cache at the ModuleReader level by overwriting via PutModule
-		return nil, storage.NewErrNotExist(newCacheKey(modulePin))
+		return nil, storage.NewErrNotExist(modulePath)
 	}
 	return module, nil
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
-	"github.com/bufbuild/buf/private/pkg/filelock"
-	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -30,20 +28,17 @@ type moduleCacher struct {
 	logger              *zap.Logger
 	dataReadWriteBucket storage.ReadWriteBucket
 	sumReadWriteBucket  storage.ReadWriteBucket
-	fileLocker          filelock.Locker
 }
 
 func newModuleCacher(
 	logger *zap.Logger,
 	dataReadWriteBucket storage.ReadWriteBucket,
 	sumReadWriteBucket storage.ReadWriteBucket,
-	fileLocker filelock.Locker,
 ) *moduleCacher {
 	return &moduleCacher{
 		logger:              logger,
 		dataReadWriteBucket: dataReadWriteBucket,
 		sumReadWriteBucket:  sumReadWriteBucket,
-		fileLocker:          fileLocker,
 	}
 }
 
@@ -51,10 +46,44 @@ func (m *moduleCacher) GetModule(
 	ctx context.Context,
 	modulePin bufmodule.ModulePin,
 ) (bufmodule.Module, error) {
-	module, storedDigest, err := m.getModuleAndStoredDigest(ctx, modulePin)
+	modulePath := newCacheKey(modulePin)
+	// We do not want the external path of the cache to be propagated to the user.
+	dataReadWriteBucket := storage.NoExternalPathReadBucket(
+		storage.MapReadWriteBucket(
+			m.dataReadWriteBucket,
+			storage.MapOnPrefix(modulePath),
+		),
+	)
+	exists, err := storage.Exists(ctx, dataReadWriteBucket, buflock.ExternalConfigFilePath)
 	if err != nil {
 		return nil, err
 	}
+	if !exists {
+		return nil, storage.NewErrNotExist(modulePath)
+	}
+	module, err := bufmodule.NewModuleForBucket(
+		ctx,
+		dataReadWriteBucket,
+		bufmodule.ModuleWithModuleIdentityAndCommit(modulePin, modulePin.Commit()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	storedDigestData, err := storage.ReadPath(ctx, m.sumReadWriteBucket, modulePath)
+	if err != nil {
+		// This can happen if we couldn't find the sum file, which means
+		// we are in an invalid state
+		if storage.IsNotExist(err) {
+			m.logger.Sugar().Warnf(
+				"Module %q has invalid cache state: no stored digest could be found. The cache will attempt to self-correct.",
+				modulePin.String(),
+			)
+			// We want to return ErrNotExist so that the ModuleReader can re-download
+			return nil, storage.NewErrNotExist(newCacheKey(modulePin))
+		}
+		return nil, err
+	}
+	storedDigest := string(storedDigestData)
 	// This can happen if we couldn't find the sum file, which means
 	// we are in an invalid state
 	if storedDigest == "" {
@@ -62,10 +91,8 @@ func (m *moduleCacher) GetModule(
 			"Module %q has invalid cache state: no stored digest could be found. The cache will attempt to self-correct.",
 			modulePin.String(),
 		)
-		if err := m.deleteInvalidModule(ctx, modulePin); err != nil {
-			return nil, err
-		}
 		// We want to return ErrNotExist so that the ModuleReader can re-download
+		// Note that we deal with invalid data in the cache at the ModuleReader level by overwriting via PutModule
 		return nil, storage.NewErrNotExist(newCacheKey(modulePin))
 	}
 	digest, err := bufmodule.ModuleDigestB2(ctx, module)
@@ -79,10 +106,8 @@ func (m *moduleCacher) GetModule(
 			digest,
 			storedDigest,
 		)
-		if err := m.deleteInvalidModule(ctx, modulePin); err != nil {
-			return nil, err
-		}
 		// We want to return ErrNotExist so that the ModuleReader can re-download
+		// Note that we deal with invalid data in the cache at the ModuleReader level by overwriting via PutModule
 		return nil, storage.NewErrNotExist(newCacheKey(modulePin))
 	}
 	return module, nil
@@ -92,21 +117,12 @@ func (m *moduleCacher) PutModule(
 	ctx context.Context,
 	modulePin bufmodule.ModulePin,
 	module bufmodule.Module,
-) (retErr error) {
+) error {
 	modulePath := newCacheKey(modulePin)
 	digest, err := bufmodule.ModuleDigestB2(ctx, module)
 	if err != nil {
 		return err
 	}
-
-	unlocker, err := m.fileLocker.Lock(ctx, modulePath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		retErr = multierr.Append(retErr, unlocker.Unlock())
-	}()
-
 	dataReadWriteBucket := storage.MapReadWriteBucket(
 		m.dataReadWriteBucket,
 		storage.MapOnPrefix(modulePath),
@@ -134,89 +150,4 @@ func (m *moduleCacher) PutModule(
 		)
 	}
 	return nil
-}
-
-// Putting these two into one function because these are the two we need a read lock for.
-// If  no digest is returned, we should assume we should delete the module from Data.
-func (m *moduleCacher) getModuleAndStoredDigest(
-	ctx context.Context,
-	modulePin bufmodule.ModulePin,
-) (_ bufmodule.Module, _ string, retErr error) {
-	modulePath := newCacheKey(modulePin)
-
-	unlocker, err := m.fileLocker.RLock(ctx, modulePath)
-	if err != nil {
-		return nil, "", err
-	}
-	defer func() {
-		retErr = multierr.Append(retErr, unlocker.Unlock())
-	}()
-
-	// We do not want the external path of the cache to be propagated to the user.
-	dataReadWriteBucket := storage.NoExternalPathReadBucket(
-		storage.MapReadWriteBucket(
-			m.dataReadWriteBucket,
-			storage.MapOnPrefix(modulePath),
-		),
-	)
-	exists, err := storage.Exists(ctx, dataReadWriteBucket, buflock.ExternalConfigFilePath)
-	if err != nil {
-		return nil, "", err
-	}
-	if !exists {
-		return nil, "", storage.NewErrNotExist(modulePath)
-	}
-	module, err := bufmodule.NewModuleForBucket(
-		ctx,
-		dataReadWriteBucket,
-		bufmodule.ModuleWithModuleIdentityAndCommit(modulePin, modulePin.Commit()),
-	)
-	if err != nil {
-		return nil, "", err
-	}
-	digestData, err := storage.ReadPath(ctx, m.sumReadWriteBucket, modulePath)
-	if err != nil {
-		if storage.IsNotExist(err) {
-			// This signals that we do not have a digest, which should signal to the
-			// calling function to delete what we found from data.
-			return nil, "", nil
-		}
-		return nil, "", err
-	}
-	return module, string(digestData), nil
-}
-
-func (m *moduleCacher) deleteInvalidModule(
-	ctx context.Context,
-	modulePin bufmodule.ModulePin,
-) (retErr error) {
-	modulePath := newCacheKey(modulePin)
-
-	unlocker, err := m.fileLocker.Lock(ctx, modulePath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		retErr = multierr.Append(retErr, unlocker.Unlock())
-	}()
-	dataReadWriteBucket := storage.MapReadWriteBucket(
-		m.dataReadWriteBucket,
-		storage.MapOnPrefix(modulePath),
-	)
-	var deleteErr error
-	// Ignore if this doesn't exist, we're just cleaning up
-	if err := dataReadWriteBucket.DeleteAll(ctx, ""); err != nil && !storage.IsNotExist(err) {
-		deleteErr = multierr.Append(deleteErr, err)
-	}
-	// Ignore if this doesn't exist, we're just cleaning up
-	if err := m.sumReadWriteBucket.Delete(ctx, modulePath); err != nil && !storage.IsNotExist(err) {
-		deleteErr = multierr.Append(deleteErr, err)
-	}
-	return deleteErr
-}
-
-// newCacheKey returns the key associated with the given module pin.
-// The cache key is of the form: remote/owner/repository/commit.
-func newCacheKey(modulePin bufmodule.ModulePin) string {
-	return normalpath.Join(modulePin.Remote(), modulePin.Owner(), modulePin.Repository(), modulePin.Commit())
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/util.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/util.go
@@ -1,0 +1,12 @@
+package bufmodulecache
+
+import (
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/pkg/normalpath"
+)
+
+// newCacheKey returns the key associated with the given module pin.
+// The cache key is of the form: remote/owner/repository/commit.
+func newCacheKey(modulePin bufmodule.ModulePin) string {
+	return normalpath.Join(modulePin.Remote(), modulePin.Owner(), modulePin.Repository(), modulePin.Commit())
+}

--- a/private/bufpkg/bufmodule/bufmodulecache/util.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/util.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bufmodulecache
 
 import (


### PR DESCRIPTION
When using file locks with the module cache, we were doing the following:

- ReadLock
- CacheGet
- ReadUnlock
- If not exists or invalid sum:
  - DelegateGet
  - WriteLock
  - CachePut
  - WriteUnlock

This was already causing duplicate downloads because we were doing a DelegateGet if the CacheGet failed without having a write lock, see https://github.com/bufbuild/buf/pull/456. However, we didn't think this was an actual issue beyond duplicate downloads.

The problem is that when inside the ReadLock, another caller could be inside the WriteLock, modifying the underlying data in the cache. If this was happening, we could have inconsistent state for a caller that expects the cache to be stable.

Instead, we move to double locking:

- ReadLock
- CacheGet
- ReadUnlock
- If not exists or invalid sum:
  - WriteLock
  - CacheGet
  - If not exists or invalid sum:
    - DelegateGet
    - CachePut
  - WriteUnlock

By proxy, fixes https://github.com/bufbuild/buf/issues/482.