### PR TITLE
Cleanup brew.sh for v1.0

### DIFF
--- a/make/buf/scripts/brew.sh
+++ b/make/buf/scripts/brew.sh
@@ -17,17 +17,15 @@ mkdir -p "${OUT_DIR}/etc/bash_completion.d"
 mkdir -p "${OUT_DIR}/share/fish/vendor_completions.d"
 mkdir -p "${OUT_DIR}/share/zsh/site-functions"
 
-set -x
-
-for binary in \
-  buf \
-  protoc-gen-buf-breaking \
-  protoc-gen-buf-lint \
-  protoc-gen-buf-check-breaking \
-  protoc-gen-buf-check-lint; do
+for binary in buf protoc-gen-buf-breaking protoc-gen-buf-lint; do
+  echo go build -ldflags \"-s -w\" -trimpath -o \"${OUT_DIR}/bin/${binary}\" \"cmd/${binary}/main.go\"
   go build -ldflags "-s -w" -trimpath -o "${OUT_DIR}/bin/${binary}" "cmd/${binary}/main.go"
 done
+echo \"${OUT_DIR}/bin/buf\" bash-completion \> \"${OUT_DIR}/etc/bash_completion.d/buf\"
 "${OUT_DIR}/bin/buf" bash-completion > "${OUT_DIR}/etc/bash_completion.d/buf"
+echo \"${OUT_DIR}/bin/buf\" fish-completion \> \"${OUT_DIR}/share/fish/vendor_completions.d/buf.fish\"
 "${OUT_DIR}/bin/buf" fish-completion > "${OUT_DIR}/share/fish/vendor_completions.d/buf.fish"
+echo \"${OUT_DIR}/bin/buf\" zsh-completion \> \"${OUT_DIR}/share/zsh/site-functions/_buf\"
 "${OUT_DIR}/bin/buf" zsh-completion > "${OUT_DIR}/share/zsh/site-functions/_buf"
+echo cp \"LICENSE\" \"${OUT_DIR}/LICENSE\"
 cp "LICENSE" "${OUT_DIR}/LICENSE"


### PR DESCRIPTION
This script is invoked by the homebrew-buf formula https://github.com/bufbuild/homebrew-buf/blob/master/Formula/buf.rb

- Remove `protoc-gen-buf-check-breaking, protoc-gen-buf-check-lint`.
- Selectively print log statements with proper escaping.