### PR TITLE
Update protoc to 3.18.0

### DIFF
--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,8 +10,8 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20210608 checked 20210712
-PROTOC_VERSION ?= 3.17.3
+# https://github.com/protocolbuffers/protobuf/releases 20210915 checked 20210918
+PROTOC_VERSION ?= 3.18.0
 
 # There are no protobuf releases for Darwin ARM so for
 # now we always use the x86_64 release through Rosetta.


### PR DESCRIPTION
Does not appear to have any significant changes: https://github.com/protocolbuffers/protobuf/releases/tag/v3.18.0