### PR TITLE
Add more tests for ls-files and switch --strip to --as-import-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 
-- Add `--strip` flag to `ls-files` that strips local directory paths and prints file paths as they
-  are imported.
+- Add `--as-import-paths` flag to `ls-files` that strips local directory paths and prints file
+  paths as they are imported.
 
 ## [v1.0.0-rc2] - 2021-09-23
 

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -672,25 +672,25 @@ func TestLsFilesIncludeImports(t *testing.T) {
 		t,
 		nil,
 		0,
-		filepath.FromSlash(`google/protobuf/descriptor.proto
-testdata/success/buf/buf.proto`),
+		`google/protobuf/descriptor.proto
+`+filepath.FromSlash(`testdata/success/buf/buf.proto`),
 		"ls-files",
 		"--include-imports",
 		filepath.Join("testdata", "success"),
 	)
 }
 
-func TestLsFilesIncludeImportsStrip(t *testing.T) {
+func TestLsFilesIncludeImportsAsImportPaths(t *testing.T) {
 	t.Parallel()
 	testRunStdout(
 		t,
 		nil,
 		0,
-		filepath.FromSlash(`buf/buf.proto
-google/protobuf/descriptor.proto`),
+		`buf/buf.proto
+google/protobuf/descriptor.proto`,
 		"ls-files",
 		"--include-imports",
-		"--strip",
+		"--as-import-paths",
 		filepath.Join("testdata", "success"),
 	)
 }

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -666,6 +666,35 @@ func TestLsFiles(t *testing.T) {
 	)
 }
 
+func TestLsFilesIncludeImports(t *testing.T) {
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		0,
+		filepath.FromSlash(`google/protobuf/descriptor.proto
+testdata/success/buf/buf.proto`),
+		"ls-files",
+		"--include-imports",
+		filepath.Join("testdata", "success"),
+	)
+}
+
+func TestLsFilesIncludeImportsStrip(t *testing.T) {
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		0,
+		filepath.FromSlash(`buf/buf.proto
+google/protobuf/descriptor.proto`),
+		"ls-files",
+		"--include-imports",
+		"--strip",
+		filepath.Join("testdata", "success"),
+	)
+}
+
 func TestLsFilesImage1(t *testing.T) {
 	t.Parallel()
 	stdout := bytes.NewBuffer(nil)

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
+	asImportPathsFlagName  = "as-import-paths"
 	configFlagName         = "config"
 	errorFormatFlagName    = "error-format"
 	includeImportsFlagName = "include-imports"
-	stripFlagName          = "strip"
 
 	// deprecated
 	inputFlagName = "input"
@@ -64,10 +64,10 @@ func NewCommand(
 }
 
 type flags struct {
+	AsImportPaths  bool
 	Config         string
 	ErrorFormat    string
 	IncludeImports bool
-	Strip          bool
 
 	// deprecated
 	Input string
@@ -83,6 +83,12 @@ func newFlags() *flags {
 
 func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	bufcli.BindInputHashtag(flagSet, &f.InputHashtag)
+	flagSet.BoolVar(
+		&f.AsImportPaths,
+		asImportPathsFlagName,
+		false,
+		"Strip local directory paths and print file paths as they are imported.",
+	)
 	flagSet.StringVar(
 		&f.Input,
 		inputFlagName,
@@ -112,12 +118,6 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		includeImportsFlagName,
 		false,
 		"Include imports.",
-	)
-	flagSet.BoolVar(
-		&f.Strip,
-		stripFlagName,
-		false,
-		"Strip local directory paths and print file paths as they are imported.",
 	)
 
 	// deprecated, but not marked as deprecated as we return error if this is used
@@ -186,7 +186,7 @@ func run(
 		}
 		return bufcli.ErrFileAnnotation
 	}
-	if flags.Strip {
+	if flags.AsImportPaths {
 		bufmoduleref.SortFileInfos(fileRefs)
 		for _, fileRef := range fileRefs {
 			if _, err := fmt.Fprintln(container.Stdout(), fileRef.Path()); err != nil {


### PR DESCRIPTION
When you print out image paths, they are (properly) not slashed, so the paths we want to print out really are different, and aren't just stripped, they're potentially always slashed. This means they are “import paths”.