### PR TITLE
Check for duplicated file paths during module file set construction

### DIFF
--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -217,7 +217,7 @@ type ModuleFileSet interface {
 func NewModuleFileSet(
 	module Module,
 	dependencies []Module,
-) ModuleFileSet {
+) (ModuleFileSet, error) {
 	return newModuleFileSet(module, dependencies)
 }
 

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
@@ -85,5 +85,5 @@ func (m *moduleFileSetBuilder) build(
 		}
 		dependencyModules = append(dependencyModules, dependencyModule)
 	}
-	return bufmodule.NewModuleFileSet(module, dependencyModules), nil
+	return bufmodule.NewModuleFileSet(module, dependencyModules)
 }


### PR DESCRIPTION
Based on discussions in #490, when file paths are duplicated across modules, such as in the following example, `pet/v1/pet.proto` exists in both the `petapis` and `paymentapis` modules, an error message without module prefixes is printed out.

```
.
├── buf.gen.yaml
├── buf.work.yaml
├── paymentapis
│   ├── buf.lock
│   ├── buf.yaml
│   ├── payment
│   │   └── v1alpha1
│   │       └── payment.proto
│   └── pet
│       └── v1
│           └── pet.proto
└── petapis
    ├── buf.lock
    ├── buf.md
    ├── buf.yaml
    └── pet
        └── v1
            └── pet.proto
```

We can solve this by catching the duplicated path at module file set build time and returning the same error, but with a module identity string prepended when available:

```
$ buf build
Failure: pet/v1/pet.proto exists in multiple locations: paymentapis/pet/v1/pet.proto buf.build/acme/petapis#petapis/pet/v1/pet.proto.
```