### PR TITLE
Move help to stdout and --version to version

### DIFF
--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -61,6 +61,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/mod/modupdate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/protoc"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/push"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/version"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 )
@@ -339,8 +340,8 @@ See https://docs.buf.build/faq for more details.`,
 				},
 			},
 			push.NewCommand("push", builder, "", false),
+			version.NewCommand("version", builder),
 		},
 		BindPersistentFlags: appcmd.BindMultiple(builder.BindRoot, globalFlags.BindRoot),
-		Version:             bufcli.Version,
 	}
 }

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1235,6 +1235,11 @@ func TestExportPaths(t *testing.T) {
 	)
 }
 
+func TestVersion(t *testing.T) {
+	t.Parallel()
+	testRunStdout(t, nil, 0, bufcli.Version, "version")
+}
+
 func TestMigrateV1Beta1(t *testing.T) {
 	t.Parallel()
 	storageosProvider := storageos.NewProvider()

--- a/private/buf/cmd/buf/command/protoc/protoc.go
+++ b/private/buf/cmd/buf/command/protoc/protoc.go
@@ -66,7 +66,6 @@ Additional flags:
 		),
 		BindFlags:     flagsBuilder.Bind,
 		NormalizeFlag: flagsBuilder.Normalize,
-		Version:       "3.13.0-buf",
 	}
 }
 

--- a/private/buf/cmd/buf/command/version/usage.gen.go
+++ b/private/buf/cmd/buf/command/version/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package version
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/version/version.go
+++ b/private/buf/cmd/buf/command/version/version.go
@@ -1,0 +1,40 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns a new Command.
+func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
+	return &appcmd.Command{
+		Use:   name,
+		Short: `Print the version.`,
+		Args:  cobra.NoArgs,
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appflag.Container) error {
+				_, err := container.Stdout().Write([]byte(bufcli.Version + "\n"))
+				return err
+			},
+			bufcli.NewErrorInterceptor(),
+		),
+	}
+}

--- a/private/pkg/app/appcmd/appcmd.go
+++ b/private/pkg/app/appcmd/appcmd.go
@@ -60,8 +60,6 @@ type Command struct {
 	// Required if there are no sub-commands.
 	// Must be unset if there are sub-commands.
 	Run func(context.Context, app.Container) error
-	// Version is the version.
-	Version string
 	// SubCommands are the sub-commands. Optional.
 	// Must be unset if there is a run function.
 	SubCommands []*Command
@@ -260,10 +258,6 @@ func commandToCobra(
 			}
 			cobraCommand.AddCommand(subCobraCommand)
 		}
-	}
-	if command.Version != "" {
-		cobraCommand.SetVersionTemplate("{{.Version}}\n")
-		cobraCommand.Version = command.Version
 	}
 	// appcommand prints errors, disable to prevent duplicates.
 	cobraCommand.SilenceErrors = true

--- a/private/pkg/app/appcmd/appcmd.go
+++ b/private/pkg/app/appcmd/appcmd.go
@@ -153,7 +153,6 @@ func run(
 		})
 	}
 
-	cobraCommand.SetOut(container.Stderr())
 	args := app.Args(container)[1:]
 	// cobra will implicitly create __complete and __completeNoDesc subcommands
 	// https://github.com/spf13/cobra/blob/4590150168e93f4b017c6e33469e26590ba839df/completions.go#L14-L17
@@ -178,8 +177,13 @@ func run(
 	// __complete _and_ has its output set to stderr. This shouldn't ever be a problem.
 	if len(args) > 0 && strings.HasPrefix(args[0], "__complete") {
 		cobraCommand.SetOut(container.Stdout())
+	} else {
+		// SetOut sets the output location for usage, help, and version messages.
+		// We want these to go to stderr instead of stdout.
+		cobraCommand.SetOut(container.Stderr())
 	}
 	cobraCommand.SetArgs(args)
+	// SetErr sets the output location for error messages.
 	cobraCommand.SetErr(container.Stderr())
 
 	if err := cobraCommand.Execute(); err != nil {

--- a/private/pkg/app/appcmd/appcmd_test.go
+++ b/private/pkg/app/appcmd/appcmd_test.go
@@ -181,16 +181,18 @@ func TestIncorrectFlagEmptyStdout(t *testing.T) {
 			return nil
 		},
 	}
-	buffer := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	stdout := bytes.NewBuffer(nil)
 	container := app.NewContainer(
 		nil,
 		nil,
-		buffer,
-		nil,
+		stdout,
+		stderr,
 		"test",
 		"--foo",
 		"1",
 	)
 	require.Error(t, Run(context.Background(), container, rootCommand))
-	require.Empty(t, buffer.String())
+	require.Empty(t, stdout.String())
+	require.NotEmpty(t, stderr.String())
 }

--- a/private/pkg/app/appcmd/appcmd_test.go
+++ b/private/pkg/app/appcmd/appcmd_test.go
@@ -108,27 +108,6 @@ func TestError(t *testing.T) {
 	require.Equal(t, app.NewError(5, "bar"), Run(context.Background(), container, rootCommand))
 }
 
-func TestVersionToStdout(t *testing.T) {
-	rootCommand := &Command{
-		Use:     "test",
-		Version: "0.0.1",
-		Run: func(context.Context, app.Container) error {
-			return nil
-		},
-	}
-	buffer := bytes.NewBuffer(nil)
-	container := app.NewContainer(
-		nil,
-		nil,
-		buffer,
-		nil,
-		"test",
-		"--version",
-	)
-	require.NoError(t, Run(context.Background(), container, rootCommand))
-	require.Equal(t, "0.0.1\n", buffer.String())
-}
-
 func TestHelpToStdout(t *testing.T) {
 	rootCommand := &Command{
 		Use: "test",

--- a/private/pkg/app/appcmd/appcmd_test.go
+++ b/private/pkg/app/appcmd/appcmd_test.go
@@ -15,6 +15,7 @@
 package appcmd
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"strings"
@@ -105,4 +106,91 @@ func TestError(t *testing.T) {
 		"sub",
 	)
 	require.Equal(t, app.NewError(5, "bar"), Run(context.Background(), container, rootCommand))
+}
+
+func TestVersionToStdout(t *testing.T) {
+	rootCommand := &Command{
+		Use:     "test",
+		Version: "0.0.1",
+		Run: func(context.Context, app.Container) error {
+			return nil
+		},
+	}
+	buffer := bytes.NewBuffer(nil)
+	container := app.NewContainer(
+		nil,
+		nil,
+		buffer,
+		nil,
+		"test",
+		"--version",
+	)
+	require.NoError(t, Run(context.Background(), container, rootCommand))
+	require.Equal(t, "0.0.1\n", buffer.String())
+}
+
+func TestHelpToStdout(t *testing.T) {
+	rootCommand := &Command{
+		Use: "test",
+		// need a sub-command for "help" to work
+		// otherwise can do -h
+		SubCommands: []*Command{
+			{
+				Use: "foo",
+				Run: func(context.Context, app.Container) error {
+					return nil
+				},
+			},
+		},
+	}
+	buffer := bytes.NewBuffer(nil)
+	container := app.NewContainer(
+		nil,
+		nil,
+		buffer,
+		nil,
+		"test",
+		"help",
+	)
+	require.NoError(t, Run(context.Background(), container, rootCommand))
+	require.NotEmpty(t, buffer.String())
+
+	rootCommand = &Command{
+		Use: "test",
+		Run: func(context.Context, app.Container) error {
+			return nil
+		},
+	}
+	buffer = bytes.NewBuffer(nil)
+	container = app.NewContainer(
+		nil,
+		nil,
+		buffer,
+		nil,
+		"test",
+		"-h",
+	)
+	require.NoError(t, Run(context.Background(), container, rootCommand))
+	require.NotEmpty(t, buffer.String())
+}
+
+func TestIncorrectFlagEmptyStdout(t *testing.T) {
+	rootCommand := &Command{
+		Use: "test",
+		Run: func(context.Context, app.Container) error {
+			return nil
+		},
+	}
+	buffer := bytes.NewBuffer(nil)
+	container := app.NewContainer(
+		nil,
+		nil,
+		buffer,
+		nil,
+		"test",
+		"--foo",
+		"1",
+	)
+	require.Error(t, Run(context.Background(), container, rootCommand))
+	require.Empty(t, buffer.String())
 }

--- a/private/pkg/app/appcmd/cobra.go
+++ b/private/pkg/app/appcmd/cobra.go
@@ -1,0 +1,41 @@
+package appcmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+	"unicode"
+
+	"github.com/spf13/cobra"
+)
+
+// The functions in this file are mostly copied from github.com/spf13/cobra.
+// https://github.com/spf13/cobra/blob/master/LICENSE.txt
+
+var templateFuncs = template.FuncMap{
+	"trim":                    strings.TrimSpace,
+	"trimRightSpace":          trimRightSpace,
+	"trimTrailingWhitespaces": trimRightSpace,
+	"rpad":                    rpad,
+	"gt":                      cobra.Gt,
+	"eq":                      cobra.Eq,
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// rpad adds padding to the right of a string.
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+// tmpl executes the given template text on data, writing the result to w.
+func tmpl(w io.Writer, text string, data interface{}) error {
+	t := template.New("top")
+	t.Funcs(templateFuncs)
+	template.Must(t.Parse(text))
+	return t.Execute(w, data)
+}

--- a/private/pkg/app/appcmd/cobra.go
+++ b/private/pkg/app/appcmd/cobra.go
@@ -50,6 +50,9 @@ func rpad(s string, padding int) string {
 func tmpl(w io.Writer, text string, data interface{}) error {
 	t := template.New("top")
 	t.Funcs(templateFuncs)
-	template.Must(t.Parse(text))
+	t, err := t.Parse(text)
+	if err != nil {
+		return err
+	}
 	return t.Execute(w, data)
 }

--- a/private/pkg/app/appcmd/cobra.go
+++ b/private/pkg/app/appcmd/cobra.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package appcmd
 
 import (

--- a/private/pkg/bandeps/cmd/bandeps/main.go
+++ b/private/pkg/bandeps/cmd/bandeps/main.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	name    = "bandeps"
-	version = "0.0.1-dev"
+	name = "bandeps"
 
 	configFileFlagName      = "config-file"
 	configFileFlagShortName = "f"
@@ -59,7 +58,6 @@ func newCommand() *appcmd.Command {
 		),
 		BindPersistentFlags: builder.BindRoot,
 		BindFlags:           flags.Bind,
-		Version:             version,
 	}
 }
 

--- a/private/pkg/licenseheader/cmd/license-header/main.go
+++ b/private/pkg/licenseheader/cmd/license-header/main.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	use     = "license-header"
-	version = "0.0.1-dev"
+	use = "license-header"
 
 	copyrightHolderFlagName = "copyright-holder"
 	licenseTypeFlagName     = "license-type"
@@ -49,7 +48,6 @@ func newCommand() *appcmd.Command {
 			return run(ctx, container, flags)
 		},
 		BindFlags: flags.Bind,
-		Version:   version,
 	}
 }
 

--- a/private/pkg/spdx/cmd/spdx-go-data/main.go
+++ b/private/pkg/spdx/cmd/spdx-go-data/main.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	programName = "spdx-go-data"
-	version     = "0.0.1-dev"
 
 	pkgFlagName = "package"
 
@@ -63,7 +62,6 @@ func newCommand() *appcmd.Command {
 			return run(ctx, container, flags)
 		},
 		BindFlags: flags.Bind,
-		Version:   version,
 	}
 }
 

--- a/private/pkg/storage/cmd/ddiff/main.go
+++ b/private/pkg/storage/cmd/ddiff/main.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	use     = "ddiff"
-	version = "0.0.1-dev"
+	use = "ddiff"
 )
 
 func main() {
@@ -38,10 +37,9 @@ func main() {
 
 func newCommand() *appcmd.Command {
 	return &appcmd.Command{
-		Use:     use + " dir1 dir2",
-		Args:    cobra.ExactArgs(2),
-		Run:     run,
-		Version: version,
+		Use:  use + " dir1 dir2",
+		Args: cobra.ExactArgs(2),
+		Run:  run,
 	}
 }
 

--- a/private/pkg/storage/cmd/storage-go-data/main.go
+++ b/private/pkg/storage/cmd/storage-go-data/main.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	programName = "storage-go-data"
-	version     = "0.0.1-dev"
 
 	pkgFlagName = "package"
 
@@ -54,7 +53,6 @@ func newCommand() *appcmd.Command {
 			return run(ctx, container, flags)
 		},
 		BindFlags: flags.Bind,
-		Version:   version,
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/535.

This moves `-h, --help, help` to stdout, and `--version` to `version, while preserving usage errors to stderr.