### PR TITLE
Split out bufmodule reference types to bufmoduleref

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -36,6 +36,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulecache"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufrpc"
 	"github.com/bufbuild/buf/private/bufpkg/buftransport"
 	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
@@ -670,7 +671,7 @@ func ReadModuleWithWorkspacesDisabled(
 	container appflag.Container,
 	storageosProvider storageos.Provider,
 	source string,
-) (bufmodule.Module, bufmodule.ModuleIdentity, error) {
+) (bufmodule.Module, bufmoduleref.ModuleIdentity, error) {
 	sourceRef, err := buffetch.NewSourceRefParser(
 		container.Logger(),
 	).GetSourceRef(

--- a/private/buf/bufcli/errors.go
+++ b/private/buf/bufcli/errors.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -139,7 +139,7 @@ func NewRepositoryNotFoundError(name string) error {
 
 // NewModuleReferenceNotFoundError informs the user that a module
 // reference does not exist.
-func NewModuleReferenceNotFoundError(reference bufmodule.ModuleReference) error {
+func NewModuleReferenceNotFoundError(reference bufmoduleref.ModuleReference) error {
 	return fmt.Errorf("%q does not exist", reference)
 }
 

--- a/private/buf/bufconfig/bufconfig.go
+++ b/private/buf/bufconfig/bufconfig.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcheck/bufbreaking/bufbreakingconfig"
 	"github.com/bufbuild/buf/private/buf/bufcheck/buflint/buflintconfig"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/zap"
 )
@@ -66,7 +66,7 @@ var (
 // Config is the user config.
 type Config struct {
 	Version        string
-	ModuleIdentity bufmodule.ModuleIdentity
+	ModuleIdentity bufmoduleref.ModuleIdentity
 	Build          *bufmoduleconfig.Config
 	Breaking       *bufbreakingconfig.Config
 	Lint           *buflintconfig.Config
@@ -109,7 +109,7 @@ type WriteConfigOption func(*writeConfigOptions)
 // module to the given ModuleIdentity.
 //
 // The default is to not set the name.
-func WriteConfigWithModuleIdentity(moduleIdentity bufmodule.ModuleIdentity) WriteConfigOption {
+func WriteConfigWithModuleIdentity(moduleIdentity bufmoduleref.ModuleIdentity) WriteConfigOption {
 	return func(writeConfigOptions *writeConfigOptions) {
 		writeConfigOptions.moduleIdentity = moduleIdentity
 	}
@@ -121,7 +121,7 @@ func WriteConfigWithModuleIdentity(moduleIdentity bufmodule.ModuleIdentity) Writ
 // The default is to not have any dependencies.
 //
 // If this option is used, WriteConfigWithModuleIdentity must also be used.
-func WriteConfigWithDependencyModuleReferences(dependencyModuleReferences ...bufmodule.ModuleReference) WriteConfigOption {
+func WriteConfigWithDependencyModuleReferences(dependencyModuleReferences ...bufmoduleref.ModuleReference) WriteConfigOption {
 	return func(writeConfigOptions *writeConfigOptions) {
 		writeConfigOptions.dependencyModuleReferences = dependencyModuleReferences
 	}

--- a/private/buf/bufconfig/provider.go
+++ b/private/buf/bufconfig/provider.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcheck/bufbreaking/bufbreakingconfig"
 	"github.com/bufbuild/buf/private/buf/bufcheck/buflint/buflintconfig"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
@@ -149,9 +149,9 @@ func (p *provider) newConfigV1Beta1(externalConfig ExternalConfigV1Beta1) (*Conf
 	if err != nil {
 		return nil, err
 	}
-	var moduleIdentity bufmodule.ModuleIdentity
+	var moduleIdentity bufmoduleref.ModuleIdentity
 	if externalConfig.Name != "" {
-		moduleIdentity, err = bufmodule.ModuleIdentityForString(externalConfig.Name)
+		moduleIdentity, err = bufmoduleref.ModuleIdentityForString(externalConfig.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -178,9 +178,9 @@ func (p *provider) newConfigV1(externalConfig ExternalConfigV1) (*Config, error)
 	if err != nil {
 		return nil, err
 	}
-	var moduleIdentity bufmodule.ModuleIdentity
+	var moduleIdentity bufmoduleref.ModuleIdentity
 	if externalConfig.Name != "" {
-		moduleIdentity, err = bufmodule.ModuleIdentityForString(externalConfig.Name)
+		moduleIdentity, err = bufmoduleref.ModuleIdentityForString(externalConfig.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/private/buf/bufconfig/write.go
+++ b/private/buf/bufconfig/write.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"text/template"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
@@ -344,8 +344,8 @@ func newTmplParam(externalConfigV1 ExternalConfigV1, uncomment bool) *tmplParam 
 }
 
 type writeConfigOptions struct {
-	moduleIdentity             bufmodule.ModuleIdentity
-	dependencyModuleReferences []bufmodule.ModuleReference
+	moduleIdentity             bufmoduleref.ModuleIdentity
+	dependencyModuleReferences []bufmoduleref.ModuleReference
 	documentationComments      bool
 	uncomment                  bool
 }

--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/git"
 	"github.com/bufbuild/buf/private/pkg/httpauth"
@@ -193,7 +194,7 @@ func NewGitRef(
 // ModuleRef is a module reference.
 type ModuleRef interface {
 	Ref
-	ModuleReference() bufmodule.ModuleReference
+	ModuleReference() bufmoduleref.ModuleReference
 	moduleRef()
 }
 
@@ -332,7 +333,7 @@ type ParsedModuleRef interface {
 // This should only be used for testing.
 func NewDirectParsedModuleRef(
 	format string,
-	moduleReference bufmodule.ModuleReference,
+	moduleReference bufmoduleref.ModuleReference,
 ) ParsedModuleRef {
 	return newDirectModuleRef(
 		format,

--- a/private/buf/buffetch/internal/module_ref.go
+++ b/private/buf/buffetch/internal/module_ref.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"strings"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 )
 
@@ -27,7 +27,7 @@ var (
 
 type moduleRef struct {
 	format          string
-	moduleReference bufmodule.ModuleReference
+	moduleReference bufmoduleref.ModuleReference
 }
 
 func newModuleRef(
@@ -46,7 +46,7 @@ func newModuleRef(
 	if strings.Contains(path, "://") {
 		return nil, NewInvalidPathError(format, path)
 	}
-	moduleReference, err := bufmodule.ModuleReferenceForString(path)
+	moduleReference, err := bufmoduleref.ModuleReferenceForString(path)
 	if err != nil {
 		// TODO: this is dumb
 		return nil, NewInvalidPathError(format, path)
@@ -54,7 +54,7 @@ func newModuleRef(
 	return newDirectModuleRef(format, moduleReference), nil
 }
 
-func newDirectModuleRef(format string, moduleReference bufmodule.ModuleReference) *moduleRef {
+func newDirectModuleRef(format string, moduleReference bufmoduleref.ModuleReference) *moduleRef {
 	return &moduleRef{
 		format:          format,
 		moduleReference: moduleReference,
@@ -65,7 +65,7 @@ func (r *moduleRef) Format() string {
 	return r.format
 }
 
-func (r *moduleRef) ModuleReference() bufmodule.ModuleReference {
+func (r *moduleRef) ModuleReference() bufmoduleref.ModuleReference {
 	return r.moduleReference
 }
 

--- a/private/buf/buffetch/ref_parser.go
+++ b/private/buf/buffetch/ref_parser.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/buf/private/buf/buffetch/internal"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -510,7 +510,7 @@ func assumeModuleOrDir(path string) (string, error) {
 	if path == "" {
 		return "", errors.New("assumeModuleOrDir: no path given")
 	}
-	if _, err := bufmodule.ModuleReferenceForString(path); err == nil {
+	if _, err := bufmoduleref.ModuleReferenceForString(path); err == nil {
 		// this is possible to be a module, check if it is a directory though
 		// OK to use os.Stat instead of os.Lstat here
 		fileInfo, err := os.Stat(path)

--- a/private/buf/buffetch/ref_parser_test.go
+++ b/private/buf/buffetch/ref_parser_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/bufbuild/buf/private/buf/buffetch/internal"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/git"
@@ -1124,8 +1124,8 @@ func testNewModuleReference(
 	owner string,
 	repository string,
 	reference string,
-) bufmodule.ModuleReference {
-	moduleReference, err := bufmodule.NewModuleReference(remote, owner, repository, reference)
+) bufmoduleref.ModuleReference {
+	moduleReference, err := bufmoduleref.NewModuleReference(remote, owner, repository, reference)
 	require.NoError(t, err)
 	return moduleReference
 }

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/storage"
@@ -175,9 +175,9 @@ type ManagedConfig struct {
 // GoPackagePrefixConfig is the go_package prefix configuration.
 type GoPackagePrefixConfig struct {
 	Default string
-	Except  []bufmodule.ModuleIdentity
-	// bufmodule.ModuleIdentity -> go_package prefix.
-	Override map[bufmodule.ModuleIdentity]string
+	Except  []bufmoduleref.ModuleIdentity
+	// bufmoduleref.ModuleIdentity -> go_package prefix.
+	Override map[bufmoduleref.ModuleIdentity]string
 }
 
 // ReadConfig reads the configuration from the OS or an override, if any.

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin"
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
@@ -258,9 +258,9 @@ func newGoPackagePrefixConfigV1(externalGoPackagePrefixConfig ExternalGoPackageP
 		return nil, fmt.Errorf("invalid go_package_prefix default: %w", err)
 	}
 	seenModuleIdentities := make(map[string]struct{}, len(externalGoPackagePrefixConfig.Except))
-	except := make([]bufmodule.ModuleIdentity, 0, len(externalGoPackagePrefixConfig.Except))
+	except := make([]bufmoduleref.ModuleIdentity, 0, len(externalGoPackagePrefixConfig.Except))
 	for _, moduleName := range externalGoPackagePrefixConfig.Except {
-		moduleIdentity, err := bufmodule.ModuleIdentityForString(moduleName)
+		moduleIdentity, err := bufmoduleref.ModuleIdentityForString(moduleName)
 		if err != nil {
 			return nil, fmt.Errorf("invalid go_package_prefix except: %w", err)
 		}
@@ -270,9 +270,9 @@ func newGoPackagePrefixConfigV1(externalGoPackagePrefixConfig ExternalGoPackageP
 		seenModuleIdentities[moduleIdentity.IdentityString()] = struct{}{}
 		except = append(except, moduleIdentity)
 	}
-	override := make(map[bufmodule.ModuleIdentity]string, len(externalGoPackagePrefixConfig.Override))
+	override := make(map[bufmoduleref.ModuleIdentity]string, len(externalGoPackagePrefixConfig.Override))
 	for moduleName, goPackagePrefix := range externalGoPackagePrefixConfig.Override {
-		moduleIdentity, err := bufmodule.ModuleIdentityForString(moduleName)
+		moduleIdentity, err := bufmoduleref.ModuleIdentityForString(moduleName)
 		if err != nil {
 			return nil, fmt.Errorf("invalid go_package_prefix override key: %w", err)
 		}

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagemodify"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/stretchr/testify/require"
@@ -343,8 +343,8 @@ func TestReadConfigV1(t *testing.T) {
 		ManagedConfig: &ManagedConfig{
 			GoPackagePrefixConfig: &GoPackagePrefixConfig{
 				Default:  "github.com/foo/bar/gen/go",
-				Except:   make([]bufmodule.ModuleIdentity, 0),
-				Override: make(map[bufmodule.ModuleIdentity]string),
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]string),
 			},
 		},
 	}

--- a/private/buf/bufwire/bufwire.go
+++ b/private/buf/bufwire/bufwire.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagebuild"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"go.uber.org/zap"
@@ -130,7 +131,7 @@ type FileLister interface {
 		container app.EnvStdinContainer,
 		ref buffetch.Ref,
 		configOverride string,
-	) ([]bufmodule.FileInfo, error)
+	) ([]bufmoduleref.FileInfo, error)
 }
 
 // NewFileLister returns a new FileLister.

--- a/private/buf/bufwire/file_lister.go
+++ b/private/buf/bufwire/file_lister.go
@@ -22,8 +22,8 @@ import (
 	"github.com/bufbuild/buf/private/buf/buffetch"
 	"github.com/bufbuild/buf/private/buf/bufwork"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagebuild"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
@@ -67,7 +67,7 @@ func (e *fileLister) ListFiles(
 	container app.EnvStdinContainer,
 	ref buffetch.Ref,
 	configOverride string,
-) (_ []bufmodule.FileInfo, retErr error) {
+) (_ []bufmoduleref.FileInfo, retErr error) {
 	switch t := ref.(type) {
 	case buffetch.ImageRef:
 		// if we have an image, list the files in the image
@@ -83,7 +83,7 @@ func (e *fileLister) ListFiles(
 			return nil, err
 		}
 		files := image.Files()
-		fileInfos := make([]bufmodule.FileInfo, len(files))
+		fileInfos := make([]bufmoduleref.FileInfo, len(files))
 		for i, file := range files {
 			fileInfos[i] = file
 		}
@@ -107,7 +107,7 @@ func (e *fileLister) ListFiles(
 		if err != nil {
 			return nil, err
 		}
-		var allSourceFileInfos []bufmodule.FileInfo
+		var allSourceFileInfos []bufmoduleref.FileInfo
 		for _, directory := range workspaceConfig.Directories {
 			sourceFileInfos, err := e.sourceFileInfosForDirectory(ctx, readBucketCloser, directory, configOverride)
 			if err != nil {
@@ -134,7 +134,7 @@ func (e *fileLister) sourceFileInfosForDirectory(
 	readBucket storage.ReadBucket,
 	directory string,
 	configOverride string,
-) ([]bufmodule.FileInfo, error) {
+) ([]bufmoduleref.FileInfo, error) {
 	mappedReadBucket := storage.MapReadBucket(readBucket, storage.MapOnPrefix(directory))
 	config, err := bufconfig.ReadConfig(
 		ctx,

--- a/private/buf/bufwire/module_config_reader.go
+++ b/private/buf/bufwire/module_config_reader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufwork"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
@@ -431,13 +432,13 @@ func workspaceDirectoryEqualsOrContainsSubDirPath(workspaceConfig *bufwork.Confi
 	return false
 }
 
-func detectMissingDependencies(references []bufmodule.ModuleReference, pins []bufmodule.ModulePin) []bufmodule.ModuleReference {
+func detectMissingDependencies(references []bufmoduleref.ModuleReference, pins []bufmoduleref.ModulePin) []bufmoduleref.ModuleReference {
 	pinSet := make(map[string]struct{})
 	for _, pin := range pins {
 		pinSet[pin.IdentityString()] = struct{}{}
 	}
 
-	var missingReferences []bufmodule.ModuleReference
+	var missingReferences []bufmoduleref.ModuleReference
 	for _, reference := range references {
 		if _, ok := pinSet[reference.IdentityString()]; !ok {
 			missingReferences = append(missingReferences, reference)

--- a/private/buf/bufwork/workspace.go
+++ b/private/buf/bufwork/workspace.go
@@ -23,12 +23,13 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 type workspace struct {
-	// bufmodule.ModuleIdentity -> bufmodule.Module
+	// bufmoduleref.ModuleIdentity -> bufmodule.Module
 	namedModules map[string]bufmodule.Module
 	allModules   []bufmodule.Module
 }
@@ -125,7 +126,7 @@ func newWorkspace(
 	}, nil
 }
 
-func (w *workspace) GetModule(moduleIdentity bufmodule.ModuleIdentity) (bufmodule.Module, bool) {
+func (w *workspace) GetModule(moduleIdentity bufmoduleref.ModuleIdentity) (bufmodule.Module, bool) {
 	module, ok := w.namedModules[moduleIdentity.IdentityString()]
 	return module, ok
 }

--- a/private/buf/cmd/buf/command/beta/registry/branch/branchcreate/branchcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/branch/branchcreate/branchcreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -74,7 +74,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Parent,
 		parentFlagName,
 		parentFlagShortName,
-		bufmodule.MainBranch,
+		bufmoduleref.MainBranch,
 		`The parent branch.`,
 	)
 }
@@ -87,13 +87,13 @@ func run(
 	if flags.Parent == "" {
 		return appcmd.NewInvalidArgumentErrorf("required flag %q not set", parentFlagName)
 	}
-	moduleReference, err := bufmodule.ModuleReferenceForString(
+	moduleReference, err := bufmoduleref.ModuleReferenceForString(
 		container.Arg(0),
 	)
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	if bufmodule.IsCommitModuleReference(moduleReference) {
+	if bufmoduleref.IsCommitModuleReference(moduleReference) {
 		return fmt.Errorf("branch is required but commit was given: %q", container.Arg(0))
 	}
 	format, err := bufprint.ParseFormat(flags.Format)

--- a/private/buf/cmd/buf/command/beta/registry/branch/branchlist/branchlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/branch/branchlist/branchlist.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -98,7 +98,7 @@ func run(
 	if container.Arg(0) == "" {
 		return appcmd.NewInvalidArgumentError("repository is required")
 	}
-	moduleIdentity, err := bufmodule.ModuleIdentityForString(container.Arg(0))
+	moduleIdentity, err := bufmoduleref.ModuleIdentityForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -72,7 +72,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleReference, err := bufmodule.ModuleReferenceForString(container.Arg(0))
+	moduleReference, err := bufmoduleref.ModuleReferenceForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -96,7 +96,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleReference, err := bufmodule.ModuleReferenceForString(container.Arg(0))
+	moduleReference, err := bufmoduleref.ModuleReferenceForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
@@ -119,7 +119,7 @@ func run(
 		moduleReference.Owner(),
 		moduleReference.Repository(),
 		//moduleReference.Reference(),
-		bufmodule.MainBranch,
+		bufmoduleref.MainBranch,
 		flags.PageSize,
 		flags.PageToken,
 		flags.Reverse,

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate/organizationcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate/organizationcreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -72,7 +72,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleOwner, err := bufmodule.ModuleOwnerForString(container.Arg(0))
+	moduleOwner, err := bufmoduleref.ModuleOwnerForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -71,7 +71,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleOwner, err := bufmodule.ModuleOwnerForString(container.Arg(0))
+	moduleOwner, err := bufmoduleref.ModuleOwnerForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationget/organizationget.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationget/organizationget.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -72,7 +72,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleOwner, err := bufmodule.ModuleOwnerForString(container.Arg(0))
+	moduleOwner, err := bufmoduleref.ModuleOwnerForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
@@ -93,7 +93,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleIdentity, err := bufmodule.ModuleIdentityForString(container.Arg(0))
+	moduleIdentity, err := bufmoduleref.ModuleIdentityForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -71,7 +71,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleIdentity, err := bufmodule.ModuleIdentityForString(container.Arg(0))
+	moduleIdentity, err := bufmoduleref.ModuleIdentityForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -72,7 +72,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleIdentity, err := bufmodule.ModuleIdentityForString(container.Arg(0))
+	moduleIdentity, err := bufmoduleref.ModuleIdentityForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -72,13 +72,13 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	moduleReference, err := bufmodule.ModuleReferenceForString(
+	moduleReference, err := bufmoduleref.ModuleReferenceForString(
 		container.Arg(0),
 	)
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	if !bufmodule.IsCommitModuleReference(moduleReference) {
+	if !bufmoduleref.IsCommitModuleReference(moduleReference) {
 		return fmt.Errorf("commit is required, but a tag was given: %q", container.Arg(0))
 	}
 	format, err := bufprint.ParseFormat(flags.Format)

--- a/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -98,7 +98,7 @@ func run(
 	if container.Arg(0) == "" {
 		return appcmd.NewInvalidArgumentError("repository is required")
 	}
-	moduleIdentity, err := bufmodule.ModuleIdentityForString(container.Arg(0))
+	moduleIdentity, err := bufmoduleref.ModuleIdentityForString(container.Arg(0))
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagebuild"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/storage"
@@ -226,7 +227,7 @@ func run(
 		fileInfosFunc = func(
 			moduleFileSet bufmodule.ModuleFileSet,
 			ctx context.Context,
-		) ([]bufmodule.FileInfo, error) {
+		) ([]bufmoduleref.FileInfo, error) {
 			return moduleFileSet.TargetFileInfos(ctx)
 		}
 	}

--- a/private/buf/cmd/buf/command/mod/modinit/modinit.go
+++ b/private/buf/cmd/buf/command/mod/modinit/modinit.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufconfig"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
@@ -143,7 +143,7 @@ func run(
 		)
 	}
 	if flags.Name != "" {
-		moduleIdentity, err := bufmodule.ModuleIdentityForString(flags.Name)
+		moduleIdentity, err := bufmoduleref.ModuleIdentityForString(flags.Name)
 		if err != nil {
 			return err
 		}
@@ -153,9 +153,9 @@ func run(
 		)
 	}
 	if len(flags.Deps) > 0 {
-		dependencyModuleReferences := make([]bufmodule.ModuleReference, len(flags.Deps))
+		dependencyModuleReferences := make([]bufmoduleref.ModuleReference, len(flags.Deps))
 		for i, dep := range flags.Deps {
-			dependencyModuleReference, err := bufmodule.ModuleReferenceForString(dep)
+			dependencyModuleReference, err := bufmoduleref.ModuleReferenceForString(dep)
 			if err != nil {
 				return err
 			}

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -21,7 +21,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufrpc"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
@@ -115,7 +115,7 @@ func run(
 	if moduleConfig.ModuleIdentity != nil && moduleConfig.ModuleIdentity.Remote() != "" {
 		remote = moduleConfig.ModuleIdentity.Remote()
 	}
-	var dependencyModulePins []bufmodule.ModulePin
+	var dependencyModulePins []bufmoduleref.ModulePin
 	if len(moduleConfig.Build.DependencyModuleReferences) != 0 {
 		apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
 		if err != nil {
@@ -128,7 +128,7 @@ func run(
 		var protoDependencyModuleReferences []*modulev1alpha1.ModuleReference
 		var currentProtoModulePins []*modulev1alpha1.ModulePin
 		if len(flags.Only) > 0 {
-			referencesByIdentity := map[string]bufmodule.ModuleReference{}
+			referencesByIdentity := map[string]bufmoduleref.ModuleReference{}
 			for _, reference := range moduleConfig.Build.DependencyModuleReferences {
 				referencesByIdentity[reference.IdentityString()] = reference
 			}
@@ -137,15 +137,15 @@ func run(
 				if !ok {
 					return fmt.Errorf("%q is not a valid --only input: no such dependency in current module deps", only)
 				}
-				protoDependencyModuleReferences = append(protoDependencyModuleReferences, bufmodule.NewProtoModuleReferenceForModuleReference(moduleReference))
+				protoDependencyModuleReferences = append(protoDependencyModuleReferences, bufmoduleref.NewProtoModuleReferenceForModuleReference(moduleReference))
 			}
-			currentModulePins, err := bufmodule.DependencyModulePinsForBucket(ctx, readWriteBucket)
+			currentModulePins, err := bufmoduleref.DependencyModulePinsForBucket(ctx, readWriteBucket)
 			if err != nil {
 				return fmt.Errorf("couldn't read current dependencies: %w", err)
 			}
-			currentProtoModulePins = bufmodule.NewProtoModulePinsForModulePins(currentModulePins...)
+			currentProtoModulePins = bufmoduleref.NewProtoModulePinsForModulePins(currentModulePins...)
 		} else {
-			protoDependencyModuleReferences = bufmodule.NewProtoModuleReferencesForModuleReferences(
+			protoDependencyModuleReferences = bufmoduleref.NewProtoModuleReferencesForModuleReferences(
 				moduleConfig.Build.DependencyModuleReferences...,
 			)
 		}
@@ -160,12 +160,12 @@ func run(
 			}
 			return err
 		}
-		dependencyModulePins, err = bufmodule.NewModulePinsForProtos(protoDependencyModulePins...)
+		dependencyModulePins, err = bufmoduleref.NewModulePinsForProtos(protoDependencyModulePins...)
 		if err != nil {
 			return bufcli.NewInternalError(err)
 		}
 	}
-	if err := bufmodule.PutDependencyModulePinsToBucket(ctx, readWriteBucket, dependencyModulePins); err != nil {
+	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, readWriteBucket, dependencyModulePins); err != nil {
 		return bufcli.NewInternalError(err)
 	}
 	return nil

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -81,7 +82,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	//	&f.Branch,
 	//	branchFlagName,
 	//	branchFlagShortName,
-	//	bufmodule.MainBranch,
+	//	bufmoduleref.MainBranch,
 	//	`The branch to push to.`,
 	//)
 	flagSet.StringSliceVarP(
@@ -146,7 +147,7 @@ func run(
 		moduleIdentity.Owner(),
 		moduleIdentity.Repository(),
 		//flags.Branch,
-		bufmodule.MainBranch,
+		bufmoduleref.MainBranch,
 		protoModule,
 		flags.Tags,
 	)

--- a/private/bufpkg/bufanalysis/bufanalysistesting/bufanalysistesting.go
+++ b/private/bufpkg/bufanalysis/bufanalysistesting/bufanalysistesting.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -87,10 +87,10 @@ func newFileAnnotation(
 	typeString string,
 	message string,
 ) bufanalysis.FileAnnotation {
-	var fileInfo bufmodule.FileInfo
+	var fileInfo bufmoduleref.FileInfo
 	var err error
 	if path != "" {
-		fileInfo, err = bufmodule.NewFileInfo(
+		fileInfo, err = bufmoduleref.NewFileInfo(
 			path,
 			"",
 			false,
@@ -142,7 +142,7 @@ func normalizeFileAnnotations(
 		fileInfo := a.FileInfo()
 		var err error
 		if fileInfo != nil {
-			fileInfo, err = bufmodule.NewFileInfo(
+			fileInfo, err = bufmoduleref.NewFileInfo(
 				fileInfo.Path(),
 				"",
 				false,

--- a/private/bufpkg/bufapimodule/module_reader.go
+++ b/private/bufpkg/bufapimodule/module_reader.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
 	"github.com/bufbuild/buf/private/pkg/rpc"
 	"github.com/bufbuild/buf/private/pkg/storage"
@@ -35,7 +36,7 @@ func newModuleReader(
 	}
 }
 
-func (m *moduleReader) GetModule(ctx context.Context, modulePin bufmodule.ModulePin) (bufmodule.Module, error) {
+func (m *moduleReader) GetModule(ctx context.Context, modulePin bufmoduleref.ModulePin) (bufmodule.Module, error) {
 	downloadService, err := m.downloadServiceProvider.NewDownloadService(ctx, modulePin.Remote())
 	if err != nil {
 		return nil, err
@@ -53,7 +54,7 @@ func (m *moduleReader) GetModule(ctx context.Context, modulePin bufmodule.Module
 		}
 		return nil, err
 	}
-	moduleIdentity, err := bufmodule.NewModuleIdentity(
+	moduleIdentity, err := bufmoduleref.NewModuleIdentity(
 		modulePin.Remote(),
 		modulePin.Owner(),
 		modulePin.Repository(),

--- a/private/bufpkg/bufapimodule/module_resolver.go
+++ b/private/bufpkg/bufapimodule/module_resolver.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -38,7 +38,7 @@ func newModuleResolver(logger *zap.Logger, resolveServiceProvider registryv1alph
 	}
 }
 
-func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmodule.ModuleReference) (bufmodule.ModulePin, error) {
+func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmoduleref.ModuleReference) (bufmoduleref.ModulePin, error) {
 	resolveService, err := m.resolveServiceProvider.NewResolveService(ctx, moduleReference.Remote())
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmo
 	protoModulePins, err := resolveService.GetModulePins(
 		ctx,
 		[]*modulev1alpha1.ModuleReference{
-			bufmodule.NewProtoModuleReferenceForModuleReference(moduleReference),
+			bufmoduleref.NewProtoModuleReferenceForModuleReference(moduleReference),
 		},
 		nil,
 	)
@@ -57,10 +57,10 @@ func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmo
 		}
 		return nil, err
 	}
-	var targetModulePin bufmodule.ModulePin
+	var targetModulePin bufmoduleref.ModulePin
 	moduleIdentity := getModuleIdentity(moduleReference)
 	for _, protoModulePin := range protoModulePins {
-		modulePin, err := bufmodule.NewModulePinForProto(protoModulePin)
+		modulePin, err := bufmoduleref.NewModulePinForProto(protoModulePin)
 		if err != nil {
 			return nil, err
 		}
@@ -77,6 +77,6 @@ func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmo
 	return targetModulePin, nil
 }
 
-func getModuleIdentity(moduleIdentity bufmodule.ModuleIdentity) string {
+func getModuleIdentity(moduleIdentity bufmoduleref.ModuleIdentity) string {
 	return moduleIdentity.Remote() + "/" + moduleIdentity.Owner() + "/" + moduleIdentity.Repository()
 }

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	imagev1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
@@ -28,7 +28,7 @@ import (
 
 // ImageFile is a Protobuf file within an image.
 type ImageFile interface {
-	bufmodule.FileInfo
+	bufmoduleref.FileInfo
 	// Proto is the backing *descriptorpb.FileDescriptorProto for this File.
 	//
 	// FileDescriptor should be preferred to Proto. We keep this method around
@@ -62,7 +62,7 @@ type ImageFile interface {
 // TODO: moduleIdentity and commit should be options since they are optional.
 func NewImageFile(
 	fileDescriptor protodescriptor.FileDescriptor,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 	externalPath string,
 	isImport bool,
@@ -177,7 +177,7 @@ func NewImageForProto(protoImage *imagev1.Image) (Image, error) {
 		var isImport bool
 		var isSyntaxUnspecified bool
 		var unusedDependencyIndexes []int32
-		var moduleIdentity bufmodule.ModuleIdentity
+		var moduleIdentity bufmoduleref.ModuleIdentity
 		var commit string
 		var err error
 		if protoImageFileExtension := protoImageFile.GetBufExtension(); protoImageFileExtension != nil {
@@ -186,7 +186,7 @@ func NewImageForProto(protoImage *imagev1.Image) (Image, error) {
 			unusedDependencyIndexes = protoImageFileExtension.GetUnusedDependency()
 			if protoModuleInfo := protoImageFileExtension.GetModuleInfo(); protoModuleInfo != nil {
 				if protoModuleName := protoModuleInfo.GetName(); protoModuleName != nil {
-					moduleIdentity, err = bufmodule.NewModuleIdentity(
+					moduleIdentity, err = bufmoduleref.NewModuleIdentity(
 						protoModuleName.GetRemote(),
 						protoModuleName.GetOwner(),
 						protoModuleName.GetRepository(),

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/data/datawkt"
 	"github.com/bufbuild/buf/private/pkg/protoversion"
 	"go.uber.org/zap"
@@ -113,8 +113,8 @@ func GoPackage(
 	logger *zap.Logger,
 	sweeper Sweeper,
 	defaultImportPathPrefix string,
-	except []bufmodule.ModuleIdentity,
-	moduleOverrides map[bufmodule.ModuleIdentity]string,
+	except []bufmoduleref.ModuleIdentity,
+	moduleOverrides map[bufmoduleref.ModuleIdentity]string,
 	overrides map[string]string,
 ) (Modifier, error) {
 	return goPackage(

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagebuild"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/stretchr/testify/assert"
@@ -93,7 +94,7 @@ func testGetModuleFileSet(t *testing.T, dirPath string) bufmodule.ModuleFileSet 
 		dirPath,
 	)
 	require.NoError(t, err)
-	moduleIdentity, err := bufmodule.NewModuleIdentity(
+	moduleIdentity, err := bufmoduleref.NewModuleIdentity(
 		testRemote,
 		testRepositoryOwner,
 		testRepositoryName,

--- a/private/bufpkg/bufimage/bufimagemodify/go_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/go_package.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -36,14 +36,14 @@ func goPackage(
 	logger *zap.Logger,
 	sweeper Sweeper,
 	defaultImportPathPrefix string,
-	except []bufmodule.ModuleIdentity,
-	moduleOverrides map[bufmodule.ModuleIdentity]string,
+	except []bufmoduleref.ModuleIdentity,
+	moduleOverrides map[bufmoduleref.ModuleIdentity]string,
 	overrides map[string]string,
 ) (Modifier, error) {
 	if defaultImportPathPrefix == "" {
 		return nil, fmt.Errorf("a non-empty import path prefix is required")
 	}
-	// Convert the bufmodule.ModuleIdentity types into
+	// Convert the bufmoduleref.ModuleIdentity types into
 	// strings so that they're comparable.
 	exceptModuleIdentityStrings := make(map[string]struct{}, len(except))
 	for _, moduleIdentity := range except {

--- a/private/bufpkg/bufimage/bufimagemodify/go_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/go_package_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -434,7 +434,7 @@ func TestGoPackageWellKnownTypes(t *testing.T) {
 func TestGoPackageWithExcept(t *testing.T) {
 	t.Parallel()
 	dirPath := filepath.Join("testdata", "emptyoptions")
-	testModuleIdentity, err := bufmodule.NewModuleIdentity(
+	testModuleIdentity, err := bufmoduleref.NewModuleIdentity(
 		testRemote,
 		testRepositoryOwner,
 		testRepositoryName,
@@ -451,7 +451,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 			zap.NewNop(),
 			sweeper,
 			testImportPathPrefix,
-			[]bufmodule.ModuleIdentity{testModuleIdentity},
+			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
 			nil,
 			nil,
 		)
@@ -477,7 +477,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 			zap.NewNop(),
 			sweeper,
 			testImportPathPrefix,
-			[]bufmodule.ModuleIdentity{testModuleIdentity},
+			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
 			nil,
 			nil,
 		)
@@ -501,7 +501,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 			zap.NewNop(),
 			sweeper,
 			testImportPathPrefix,
-			[]bufmodule.ModuleIdentity{testModuleIdentity},
+			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
 			nil,
 			map[string]string{"a.proto": "override"},
 		)
@@ -526,7 +526,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 			zap.NewNop(),
 			sweeper,
 			testImportPathPrefix,
-			[]bufmodule.ModuleIdentity{testModuleIdentity},
+			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
 			nil,
 			map[string]string{"a.proto": "override"},
 		)
@@ -544,7 +544,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 	t.Parallel()
 	dirPath := filepath.Join("testdata", "emptyoptions")
 	overrideGoPackagePrefix := "github.com/foo/bar/private/private/gen/proto/go"
-	testModuleIdentity, err := bufmodule.NewModuleIdentity(
+	testModuleIdentity, err := bufmoduleref.NewModuleIdentity(
 		testRemote,
 		testRepositoryOwner,
 		testRepositoryName,
@@ -562,7 +562,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 			sweeper,
 			testImportPathPrefix,
 			nil,
-			map[bufmodule.ModuleIdentity]string{
+			map[bufmoduleref.ModuleIdentity]string{
 				testModuleIdentity: overrideGoPackagePrefix,
 			},
 			nil,
@@ -598,7 +598,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 			sweeper,
 			testImportPathPrefix,
 			nil,
-			map[bufmodule.ModuleIdentity]string{
+			map[bufmoduleref.ModuleIdentity]string{
 				testModuleIdentity: overrideGoPackagePrefix,
 			},
 			nil,
@@ -632,7 +632,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 			sweeper,
 			testImportPathPrefix,
 			nil,
-			map[bufmodule.ModuleIdentity]string{
+			map[bufmoduleref.ModuleIdentity]string{
 				testModuleIdentity: overrideGoPackagePrefix,
 			},
 			map[string]string{"a.proto": "override"},
@@ -665,7 +665,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 			sweeper,
 			testImportPathPrefix,
 			nil,
-			map[bufmodule.ModuleIdentity]string{
+			map[bufmoduleref.ModuleIdentity]string{
 				testModuleIdentity: overrideGoPackagePrefix,
 			},
 			map[string]string{"a.proto": "override"},

--- a/private/bufpkg/bufimage/bufimagetesting/bufimagetesting.go
+++ b/private/bufpkg/bufimage/bufimagetesting/bufimagetesting.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	imagev1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +32,7 @@ import (
 func NewImageFile(
 	t testing.TB,
 	fileDescriptor protodescriptor.FileDescriptor,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 	externalPath string,
 	isImport bool,

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -24,8 +24,8 @@ import (
 
 // NewInputFiles converts the ImageFiles to InputFiles.
 //
-// Since protosource is a pkg package, it cannot depend on bufmodule, which has the
-// definition for bufmodule.ModuleIdentity, so we have our own interfaces for this
+// Since protosource is a pkg package, it cannot depend on bufmoduleref, which has the
+// definition for bufmoduleref.ModuleIdentity, so we have our own interfaces for this
 // in protosource. Given Go's type system, we need to do a conversion here.
 func NewInputFiles(imageFiles []bufimage.ImageFile) []protosource.InputFile {
 	inputFiles := make([]protosource.InputFile, len(imageFiles))

--- a/private/bufpkg/bufimage/image_file.go
+++ b/private/bufpkg/bufimage/image_file.go
@@ -15,7 +15,7 @@
 package bufimage
 
 import (
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -23,7 +23,7 @@ import (
 var _ ImageFile = &imageFile{}
 
 type imageFile struct {
-	bufmodule.FileInfo
+	bufmoduleref.FileInfo
 
 	fileDescriptorProto *descriptorpb.FileDescriptorProto
 
@@ -33,7 +33,7 @@ type imageFile struct {
 
 func newImageFile(
 	fileDescriptor protodescriptor.FileDescriptor,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 	externalPath string,
 	isImport bool,
@@ -43,7 +43,7 @@ func newImageFile(
 	if err := protodescriptor.ValidateFileDescriptor(fileDescriptor); err != nil {
 		return nil, err
 	}
-	fileInfo, err := bufmodule.NewFileInfo(
+	fileInfo, err := bufmoduleref.NewFileInfo(
 		fileDescriptor.GetName(),
 		externalPath,
 		isImport,

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/data/datawkt"
 	imagev1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
@@ -220,7 +220,7 @@ func fileDescriptorProtoToProtoImageFile(
 	isImport bool,
 	isSyntaxUnspecified bool,
 	unusedDependencyIndexes []int32,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	moduleCommit string,
 ) *imagev1.ImageFile {
 	var protoModuleInfo *imagev1.ModuleInfo

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -20,24 +20,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"sort"
-	"strings"
-	"time"
 
-	"github.com/bufbuild/buf/private/bufpkg/buflock"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/storage"
-	"github.com/bufbuild/buf/private/pkg/uuidutil"
 	"go.uber.org/multierr"
 )
 
 const (
 	// DocumentationFilePath defines the path to the documentation file, relative to the root of the module.
 	DocumentationFilePath = "buf.md"
-
-	// MainBranch is the name of the branch created for every repository.
-	// This is the default branch used if no branch or commit is specified.
-	MainBranch = "main"
 
 	// b1DigestPrefix is the digest prefix for the first version of the digest function.
 	//
@@ -51,315 +43,12 @@ const (
 	b2DigestPrefix = "b2"
 )
 
-// FileInfo contains module file info.
-type FileInfo interface {
-	// Path is the path of the file relative to the root it is contained within.
-	// This will be normalized, validated and never empty,
-	// This will be unique within a given Image.
-	Path() string
-	// ExternalPath returns the path that identifies this file externally.
-	//
-	// This will be unnormalized.
-	// Never empty. Falls back to Path if there is not an external path.
-	//
-	// Example:
-	//	 Assume we had the input path /foo/bar which is a local directory.
-
-	//   Path: one/one.proto
-	//   RootDirPath: proto
-	//   ExternalPath: /foo/bar/proto/one/one.proto
-	ExternalPath() string
-	// IsImport returns true if this file is an import.
-	IsImport() bool
-	// ModuleIdentity is the module that this file came from.
-	//
-	// Note this *can* be nil if we did not build from a named module.
-	// All code must assume this can be nil.
-	// Note that nil checking should work since the backing type is always a pointer.
-	ModuleIdentity() ModuleIdentity
-	// Commit is the commit for the module that this file came from.
-	//
-	// This will only be set if ModuleIdentity is set. but may not be set
-	// even if ModuleIdentity is set, that is commit is optional information
-	// even if we know what module this file came from.
-	Commit() string
-	// WithIsImport returns this FileInfo with the given IsImport value.
-	WithIsImport(isImport bool) FileInfo
-
-	isFileInfo()
-}
-
-// NewFileInfo returns a new FileInfo.
-//
-// TODO: we should make moduleIdentity and commit options.
-// TODO: we don't validate commit
-func NewFileInfo(
-	path string,
-	externalPath string,
-	isImport bool,
-	moduleIdentity ModuleIdentity,
-	commit string,
-) (FileInfo, error) {
-	return newFileInfo(
-		path,
-		externalPath,
-		isImport,
-		moduleIdentity,
-		commit,
-	)
-}
-
 // ModuleFile is a module file.
 type ModuleFile interface {
-	FileInfo
+	bufmoduleref.FileInfo
 	io.ReadCloser
 
 	isModuleFile()
-}
-
-// ModuleOwner is a module owner.
-//
-// It just contains remote, owner.
-//
-// This is shared by ModuleIdentity.
-type ModuleOwner interface {
-	Remote() string
-	Owner() string
-
-	isModuleOwner()
-}
-
-// NewModuleOwner returns a new ModuleOwner.
-func NewModuleOwner(
-	remote string,
-	owner string,
-) (ModuleOwner, error) {
-	return newModuleOwner(remote, owner)
-}
-
-// ModuleOwnerForString returns a new ModuleOwner for the given string.
-//
-// This parses the path in the form remote/owner.
-func ModuleOwnerForString(path string) (ModuleOwner, error) {
-	slashSplit := strings.Split(path, "/")
-	if len(slashSplit) != 2 {
-		return nil, newInvalidModuleOwnerStringError(path)
-	}
-	remote := strings.TrimSpace(slashSplit[0])
-	if remote == "" {
-		return nil, newInvalidModuleIdentityStringError(path)
-	}
-	owner := strings.TrimSpace(slashSplit[1])
-	if owner == "" {
-		return nil, newInvalidModuleIdentityStringError(path)
-	}
-	return NewModuleOwner(remote, owner)
-}
-
-// ModuleIdentity is a module identity.
-//
-// It just contains remote, owner, repository.
-//
-// This is shared by ModuleReference and ModulePin.
-type ModuleIdentity interface {
-	ModuleOwner
-
-	Repository() string
-
-	// IdentityString is the string remote/owner/repository.
-	IdentityString() string
-
-	isModuleIdentity()
-}
-
-// NewModuleIdentity returns a new ModuleIdentity.
-func NewModuleIdentity(
-	remote string,
-	owner string,
-	repository string,
-) (ModuleIdentity, error) {
-	return newModuleIdentity(remote, owner, repository)
-}
-
-// ModuleIdentityForString returns a new ModuleIdentity for the given string.
-//
-// This parses the path in the form remote/owner/repository
-//
-// TODO: we may want to add a special error if we detect / or @ as this may be a common mistake.
-func ModuleIdentityForString(path string) (ModuleIdentity, error) {
-	remote, owner, repository, err := parseModuleIdentityComponents(path)
-	if err != nil {
-		return nil, err
-	}
-	return NewModuleIdentity(remote, owner, repository)
-}
-
-// ModuleReference is a module reference.
-//
-// It references either a branch, tag, or a commit.
-// Note that since commits belong to branches, we can deduce
-// the branch from the commit when resolving.
-type ModuleReference interface {
-	ModuleIdentity
-
-	// Prints either remote/owner/repository:{branch,commit}
-	// If the reference is equal to MainBranch, prints remote/owner/repository.
-	fmt.Stringer
-
-	// Either branch, tag, or commit
-	Reference() string
-
-	isModuleReference()
-}
-
-// NewModuleReference returns a new validated ModuleReference.
-func NewModuleReference(
-	remote string,
-	owner string,
-	repository string,
-	reference string,
-) (ModuleReference, error) {
-	return newModuleReference(remote, owner, repository, reference)
-}
-
-// NewModuleReferenceForProto returns a new ModuleReference for the given proto ModuleReference.
-func NewModuleReferenceForProto(protoModuleReference *modulev1alpha1.ModuleReference) (ModuleReference, error) {
-	return newModuleReferenceForProto(protoModuleReference)
-}
-
-// NewModuleReferencesForProtos maps the Protobuf equivalent into the internal representation.
-func NewModuleReferencesForProtos(protoModuleReferences ...*modulev1alpha1.ModuleReference) ([]ModuleReference, error) {
-	if len(protoModuleReferences) == 0 {
-		return nil, nil
-	}
-	moduleReferences := make([]ModuleReference, len(protoModuleReferences))
-	for i, protoModuleReference := range protoModuleReferences {
-		moduleReference, err := NewModuleReferenceForProto(protoModuleReference)
-		if err != nil {
-			return nil, err
-		}
-		moduleReferences[i] = moduleReference
-	}
-	return moduleReferences, nil
-}
-
-// NewProtoModuleReferenceForModuleReference returns a new proto ModuleReference for the given ModuleReference.
-func NewProtoModuleReferenceForModuleReference(moduleReference ModuleReference) *modulev1alpha1.ModuleReference {
-	return newProtoModuleReferenceForModuleReference(moduleReference)
-}
-
-// NewProtoModuleReferencesForModuleReferences maps the given module references into the protobuf representation.
-func NewProtoModuleReferencesForModuleReferences(moduleReferences ...ModuleReference) []*modulev1alpha1.ModuleReference {
-	if len(moduleReferences) == 0 {
-		return nil
-	}
-	protoModuleReferences := make([]*modulev1alpha1.ModuleReference, len(moduleReferences))
-	for i, moduleReference := range moduleReferences {
-		protoModuleReferences[i] = NewProtoModuleReferenceForModuleReference(moduleReference)
-	}
-	return protoModuleReferences
-}
-
-// ModuleReferenceForString returns a new ModuleReference for the given string.
-// If a branch or commit is not provided, the "main" branch is used.
-//
-// This parses the path in the form remote/owner/repository{:branch,:commit}.
-func ModuleReferenceForString(path string) (ModuleReference, error) {
-	remote, owner, repository, reference, err := parseModuleReferenceComponents(path)
-	if err != nil {
-		return nil, err
-	}
-	if reference == "" {
-		// Default to the main branch if a ':' separator was not specified.
-		reference = MainBranch
-	}
-	return NewModuleReference(remote, owner, repository, reference)
-}
-
-// IsCommitModuleReference returns true if the ModuleReference references a commit.
-//
-// If false, this means the ModuleReference references a branch or tag.
-// Branch and tag disambiguation needs to be done server-side.
-func IsCommitModuleReference(moduleReference ModuleReference) bool {
-	return IsCommitReference(moduleReference.Reference())
-}
-
-// IsCommitReference returns whether the provided reference is a commit.
-func IsCommitReference(reference string) bool {
-	_, err := uuidutil.FromDashless(reference)
-	return err == nil
-}
-
-// ModulePin is a module pin.
-//
-// It references a specific point in time of a Module.
-//
-// Note that a commit does this itself, but we want all this information.
-// This is what is stored in a buf.lock file.
-type ModulePin interface {
-	ModuleIdentity
-
-	// Prints remote/owner/repository:commit, which matches ModuleReference
-	fmt.Stringer
-
-	// all of these will be set
-	Branch() string
-	Commit() string
-	Digest() string
-	CreateTime() time.Time
-
-	isModulePin()
-}
-
-// NewModulePin returns a new validated ModulePin.
-func NewModulePin(
-	remote string,
-	owner string,
-	repository string,
-	branch string,
-	commit string,
-	digest string,
-	createTime time.Time,
-) (ModulePin, error) {
-	return newModulePin(remote, owner, repository, branch, commit, digest, createTime)
-}
-
-// NewModulePinForProto returns a new ModulePin for the given proto ModulePin.
-func NewModulePinForProto(protoModulePin *modulev1alpha1.ModulePin) (ModulePin, error) {
-	return newModulePinForProto(protoModulePin)
-}
-
-// NewModulePinsForProtos maps the Protobuf equivalent into the internal representation.
-func NewModulePinsForProtos(protoModulePins ...*modulev1alpha1.ModulePin) ([]ModulePin, error) {
-	if len(protoModulePins) == 0 {
-		return nil, nil
-	}
-	modulePins := make([]ModulePin, len(protoModulePins))
-	for i, protoModulePin := range protoModulePins {
-		modulePin, err := NewModulePinForProto(protoModulePin)
-		if err != nil {
-			return nil, err
-		}
-		modulePins[i] = modulePin
-	}
-	return modulePins, nil
-}
-
-// NewProtoModulePinForModulePin returns a new proto ModulePin for the given ModulePin.
-func NewProtoModulePinForModulePin(modulePin ModulePin) *modulev1alpha1.ModulePin {
-	return newProtoModulePinForModulePin(modulePin)
-}
-
-// NewProtoModulePinsForModulePins maps the given module pins into the protobuf representation.
-func NewProtoModulePinsForModulePins(modulePins ...ModulePin) []*modulev1alpha1.ModulePin {
-	if len(modulePins) == 0 {
-		return nil
-	}
-	protoModulePins := make([]*modulev1alpha1.ModulePin, len(modulePins))
-	for i, modulePin := range modulePins {
-		protoModulePins[i] = NewProtoModulePinForModulePin(modulePin)
-	}
-	return protoModulePins
 }
 
 // Module is a Protobuf module.
@@ -383,13 +72,13 @@ type Module interface {
 	// It does not include dependencies.
 	//
 	// The returned TargetFileInfos are sorted by path.
-	TargetFileInfos(ctx context.Context) ([]FileInfo, error)
+	TargetFileInfos(ctx context.Context) ([]bufmoduleref.FileInfo, error)
 	// SourceFileInfos gets all FileInfos belonging to the module.
 	//
 	// It does not include dependencies.
 	//
 	// The returned SourceFileInfos are sorted by path.
-	SourceFileInfos(ctx context.Context) ([]FileInfo, error)
+	SourceFileInfos(ctx context.Context) ([]bufmoduleref.FileInfo, error)
 	// GetModuleFile gets the source file for the given path.
 	//
 	// Returns storage.IsNotExist error if the file does not exist.
@@ -400,7 +89,7 @@ type Module interface {
 	// The returned ModulePins are unique by remote, owner, repository.
 	//
 	// This includes all transitive dependencies.
-	DependencyModulePins() []ModulePin
+	DependencyModulePins() []bufmoduleref.ModulePin
 	// Documentation gets the contents of the module documentation file, buf.md and returns the string representation.
 	// This may return an empty string if the documentation file does not exist.
 	Documentation() string
@@ -416,7 +105,7 @@ type Module interface {
 	// This approach assumes that all of the FileInfos returned
 	// from SourceFileInfos will have their ModuleReference
 	// set to the same value, which can be validated.
-	getModuleIdentity() ModuleIdentity
+	getModuleIdentity() bufmoduleref.ModuleIdentity
 	// Note this can be empty.
 	getCommit() string
 	isModule()
@@ -426,14 +115,14 @@ type Module interface {
 type ModuleOption func(*module)
 
 // ModuleWithModuleIdentity is used to construct a Module with a ModuleIdentity.
-func ModuleWithModuleIdentity(moduleIdentity ModuleIdentity) ModuleOption {
+func ModuleWithModuleIdentity(moduleIdentity bufmoduleref.ModuleIdentity) ModuleOption {
 	return func(module *module) {
 		module.moduleIdentity = moduleIdentity
 	}
 }
 
 // ModuleWithModuleIdentityAndCommit is used to construct a Module with a ModuleIdentity and commit.
-func ModuleWithModuleIdentityAndCommit(moduleIdentity ModuleIdentity, commit string) ModuleOption {
+func ModuleWithModuleIdentityAndCommit(moduleIdentity bufmoduleref.ModuleIdentity, commit string) ModuleOption {
 	return func(module *module) {
 		module.moduleIdentity = moduleIdentity
 		module.commit = commit
@@ -487,7 +176,7 @@ type ModuleResolver interface {
 	// GetModulePin resolves the provided ModuleReference to a ModulePin.
 	//
 	// Returns an error that fufills storage.IsNotExist if the named Module does not exist.
-	GetModulePin(ctx context.Context, moduleReference ModuleReference) (ModulePin, error)
+	GetModulePin(ctx context.Context, moduleReference bufmoduleref.ModuleReference) (bufmoduleref.ModulePin, error)
 }
 
 // NewNopModuleResolver returns a new ModuleResolver that always returns a storage.IsNotExist error.
@@ -500,7 +189,7 @@ type ModuleReader interface {
 	// GetModule gets the Module for the ModulePin.
 	//
 	// Returns an error that fufills storage.IsNotExist if the Module does not exist.
-	GetModule(ctx context.Context, modulePin ModulePin) (Module, error)
+	GetModule(ctx context.Context, modulePin bufmoduleref.ModulePin) (Module, error)
 }
 
 // NewNopModuleReader returns a new ModuleReader that always returns a storage.IsNotExist error.
@@ -519,7 +208,7 @@ type ModuleFileSet interface {
 	// AllFileInfos gets all FileInfos associated with the module, including dependencies.
 	//
 	// The returned FileInfos are sorted by path.
-	AllFileInfos(ctx context.Context) ([]FileInfo, error)
+	AllFileInfos(ctx context.Context) ([]bufmoduleref.FileInfo, error)
 
 	isModuleFileSet()
 }
@@ -535,7 +224,7 @@ func NewModuleFileSet(
 // Workspace represents a module workspace.
 type Workspace interface {
 	// GetModule gets the module identified by the given ModuleIdentity.
-	GetModule(moduleIdentity ModuleIdentity) (Module, bool)
+	GetModule(moduleIdentity bufmoduleref.ModuleIdentity) (Module, bool)
 	// GetModules returns all of the modules found in the workspace.
 	GetModules() []Module
 }
@@ -563,7 +252,7 @@ func ModuleToProtoModule(ctx context.Context, module Module) (*modulev1alpha1.Mo
 	dependencyModulePins := module.DependencyModulePins()
 	protoModulePins := make([]*modulev1alpha1.ModulePin, len(dependencyModulePins))
 	for i, dependencyModulePin := range dependencyModulePins {
-		protoModulePins[i] = NewProtoModulePinForModulePin(dependencyModulePin)
+		protoModulePins[i] = bufmoduleref.NewProtoModulePinForModulePin(dependencyModulePin)
 	}
 	protoModule := &modulev1alpha1.Module{
 		Files:         protoModuleFiles,
@@ -717,7 +406,7 @@ func ModuleToBucket(
 			return err
 		}
 	}
-	return PutDependencyModulePinsToBucket(ctx, writeBucket, module.DependencyModulePins())
+	return bufmoduleref.PutDependencyModulePinsToBucket(ctx, writeBucket, module.DependencyModulePins())
 }
 
 // TargetModuleFilesToBucket writes the target files of the given Module to the WriteBucket.
@@ -739,135 +428,4 @@ func TargetModuleFilesToBucket(
 		}
 	}
 	return nil
-}
-
-// ValidateModuleReferencesUniqueByIdentity returns an error if the module references contain any duplicates.
-//
-// This only checks remote, owner, repository.
-func ValidateModuleReferencesUniqueByIdentity(moduleReferences []ModuleReference) error {
-	seenModuleReferences := make(map[string]struct{})
-	for _, moduleReference := range moduleReferences {
-		moduleIdentityString := moduleReference.IdentityString()
-		if _, ok := seenModuleReferences[moduleIdentityString]; ok {
-			return fmt.Errorf("module %s appeared twice", moduleIdentityString)
-		}
-		seenModuleReferences[moduleIdentityString] = struct{}{}
-	}
-	return nil
-}
-
-// ValidateModulePinsUniqueByIdentity returns an error if the module pins contain any duplicates.
-//
-// This only checks remote, owner, repository.
-func ValidateModulePinsUniqueByIdentity(modulePins []ModulePin) error {
-	seenModulePins := make(map[string]struct{})
-	for _, modulePin := range modulePins {
-		moduleIdentityString := modulePin.IdentityString()
-		if _, ok := seenModulePins[moduleIdentityString]; ok {
-			return fmt.Errorf("module %s appeared twice", moduleIdentityString)
-		}
-		seenModulePins[moduleIdentityString] = struct{}{}
-	}
-	return nil
-}
-
-// ModuleReferenceEqual returns true if a equals b.
-func ModuleReferenceEqual(a ModuleReference, b ModuleReference) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return a.Remote() == b.Remote() &&
-		a.Owner() == b.Owner() &&
-		a.Repository() == b.Repository() &&
-		a.Reference() == b.Reference()
-}
-
-// ModulePinEqual returns true if a equals b.
-func ModulePinEqual(a ModulePin, b ModulePin) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-	if a == nil {
-		return true
-	}
-	return a.Remote() == b.Remote() &&
-		a.Owner() == b.Owner() &&
-		a.Repository() == b.Repository() &&
-		a.Branch() == b.Branch() &&
-		a.Commit() == b.Commit() &&
-		a.Digest() == b.Digest() &&
-		a.CreateTime().Equal(b.CreateTime())
-}
-
-// DependencyModulePinsForBucket reads the module dependencies from the lock file in the bucket.
-func DependencyModulePinsForBucket(
-	ctx context.Context,
-	readBucket storage.ReadBucket,
-) ([]ModulePin, error) {
-	lockFile, err := buflock.ReadConfig(ctx, readBucket)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read lock file: %w", err)
-	}
-	modulePins := make([]ModulePin, 0, len(lockFile.Dependencies))
-	for _, dep := range lockFile.Dependencies {
-		modulePin, err := NewModulePin(
-			dep.Remote,
-			dep.Owner,
-			dep.Repository,
-			dep.Branch,
-			dep.Commit,
-			dep.Digest,
-			dep.CreateTime,
-		)
-		if err != nil {
-			return nil, err
-		}
-		modulePins = append(modulePins, modulePin)
-	}
-	// just to be safe
-	SortModulePins(modulePins)
-	if err := ValidateModulePinsUniqueByIdentity(modulePins); err != nil {
-		return nil, err
-	}
-	return modulePins, nil
-}
-
-// PutDependencyModulePinsToBucket writes the module dependencies to the write bucket in the form of a lock file.
-func PutDependencyModulePinsToBucket(
-	ctx context.Context,
-	writeBucket storage.WriteBucket,
-	modulePins []ModulePin,
-) error {
-	if err := ValidateModulePinsUniqueByIdentity(modulePins); err != nil {
-		return err
-	}
-	SortModulePins(modulePins)
-	lockFile := &buflock.Config{
-		Dependencies: make([]buflock.Dependency, 0, len(modulePins)),
-	}
-	for _, pin := range modulePins {
-		lockFile.Dependencies = append(
-			lockFile.Dependencies,
-			buflock.Dependency{
-				Remote:     pin.Remote(),
-				Owner:      pin.Owner(),
-				Repository: pin.Repository(),
-				Branch:     pin.Branch(),
-				Commit:     pin.Commit(),
-				Digest:     pin.Digest(),
-				CreateTime: pin.CreateTime(),
-			},
-		)
-	}
-	return buflock.WriteConfig(ctx, writeBucket, lockFile)
-}
-
-// SortModulePins sorts the ModulePins.
-func SortModulePins(modulePins []ModulePin) {
-	sort.Slice(modulePins, func(i, j int) bool {
-		return modulePinLess(modulePins[i], modulePins[j])
-	})
 }

--- a/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"go.uber.org/zap"
@@ -134,7 +135,7 @@ func WithPathsAllowNotExist(paths []string) BuildOption {
 // TODO: we also have ModuleWithModuleIdentityAndCommit in bufmodule
 // We need to disambiguate module building between bufmodule and bufmodulebuild
 // bufimage and bufimagebuild work, but bufmodule and bufmodulebuild are a mess
-func WithModuleIdentity(moduleIdentity bufmodule.ModuleIdentity) BuildOption {
+func WithModuleIdentity(moduleIdentity bufmoduleref.ModuleIdentity) BuildOption {
 	return func(buildOptions *buildOptions) {
 		buildOptions.moduleIdentity = moduleIdentity
 	}

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
@@ -62,7 +63,7 @@ func (b *moduleBucketBuilder) buildForBucket(
 	ctx context.Context,
 	readBucket storage.ReadBucket,
 	config *bufmoduleconfig.Config,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	bucketRelPaths *[]string,
 	bucketRelPathsAllowNotExist bool,
 ) (bufmodule.Module, error) {

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
@@ -19,8 +19,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
@@ -308,7 +308,7 @@ func testBucketGetFileInfos(
 	t *testing.T,
 	relDir string,
 	config *bufmoduleconfig.Config,
-	expectedFileInfos ...bufmodule.FileInfo,
+	expectedFileInfos ...bufmoduleref.FileInfo,
 ) {
 	t.Parallel()
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
@@ -415,7 +415,7 @@ func testBucketGetFileInfosForExternalPathsError(
 func testDocumentationBucket(
 	t *testing.T,
 	relDir string,
-	expectedFileInfos ...bufmodule.FileInfo,
+	expectedFileInfos ...bufmoduleref.FileInfo,
 ) {
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	readWriteBucket, err := storageosProvider.NewReadWriteBucket(

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_include_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_include_builder_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
@@ -83,7 +83,7 @@ func testIncludeGetFileInfos(
 	t *testing.T,
 	relDir string,
 	relRoots []string,
-	expectedFileInfos ...bufmodule.FileInfo,
+	expectedFileInfos ...bufmoduleref.FileInfo,
 ) {
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	for _, isAbs := range []bool{true, false} {
@@ -174,11 +174,11 @@ func testIncludeDirPaths(
 }
 
 // fileInfosToAbs converts the external paths to absolute.
-func fileInfosToAbs(t *testing.T, fileInfos []bufmodule.FileInfo) []bufmodule.FileInfo {
+func fileInfosToAbs(t *testing.T, fileInfos []bufmoduleref.FileInfo) []bufmoduleref.FileInfo {
 	if fileInfos == nil {
 		return nil
 	}
-	newFileInfos := make([]bufmodule.FileInfo, len(fileInfos))
+	newFileInfos := make([]bufmoduleref.FileInfo, len(fileInfos))
 	for i, fileInfo := range fileInfos {
 		absExternalPath, err := normalpath.NormalizeAndAbsolute(fileInfo.ExternalPath())
 		require.NoError(t, err)

--- a/private/bufpkg/bufmodule/bufmodulebuild/util.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/util.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 )
@@ -90,7 +91,7 @@ func pathToTargetPath(roots []string, path string, pathType normalpath.PathType)
 }
 
 type buildOptions struct {
-	moduleIdentity bufmodule.ModuleIdentity
+	moduleIdentity bufmoduleref.ModuleIdentity
 	// If nil, all files are considered targets.
 	// If empty (but non-nil), the module will have no target paths.
 	paths              *[]string

--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/filelock"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
@@ -35,7 +36,7 @@ import (
 func TestReaderBasic(t *testing.T) {
 	ctx := context.Background()
 
-	modulePin, err := bufmodule.NewModulePin(
+	modulePin, err := bufmoduleref.NewModulePin(
 		"buf.build",
 		"foob",
 		"bar",
@@ -168,7 +169,7 @@ func TestReaderBasic(t *testing.T) {
 func TestCacherBasic(t *testing.T) {
 	ctx := context.Background()
 
-	modulePin, err := bufmodule.NewModulePin(
+	modulePin, err := bufmoduleref.NewModulePin(
 		"buf.build",
 		"foob",
 		"bar",
@@ -210,7 +211,7 @@ func TestCacherBasic(t *testing.T) {
 func TestModuleReaderCacherWithDocumentation(t *testing.T) {
 	ctx := context.Background()
 
-	modulePin, err := bufmodule.NewModulePin(
+	modulePin, err := bufmoduleref.NewModulePin(
 		"buf.build",
 		"foob",
 		"bar",

--- a/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -44,7 +45,7 @@ func newModuleCacher(
 
 func (m *moduleCacher) GetModule(
 	ctx context.Context,
-	modulePin bufmodule.ModulePin,
+	modulePin bufmoduleref.ModulePin,
 ) (bufmodule.Module, error) {
 	modulePath := newCacheKey(modulePin)
 	// We do not want the external path of the cache to be propagated to the user.
@@ -115,7 +116,7 @@ func (m *moduleCacher) GetModule(
 
 func (m *moduleCacher) PutModule(
 	ctx context.Context,
-	modulePin bufmodule.ModulePin,
+	modulePin bufmoduleref.ModulePin,
 	module bufmodule.Module,
 ) error {
 	modulePath := newCacheKey(modulePin)

--- a/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/filelock"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/verbose"
@@ -61,7 +62,7 @@ func newModuleReader(
 
 func (m *moduleReader) GetModule(
 	ctx context.Context,
-	modulePin bufmodule.ModulePin,
+	modulePin bufmoduleref.ModulePin,
 ) (_ bufmodule.Module, retErr error) {
 	cacheKey := newCacheKey(modulePin)
 

--- a/private/bufpkg/bufmodule/bufmodulecache/util.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/util.go
@@ -15,12 +15,12 @@
 package bufmodulecache
 
 import (
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 )
 
 // newCacheKey returns the key associated with the given module pin.
 // The cache key is of the form: remote/owner/repository/commit.
-func newCacheKey(modulePin bufmodule.ModulePin) string {
+func newCacheKey(modulePin bufmoduleref.ModulePin) string {
 	return normalpath.Join(modulePin.Remote(), modulePin.Owner(), modulePin.Repository(), modulePin.Commit())
 }

--- a/private/bufpkg/bufmodule/bufmoduleconfig/bufmoduleconfig.go
+++ b/private/bufpkg/bufmodule/bufmoduleconfig/bufmoduleconfig.go
@@ -14,7 +14,7 @@
 
 package bufmoduleconfig
 
-import "github.com/bufbuild/buf/private/bufpkg/bufmodule"
+import "github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 
 // Config is a configuration for build.
 type Config struct {
@@ -38,7 +38,7 @@ type Config struct {
 	//
 	// If RootToExcludes is empty, the default is "." with no excludes.
 	RootToExcludes             map[string][]string
-	DependencyModuleReferences []bufmodule.ModuleReference
+	DependencyModuleReferences []bufmoduleref.ModuleReference
 }
 
 // NewConfigV1Beta1 returns a new, validated Config for the ExternalConfig.

--- a/private/bufpkg/bufmodule/bufmoduleconfig/config.go
+++ b/private/bufpkg/bufmodule/bufmoduleconfig/config.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/internal"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
@@ -141,20 +141,20 @@ func newConfigV1(externalConfig ExternalConfigV1, deps ...string) (*Config, erro
 	}, nil
 }
 
-func parseDependencyModuleReferences(deps ...string) ([]bufmodule.ModuleReference, error) {
+func parseDependencyModuleReferences(deps ...string) ([]bufmoduleref.ModuleReference, error) {
 	if len(deps) == 0 {
 		return nil, nil
 	}
-	moduleReferences := make([]bufmodule.ModuleReference, 0, len(deps))
+	moduleReferences := make([]bufmoduleref.ModuleReference, 0, len(deps))
 	for _, dep := range deps {
 		dep := strings.TrimSpace(dep)
-		moduleReference, err := bufmodule.ModuleReferenceForString(dep)
+		moduleReference, err := bufmoduleref.ModuleReferenceForString(dep)
 		if err != nil {
 			return nil, err
 		}
 		moduleReferences = append(moduleReferences, moduleReference)
 	}
-	if err := bufmodule.ValidateModuleReferencesUniqueByIdentity(moduleReferences); err != nil {
+	if err := bufmoduleref.ValidateModuleReferencesUniqueByIdentity(moduleReferences); err != nil {
 		return nil, err
 	}
 	return moduleReferences, nil

--- a/private/bufpkg/bufmodule/bufmoduleconfig/config_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleconfig/config_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -429,7 +429,7 @@ func testNewConfigV1Equal(
 	assert.Equal(t, expectedConfig, config)
 }
 
-func testParseDependencyModuleReferences(t *testing.T, deps ...string) []bufmodule.ModuleReference {
+func testParseDependencyModuleReferences(t *testing.T, deps ...string) []bufmoduleref.ModuleReference {
 	moduleReferences, err := parseDependencyModuleReferences(deps...)
 	require.NoError(t, err)
 	return moduleReferences

--- a/private/bufpkg/bufmodule/bufmoduleprotoparse/bufmoduleprotoparse.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotoparse/bufmoduleprotoparse.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/jhump/protoreflect/desc/protoparse"
 )
@@ -37,7 +38,7 @@ type ParserAccessorHandler interface {
 	// IsImport returns true if the path is an import.
 	IsImport(path string) bool
 	// Returns nil if not available.
-	ModuleIdentity(path string) bufmodule.ModuleIdentity
+	ModuleIdentity(path string) bufmoduleref.ModuleIdentity
 	// Returns empty if not available.
 	Commit(path string) string
 }
@@ -79,7 +80,7 @@ func GetFileAnnotation(
 	parserAccessorHandler ParserAccessorHandler,
 	errorWithPos protoparse.ErrorWithPos,
 ) (bufanalysis.FileAnnotation, error) {
-	var fileInfo bufmodule.FileInfo
+	var fileInfo bufmoduleref.FileInfo
 	var startLine int
 	var startColumn int
 	var endLine int
@@ -102,7 +103,7 @@ func GetFileAnnotation(
 		if err != nil {
 			return nil, err
 		}
-		fileInfo, err = bufmodule.NewFileInfo(
+		fileInfo, err = bufmoduleref.NewFileInfo(
 			path,
 			parserAccessorHandler.ExternalPath(path),
 			parserAccessorHandler.IsImport(path),

--- a/private/bufpkg/bufmodule/bufmoduleprotoparse/path_resolver.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotoparse/path_resolver.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/data/datawkt"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
@@ -31,7 +32,7 @@ type parserAccessorHandler struct {
 	module               bufmodule.Module
 	pathToExternalPath   map[string]string
 	nonImportPaths       map[string]struct{}
-	pathToModuleIdentity map[string]bufmodule.ModuleIdentity
+	pathToModuleIdentity map[string]bufmoduleref.ModuleIdentity
 	pathToCommit         map[string]string
 	lock                 sync.RWMutex
 }
@@ -45,7 +46,7 @@ func newParserAccessorHandler(
 		module:               module,
 		pathToExternalPath:   make(map[string]string),
 		nonImportPaths:       make(map[string]struct{}),
-		pathToModuleIdentity: make(map[string]bufmodule.ModuleIdentity),
+		pathToModuleIdentity: make(map[string]bufmoduleref.ModuleIdentity),
 		pathToCommit:         make(map[string]string),
 	}
 }
@@ -105,7 +106,7 @@ func (p *parserAccessorHandler) IsImport(path string) bool {
 	return !isNotImport
 }
 
-func (p *parserAccessorHandler) ModuleIdentity(path string) bufmodule.ModuleIdentity {
+func (p *parserAccessorHandler) ModuleIdentity(path string) bufmoduleref.ModuleIdentity {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	return p.pathToModuleIdentity[path] // nil is a valid value.
@@ -121,7 +122,7 @@ func (p *parserAccessorHandler) addPath(
 	path string,
 	externalPath string,
 	isImport bool,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 ) error {
 	p.lock.Lock()

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -1,0 +1,467 @@
+package bufmoduleref
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bufbuild/buf/private/bufpkg/buflock"
+	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/storage"
+	"github.com/bufbuild/buf/private/pkg/uuidutil"
+)
+
+const (
+	// MainBranch is the name of the branch created for every repository.
+	// This is the default branch used if no branch or commit is specified.
+	MainBranch = "main"
+)
+
+// FileInfo contains module file info.
+type FileInfo interface {
+	// Path is the path of the file relative to the root it is contained within.
+	// This will be normalized, validated and never empty,
+	// This will be unique within a given Image.
+	Path() string
+	// ExternalPath returns the path that identifies this file externally.
+	//
+	// This will be unnormalized.
+	// Never empty. Falls back to Path if there is not an external path.
+	//
+	// Example:
+	//	 Assume we had the input path /foo/bar which is a local directory.
+
+	//   Path: one/one.proto
+	//   RootDirPath: proto
+	//   ExternalPath: /foo/bar/proto/one/one.proto
+	ExternalPath() string
+	// IsImport returns true if this file is an import.
+	IsImport() bool
+	// ModuleIdentity is the module that this file came from.
+	//
+	// Note this *can* be nil if we did not build from a named module.
+	// All code must assume this can be nil.
+	// Note that nil checking should work since the backing type is always a pointer.
+	ModuleIdentity() ModuleIdentity
+	// Commit is the commit for the module that this file came from.
+	//
+	// This will only be set if ModuleIdentity is set. but may not be set
+	// even if ModuleIdentity is set, that is commit is optional information
+	// even if we know what module this file came from.
+	Commit() string
+	// WithIsImport returns this FileInfo with the given IsImport value.
+	WithIsImport(isImport bool) FileInfo
+
+	isFileInfo()
+}
+
+// NewFileInfo returns a new FileInfo.
+//
+// TODO: we should make moduleIdentity and commit options.
+// TODO: we don't validate commit
+func NewFileInfo(
+	path string,
+	externalPath string,
+	isImport bool,
+	moduleIdentity ModuleIdentity,
+	commit string,
+) (FileInfo, error) {
+	return newFileInfo(
+		path,
+		externalPath,
+		isImport,
+		moduleIdentity,
+		commit,
+	)
+}
+
+// ModuleOwner is a module owner.
+//
+// It just contains remote, owner.
+//
+// This is shared by ModuleIdentity.
+type ModuleOwner interface {
+	Remote() string
+	Owner() string
+
+	isModuleOwner()
+}
+
+// NewModuleOwner returns a new ModuleOwner.
+func NewModuleOwner(
+	remote string,
+	owner string,
+) (ModuleOwner, error) {
+	return newModuleOwner(remote, owner)
+}
+
+// ModuleOwnerForString returns a new ModuleOwner for the given string.
+//
+// This parses the path in the form remote/owner.
+func ModuleOwnerForString(path string) (ModuleOwner, error) {
+	slashSplit := strings.Split(path, "/")
+	if len(slashSplit) != 2 {
+		return nil, newInvalidModuleOwnerStringError(path)
+	}
+	remote := strings.TrimSpace(slashSplit[0])
+	if remote == "" {
+		return nil, newInvalidModuleIdentityStringError(path)
+	}
+	owner := strings.TrimSpace(slashSplit[1])
+	if owner == "" {
+		return nil, newInvalidModuleIdentityStringError(path)
+	}
+	return NewModuleOwner(remote, owner)
+}
+
+// ModuleIdentity is a module identity.
+//
+// It just contains remote, owner, repository.
+//
+// This is shared by ModuleReference and ModulePin.
+type ModuleIdentity interface {
+	ModuleOwner
+
+	Repository() string
+
+	// IdentityString is the string remote/owner/repository.
+	IdentityString() string
+
+	isModuleIdentity()
+}
+
+// NewModuleIdentity returns a new ModuleIdentity.
+func NewModuleIdentity(
+	remote string,
+	owner string,
+	repository string,
+) (ModuleIdentity, error) {
+	return newModuleIdentity(remote, owner, repository)
+}
+
+// ModuleIdentityForString returns a new ModuleIdentity for the given string.
+//
+// This parses the path in the form remote/owner/repository
+//
+// TODO: we may want to add a special error if we detect / or @ as this may be a common mistake.
+func ModuleIdentityForString(path string) (ModuleIdentity, error) {
+	remote, owner, repository, err := parseModuleIdentityComponents(path)
+	if err != nil {
+		return nil, err
+	}
+	return NewModuleIdentity(remote, owner, repository)
+}
+
+// ModuleReference is a module reference.
+//
+// It references either a branch, tag, or a commit.
+// Note that since commits belong to branches, we can deduce
+// the branch from the commit when resolving.
+type ModuleReference interface {
+	ModuleIdentity
+
+	// Prints either remote/owner/repository:{branch,commit}
+	// If the reference is equal to MainBranch, prints remote/owner/repository.
+	fmt.Stringer
+
+	// Either branch, tag, or commit
+	Reference() string
+
+	isModuleReference()
+}
+
+// NewModuleReference returns a new validated ModuleReference.
+func NewModuleReference(
+	remote string,
+	owner string,
+	repository string,
+	reference string,
+) (ModuleReference, error) {
+	return newModuleReference(remote, owner, repository, reference)
+}
+
+// NewModuleReferenceForProto returns a new ModuleReference for the given proto ModuleReference.
+func NewModuleReferenceForProto(protoModuleReference *modulev1alpha1.ModuleReference) (ModuleReference, error) {
+	return newModuleReferenceForProto(protoModuleReference)
+}
+
+// NewModuleReferencesForProtos maps the Protobuf equivalent into the internal representation.
+func NewModuleReferencesForProtos(protoModuleReferences ...*modulev1alpha1.ModuleReference) ([]ModuleReference, error) {
+	if len(protoModuleReferences) == 0 {
+		return nil, nil
+	}
+	moduleReferences := make([]ModuleReference, len(protoModuleReferences))
+	for i, protoModuleReference := range protoModuleReferences {
+		moduleReference, err := NewModuleReferenceForProto(protoModuleReference)
+		if err != nil {
+			return nil, err
+		}
+		moduleReferences[i] = moduleReference
+	}
+	return moduleReferences, nil
+}
+
+// NewProtoModuleReferenceForModuleReference returns a new proto ModuleReference for the given ModuleReference.
+func NewProtoModuleReferenceForModuleReference(moduleReference ModuleReference) *modulev1alpha1.ModuleReference {
+	return newProtoModuleReferenceForModuleReference(moduleReference)
+}
+
+// NewProtoModuleReferencesForModuleReferences maps the given module references into the protobuf representation.
+func NewProtoModuleReferencesForModuleReferences(moduleReferences ...ModuleReference) []*modulev1alpha1.ModuleReference {
+	if len(moduleReferences) == 0 {
+		return nil
+	}
+	protoModuleReferences := make([]*modulev1alpha1.ModuleReference, len(moduleReferences))
+	for i, moduleReference := range moduleReferences {
+		protoModuleReferences[i] = NewProtoModuleReferenceForModuleReference(moduleReference)
+	}
+	return protoModuleReferences
+}
+
+// ModuleReferenceForString returns a new ModuleReference for the given string.
+// If a branch or commit is not provided, the "main" branch is used.
+//
+// This parses the path in the form remote/owner/repository{:branch,:commit}.
+func ModuleReferenceForString(path string) (ModuleReference, error) {
+	remote, owner, repository, reference, err := parseModuleReferenceComponents(path)
+	if err != nil {
+		return nil, err
+	}
+	if reference == "" {
+		// Default to the main branch if a ':' separator was not specified.
+		reference = MainBranch
+	}
+	return NewModuleReference(remote, owner, repository, reference)
+}
+
+// IsCommitModuleReference returns true if the ModuleReference references a commit.
+//
+// If false, this means the ModuleReference references a branch or tag.
+// Branch and tag disambiguation needs to be done server-side.
+func IsCommitModuleReference(moduleReference ModuleReference) bool {
+	return IsCommitReference(moduleReference.Reference())
+}
+
+// IsCommitReference returns whether the provided reference is a commit.
+func IsCommitReference(reference string) bool {
+	_, err := uuidutil.FromDashless(reference)
+	return err == nil
+}
+
+// ModulePin is a module pin.
+//
+// It references a specific point in time of a Module.
+//
+// Note that a commit does this itself, but we want all this information.
+// This is what is stored in a buf.lock file.
+type ModulePin interface {
+	ModuleIdentity
+
+	// Prints remote/owner/repository:commit, which matches ModuleReference
+	fmt.Stringer
+
+	// all of these will be set
+	Branch() string
+	Commit() string
+	Digest() string
+	CreateTime() time.Time
+
+	isModulePin()
+}
+
+// NewModulePin returns a new validated ModulePin.
+func NewModulePin(
+	remote string,
+	owner string,
+	repository string,
+	branch string,
+	commit string,
+	digest string,
+	createTime time.Time,
+) (ModulePin, error) {
+	return newModulePin(remote, owner, repository, branch, commit, digest, createTime)
+}
+
+// NewModulePinForProto returns a new ModulePin for the given proto ModulePin.
+func NewModulePinForProto(protoModulePin *modulev1alpha1.ModulePin) (ModulePin, error) {
+	return newModulePinForProto(protoModulePin)
+}
+
+// NewModulePinsForProtos maps the Protobuf equivalent into the internal representation.
+func NewModulePinsForProtos(protoModulePins ...*modulev1alpha1.ModulePin) ([]ModulePin, error) {
+	if len(protoModulePins) == 0 {
+		return nil, nil
+	}
+	modulePins := make([]ModulePin, len(protoModulePins))
+	for i, protoModulePin := range protoModulePins {
+		modulePin, err := NewModulePinForProto(protoModulePin)
+		if err != nil {
+			return nil, err
+		}
+		modulePins[i] = modulePin
+	}
+	return modulePins, nil
+}
+
+// NewProtoModulePinForModulePin returns a new proto ModulePin for the given ModulePin.
+func NewProtoModulePinForModulePin(modulePin ModulePin) *modulev1alpha1.ModulePin {
+	return newProtoModulePinForModulePin(modulePin)
+}
+
+// NewProtoModulePinsForModulePins maps the given module pins into the protobuf representation.
+func NewProtoModulePinsForModulePins(modulePins ...ModulePin) []*modulev1alpha1.ModulePin {
+	if len(modulePins) == 0 {
+		return nil
+	}
+	protoModulePins := make([]*modulev1alpha1.ModulePin, len(modulePins))
+	for i, modulePin := range modulePins {
+		protoModulePins[i] = NewProtoModulePinForModulePin(modulePin)
+	}
+	return protoModulePins
+}
+
+// ValidateModuleReferencesUniqueByIdentity returns an error if the module references contain any duplicates.
+//
+// This only checks remote, owner, repository.
+func ValidateModuleReferencesUniqueByIdentity(moduleReferences []ModuleReference) error {
+	seenModuleReferences := make(map[string]struct{})
+	for _, moduleReference := range moduleReferences {
+		moduleIdentityString := moduleReference.IdentityString()
+		if _, ok := seenModuleReferences[moduleIdentityString]; ok {
+			return fmt.Errorf("module %s appeared twice", moduleIdentityString)
+		}
+		seenModuleReferences[moduleIdentityString] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateModulePinsUniqueByIdentity returns an error if the module pins contain any duplicates.
+//
+// This only checks remote, owner, repository.
+func ValidateModulePinsUniqueByIdentity(modulePins []ModulePin) error {
+	seenModulePins := make(map[string]struct{})
+	for _, modulePin := range modulePins {
+		moduleIdentityString := modulePin.IdentityString()
+		if _, ok := seenModulePins[moduleIdentityString]; ok {
+			return fmt.Errorf("module %s appeared twice", moduleIdentityString)
+		}
+		seenModulePins[moduleIdentityString] = struct{}{}
+	}
+	return nil
+}
+
+// ModuleReferenceEqual returns true if a equals b.
+func ModuleReferenceEqual(a ModuleReference, b ModuleReference) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return a.Remote() == b.Remote() &&
+		a.Owner() == b.Owner() &&
+		a.Repository() == b.Repository() &&
+		a.Reference() == b.Reference()
+}
+
+// ModulePinEqual returns true if a equals b.
+func ModulePinEqual(a ModulePin, b ModulePin) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return a.Remote() == b.Remote() &&
+		a.Owner() == b.Owner() &&
+		a.Repository() == b.Repository() &&
+		a.Branch() == b.Branch() &&
+		a.Commit() == b.Commit() &&
+		a.Digest() == b.Digest() &&
+		a.CreateTime().Equal(b.CreateTime())
+}
+
+// DependencyModulePinsForBucket reads the module dependencies from the lock file in the bucket.
+func DependencyModulePinsForBucket(
+	ctx context.Context,
+	readBucket storage.ReadBucket,
+) ([]ModulePin, error) {
+	lockFile, err := buflock.ReadConfig(ctx, readBucket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read lock file: %w", err)
+	}
+	modulePins := make([]ModulePin, 0, len(lockFile.Dependencies))
+	for _, dep := range lockFile.Dependencies {
+		modulePin, err := NewModulePin(
+			dep.Remote,
+			dep.Owner,
+			dep.Repository,
+			dep.Branch,
+			dep.Commit,
+			dep.Digest,
+			dep.CreateTime,
+		)
+		if err != nil {
+			return nil, err
+		}
+		modulePins = append(modulePins, modulePin)
+	}
+	// just to be safe
+	SortModulePins(modulePins)
+	if err := ValidateModulePinsUniqueByIdentity(modulePins); err != nil {
+		return nil, err
+	}
+	return modulePins, nil
+}
+
+// PutDependencyModulePinsToBucket writes the module dependencies to the write bucket in the form of a lock file.
+func PutDependencyModulePinsToBucket(
+	ctx context.Context,
+	writeBucket storage.WriteBucket,
+	modulePins []ModulePin,
+) error {
+	if err := ValidateModulePinsUniqueByIdentity(modulePins); err != nil {
+		return err
+	}
+	SortModulePins(modulePins)
+	lockFile := &buflock.Config{
+		Dependencies: make([]buflock.Dependency, 0, len(modulePins)),
+	}
+	for _, pin := range modulePins {
+		lockFile.Dependencies = append(
+			lockFile.Dependencies,
+			buflock.Dependency{
+				Remote:     pin.Remote(),
+				Owner:      pin.Owner(),
+				Repository: pin.Repository(),
+				Branch:     pin.Branch(),
+				Commit:     pin.Commit(),
+				Digest:     pin.Digest(),
+				CreateTime: pin.CreateTime(),
+			},
+		)
+	}
+	return buflock.WriteConfig(ctx, writeBucket, lockFile)
+}
+
+// SortFileInfos sorts the FileInfos.
+func SortFileInfos(fileInfos []FileInfo) {
+	if len(fileInfos) == 0 {
+		return
+	}
+	sort.Slice(
+		fileInfos,
+		func(i int, j int) bool {
+			return fileInfos[i].Path() < fileInfos[j].Path()
+		},
+	)
+}
+
+// SortModulePins sorts the ModulePins.
+func SortModulePins(modulePins []ModulePin) {
+	sort.Slice(modulePins, func(i, j int) bool {
+		return modulePinLess(modulePins[i], modulePins[j])
+	})
+}

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bufmoduleref
 
 import (

--- a/private/bufpkg/bufmodule/bufmoduleref/file_info.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/file_info.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 import (
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"

--- a/private/bufpkg/bufmodule/bufmoduleref/module_identity.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_identity.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 type moduleIdentity struct {
 	remote     string

--- a/private/bufpkg/bufmodule/bufmoduleref/module_owner.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_owner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 type moduleOwner struct {
 	remote string

--- a/private/bufpkg/bufmodule/bufmoduleref/module_owner_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_owner_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 import (
 	"testing"

--- a/private/bufpkg/bufmodule/bufmoduleref/module_pin.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_pin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 import (
 	"time"

--- a/private/bufpkg/bufmodule/bufmoduleref/module_reference.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_reference.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 import (
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"

--- a/private/bufpkg/bufmodule/bufmoduleref/module_reference_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_reference_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmoduleref
 
 import (
 	"testing"

--- a/private/bufpkg/bufmodule/bufmoduleref/usage.gen.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package bufmoduleref
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/bufpkg/bufmodule/bufmoduleref/util.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/util.go
@@ -1,0 +1,136 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufmoduleref
+
+import (
+	"fmt"
+	"strings"
+)
+
+// parseModuleReferenceComponents parses and returns the remote, owner, repository,
+// and ref (branch or commit) from the given path.
+func parseModuleReferenceComponents(path string) (remote string, owner string, repository string, ref string, err error) {
+	remote, owner, rest, err := parseModuleIdentityComponents(path)
+	if err != nil {
+		return "", "", "", "", newInvalidModuleReferenceStringError(path)
+	}
+	restSplit := strings.Split(rest, ":")
+	repository = strings.TrimSpace(restSplit[0])
+	if len(restSplit) == 1 {
+		return remote, owner, repository, "", nil
+	}
+	if len(restSplit) == 2 {
+		ref := strings.TrimSpace(restSplit[1])
+		if ref == "" {
+			return "", "", "", "", newInvalidModuleReferenceStringError(path)
+		}
+		return remote, owner, repository, ref, nil
+	}
+	return "", "", "", "", newInvalidModuleReferenceStringError(path)
+}
+
+func parseModuleIdentityComponents(path string) (remote string, owner string, repository string, err error) {
+	slashSplit := strings.Split(path, "/")
+	if len(slashSplit) != 3 {
+		return "", "", "", newInvalidModuleIdentityStringError(path)
+	}
+	remote = strings.TrimSpace(slashSplit[0])
+	if remote == "" {
+		return "", "", "", newInvalidModuleIdentityStringError(path)
+	}
+	owner = strings.TrimSpace(slashSplit[1])
+	if owner == "" {
+		return "", "", "", newInvalidModuleIdentityStringError(path)
+	}
+	repository = strings.TrimSpace(slashSplit[2])
+	if repository == "" {
+		return "", "", "", newInvalidModuleIdentityStringError(path)
+	}
+	return remote, owner, repository, nil
+}
+
+func modulePinLess(a ModulePin, b ModulePin) bool {
+	return modulePinCompareTo(a, b) < 0
+}
+
+// return -1 if less
+// return 1 if greater
+// return 0 if equal
+func modulePinCompareTo(a ModulePin, b ModulePin) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil && b != nil {
+		return -1
+	}
+	if a != nil && b == nil {
+		return 1
+	}
+	if a.Remote() < b.Remote() {
+		return -1
+	}
+	if a.Remote() > b.Remote() {
+		return 1
+	}
+	if a.Owner() < b.Owner() {
+		return -1
+	}
+	if a.Owner() > b.Owner() {
+		return 1
+	}
+	if a.Repository() < b.Repository() {
+		return -1
+	}
+	if a.Repository() > b.Repository() {
+		return 1
+	}
+	if a.Branch() < b.Branch() {
+		return -1
+	}
+	if a.Branch() > b.Branch() {
+		return 1
+	}
+	if a.Commit() < b.Commit() {
+		return -1
+	}
+	if a.Commit() > b.Commit() {
+		return 1
+	}
+	if a.Digest() < b.Digest() {
+		return -1
+	}
+	if a.Digest() > b.Digest() {
+		return 1
+	}
+	if a.CreateTime().Before(b.CreateTime()) {
+		return -1
+	}
+	if a.CreateTime().After(b.CreateTime()) {
+		return 1
+	}
+	return 0
+}
+
+func newInvalidModuleOwnerStringError(s string) error {
+	return fmt.Errorf("module owner %q is invalid: must be in the form remote/owner", s)
+}
+
+func newInvalidModuleIdentityStringError(s string) error {
+	return fmt.Errorf("module identity %q is invalid: must be in the form remote/owner/repository", s)
+}
+
+func newInvalidModuleReferenceStringError(s string) error {
+	return fmt.Errorf("module reference %q is invalid: must be in the form remote/owner/repository:branch or remote/owner/repository:commit", s)
+}

--- a/private/bufpkg/bufmodule/bufmoduleref/validate.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/validate.go
@@ -1,0 +1,232 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufmoduleref
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/netextended"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ValidateProtoModuleReference verifies the given module reference is well-formed.
+// It performs client-side validation only, and is limited to fields
+// we do not think will change in the future.
+func ValidateProtoModuleReference(protoModuleReference *modulev1alpha1.ModuleReference) error {
+	if protoModuleReference == nil {
+		return errors.New("module reference is required")
+	}
+	if err := validateRemote(protoModuleReference.Remote); err != nil {
+		return err
+	}
+	if err := ValidateOwner(protoModuleReference.Owner, "owner"); err != nil {
+		return err
+	}
+	if err := ValidateRepository(protoModuleReference.Repository); err != nil {
+		return err
+	}
+	return ValidateReference(protoModuleReference.Reference)
+}
+
+// ValidateProtoModulePin verifies the given module pin is well-formed.
+// It performs client-side validation only, and is limited to fields
+// we do not think will change in the future.
+func ValidateProtoModulePin(protoModulePin *modulev1alpha1.ModulePin) error {
+	if protoModulePin == nil {
+		return errors.New("module pin is required")
+	}
+	if err := validateRemote(protoModulePin.Remote); err != nil {
+		return err
+	}
+	if err := ValidateOwner(protoModulePin.Owner, "owner"); err != nil {
+		return err
+	}
+	if err := ValidateRepository(protoModulePin.Repository); err != nil {
+		return err
+	}
+	if err := ValidateBranch(protoModulePin.Branch); err != nil {
+		return err
+	}
+	if err := ValidateCommit(protoModulePin.Commit); err != nil {
+		return err
+	}
+	if err := validateDigest(protoModulePin.Digest); err != nil {
+		return err
+	}
+	if err := validateCreateTime(protoModulePin.CreateTime); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateUser verifies the given user name is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateUser(user string) error {
+	return ValidateOwner(user, "user")
+}
+
+// ValidateOrganization verifies the given organization name is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateOrganization(organization string) error {
+	return ValidateOwner(organization, "organization")
+}
+
+// ValidateOwner verifies the given owner name is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateOwner(owner string, ownerType string) error {
+	if owner == "" {
+		return fmt.Errorf("%s name is required", ownerType)
+	}
+	return nil
+}
+
+// ValidateRepository verifies the given repository name is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateRepository(repository string) error {
+	if repository == "" {
+		return errors.New("repository name is required")
+	}
+	return nil
+}
+
+// ValidateReference validates that the given ModuleReference reference is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateReference(reference string) error {
+	if reference == "" {
+		return errors.New("repository reference is required")
+	}
+	return nil
+}
+
+// ValidateCommit verifies the given commit is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateCommit(commit string) error {
+	if commit == "" {
+		return errors.New("empty commit")
+	}
+	return nil
+}
+
+// ValidateBranch verifies the given repository branch is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateBranch(branch string) error {
+	if branch != MainBranch {
+		return fmt.Errorf("branch is not %s", MainBranch)
+	}
+	//if branch == "" {
+	//	return errors.New("repository branch is required")
+	//}
+	return nil
+}
+
+// ValidateTag verifies the given tag is well-formed.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateTag(tag string) error {
+	if tag == "" {
+		return errors.New("repository tag is required")
+	}
+	return nil
+}
+
+// ValidateModuleFilePath validates that the module file path is not empty.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func ValidateModuleFilePath(path string) error {
+	if path == "" {
+		return errors.New("empty path")
+	}
+	return nil
+}
+
+// validateDigest verifies the given digest's prefix,
+// decodes its base64 representation and checks the
+// length of the encoded bytes.
+// It performs client-side validation only, and is limited to properties
+// we do not think will change in the future.
+func validateDigest(digest string) error {
+	if digest == "" {
+		return errors.New("empty digest")
+	}
+	split := strings.SplitN(digest, "-", 2)
+	if len(split) != 2 {
+		return fmt.Errorf("invalid digest: %s", digest)
+	}
+	digestPrefix := split[0]
+	digestValue := split[1]
+	if digestPrefix == "" {
+		return fmt.Errorf("empty digest prefix for %s", digest)
+	}
+	if digestValue == "" {
+		return fmt.Errorf("empty digest value for %s", digest)
+	}
+	return nil
+}
+
+func validateModuleOwner(moduleOwner ModuleOwner) error {
+	if moduleOwner == nil {
+		return errors.New("module owner is required")
+	}
+	if err := validateRemote(moduleOwner.Remote()); err != nil {
+		return err
+	}
+	if err := ValidateOwner(moduleOwner.Owner(), "owner"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateModuleIdentity(moduleIdentity ModuleIdentity) error {
+	if moduleIdentity == nil {
+		return errors.New("module identity is required")
+	}
+	if err := validateRemote(moduleIdentity.Remote()); err != nil {
+		return err
+	}
+	if err := ValidateOwner(moduleIdentity.Owner(), "owner"); err != nil {
+		return err
+	}
+	if err := ValidateRepository(moduleIdentity.Repository()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateRemote(remote string) error {
+	if _, err := netextended.ValidateHostname(remote); err != nil {
+		return fmt.Errorf("invalid remote %q: %w", remote, err)
+	}
+	return nil
+}
+
+func validateCreateTime(createTime *timestamppb.Timestamp) error {
+	if createTime == nil {
+		return errors.New("create_time is required")
+	}
+	if createTime.Seconds == 0 && createTime.Nanos == 0 {
+		return errors.New("create_time must not be 0")
+	}
+	return createTime.CheckValid()
+}

--- a/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_unix.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_unix.go
@@ -23,7 +23,7 @@ package bufmoduletesting
 import (
 	"testing"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,10 +33,10 @@ func NewFileInfo(
 	path string,
 	externalPath string,
 	isImport bool,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
-) bufmodule.FileInfo {
-	fileInfo, err := bufmodule.NewFileInfo(
+) bufmoduleref.FileInfo {
+	fileInfo, err := bufmoduleref.NewFileInfo(
 		path,
 		externalPath,
 		isImport,

--- a/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_windows.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_windows.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,10 +31,10 @@ func NewFileInfo(
 	path string,
 	externalPath string,
 	isImport bool,
-	moduleIdentity bufmodule.ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
-) bufmodule.FileInfo {
-	fileInfo, err := bufmodule.NewFileInfo(
+) bufmoduleref.FileInfo {
+	fileInfo, err := bufmoduleref.NewFileInfo(
 		path,
 		filepath.Clean(filepath.FromSlash(externalPath)),
 		isImport,

--- a/private/bufpkg/bufmodule/module_file.go
+++ b/private/bufpkg/bufmodule/module_file.go
@@ -16,16 +16,18 @@ package bufmodule
 
 import (
 	"io"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 )
 
 var _ ModuleFile = &moduleFile{}
 
 type moduleFile struct {
-	FileInfo
+	bufmoduleref.FileInfo
 	io.ReadCloser
 }
 
-func newModuleFile(fileInfo FileInfo, readCloser io.ReadCloser) moduleFile {
+func newModuleFile(fileInfo bufmoduleref.FileInfo, readCloser io.ReadCloser) moduleFile {
 	return moduleFile{
 		FileInfo:   fileInfo,
 		ReadCloser: readCloser,

--- a/private/bufpkg/bufmodule/module_object_info.go
+++ b/private/bufpkg/bufmodule/module_object_info.go
@@ -14,19 +14,22 @@
 
 package bufmodule
 
-import "github.com/bufbuild/buf/private/pkg/storage"
+import (
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/pkg/storage"
+)
 
 // moduleObjectInfo is used in moduleReadBucket.
 type moduleObjectInfo struct {
 	storage.ObjectInfo
 
-	moduleIdentity ModuleIdentity
+	moduleIdentity bufmoduleref.ModuleIdentity
 	commit         string
 }
 
 func newModuleObjectInfo(
 	storageObjectInfo storage.ObjectInfo,
-	moduleIdentity ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 ) *moduleObjectInfo {
 	return &moduleObjectInfo{
@@ -36,7 +39,7 @@ func newModuleObjectInfo(
 	}
 }
 
-func (o *moduleObjectInfo) ModuleIdentity() ModuleIdentity {
+func (o *moduleObjectInfo) ModuleIdentity() bufmoduleref.ModuleIdentity {
 	return o.moduleIdentity
 }
 

--- a/private/bufpkg/bufmodule/nop_module_reader.go
+++ b/private/bufpkg/bufmodule/nop_module_reader.go
@@ -17,6 +17,7 @@ package bufmodule
 import (
 	"context"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
@@ -26,6 +27,6 @@ func newNopModuleReader() *nopModuleReader {
 	return &nopModuleReader{}
 }
 
-func (*nopModuleReader) GetModule(_ context.Context, modulePin ModulePin) (Module, error) {
+func (*nopModuleReader) GetModule(_ context.Context, modulePin bufmoduleref.ModulePin) (Module, error) {
 	return nil, storage.NewErrNotExist(modulePin.String())
 }

--- a/private/bufpkg/bufmodule/nop_module_resolver.go
+++ b/private/bufpkg/bufmodule/nop_module_resolver.go
@@ -17,6 +17,7 @@ package bufmodule
 import (
 	"context"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
@@ -26,6 +27,6 @@ func newNopModuleResolver() *nopModuleResolver {
 	return &nopModuleResolver{}
 }
 
-func (*nopModuleResolver) GetModulePin(_ context.Context, moduleReference ModuleReference) (ModulePin, error) {
+func (*nopModuleResolver) GetModulePin(_ context.Context, moduleReference bufmoduleref.ModuleReference) (bufmoduleref.ModulePin, error) {
 	return nil, storage.NewErrNotExist(moduleReference.String())
 }

--- a/private/bufpkg/bufmodule/single_module_read_bucket.go
+++ b/private/bufpkg/bufmodule/single_module_read_bucket.go
@@ -17,19 +17,20 @@ package bufmodule
 import (
 	"context"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 type singleModuleReadBucket struct {
 	storage.ReadBucket
 
-	moduleIdentity ModuleIdentity
+	moduleIdentity bufmoduleref.ModuleIdentity
 	commit         string
 }
 
 func newSingleModuleReadBucket(
 	sourceReadBucket storage.ReadBucket,
-	moduleIdentity ModuleIdentity,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 ) *singleModuleReadBucket {
 	return &singleModuleReadBucket{

--- a/private/bufpkg/bufmodule/targeting_module.go
+++ b/private/bufpkg/bufmodule/targeting_module.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
@@ -44,10 +45,10 @@ func newTargetingModule(
 	}, nil
 }
 
-func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []FileInfo, retErr error) {
+func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufmoduleref.FileInfo, retErr error) {
 	defer func() {
 		if retErr == nil {
-			sortFileInfos(fileInfos)
+			bufmoduleref.SortFileInfos(fileInfos)
 		}
 	}()
 	sourceReadBucket := m.getSourceReadBucket()
@@ -76,7 +77,7 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []File
 				// add to the nonImportImageFiles if does not already exist
 				if _, ok := fileInfoPaths[targetPath]; !ok {
 					fileInfoPaths[targetPath] = struct{}{}
-					fileInfo, err := NewFileInfo(
+					fileInfo, err := bufmoduleref.NewFileInfo(
 						objectInfo.Path(),
 						objectInfo.ExternalPath(),
 						false,
@@ -126,7 +127,7 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []File
 				// then, add the file if it is not added
 				if _, ok := fileInfoPaths[path]; !ok {
 					fileInfoPaths[path] = struct{}{}
-					fileInfo, err := NewFileInfo(
+					fileInfo, err := bufmoduleref.NewFileInfo(
 						objectInfo.Path(),
 						objectInfo.ExternalPath(),
 						false,

--- a/private/bufpkg/bufmodule/targeting_module_test.go
+++ b/private/bufpkg/bufmodule/targeting_module_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "a/a.proto", "a/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "a/b.proto", "a/b.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
@@ -87,7 +88,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
 		},
@@ -105,7 +106,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
 		},
@@ -124,7 +125,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
 		},
@@ -143,7 +144,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "a/a.proto", "a/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "a/b.proto", "a/b.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
@@ -177,7 +178,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
 		},
@@ -196,7 +197,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
 			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", false, nil, ""),
@@ -216,7 +217,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(
 		t,
-		[]bufmodule.FileInfo{
+		[]bufmoduleref.FileInfo{
 			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", false, nil, ""),
 		},
 		targetFileInfos,

--- a/private/bufpkg/bufmodule/util.go
+++ b/private/bufpkg/bufmodule/util.go
@@ -16,185 +16,14 @@ package bufmodule
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sort"
-	"strings"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
 )
-
-// sortFileInfos sorts the FileInfos.
-func sortFileInfos(fileInfos []FileInfo) {
-	if len(fileInfos) == 0 {
-		return
-	}
-	sort.Slice(
-		fileInfos,
-		func(i int, j int) bool {
-			return fileInfos[i].Path() < fileInfos[j].Path()
-		},
-	)
-}
-
-// parseModuleReferenceComponents parses and returns the remote, owner, repository,
-// and ref (branch or commit) from the given path.
-func parseModuleReferenceComponents(path string) (remote string, owner string, repository string, ref string, err error) {
-	remote, owner, rest, err := parseModuleIdentityComponents(path)
-	if err != nil {
-		return "", "", "", "", newInvalidModuleReferenceStringError(path)
-	}
-	restSplit := strings.Split(rest, ":")
-	repository = strings.TrimSpace(restSplit[0])
-	if len(restSplit) == 1 {
-		return remote, owner, repository, "", nil
-	}
-	if len(restSplit) == 2 {
-		ref := strings.TrimSpace(restSplit[1])
-		if ref == "" {
-			return "", "", "", "", newInvalidModuleReferenceStringError(path)
-		}
-		return remote, owner, repository, ref, nil
-	}
-	return "", "", "", "", newInvalidModuleReferenceStringError(path)
-}
-
-func parseModuleIdentityComponents(path string) (remote string, owner string, repository string, err error) {
-	slashSplit := strings.Split(path, "/")
-	if len(slashSplit) != 3 {
-		return "", "", "", newInvalidModuleIdentityStringError(path)
-	}
-	remote = strings.TrimSpace(slashSplit[0])
-	if remote == "" {
-		return "", "", "", newInvalidModuleIdentityStringError(path)
-	}
-	owner = strings.TrimSpace(slashSplit[1])
-	if owner == "" {
-		return "", "", "", newInvalidModuleIdentityStringError(path)
-	}
-	repository = strings.TrimSpace(slashSplit[2])
-	if repository == "" {
-		return "", "", "", newInvalidModuleIdentityStringError(path)
-	}
-	return remote, owner, repository, nil
-}
-
-func modulePinLess(a ModulePin, b ModulePin) bool {
-	return modulePinCompareTo(a, b) < 0
-}
-
-// return -1 if less
-// return 1 if greater
-// return 0 if equal
-func modulePinCompareTo(a ModulePin, b ModulePin) int {
-	if a == nil && b == nil {
-		return 0
-	}
-	if a == nil && b != nil {
-		return -1
-	}
-	if a != nil && b == nil {
-		return 1
-	}
-	if a.Remote() < b.Remote() {
-		return -1
-	}
-	if a.Remote() > b.Remote() {
-		return 1
-	}
-	if a.Owner() < b.Owner() {
-		return -1
-	}
-	if a.Owner() > b.Owner() {
-		return 1
-	}
-	if a.Repository() < b.Repository() {
-		return -1
-	}
-	if a.Repository() > b.Repository() {
-		return 1
-	}
-	if a.Branch() < b.Branch() {
-		return -1
-	}
-	if a.Branch() > b.Branch() {
-		return 1
-	}
-	if a.Commit() < b.Commit() {
-		return -1
-	}
-	if a.Commit() > b.Commit() {
-		return 1
-	}
-	if a.Digest() < b.Digest() {
-		return -1
-	}
-	if a.Digest() > b.Digest() {
-		return 1
-	}
-	if a.CreateTime().Before(b.CreateTime()) {
-		return -1
-	}
-	if a.CreateTime().After(b.CreateTime()) {
-		return 1
-	}
-	return 0
-}
-
-func copyModulePinsSortedByOnlyCommit(modulePins []ModulePin) []ModulePin {
-	s := make([]ModulePin, len(modulePins))
-	copy(s, modulePins)
-	sort.Slice(s, func(i, j int) bool {
-		return modulePinLessOnlyCommit(s[i], s[j])
-	})
-	return s
-}
-
-func modulePinLessOnlyCommit(a ModulePin, b ModulePin) bool {
-	return modulePinCompareToOnlyCommit(a, b) < 0
-}
-
-// return -1 if less
-// return 1 if greater
-// return 0 if equal
-func modulePinCompareToOnlyCommit(a ModulePin, b ModulePin) int {
-	if a == nil && b == nil {
-		return 0
-	}
-	if a == nil && b != nil {
-		return -1
-	}
-	if a != nil && b == nil {
-		return 1
-	}
-	if a.Remote() < b.Remote() {
-		return -1
-	}
-	if a.Remote() > b.Remote() {
-		return 1
-	}
-	if a.Owner() < b.Owner() {
-		return -1
-	}
-	if a.Owner() > b.Owner() {
-		return 1
-	}
-	if a.Repository() < b.Repository() {
-		return -1
-	}
-	if a.Repository() > b.Repository() {
-		return 1
-	}
-	if a.Commit() < b.Commit() {
-		return -1
-	}
-	if a.Commit() > b.Commit() {
-		return 1
-	}
-	return 0
-}
 
 func putModuleFileToBucket(ctx context.Context, module Module, path string, writeBucket storage.WriteBucket) (retErr error) {
 	moduleFile, err := module.GetModuleFile(ctx, path)
@@ -243,14 +72,55 @@ func getDocumentationForBucket(
 	return string(documentationData), nil
 }
 
-func newInvalidModuleOwnerStringError(s string) error {
-	return fmt.Errorf("module owner %q is invalid: must be in the form remote/owner", s)
+func copyModulePinsSortedByOnlyCommit(modulePins []bufmoduleref.ModulePin) []bufmoduleref.ModulePin {
+	s := make([]bufmoduleref.ModulePin, len(modulePins))
+	copy(s, modulePins)
+	sort.Slice(s, func(i, j int) bool {
+		return modulePinLessOnlyCommit(s[i], s[j])
+	})
+	return s
 }
 
-func newInvalidModuleIdentityStringError(s string) error {
-	return fmt.Errorf("module identity %q is invalid: must be in the form remote/owner/repository", s)
+func modulePinLessOnlyCommit(a bufmoduleref.ModulePin, b bufmoduleref.ModulePin) bool {
+	return modulePinCompareToOnlyCommit(a, b) < 0
 }
 
-func newInvalidModuleReferenceStringError(s string) error {
-	return fmt.Errorf("module reference %q is invalid: must be in the form remote/owner/repository:branch or remote/owner/repository:commit", s)
+// return -1 if less
+// return 1 if greater
+// return 0 if equal
+func modulePinCompareToOnlyCommit(a bufmoduleref.ModulePin, b bufmoduleref.ModulePin) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil && b != nil {
+		return -1
+	}
+	if a != nil && b == nil {
+		return 1
+	}
+	if a.Remote() < b.Remote() {
+		return -1
+	}
+	if a.Remote() > b.Remote() {
+		return 1
+	}
+	if a.Owner() < b.Owner() {
+		return -1
+	}
+	if a.Owner() > b.Owner() {
+		return 1
+	}
+	if a.Repository() < b.Repository() {
+		return -1
+	}
+	if a.Repository() > b.Repository() {
+		return 1
+	}
+	if a.Commit() < b.Commit() {
+		return -1
+	}
+	if a.Commit() > b.Commit() {
+		return 1
+	}
+	return 0
 }

--- a/private/bufpkg/bufmodule/validate.go
+++ b/private/bufpkg/bufmodule/validate.go
@@ -15,14 +15,11 @@
 package bufmodule
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"strings"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
-	"github.com/bufbuild/buf/private/pkg/netextended"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -47,7 +44,7 @@ func ValidateProtoModule(protoModule *modulev1alpha1.Module) error {
 	totalContentLength := 0
 	filePathMap := make(map[string]struct{}, len(protoModule.Files))
 	for _, protoModuleFile := range protoModule.Files {
-		if err := ValidateModuleFilePath(protoModuleFile.Path); err != nil {
+		if err := bufmoduleref.ValidateModuleFilePath(protoModuleFile.Path); err != nil {
 			return err
 		}
 		if _, ok := filePathMap[protoModuleFile.Path]; ok {
@@ -60,218 +57,9 @@ func ValidateProtoModule(protoModule *modulev1alpha1.Module) error {
 		return fmt.Errorf("total module content length is %d when max is %d", totalContentLength, maxModuleTotalContentLength)
 	}
 	for _, dependency := range protoModule.Dependencies {
-		if err := ValidateProtoModulePin(dependency); err != nil {
+		if err := bufmoduleref.ValidateProtoModulePin(dependency); err != nil {
 			return fmt.Errorf("module had invalid dependency: %v", err)
 		}
 	}
 	return nil
-}
-
-// ValidateProtoModuleReference verifies the given module reference is well-formed.
-// It performs client-side validation only, and is limited to fields
-// we do not think will change in the future.
-func ValidateProtoModuleReference(protoModuleReference *modulev1alpha1.ModuleReference) error {
-	if protoModuleReference == nil {
-		return errors.New("module reference is required")
-	}
-	if err := validateRemote(protoModuleReference.Remote); err != nil {
-		return err
-	}
-	if err := ValidateOwner(protoModuleReference.Owner, "owner"); err != nil {
-		return err
-	}
-	if err := ValidateRepository(protoModuleReference.Repository); err != nil {
-		return err
-	}
-	return ValidateReference(protoModuleReference.Reference)
-}
-
-// ValidateProtoModulePin verifies the given module pin is well-formed.
-// It performs client-side validation only, and is limited to fields
-// we do not think will change in the future.
-func ValidateProtoModulePin(protoModulePin *modulev1alpha1.ModulePin) error {
-	if protoModulePin == nil {
-		return errors.New("module pin is required")
-	}
-	if err := validateRemote(protoModulePin.Remote); err != nil {
-		return err
-	}
-	if err := ValidateOwner(protoModulePin.Owner, "owner"); err != nil {
-		return err
-	}
-	if err := ValidateRepository(protoModulePin.Repository); err != nil {
-		return err
-	}
-	if err := ValidateBranch(protoModulePin.Branch); err != nil {
-		return err
-	}
-	if err := ValidateCommit(protoModulePin.Commit); err != nil {
-		return err
-	}
-	if err := ValidateDigest(protoModulePin.Digest); err != nil {
-		return err
-	}
-	if err := validateCreateTime(protoModulePin.CreateTime); err != nil {
-		return err
-	}
-	return nil
-}
-
-// ValidateUser verifies the given user name is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateUser(user string) error {
-	return ValidateOwner(user, "user")
-}
-
-// ValidateOrganization verifies the given organization name is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateOrganization(organization string) error {
-	return ValidateOwner(organization, "organization")
-}
-
-// ValidateOwner verifies the given owner name is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateOwner(owner string, ownerType string) error {
-	if owner == "" {
-		return fmt.Errorf("%s name is required", ownerType)
-	}
-	return nil
-}
-
-// ValidateRepository verifies the given repository name is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateRepository(repository string) error {
-	if repository == "" {
-		return errors.New("repository name is required")
-	}
-	return nil
-}
-
-// ValidateReference validates that the given ModuleReference reference is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateReference(reference string) error {
-	if reference == "" {
-		return errors.New("repository reference is required")
-	}
-	return nil
-}
-
-// ValidateCommit verifies the given commit is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateCommit(commit string) error {
-	if commit == "" {
-		return errors.New("empty commit")
-	}
-	return nil
-}
-
-// ValidateBranch verifies the given repository branch is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateBranch(branch string) error {
-	if branch != MainBranch {
-		return fmt.Errorf("branch is not %s", MainBranch)
-	}
-	//if branch == "" {
-	//	return errors.New("repository branch is required")
-	//}
-	return nil
-}
-
-// ValidateTag verifies the given tag is well-formed.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateTag(tag string) error {
-	if tag == "" {
-		return errors.New("repository tag is required")
-	}
-	return nil
-}
-
-// ValidateDigest verifies the given digest's prefix,
-// decodes its base64 representation and checks the
-// length of the encoded bytes.
-func ValidateDigest(digest string) error {
-	if digest == "" {
-		return errors.New("empty digest")
-	}
-	split := strings.SplitN(digest, "-", 2)
-	if len(split) != 2 {
-		return fmt.Errorf("invalid digest: %s", digest)
-	}
-	digestPrefix := split[0]
-	digestValue := split[1]
-	if digestPrefix != b1DigestPrefix {
-		return fmt.Errorf("unknown digest prefix: %s", digestPrefix)
-	}
-	decoded, err := base64.URLEncoding.DecodeString(digestValue)
-	if err != nil {
-		return fmt.Errorf("failed to decode digest %s: %v", digestValue, err)
-	}
-	if len(decoded) != 32 {
-		return fmt.Errorf("invalid sha256 hash, expected 32 bytes: %s", digestValue)
-	}
-	return nil
-}
-
-// ValidateModuleFilePath validates that the module file path is not empty.
-// It performs client-side validation only, and is limited to properties
-// we do not think will change in the future.
-func ValidateModuleFilePath(path string) error {
-	if path == "" {
-		return errors.New("empty path")
-	}
-	return nil
-}
-
-func validateModuleOwner(moduleOwner ModuleOwner) error {
-	if moduleOwner == nil {
-		return errors.New("module owner is required")
-	}
-	if err := validateRemote(moduleOwner.Remote()); err != nil {
-		return err
-	}
-	if err := ValidateOwner(moduleOwner.Owner(), "owner"); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateModuleIdentity(moduleIdentity ModuleIdentity) error {
-	if moduleIdentity == nil {
-		return errors.New("module identity is required")
-	}
-	if err := validateRemote(moduleIdentity.Remote()); err != nil {
-		return err
-	}
-	if err := ValidateOwner(moduleIdentity.Owner(), "owner"); err != nil {
-		return err
-	}
-	if err := ValidateRepository(moduleIdentity.Repository()); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateRemote(remote string) error {
-	if _, err := netextended.ValidateHostname(remote); err != nil {
-		return fmt.Errorf("invalid remote %q: %w", remote, err)
-	}
-	return nil
-}
-
-func validateCreateTime(createTime *timestamppb.Timestamp) error {
-	if createTime == nil {
-		return errors.New("create_time is required")
-	}
-	if createTime.Seconds == 0 && createTime.Nanos == 0 {
-		return errors.New("create_time must not be 0")
-	}
-	return createTime.CheckValid()
 }


### PR DESCRIPTION
Supports #484.
Supports #488.
See #509.

The problem is that we want `bufmodule` to be able to depend on `bufconfig`, so that we can read lint, breaking, and in the future license information from the configuration. However, `bufconfig` has a dependency on `bufmodule` via `ModuleIdentity`.

This PR splits out the "reference" types of `bufmodule` into a new package `bufmodule/bufmoduleref` that both `bufconfig` and `bufmodule` depend on.

This isn't the cleanest, and we can move the package somewhere else, but this does work.