### PR TITLE
Add ability to install buf directly in makego

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -34,6 +34,8 @@ LICENSE_HEADER_LICENSE_TYPE := apache
 LICENSE_HEADER_COPYRIGHT_HOLDER := Buf Technologies, Inc.
 LICENSE_HEADER_YEAR_RANGE := 2020-2021
 LICENSE_HEADER_IGNORES := \/testdata enterprise
+# Comment out to use released buf
+BUF_GO_INSTALL_PATH := ./cmd/buf
 
 BUF_LINT_INPUT := .
 BUF_BREAKING_INPUT := .
@@ -105,11 +107,11 @@ bufgenerateclean:: bufgeneratecleango
 
 .PHONY: bufgenerateprotogo
 bufgenerateprotogo:
-	buf generate proto --template data/template/buf.go.gen.yaml
+	$(BUF_BIN) generate proto --template data/template/buf.go.gen.yaml
 
 .PHONY: bufgenerateprotogoclient
 bufgenerateprotogoclient:
-	buf generate proto --template data/template/buf.go-client.gen.yaml
+	$(BUF_BIN) generate proto --template data/template/buf.go-client.gen.yaml
 
 bufgeneratesteps:: \
 	bufgenerateprotogo \

--- a/make/go/buf.mk
+++ b/make/go/buf.mk
@@ -33,7 +33,7 @@ pregenerate:: bufgenerate
 ifneq ($(BUF_LINT_INPUT),)
 .PHONY: buflint
 buflint: $(BUF)
-	buf lint $(BUF_LINT_INPUT)
+	$(BUF_BIN) lint $(BUF_LINT_INPUT)
 
 postlint:: buflint
 endif
@@ -42,7 +42,7 @@ ifneq ($(BUF_BREAKING_INPUT),)
 ifneq ($(BUF_BREAKING_AGAINST_INPUT),)
 .PHONY: bufbreaking
 bufbreaking: $(BUF)
-	buf breaking $(BUF_BREAKING_INPUT) --against $(BUF_BREAKING_AGAINST_INPUT)
+	$(BUF_BIN) breaking $(BUF_BREAKING_INPUT) --against $(BUF_BREAKING_AGAINST_INPUT)
 
 postlint:: bufbreaking
 endif

--- a/make/go/dep_buf.mk
+++ b/make/go/dep_buf.mk
@@ -9,7 +9,24 @@ $(call _assert_var,CACHE_BIN)
 # Settable
 # https://github.com/bufbuild/buf/releases
 BUF_VERSION ?= v0.55.0
+# Settable
+#
+# If set, this path will be installed every time someone depends on $(BUF)
+# as opposed to installing from github with @$(BUF_VERSION).
+#
+# This can be used to always do "go install ./cmd/buf" or
+# "go install github.com/bufbuild/buf/cmd/buf".
+BUF_GO_INSTALL_PATH ?=
+ifneq ($(BUF_GO_INSTALL_PATH),)
+.PHONY: __goinstallbuf
+__goinstallbuf:
+	go install $(BUF_GO_INSTALL_PATH)
 
+BUF := __goinstallbuf
+
+# Use this instead of "buf" when using buf.
+BUF_BIN := $(CACHE_GOBIN)/buf
+else
 BUF := $(CACHE_VERSIONS)/buf/$(BUF_VERSION)
 $(BUF):
 	@rm -f $(CACHE_BIN)/buf
@@ -18,4 +35,11 @@ $(BUF):
 	@mkdir -p $(dir $(BUF))
 	@touch $(BUF)
 
+# Use this instead of "buf" when using buf.
+BUF_BIN := $(CACHE_BIN)/buf
+
 dockerdeps:: $(BUF)
+endif
+
+
+

--- a/make/go/dep_buf.mk
+++ b/make/go/dep_buf.mk
@@ -40,6 +40,3 @@ BUF_BIN := $(CACHE_BIN)/buf
 
 dockerdeps:: $(BUF)
 endif
-
-
-


### PR DESCRIPTION
This allows us to use `buf` from `./cmd/buf` instead of from releases. We can turn this off selectively if there is a bug and we need to run `make generate`. This is similar to what we had in the past.