### PR TITLE
Remove unnecessary error wrapping in 'buf generate'

### DIFF
--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -311,7 +311,7 @@ func MergeInsertionPoints(responses []*pluginpb.CodeGeneratorResponse) ([]Merged
 				continue
 			}
 			if _, ok := allFiles[fileName]; ok {
-				return nil, fmt.Errorf("file %q defined multiple times", fileName)
+				return nil, fmt.Errorf("file %q was generated multiple times", fileName)
 			}
 			file := &File{
 				Name:    fileName,


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/541

This removes all of the unnecessary error wrapping in the `buf generate` command, and makes slight improvements to the places where wrapping makes sense.

Now, when users run `buf generate` with duplicate plugins like so:

```yaml
# This template is for go only for OSS types.
version: v1
managed:
  enabled: true
  go_package_prefix:
    default: github.com/bufbuild/buf/private/gen/proto/go
plugins:
  - name: go
    out: private/gen/proto/go
    opt: paths=source_relative
  - name: go
    out: private/gen/proto/go
    opt: paths=source_relative
```

They will see:
```sh
$ buf generate
Failure: file "buf/alpha/module/v1alpha1/module.pb.go" was generated multiple times
```

And for plugins that don't exist, they will see:

```sh
$ buf generate
Failure: could not find protoc plugin for name foo
```