### PR TITLE
Add GetErrorMessage to rpc package

### DIFF
--- a/private/pkg/rpc/errors.go
+++ b/private/pkg/rpc/errors.go
@@ -369,6 +369,18 @@ func GetErrorCode(err error) ErrorCode {
 	return ErrorCodeInternal
 }
 
+// GetErrorMessage gets the rpc error message, if there is an RPC
+// error in the error chain. If not, it returns an empty string.
+func GetErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	if rpcErr := new(rpcError); errors.As(err, &rpcErr) {
+		return rpcErr.message
+	}
+	return ""
+}
+
 // IsError returns true if err is an error created by this package.
 //
 // If the error is nil, this returns false.

--- a/private/pkg/rpc/errors_test.go
+++ b/private/pkg/rpc/errors_test.go
@@ -1,0 +1,12 @@
+package rpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetErrorMessage(t *testing.T) {
+	require.Equal(t, "test", GetErrorMessage(fmt.Errorf("some error: %w", NewInvalidArgumentError("test"))))
+}

--- a/private/pkg/rpc/errors_test.go
+++ b/private/pkg/rpc/errors_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rpc
 
 import (


### PR DESCRIPTION
This is useful for unwrapping just the message from
a wrapped RPC error.