### PR TITLE
CLI V1: Remove all deprecated flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 - The version key in all configuration files (`buf.yaml`, `buf.gen.yaml`, `buf.work.yaml`) is now required.
 - The `--help` flag now writes to stdout instead of stderr.
+- Removed the `--source` flag on `buf build` in favor of the first positional parameter.
+- Removed the `--source-config` flag on `buf build` in favor of the `--config` flag.
+- Removed the `--file` flag on `buf build` in favor of the `--path` flag.
+- Removed the `--input` flag on `buf lint` in favor of the first positional parameter.
+- Removed the `--input-config` flag on `buf lint` in favor of the `--config` flag.
+- Removed the `--file` flag on `buf lint` in favor of the `--path` flag.
+- Removed the `--input` flag on `buf breaking` in favor of the first positional parameter.
+- Removed the `--input-config` flag on `buf breaking` in favor of the `--config` flag.
+- Removed the `--against-input` flag on `buf breaking` in favor of the `--against` flag.
+- Removed the `--against-input-config` flag on `buf breaking` in favor of the `--against-config` flag.
+- Removed the `--file` flag on `buf breaking` in favor of the `--path` flag.
+- Removed the `--input` flag on `buf generate` in favor of the first positional parameter.
+- Removed the `--input-config` flag on `buf generate` in favor of the `--config` flag.
+- Removed the `--file` flag on `buf generate` in favor of the `--path` flag.
+- Removed the `--input` flag on `buf ls-files` in favor of the first positional parameter.
+- Removed the `--input-config` flag on `buf ls-files` in favor of the `--config` flag.
+- Removed the `--file` flag on `buf export` in favor of the `--path` flag.
 - Removed the `--name` and `--dep` flags in `buf mod init`.
 - Removed the `--version` flag in favor of the `buf version` command, which writes to stdout.
 - Removed the `buf image build` command in favor of `buf build`.

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -60,9 +60,9 @@ const (
 	// Version is the CLI version of buf.
 	Version = "0.57.0-dev"
 
-	// FlagDeprecationMessageSuffix is the suffix for flag deprecation messages.
+	// FlagDeprecationMessageSuffix is the suffix for deprecated flag messages.
 	FlagDeprecationMessageSuffix = `
-We recommend migrating, however this flag continues to work.
+This flag was removed for buf's v1 release.
 See https://docs.buf.build/faq for more details.`
 
 	inputHTTPSUsernameEnvKey      = "BUF_INPUT_HTTPS_USERNAME"
@@ -205,7 +205,7 @@ If specified multiple times, the union will be taken.`,
 	)
 }
 
-// BindPathAndDeprecatedFiles binds the paths flag and the deprecated files flag.
+// BindPathsAndDeprecatedFiles binds the paths flag and the deprecated files flag.
 func BindPathsAndDeprecatedFiles(
 	flagSet *pflag.FlagSet,
 	pathsAddr *[]string,
@@ -296,13 +296,13 @@ func GetInputValue(
 		return "", fmt.Errorf("only 1 argument allowed but %d arguments specified", numArgs)
 	}
 	if arg != "" && deprecatedFlag != "" {
-		return "", fmt.Errorf("cannot specify both first argument and deprecated flag --%s", deprecatedFlagName)
+		return "", fmt.Errorf("cannot specify both first argument and deprecated flag --%s - use the first argument instead", deprecatedFlagName)
 	}
 	if arg != "" {
 		return arg, nil
 	}
 	if deprecatedFlag != "" {
-		return deprecatedFlag, nil
+		return "", fmt.Errorf("flag --%s is no longer supported - use the first argument instead", deprecatedFlagName)
 	}
 	return defaultValue, nil
 }
@@ -315,12 +315,15 @@ func GetStringFlagOrDeprecatedFlag(
 	deprecatedFlagName string,
 ) (string, error) {
 	if flag != "" && deprecatedFlag != "" {
-		return "", fmt.Errorf("cannot specify both --%s and --%s", flagName, deprecatedFlagName)
+		return "", fmt.Errorf("cannot specify both --%s and --%s - use --%s instead", flagName, deprecatedFlagName, flagName)
 	}
 	if flag != "" {
 		return flag, nil
 	}
-	return deprecatedFlag, nil
+	if deprecatedFlag != "" {
+		return "", fmt.Errorf("flag --%s is no longer supported - use --%s instead", deprecatedFlagName, flagName)
+	}
+	return "", nil
 }
 
 // GetStringSliceFlagOrDeprecatedFlag gets the flag, or the deprecated flag.
@@ -331,12 +334,15 @@ func GetStringSliceFlagOrDeprecatedFlag(
 	deprecatedFlagName string,
 ) ([]string, error) {
 	if len(flag) > 0 && len(deprecatedFlag) > 0 {
-		return nil, fmt.Errorf("cannot specify both --%s and --%s", flagName, deprecatedFlagName)
+		return nil, fmt.Errorf("cannot specify both --%s and --%s - use --%s instead", flagName, deprecatedFlagName, flagName)
 	}
 	if len(flag) > 0 {
 		return flag, nil
 	}
-	return deprecatedFlag, nil
+	if len(deprecatedFlag) > 0 {
+		return nil, fmt.Errorf("flag --%s is no longer supported - use --%s instead", deprecatedFlagName, flagName)
+	}
+	return nil, nil
 }
 
 // NewWireImageConfigReader returns a new ImageConfigReader.

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -37,43 +37,42 @@ import (
 
 func TestSuccess1(t *testing.T) {
 	t.Parallel()
-	testRunStdout(t, nil, 0, ``, "build", "--source", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "build", "--source", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "build", filepath.Join("testdata", "success"))
 }
 
 func TestSuccess2(t *testing.T) {
 	t.Parallel()
-	testRunStdout(t, nil, 0, ``, "build", "--exclude-imports", "--source", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "build", "--exclude-imports", "--source", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "build", "--exclude-imports", filepath.Join("testdata", "success"))
 }
 
 func TestSuccess3(t *testing.T) {
 	t.Parallel()
-	testRunStdout(t, nil, 0, ``, "build", "--exclude-source-info", "--source", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "build", "--exclude-source-info", "--source", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "build", "--exclude-source-info", filepath.Join("testdata", "success"))
 }
 
 func TestSuccess4(t *testing.T) {
 	t.Parallel()
-	testRunStdout(t, nil, 0, ``, "build", "--exclude-imports", "--exclude-source-info", "--source", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "build", "--exclude-imports", "--exclude-source-info", "--source", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "build", "--exclude-imports", "--exclude-source-info", filepath.Join("testdata", "success"))
 }
 
 func TestSuccess5(t *testing.T) {
 	t.Parallel()
-	testRunStdout(t, nil, 0, ``, "build", "--exclude-imports", "--exclude-source-info", "--source", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "build", "--exclude-imports", "--exclude-source-info", "--source", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "build", "--exclude-imports", "--exclude-source-info", filepath.Join("testdata", "success"))
 }
 
 func TestSuccess6(t *testing.T) {
 	t.Parallel()
-	testRunStdout(t, nil, 0, ``, "lint", "--input", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "lint", "--input", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "lint", filepath.Join("testdata", "success"))
 }
 
 func TestSuccessProfile1(t *testing.T) {
 	t.Parallel()
-	testRunStdoutProfile(t, nil, 0, ``, "build", "--source", filepath.Join("testdata", "success"))
 	testRunStdoutProfile(t, nil, 0, ``, "build", filepath.Join("testdata", "success"))
 }
 
@@ -82,7 +81,7 @@ func TestFail1(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		0,
+		1,
 		``,
 		"build",
 		"--source",
@@ -103,7 +102,7 @@ func TestFail2(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		0,
+		1,
 		``,
 		"build",
 		"--exclude-imports",
@@ -126,7 +125,7 @@ func TestFail3(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		0,
+		1,
 		``,
 		"build",
 		"--exclude-source-info",
@@ -149,7 +148,7 @@ func TestFail4(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		0,
+		1,
 		``,
 		"build",
 		"--exclude-imports",
@@ -174,9 +173,8 @@ func TestFail5(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		``,
 		"lint",
 		"--input",
 		filepath.Join("testdata", "fail"),
@@ -197,9 +195,8 @@ func TestFail6(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		``,
 		"lint",
 		"--input",
 		filepath.Join("testdata", "fail"),
@@ -225,9 +222,8 @@ func TestFail7(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "fail/buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		``,
 		"lint",
 		"--path",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
@@ -252,9 +248,8 @@ func TestFail7(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "fail/buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		``,
 		"lint",
 		"--path",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
@@ -283,9 +278,8 @@ func TestFail8(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail2/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".
-		testdata/fail2/buf/buf2.proto:9:9:Field name "oneThree" should be lower_snake_case, such as "one_three".`),
+		1,
+		``,
 		"lint",
 		"--input",
 		filepath.Join("testdata", "fail2"),
@@ -306,8 +300,8 @@ func TestFail9(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail2/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		``,
 		"lint",
 		"--input",
 		filepath.Join("testdata", "fail2"),
@@ -331,7 +325,7 @@ func TestFail10(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		0,
+		1,
 		``,
 		"lint",
 		"--input",
@@ -356,8 +350,8 @@ func TestFail11(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		fmt.Sprintf("%v:5:8:buf/buf.proto: does not exist", filepath.FromSlash("testdata/fail2/buf/buf2.proto")),
+		1,
+		``,
 		"lint",
 		"--path",
 		filepath.Join("testdata", "fail2", "buf", "buf2.proto"),
@@ -381,14 +375,8 @@ func TestFail12(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		`version: v1
-lint:
-  ignore_only:
-    FIELD_LOWER_SNAKE_CASE:
-	  - buf/buf.proto
-	PACKAGE_DIRECTORY_MATCH:
-	  - buf/buf.proto`,
+		1,
+		``,
 		"lint",
 		"--input",
 		filepath.Join("testdata", "fail"),
@@ -506,14 +494,8 @@ func TestFailCheckBreaking1(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`
-		../../bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:5:1:Previously present field "3" with name "three" on message "Two" was deleted.
-		../../bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:10:1:Previously present field "3" with name "three" on message "Three" was deleted.
-		../../bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:12:5:Previously present field "3" with name "three" on message "Five" was deleted.
-		../../bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:22:3:Previously present field "3" with name "three" on message "Seven" was deleted.
-		../../bufcheck/bufbreaking/testdata/breaking_field_no_delete/2.proto:57:1:Previously present field "3" with name "three" on message "Nine" was deleted.
-		`),
+		1,
+		``,
 		"breaking",
 		"--input",
 		// can't bother right now to filepath.Join this
@@ -863,8 +845,8 @@ func TestLsFiles(t *testing.T) {
 	testRunStdout(
 		t,
 		nil,
-		0,
-		filepath.FromSlash(`testdata/success/buf/buf.proto`),
+		1,
+		``,
 		"ls-files",
 		"--input",
 		filepath.Join("testdata", "success"),

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -153,7 +153,7 @@ Overrides --%s.`,
 		`The config file or data to use for the against source, module, or image.`,
 	)
 
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.Input,
 		inputFlagName,
@@ -163,24 +163,16 @@ Overrides --%s.`,
 			buffetch.AllFormatsString,
 		),
 	)
-	_ = flagSet.MarkDeprecated(
-		inputFlagName,
-		`input as the first argument instead.`+bufcli.FlagDeprecationMessageSuffix,
-	)
 	_ = flagSet.MarkHidden(inputFlagName)
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.InputConfig,
 		inputConfigFlagName,
 		"",
 		`The config file or data to use.`,
 	)
-	_ = flagSet.MarkDeprecated(
-		inputConfigFlagName,
-		fmt.Sprintf("use --%s instead.%s", configFlagName, bufcli.FlagDeprecationMessageSuffix),
-	)
 	_ = flagSet.MarkHidden(inputConfigFlagName)
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.AgainstInput,
 		againstInputFlagName,
@@ -190,21 +182,13 @@ Overrides --%s.`,
 			buffetch.AllFormatsString,
 		),
 	)
-	_ = flagSet.MarkDeprecated(
-		againstInputFlagName,
-		fmt.Sprintf("use --%s instead.%s", againstFlagName, bufcli.FlagDeprecationMessageSuffix),
-	)
 	_ = flagSet.MarkHidden(againstInputFlagName)
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.AgainstInputConfig,
 		againstInputConfigFlagName,
 		"",
 		`The config file or data to use for the against source or image.`,
-	)
-	_ = flagSet.MarkDeprecated(
-		againstInputConfigFlagName,
-		fmt.Sprintf("use --%s instead.%s", againstConfigFlagName, bufcli.FlagDeprecationMessageSuffix),
 	)
 	_ = flagSet.MarkHidden(againstInputConfigFlagName)
 }

--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -125,7 +125,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		`The config file or data to use.`,
 	)
 
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.Source,
 		sourceFlagName,
@@ -135,21 +135,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			buffetch.AllFormatsString,
 		),
 	)
-	_ = flagSet.MarkDeprecated(
-		sourceFlagName,
-		`input as the first argument instead.`+bufcli.FlagDeprecationMessageSuffix,
-	)
 	_ = flagSet.MarkHidden(sourceFlagName)
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.SourceConfig,
 		sourceConfigFlagName,
 		"",
 		`The config file or data to use.`,
-	)
-	_ = flagSet.MarkDeprecated(
-		sourceConfigFlagName,
-		fmt.Sprintf("use --%s instead.%s", configFlagName, bufcli.FlagDeprecationMessageSuffix),
 	)
 	_ = flagSet.MarkHidden(sourceConfigFlagName)
 }

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -243,7 +243,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		`The config file or data to use.`,
 	)
 
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.Input,
 		inputFlagName,
@@ -253,21 +253,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			buffetch.AllFormatsString,
 		),
 	)
-	_ = flagSet.MarkDeprecated(
-		inputFlagName,
-		`input as the first argument instead.`+bufcli.FlagDeprecationMessageSuffix,
-	)
 	_ = flagSet.MarkHidden(inputFlagName)
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.InputConfig,
 		inputConfigFlagName,
 		"",
 		`The config file or data to use.`,
-	)
-	_ = flagSet.MarkDeprecated(
-		inputConfigFlagName,
-		fmt.Sprintf("use --%s instead.%s", configFlagName, bufcli.FlagDeprecationMessageSuffix),
 	)
 	_ = flagSet.MarkHidden(inputConfigFlagName)
 }

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -166,7 +166,6 @@ func testCompareGeneratedStubs(
 		actualProtocPluginFlags...,
 	)
 	genFlags := []string{
-		"--input",
 		dirPath,
 		"--template",
 		newExternalConfigV1String(t, plugins, bufGenDir),

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -104,7 +104,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		`The config file or data to use.`,
 	)
 
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.Input,
 		inputFlagName,
@@ -114,21 +114,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			buffetch.AllFormatsString,
 		),
 	)
-	_ = flagSet.MarkDeprecated(
-		inputFlagName,
-		`input as the first argument instead.`+bufcli.FlagDeprecationMessageSuffix,
-	)
 	_ = flagSet.MarkHidden(inputFlagName)
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.InputConfig,
 		inputConfigFlagName,
 		"",
 		`The config file or data to use.`,
-	)
-	_ = flagSet.MarkDeprecated(
-		inputConfigFlagName,
-		fmt.Sprintf("use --%s instead.%s", configFlagName, bufcli.FlagDeprecationMessageSuffix),
 	)
 	_ = flagSet.MarkHidden(inputConfigFlagName)
 }

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -84,7 +84,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		),
 	)
 	flagSet.StringVar(
-		&f.InputConfig,
+		&f.Config,
 		configFlagName,
 		"",
 		`The config file or data to use.`,

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -90,16 +90,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		`The config file or data to use.`,
 	)
 
-	// deprecated
+	// deprecated, but not marked as deprecated as we return error if this is used
 	flagSet.StringVar(
 		&f.InputConfig,
 		inputConfigFlagName,
 		"",
 		`The config file or data to use.`,
-	)
-	_ = flagSet.MarkDeprecated(
-		inputConfigFlagName,
-		fmt.Sprintf("use --%s instead.%s", configFlagName, bufcli.FlagDeprecationMessageSuffix),
 	)
 	_ = flagSet.MarkHidden(inputConfigFlagName)
 }


### PR DESCRIPTION
Re: #483

This builds upon #526 and removes all of the previously deprecated flags from `buf`. All of the tests that used deprecated flags are now removed.

Note that a couple `bufcli` helpers are kept so that we can more easily deprecate flags in the future (i.e. `bufcli.GetString[Slice]FlagOrDeprecatedFlag`).