### PR TITLE
Fix go module cache on Windows Github Actions

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -19,7 +19,7 @@ jobs:
         if: success()
         uses: actions/cache@v2
         with:
-          path: $HOME\go\pkg\mod
+          path: C:\Users\runneradmin\go\pkg\mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -19,7 +19,7 @@ jobs:
         if: success()
         uses: actions/cache@v2
         with:
-          path: C:\Users\runneradmin\AppData\Local\go-build
+          path: $HOME\go\pkg\mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-


### PR DESCRIPTION
Change the cache to point at the Go module cache on Windows, fixes #522. 

<img width="910" alt="Screen Shot 2021-09-08 at 12 30 44" src="https://user-images.githubusercontent.com/9167065/132548610-bac0e029-a004-470e-a9b4-3df7d9c42c13.png">


