### PR TITLE
Managed Mode: Add warnings for missing file overrides

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -421,18 +421,19 @@ func newModifier(
 	sweeper bufimagemodify.Sweeper,
 ) (bufimagemodify.Modifier, error) {
 	modifier := bufimagemodify.NewMultiModifier(
-		bufimagemodify.JavaOuterClassname(sweeper, managedConfig.Override[bufimagemodify.JavaOuterClassNameID]),
-		bufimagemodify.ObjcClassPrefix(sweeper, managedConfig.Override[bufimagemodify.ObjcClassPrefixID]),
-		bufimagemodify.CsharpNamespace(sweeper, managedConfig.Override[bufimagemodify.CsharpNamespaceID]),
-		bufimagemodify.PhpNamespace(sweeper, managedConfig.Override[bufimagemodify.PhpNamespaceID]),
-		bufimagemodify.PhpMetadataNamespace(sweeper, managedConfig.Override[bufimagemodify.PhpMetadataNamespaceID]),
-		bufimagemodify.RubyPackage(sweeper, managedConfig.Override[bufimagemodify.RubyPackageID]),
+		bufimagemodify.JavaOuterClassname(logger, sweeper, managedConfig.Override[bufimagemodify.JavaOuterClassNameID]),
+		bufimagemodify.ObjcClassPrefix(logger, sweeper, managedConfig.Override[bufimagemodify.ObjcClassPrefixID]),
+		bufimagemodify.CsharpNamespace(logger, sweeper, managedConfig.Override[bufimagemodify.CsharpNamespaceID]),
+		bufimagemodify.PhpNamespace(logger, sweeper, managedConfig.Override[bufimagemodify.PhpNamespaceID]),
+		bufimagemodify.PhpMetadataNamespace(logger, sweeper, managedConfig.Override[bufimagemodify.PhpMetadataNamespaceID]),
+		bufimagemodify.RubyPackage(logger, sweeper, managedConfig.Override[bufimagemodify.RubyPackageID]),
 	)
 	javaPackagePrefix := bufimagemodify.DefaultJavaPackagePrefix
 	if managedConfig.JavaPackagePrefix != "" {
 		javaPackagePrefix = managedConfig.JavaPackagePrefix
 	}
 	javaPackageModifier, err := bufimagemodify.JavaPackage(
+		logger,
 		sweeper,
 		javaPackagePrefix,
 		managedConfig.Override[bufimagemodify.JavaPackageID],
@@ -446,6 +447,7 @@ func newModifier(
 		javaMultipleFilesValue = *managedConfig.JavaMultipleFiles
 	}
 	javaMultipleFilesModifier, err := bufimagemodify.JavaMultipleFiles(
+		logger,
 		sweeper,
 		javaMultipleFilesValue,
 		managedConfig.Override[bufimagemodify.JavaMultipleFilesID],
@@ -456,6 +458,7 @@ func newModifier(
 	modifier = bufimagemodify.Merge(modifier, javaMultipleFilesModifier)
 	if managedConfig.CcEnableArenas != nil {
 		ccEnableArenasModifier, err := bufimagemodify.CcEnableArenas(
+			logger,
 			sweeper,
 			*managedConfig.CcEnableArenas,
 			managedConfig.Override[bufimagemodify.CcEnableArenasID],
@@ -467,6 +470,7 @@ func newModifier(
 	}
 	if managedConfig.JavaStringCheckUtf8 != nil {
 		javaStringCheckUtf8, err := bufimagemodify.JavaStringCheckUtf8(
+			logger,
 			sweeper,
 			*managedConfig.JavaStringCheckUtf8,
 			managedConfig.Override[bufimagemodify.JavaStringCheckUtf8ID],
@@ -478,6 +482,7 @@ func newModifier(
 	}
 	if managedConfig.OptimizeFor != nil {
 		optimizeFor, err := bufimagemodify.OptimizeFor(
+			logger,
 			sweeper,
 			*managedConfig.OptimizeFor,
 			managedConfig.Override[bufimagemodify.OptimizeForID],

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -93,12 +93,17 @@ func Merge(left Modifier, right Modifier) Modifier {
 // CcEnableArenas returns a Modifier that sets the cc_enable_arenas
 // file option to the given value in all of the files contained in
 // the Image.
-func CcEnableArenas(sweeper Sweeper, value bool, overrides map[string]string) (Modifier, error) {
+func CcEnableArenas(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	value bool,
+	overrides map[string]string,
+) (Modifier, error) {
 	validatedOverrides, err := stringOverridesToBoolOverrides(overrides)
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", CcEnableArenasID, err)
 	}
-	return ccEnableArenas(sweeper, value, validatedOverrides), nil
+	return ccEnableArenas(logger, sweeper, value, validatedOverrides), nil
 }
 
 // GoPackage returns a Modifier that sets the go_package file option
@@ -125,40 +130,60 @@ func GoPackage(
 // JavaMultipleFiles returns a Modifier that sets the java_multiple_files
 // file option to the given value in all of the files contained in
 // the Image.
-func JavaMultipleFiles(sweeper Sweeper, value bool, overrides map[string]string) (Modifier, error) {
+func JavaMultipleFiles(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	value bool,
+	overrides map[string]string,
+) (Modifier, error) {
 	validatedOverrides, err := stringOverridesToBoolOverrides(overrides)
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", JavaMultipleFilesID, err)
 	}
-	return javaMultipleFiles(sweeper, value, validatedOverrides), nil
+	return javaMultipleFiles(logger, sweeper, value, validatedOverrides), nil
 }
 
 // JavaOuterClassname returns a Modifier that sets the java_outer_classname file option
 // in all of the files contained in the Image based on the PascalCase of their filename.
-func JavaOuterClassname(sweeper Sweeper, overrides map[string]string) Modifier {
-	return javaOuterClassname(sweeper, overrides)
+func JavaOuterClassname(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	overrides map[string]string,
+) Modifier {
+	return javaOuterClassname(logger, sweeper, overrides)
 }
 
 // JavaPackage returns a Modifier that sets the java_package file option
 // according to the given packagePrefix.
-func JavaPackage(sweeper Sweeper, packagePrefix string, overrides map[string]string) (Modifier, error) {
-	return javaPackage(sweeper, packagePrefix, overrides)
+func JavaPackage(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	packagePrefix string,
+	overrides map[string]string,
+) (Modifier, error) {
+	return javaPackage(logger, sweeper, packagePrefix, overrides)
 }
 
 // JavaStringCheckUtf8 returns a Modifier that sets the java_string_check_utf8 file option according
 // to the given value.
-func JavaStringCheckUtf8(sweeper Sweeper, value bool, overrides map[string]string) (Modifier, error) {
+func JavaStringCheckUtf8(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	value bool,
+	overrides map[string]string,
+) (Modifier, error) {
 	validatedOverrides, err := stringOverridesToBoolOverrides(overrides)
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", JavaStringCheckUtf8ID, err)
 	}
-	return javaStringCheckUtf8(sweeper, value, validatedOverrides), nil
+	return javaStringCheckUtf8(logger, sweeper, value, validatedOverrides), nil
 }
 
 // OptimizeFor returns a Modifier that sets the optimize_for file
 // option to the given value in all of the files contained in
 // the Image.
 func OptimizeFor(
+	logger *zap.Logger,
 	sweeper Sweeper,
 	value descriptorpb.FileOptions_OptimizeMode,
 	overrides map[string]string,
@@ -167,7 +192,7 @@ func OptimizeFor(
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", OptimizeForID, err)
 	}
-	return optimizeFor(sweeper, value, validatedOverrides), nil
+	return optimizeFor(logger, sweeper, value, validatedOverrides), nil
 }
 
 // GoPackageImportPathForFile returns the go_package import path for the given
@@ -196,34 +221,54 @@ func GoPackageImportPathForFile(imageFile bufimage.ImageFile, importPathPrefix s
 //  * If the resulting abbreviation is 1 character, add "XX".
 //  * If the resulting abbreviation is "GPB", change it to "GPX".
 //    "GPB" is reserved by Google for the Protocol Buffers implementation.
-func ObjcClassPrefix(sweeper Sweeper, overrides map[string]string) Modifier {
-	return objcClassPrefix(sweeper, overrides)
+func ObjcClassPrefix(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	overrides map[string]string,
+) Modifier {
+	return objcClassPrefix(logger, sweeper, overrides)
 }
 
 // CsharpNamespace returns a Modifier that sets the csharp_namespace file option
 // according to the package name. It is set to the package name with each package sub-name capitalized.
-func CsharpNamespace(sweeper Sweeper, overrides map[string]string) Modifier {
-	return csharpNamespace(sweeper, overrides)
+func CsharpNamespace(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	overrides map[string]string,
+) Modifier {
+	return csharpNamespace(logger, sweeper, overrides)
 }
 
 // PhpNamespace returns a Modifier that sets the php_namespace file option
 // according to the package name. It is set to the package name with each package sub-name capitalized
 // and each "." replaced with "\\".
-func PhpNamespace(sweeper Sweeper, overrides map[string]string) Modifier {
-	return phpNamespace(sweeper, overrides)
+func PhpNamespace(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	overrides map[string]string,
+) Modifier {
+	return phpNamespace(logger, sweeper, overrides)
 }
 
 // PhpMetadataNamespace returns a Modifier that sets the php_metadata_namespace file option
 // according to the package name. It appends "\\GPBMetadata" to the heuristic used by PhpNamespace.
-func PhpMetadataNamespace(sweeper Sweeper, overrides map[string]string) Modifier {
-	return phpMetadataNamespace(sweeper, overrides)
+func PhpMetadataNamespace(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	overrides map[string]string,
+) Modifier {
+	return phpMetadataNamespace(logger, sweeper, overrides)
 }
 
 // RubyPackage returns a Modifier that sets the ruby_package file option
 // according to the given packagePrefix. It is set to the package name with each package sub-name capitalized
 // and each "." replaced with "::".
-func RubyPackage(sweeper Sweeper, overrides map[string]string) Modifier {
-	return rubyPackage(sweeper, overrides)
+func RubyPackage(
+	logger *zap.Logger,
+	sweeper Sweeper,
+	overrides map[string]string,
+) Modifier {
+	return rubyPackage(logger, sweeper, overrides)
 }
 
 // isWellKnownType returns true if the given path is one of the well-known types.

--- a/private/bufpkg/bufimage/bufimagemodify/cc_enable_arenas_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/cc_enable_arenas_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestCcEnableArenasEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, false, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -57,7 +58,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, false, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),
@@ -78,7 +79,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, false, map[string]string{"a.proto": "true"})
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, false, map[string]string{"a.proto": "true"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -107,7 +108,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, false, map[string]string{"a.proto": "true"})
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, false, map[string]string{"a.proto": "true"})
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),
@@ -136,7 +137,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, ccEnableArenasPath)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -162,7 +163,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),
@@ -183,7 +184,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, ccEnableArenasPath)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, map[string]string{"a.proto": "false"})
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -213,7 +214,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, map[string]string{"a.proto": "false"})
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),
@@ -242,7 +243,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, ccEnableArenasPath)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -268,7 +269,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),
@@ -290,7 +291,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, ccEnableArenasPath)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, map[string]string{"a.proto": "false"})
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -318,7 +319,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, map[string]string{"a.proto": "false"})
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),
@@ -347,7 +348,7 @@ func TestCcEnableArenasWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			ccEnableArenasModifier,
@@ -369,7 +370,7 @@ func TestCcEnableArenasWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		ccEnableArenasModifier, err := CcEnableArenas(sweeper, true, nil)
+		ccEnableArenasModifier, err := CcEnableArenas(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = ccEnableArenasModifier.Modify(
 			context.Background(),

--- a/private/bufpkg/bufimage/bufimagemodify/csharp_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/csharp_namespace_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestCsharpNamespaceEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestCsharpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, nil)
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -49,7 +50,7 @@ func TestCsharpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, nil)
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -64,7 +65,7 @@ func TestCsharpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, map[string]string{"a.proto": "foo"})
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "foo"})
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -85,7 +86,7 @@ func TestCsharpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, map[string]string{"a.proto": "foo"})
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "foo"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -107,7 +108,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, csharpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, nil)
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -129,7 +130,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, nil)
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -149,7 +150,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, csharpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, map[string]string{"a.proto": "bar"})
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "bar"})
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -172,7 +173,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, map[string]string{"a.proto": "bar"})
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "bar"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -203,7 +204,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, csharpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, nil)
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -226,7 +227,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, nil)
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -247,7 +248,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, csharpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, map[string]string{"override.proto": "Acme.Override.V1"})
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, map[string]string{"override.proto": "Acme.Override.V1"})
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -274,7 +275,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, map[string]string{"override.proto": "Acme.Override.V1"})
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, map[string]string{"override.proto": "Acme.Override.V1"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -303,7 +304,7 @@ func TestCsharpNamespaceWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		csharpNamespaceModifier := CsharpNamespace(sweeper, nil)
+		csharpNamespaceModifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(csharpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -331,7 +332,7 @@ func TestCsharpNamespaceWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := CsharpNamespace(sweeper, nil)
+		modifier := CsharpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,

--- a/private/bufpkg/bufimage/bufimagemodify/java_multiple_files_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_multiple_files_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -58,7 +59,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -80,7 +81,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -106,7 +107,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -132,7 +133,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -158,7 +159,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -179,7 +180,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -209,7 +210,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -238,7 +239,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, false, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -263,7 +264,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, false, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -288,7 +289,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, false, map[string]string{"override.proto": "true"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, map[string]string{"override.proto": "true"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -316,7 +317,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, false, map[string]string{"override.proto": "true"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, map[string]string{"override.proto": "true"})
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -344,7 +345,7 @@ func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -366,7 +367,7 @@ func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),

--- a/private/bufpkg/bufimage/bufimagemodify/java_outer_classname_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_outer_classname_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
@@ -35,7 +36,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, nil),
+			JavaOuterClassname(zap.NewNop(), sweeper, nil),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -58,7 +59,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, nil).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, nil).Modify(
 			context.Background(),
 			image,
 		)
@@ -79,7 +80,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, map[string]string{"a.proto": "override"}),
+			JavaOuterClassname(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"}),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -102,7 +103,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, map[string]string{"a.proto": "override"}).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"}).Modify(
 			context.Background(),
 			image,
 		)
@@ -127,7 +128,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, nil),
+			JavaOuterClassname(zap.NewNop(), sweeper, nil),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -150,7 +151,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, nil).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, nil).Modify(
 			context.Background(),
 			image,
 		)
@@ -170,7 +171,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, map[string]string{"a.proto": "override"}),
+			JavaOuterClassname(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"}),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -193,7 +194,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, map[string]string{"a.proto": "override"}).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"}).Modify(
 			context.Background(),
 			image,
 		)
@@ -217,7 +218,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, nil),
+			JavaOuterClassname(zap.NewNop(), sweeper, nil),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -239,7 +240,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, nil).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, nil).Modify(
 			context.Background(),
 			image,
 		)
@@ -259,7 +260,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, map[string]string{"override.proto": "override"}),
+			JavaOuterClassname(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"}),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -285,7 +286,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, map[string]string{"override.proto": "override"}).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"}).Modify(
 			context.Background(),
 			image,
 		)
@@ -312,7 +313,7 @@ func TestJavaOuterClassnameWellKnownTypes(t *testing.T) {
 
 		sweeper := NewFileOptionSweeper()
 		modifier := NewMultiModifier(
-			JavaOuterClassname(sweeper, nil),
+			JavaOuterClassname(zap.NewNop(), sweeper, nil),
 			ModifierFunc(sweeper.Sweep),
 		)
 		err := modifier.Modify(
@@ -339,7 +340,7 @@ func TestJavaOuterClassnameWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		err := JavaOuterClassname(sweeper, nil).Modify(
+		err := JavaOuterClassname(zap.NewNop(), sweeper, nil).Modify(
 			context.Background(),
 			image,
 		)

--- a/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 const testJavaPackagePrefix = "com"
 
 func TestJavaPackageError(t *testing.T) {
 	t.Parallel()
-	_, err := JavaPackage(NewFileOptionSweeper(), "", nil)
+	_, err := JavaPackage(zap.NewNop(), NewFileOptionSweeper(), "", nil)
 	require.Error(t, err)
 }
 
@@ -40,7 +41,7 @@ func TestJavaPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix, nil)
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -58,7 +59,7 @@ func TestJavaPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix, nil)
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -74,7 +75,7 @@ func TestJavaPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -94,7 +95,7 @@ func TestJavaPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -116,7 +117,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix, nil)
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -139,7 +140,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix, nil)
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -160,7 +161,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -187,7 +188,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -217,7 +218,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix, nil)
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -241,7 +242,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix, nil)
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -263,7 +264,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, testJavaPackagePrefix, map[string]string{"override.proto": "override"})
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, map[string]string{"override.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -291,7 +292,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, testJavaPackagePrefix, map[string]string{"override.proto": "override"})
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, testJavaPackagePrefix, map[string]string{"override.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -322,7 +323,7 @@ func TestJavaPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaPackageModifier, err := JavaPackage(sweeper, javaPackagePrefix, nil)
+		javaPackageModifier, err := JavaPackage(zap.NewNop(), sweeper, javaPackagePrefix, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(javaPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -351,7 +352,7 @@ func TestJavaPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaPackage(sweeper, javaPackagePrefix, nil)
+		modifier, err := JavaPackage(zap.NewNop(), sweeper, javaPackagePrefix, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),

--- a/private/bufpkg/bufimage/bufimagemodify/java_string_check_utf8_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_string_check_utf8_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, true)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, false, nil)
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -49,7 +50,7 @@ func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, false, nil)
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -65,7 +66,7 @@ func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, true)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, false, map[string]string{"a.proto": "true"})
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, map[string]string{"a.proto": "true"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -84,7 +85,7 @@ func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, false, map[string]string{"a.proto": "true"})
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, map[string]string{"a.proto": "true"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -106,7 +107,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaStringCheckUtf8Path)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, false, nil)
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -128,7 +129,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, false, nil)
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -149,7 +150,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaStringCheckUtf8Path)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, false, map[string]string{"a.proto": "true"})
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, map[string]string{"a.proto": "true"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -175,7 +176,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, false, map[string]string{"a.proto": "true"})
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, false, map[string]string{"a.proto": "true"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -204,7 +205,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaStringCheckUtf8Path)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, true, nil)
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -227,7 +228,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, true, nil)
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -249,7 +250,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaStringCheckUtf8Path)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, true, map[string]string{"override.proto": "false"})
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, true, map[string]string{"override.proto": "false"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -274,7 +275,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, true, map[string]string{"override.proto": "false"})
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, true, map[string]string{"override.proto": "false"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -301,7 +302,7 @@ func TestJavaStringCheckUtf8WellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(sweeper, true, nil)
+		JavaStringCheckUtf8Modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(JavaStringCheckUtf8Modifier, ModifierFunc(sweeper.Sweep))
 		err = modifier.Modify(
@@ -325,7 +326,7 @@ func TestJavaStringCheckUtf8WellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := JavaStringCheckUtf8(sweeper, true, nil)
+		modifier, err := JavaStringCheckUtf8(zap.NewNop(), sweeper, true, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),

--- a/private/bufpkg/bufimage/bufimagemodify/objc_class_prefix_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/objc_class_prefix_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestObjcClassPrefixEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestObjcClassPrefixEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, nil)
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -49,7 +50,7 @@ func TestObjcClassPrefixEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, nil)
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -64,7 +65,7 @@ func TestObjcClassPrefixEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, map[string]string{"a.proto": "override"})
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -83,7 +84,7 @@ func TestObjcClassPrefixEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, map[string]string{"a.proto": "override"})
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -104,7 +105,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, objcClassPrefixPath)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, nil)
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -126,7 +127,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, nil)
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -146,7 +147,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, objcClassPrefixPath)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, map[string]string{"a.proto": "override"})
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -172,7 +173,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, map[string]string{"a.proto": "override"})
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -207,7 +208,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, objcClassPrefixPath)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, nil)
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -230,7 +231,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, nil)
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -251,7 +252,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, objcClassPrefixPath)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, map[string]string{"override.proto": "override"})
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -278,7 +279,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, map[string]string{"override.proto": "override"})
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -307,7 +308,7 @@ func TestObjcClassPrefixWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		objcClassPrefixModifier := ObjcClassPrefix(sweeper, nil)
+		objcClassPrefixModifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(objcClassPrefixModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -335,7 +336,7 @@ func TestObjcClassPrefixWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := ObjcClassPrefix(sweeper, nil)
+		modifier := ObjcClassPrefix(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,

--- a/private/bufpkg/bufimage/bufimagemodify/optimize_for_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/optimize_for_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -33,7 +34,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -58,7 +59,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -79,7 +80,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -108,7 +109,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -137,7 +138,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -163,7 +164,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -184,7 +185,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -213,7 +214,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -242,7 +243,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -268,7 +269,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -290,7 +291,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_SPEED, map[string]string{"a.proto": "LITE_RUNTIME"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, map[string]string{"a.proto": "LITE_RUNTIME"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -318,7 +319,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_SPEED, map[string]string{"a.proto": "LITE_RUNTIME"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, map[string]string{"a.proto": "LITE_RUNTIME"})
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -346,7 +347,7 @@ func TestOptimizeForWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -369,7 +370,7 @@ func TestOptimizeForWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),

--- a/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, nil)
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -49,7 +50,7 @@ func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, nil)
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -64,7 +65,7 @@ func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, map[string]string{"a.proto": "override"})
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -83,7 +84,7 @@ func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, map[string]string{"a.proto": "override"})
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -104,7 +105,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpMetadataNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, nil)
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -126,7 +127,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, map[string]string{"a.proto": "override"})
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -150,7 +151,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpMetadataNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, nil)
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -172,7 +173,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, map[string]string{"a.proto": "override"})
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -206,7 +207,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpMetadataNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, nil)
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -229,7 +230,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, nil)
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -250,7 +251,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpMetadataNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, map[string]string{"override.proto": "override"})
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -277,7 +278,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, map[string]string{"override.proto": "override"})
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -306,7 +307,7 @@ func TestPhpMetadataNamespaceWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		phpMetadataNamespaceModifier := PhpMetadataNamespace(sweeper, nil)
+		phpMetadataNamespaceModifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpMetadataNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -334,7 +335,7 @@ func TestPhpMetadataNamespaceWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpMetadataNamespace(sweeper, nil)
+		modifier := PhpMetadataNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,

--- a/private/bufpkg/bufimage/bufimagemodify/php_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_namespace_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestPhpNamespaceEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestPhpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, nil)
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -49,7 +50,7 @@ func TestPhpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, nil)
+		modifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -64,7 +65,7 @@ func TestPhpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, map[string]string{"a.proto": "override"})
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -83,7 +84,7 @@ func TestPhpNamespaceEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, map[string]string{"a.proto": "override"})
+		modifier := PhpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -104,7 +105,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, nil)
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -126,7 +127,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, nil)
+		modifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -146,7 +147,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, map[string]string{"a.proto": "override"})
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -172,7 +173,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, map[string]string{"a.proto": "override"})
+		modifier := PhpNamespace(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -207,7 +208,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, nil)
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -230,7 +231,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, nil)
+		modifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -251,7 +252,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpNamespacePath)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, map[string]string{"override.proto": "override"})
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -278,7 +279,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, map[string]string{"override.proto": "override"})
+		modifier := PhpNamespace(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -307,7 +308,7 @@ func TestPhpNamespaceWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		phpNamespaceModifier := PhpNamespace(sweeper, nil)
+		phpNamespaceModifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(phpNamespaceModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -335,7 +336,7 @@ func TestPhpNamespaceWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := PhpNamespace(sweeper, nil)
+		modifier := PhpNamespace(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,

--- a/private/bufpkg/bufimage/bufimagemodify/ruby_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/ruby_package_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestRubyPackageEmptyOptions(t *testing.T) {
@@ -32,7 +33,7 @@ func TestRubyPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, nil)
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -49,7 +50,7 @@ func TestRubyPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, nil)
+		modifier := RubyPackage(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -64,7 +65,7 @@ func TestRubyPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, map[string]string{"a.proto": "override"})
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -83,7 +84,7 @@ func TestRubyPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, map[string]string{"a.proto": "override"})
+		modifier := RubyPackage(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -104,7 +105,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, rubyPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, nil)
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -126,7 +127,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, nil)
+		modifier := RubyPackage(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -146,7 +147,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, rubyPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, map[string]string{"a.proto": "override"})
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -172,7 +173,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, map[string]string{"a.proto": "override"})
+		modifier := RubyPackage(zap.NewNop(), sweeper, map[string]string{"a.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -206,7 +207,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, rubyPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, nil)
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -229,7 +230,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, nil)
+		modifier := RubyPackage(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -250,7 +251,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, rubyPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, map[string]string{"override.proto": "override"})
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -276,7 +277,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, map[string]string{"override.proto": "override"})
+		modifier := RubyPackage(zap.NewNop(), sweeper, map[string]string{"override.proto": "override"})
 		err := modifier.Modify(
 			context.Background(),
 			image,
@@ -304,7 +305,7 @@ func TestRubyPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		rubyPackageModifier := RubyPackage(sweeper, nil)
+		rubyPackageModifier := RubyPackage(zap.NewNop(), sweeper, nil)
 
 		modifier := NewMultiModifier(rubyPackageModifier, ModifierFunc(sweeper.Sweep))
 		err := modifier.Modify(
@@ -332,7 +333,7 @@ func TestRubyPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier := RubyPackage(sweeper, nil)
+		modifier := RubyPackage(zap.NewNop(), sweeper, nil)
 		err := modifier.Modify(
 			context.Background(),
 			image,


### PR DESCRIPTION
Fixes #485

This adds a `WARN` log similar to the one introduced for unused `override` modules in the `go_package_prefix` configuration, but for per-file overrides in general.

Using a `buf.gen.yaml` that includes an override for each file option for a non-existent filename, the user will see something along the lines of the following:

```yaml
# buf.gen.yaml
version: v1
managed:
  enabled: true
  cc_enable_arenas: true
  java_string_check_utf8: true
  optimize_for: CODE_SIZE
  override:
    CSHARP_NAMESPACE:
      buf/alpha/image/v1/image.proto: Buf.Alpha.Image.V1
      foo/bar/baz.proto: Foo.Bar
    CC_ENABLE_ARENAS:
      buf/alpha/image/v1/image.proto: false
      foo/bar/baz.proto: false
    ...
```

```sh
$ buf generate
WARN	CSHARP_NAMESPACE override for "foo/bar/baz.proto" was unused
WARN	CC_ENABLE_ARENAS override for "foo/bar/baz.proto" was unused
...
```