### PR TITLE
Add --strip flag to ls-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add `--strip` flag to `ls-files` that strips local directory paths and prints file paths as they
+  are imported.
 
 ## [v1.0.0-rc2] - 2021-09-23
 

--- a/private/buf/bufwire/bufwire.go
+++ b/private/buf/bufwire/bufwire.go
@@ -119,7 +119,7 @@ type FileLister interface {
 	// ListFiles lists the files.
 	//
 	// If includeImports is set, the ref is built, which can result in FileAnnotations.
-	// There is no defined returned sorting order. If yoyu need the FileInfos to
+	// There is no defined returned sorting order. If you need the FileInfos to
 	// be sorted, do so with bufmoduleref.SortFileInfos or bufmoduleref.SortFileInfosByExternalPath.
 	ListFiles(
 		ctx context.Context,

--- a/private/buf/bufwire/bufwire.go
+++ b/private/buf/bufwire/bufwire.go
@@ -118,8 +118,9 @@ func NewModuleConfigReader(
 type FileLister interface {
 	// ListFiles lists the files.
 	//
-	// If includeImports is set, the ref is built, which can result
-	// in FileAnnotations.
+	// If includeImports is set, the ref is built, which can result in FileAnnotations.
+	// There is no defined returned sorting order. If yoyu need the FileInfos to
+	// be sorted, do so with bufmoduleref.SortFileInfos or bufmoduleref.SortFileInfosByExternalPath.
 	ListFiles(
 		ctx context.Context,
 		container app.EnvStdinContainer,

--- a/private/buf/bufwire/file_lister.go
+++ b/private/buf/bufwire/file_lister.go
@@ -134,9 +134,6 @@ func (e *fileLister) listFilesWithImports(
 	for i, imageFile := range imageFiles {
 		fileInfos[i] = imageFile
 	}
-	// The image is ordered in DAG order, which isn't consistent with what we do
-	// in the withoutImports flow and is a little annoying for a user.
-	bufmoduleref.SortFileInfos(fileInfos)
 	return fileInfos, nil, nil
 }
 

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -879,8 +879,8 @@ func TestLsFilesImage1(t *testing.T) {
 		stdout,
 		0,
 		`
-		google/protobuf/descriptor.proto
 		buf/buf.proto
+		google/protobuf/descriptor.proto
 		`,
 		"ls-files",
 		"-",

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -460,7 +460,9 @@ func PutDependencyModulePinsToBucket(
 	return buflock.WriteConfig(ctx, writeBucket, lockFile)
 }
 
-// SortFileInfos sorts the FileInfos.
+// SortFileInfos sorts the FileInfos by Path.
+//
+// This should be treated as the default sorting mechanism.
 func SortFileInfos(fileInfos []FileInfo) {
 	if len(fileInfos) == 0 {
 		return
@@ -469,6 +471,19 @@ func SortFileInfos(fileInfos []FileInfo) {
 		fileInfos,
 		func(i int, j int) bool {
 			return fileInfos[i].Path() < fileInfos[j].Path()
+		},
+	)
+}
+
+// SortFileInfosByExternalPath sorts the FileInfos by ExternalPath.
+func SortFileInfosByExternalPath(fileInfos []FileInfo) {
+	if len(fileInfos) == 0 {
+		return
+	}
+	sort.Slice(
+		fileInfos,
+		func(i int, j int) bool {
+			return fileInfos[i].ExternalPath() < fileInfos[j].ExternalPath()
 		},
 	)
 }


### PR DESCRIPTION
Other potential names for this flag:

- `--as-image-paths`: I don't like this as it makes people understand what an Image is.
- `--as-import-paths`: Just seems long, and we don't use the terminology "import paths" anywhere else.

We can always easily change the flag name later.