### PR TITLE
Add newline to push log message

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -154,7 +154,7 @@ func run(
 	if err != nil {
 		if rpc.GetErrorCode(err) == rpc.ErrorCodeAlreadyExists {
 			if _, err := container.Stderr().Write(
-				[]byte("The latest commit has the same content, not creating a new commit."),
+				[]byte("The latest commit has the same content, not creating a new commit.\n"),
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #540, I took a look at the log statements in the `command` directory to make sure that we have new lines where approriate.﻿
