### PR TITLE
Cascade ENUM_ZERO_VALUE_SUFFIX comment ignore from the enum level

### DIFF
--- a/private/buf/bufcheck/buflint/buflint_test.go
+++ b/private/buf/bufcheck/buflint/buflint_test.go
@@ -828,8 +828,8 @@ func TestCommentIgnoresCascadeOff(t *testing.T) {
 	testLint(
 		t,
 		"comment_ignores_cascade",
-		bufanalysistesting.NewFileAnnotation(t, "a.proto", 12, 6, 12, 13, "ENUM_PASCAL_CASE"),
-		bufanalysistesting.NewFileAnnotation(t, "a.proto", 14, 3, 14, 29, "ENUM_NO_ALLOW_ALIAS"),
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 13, 6, 13, 13, "ENUM_PASCAL_CASE"),
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 15, 3, 15, 29, "ENUM_NO_ALLOW_ALIAS"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 16, 3, 16, 14, "ENUM_VALUE_UPPER_SNAKE_CASE"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 16, 3, 16, 14, "ENUM_ZERO_VALUE_SUFFIX"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 17, 3, 17, 13, "ENUM_VALUE_UPPER_SNAKE_CASE"),

--- a/private/buf/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
+++ b/private/buf/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
@@ -220,7 +220,18 @@ func checkEnumZeroValueSuffix(add addFunc, enumValue protosource.EnumValue, suff
 	}
 	name := enumValue.Name()
 	if !strings.HasSuffix(name, suffix) {
-		add(enumValue, enumValue.NameLocation(), nil, "Enum zero value name %q should be suffixed with %q.", name, suffix)
+		add(
+			enumValue,
+			enumValue.NameLocation(),
+			// also check the enum for this comment ignore
+			// this allows users to set this "globally" for an enum
+			[]protosource.Location{
+				enumValue.Enum().Location(),
+			},
+			"Enum zero value name %q should be suffixed with %q.",
+			name,
+			suffix,
+		)
 	}
 	return nil
 }

--- a/private/buf/bufcheck/buflint/testdata/comment_ignores_cascade/a.proto
+++ b/private/buf/bufcheck/buflint/testdata/comment_ignores_cascade/a.proto
@@ -9,10 +9,10 @@ import "google/protobuf/empty.proto";
 
 // buf:lint:ignore ENUM_PASCAL_CASE
 // buf:lint:ignore ENUM_VALUE_UPPER_SNAKE_CASE
+// buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX
 enum enumFoo {
   // buf:lint:ignore ENUM_NO_ALLOW_ALIAS
   option allow_alias = true;
-  // buf:lint:ignore ENUM_ZERO_VALUE_SUFFIX
   enumFooNone = 0;
   enumFooOne = 1;
   enumFooTwo = 1;


### PR DESCRIPTION
See #161 and #243. This adds cascading for `ENUM_ZERO_VALUE_SUFFIX` at the enum level as well.