### PR TITLE
Update Go to v1.17.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.0
+          go-version: 1.17.1
       - name: cache
         if: success()
         uses: actions/cache@v2
@@ -44,7 +44,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.0
+          go-version: 1.17.1
       - name: cache
         if: success()
         uses: actions/cache@v2

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,7 +27,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v2.1.4 # this contains a fix for Windows file extraction
         with:
-          go-version: 1.17.0
+          go-version: 1.17.1
       - name: install-protoc
         if: success()
         run: choco install --confirm protoc

--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.17.0-alpine3.14 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.17.1-alpine3.14 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.workspace
+++ b/Dockerfile.workspace
@@ -1,4 +1,4 @@
-FROM golang:1.17.0-alpine3.14
+FROM golang:1.17.1-alpine3.14
 
 ARG PROJECT
 ARG GO_MODULE

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -117,7 +117,7 @@ bufgeneratesteps:: \
 
 .PHONY: bufrelease
 bufrelease: $(MINISIGN)
-	DOCKER_IMAGE=golang:1.17.0-buster bash make/buf/scripts/release.bash
+	DOCKER_IMAGE=golang:1.17.1-buster bash make/buf/scripts/release.bash
 
 # We have to manually set the Homebrew version on the Homebrew badge as there
 # is no badge on shields.io for Homebrew packages outside of homebrew-core


### PR DESCRIPTION
1.17.1 contains a security fix for archive/zip: https://groups.google.com/g/golang-announce/c/dx9d7IOseHw