### PR TITLE
Include plugin name in 'buf generate' errors

### DIFF
--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -259,10 +259,28 @@ func ParseTemplateVersionConfig(config string) (*TemplateVersionConfig, error) {
 	return templateVersionConfig, nil
 }
 
-// File represents a generated file
+// File represents a generated file, and tracks the plugin
+// that originally generated it (i.e. if insertion points
+// are applied to this File, the PluginName will be unchanged).
 type File struct {
-	Name    string
-	Content []byte
+	Name       string
+	Content    []byte
+	PluginName string
+}
+
+// PluginResponse encapsulates a CodeGeneratorResponse,
+// along with the name of the plugin that created it.
+type PluginResponse struct {
+	Response   *pluginpb.CodeGeneratorResponse
+	PluginName string
+}
+
+// NewPluginResponse retruns a new *PluginResponse.
+func NewPluginResponse(response *pluginpb.CodeGeneratorResponse, pluginName string) *PluginResponse {
+	return &PluginResponse{
+		Response:   response,
+		PluginName: pluginName,
+	}
 }
 
 // MergedPluginResult holds the files for a plugin result.
@@ -273,10 +291,12 @@ type MergedPluginResult struct {
 // MergeInsertionPoints traverses the plugin results and merges any insertion points present in any responses.
 // The order of inserts depends on the order of the input plugins. The returned results are in the same order
 // as the input plugin results.
-func MergeInsertionPoints(responses []*pluginpb.CodeGeneratorResponse) ([]MergedPluginResult, error) {
+func MergeInsertionPoints(pluginResponses []*PluginResponse) ([]*MergedPluginResult, error) {
 	allFiles := make(map[string]*File)
-	results := make([]MergedPluginResult, len(responses))
-	for i, response := range responses {
+	results := make([]*MergedPluginResult, len(pluginResponses))
+	for i, pluginResponse := range pluginResponses {
+		response := pluginResponse.Response
+		pluginName := pluginResponse.PluginName
 		if response.Error != nil {
 			return nil, fmt.Errorf("unexpected response error: %s", *response.Error)
 		}
@@ -288,8 +308,8 @@ func MergeInsertionPoints(responses []*pluginpb.CodeGeneratorResponse) ([]Merged
 				parentFile, ok := allFiles[fileName]
 				if !ok {
 					return nil, fmt.Errorf(
-						"response %d requested insertion point in file %q which does not exist",
-						i,
+						"plugin %q requested insertion point in file %q which does not exist",
+						pluginName,
 						fileName,
 					)
 				}
@@ -300,31 +320,36 @@ func MergeInsertionPoints(responses []*pluginpb.CodeGeneratorResponse) ([]Merged
 				)
 				if err != nil {
 					return nil, fmt.Errorf(
-						"failed to apply insertion point %q in file %q for response %d: %w",
+						"failed to apply insertion point %q in file %q for plugin %q: %w",
 						insertionPoint,
 						fileName,
-						i,
+						pluginName,
 						err,
 					)
 				}
 				allFiles[fileName].Content = newFileContents
 				continue
 			}
-			if _, ok := allFiles[fileName]; ok {
-				return nil, fmt.Errorf("file %q was generated multiple times", fileName)
+			if previousFile, ok := allFiles[fileName]; ok {
+				return nil, fmt.Errorf(
+					"file %q was generated multiple times: once by plugin %q and again by plugin %q",
+					fileName,
+					previousFile.PluginName,
+					pluginName,
+				)
 			}
 			file := &File{
-				Name:    fileName,
-				Content: []byte(generatedFile.GetContent()),
+				Name:       fileName,
+				Content:    []byte(generatedFile.GetContent()),
+				PluginName: pluginName,
 			}
 			files = append(files, file)
 			allFiles[fileName] = file
 		}
-		results[i] = MergedPluginResult{
+		results[i] = &MergedPluginResult{
 			Files: files,
 		}
 	}
-
 	return results, nil
 }
 

--- a/private/bufpkg/bufplugin/bufplugin_test.go
+++ b/private/bufpkg/bufplugin/bufplugin_test.go
@@ -414,21 +414,27 @@ plugin_versions:
 }
 
 func TestMergeInsertionPoints(t *testing.T) {
-	results := []*pluginpb.CodeGeneratorResponse{
+	results := []*PluginResponse{
 		{
-			File: []*pluginpb.CodeGeneratorResponse_File{
-				{
-					Name:    testStringPointer("file1.java"),
-					Content: testStringPointer("// @@protoc_insertion_point(insertionPoint1)"),
+			PluginName: "protoc-gen-java",
+			Response: &pluginpb.CodeGeneratorResponse{
+				File: []*pluginpb.CodeGeneratorResponse_File{
+					{
+						Name:    testStringPointer("file1.java"),
+						Content: testStringPointer("// @@protoc_insertion_point(insertionPoint1)"),
+					},
 				},
 			},
 		},
 		{
-			File: []*pluginpb.CodeGeneratorResponse_File{
-				{
-					Name:           testStringPointer("file1.java"),
-					Content:        testStringPointer("!! this was inserted !!"),
-					InsertionPoint: testStringPointer("insertionPoint1"),
+			PluginName: "protoc-gen-java-insertion",
+			Response: &pluginpb.CodeGeneratorResponse{
+				File: []*pluginpb.CodeGeneratorResponse_File{
+					{
+						Name:           testStringPointer("file1.java"),
+						Content:        testStringPointer("!! this was inserted !!"),
+						InsertionPoint: testStringPointer("insertionPoint1"),
+					},
 				},
 			},
 		},
@@ -438,6 +444,7 @@ func TestMergeInsertionPoints(t *testing.T) {
 	require.Len(t, mergedResults, 2)
 	require.Len(t, mergedResults[0].Files, 1)
 	require.EqualValues(t, "file1.java", mergedResults[0].Files[0].Name)
+	require.EqualValues(t, "protoc-gen-java", mergedResults[0].Files[0].PluginName)
 	require.EqualValues(t, "!! this was inserted !!\n// @@protoc_insertion_point(insertionPoint1)", string(mergedResults[0].Files[0].Content))
 }
 


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/560

> The issue described above is only loosely related to this change - the only action item there was to improve our error messages (hence why this PR fixes the issue).

This builds upon https://github.com/bufbuild/buf/pull/564, and introduces a new `PluginResponse` type that includes the `PluginName` responsible for the creation of a given `CodeGeneratorResponse`.

This was tested with a variety of configurations, including:

#### Two Remote Plugins
```sh
$ buf generate
Failure: file "buf/alpha/image/v1/image.pb.go" was generated multiple times: once by plugin "buf.build/library/plugins/go:v1.27.1-1" and again by plugin "buf.build/library/plugins/go"
```

#### Local + Remote Plugins
```sh
$ buf generate
Failure: file "buf/alpha/image/v1/image.pb.go" was generated multiple times: once by plugin "buf.build/library/plugins/go" and again by plugin "go"
```

#### Two Local Plugins
```sh
$ buf generate
Failure: file "buf/alpha/image/v1/image.pb.go" was generated multiple times: once by plugin "go" and again by plugin "go"
```

We _could_ include the index of each plugin in the error to disambiguate two plugins with the same name, but this error message should be sufficient in telling the user that they've configured something twice. Plus, reporting the index makes the error message a little harder to read and understand at first glance.

If we proceed with this change, we'll need to carry it over to the server-side generator. I have the change complete locally, but I'll need to discuss with the team since there are a couple of minor caveats.