### PR TITLE
[WIP] Support a single proto file as a reference for lint in a valid module or workspace

### DIFF
--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -157,8 +157,24 @@ type RefParser interface {
 // NewRefParser returns a new RefParser.
 //
 // This defaults to dir or module.
-func NewRefParser(logger *zap.Logger) RefParser {
-	return newRefParser(logger)
+func NewRefParser(logger *zap.Logger, options ...NewRefParserOption) RefParser {
+	return newRefParser(logger, options...)
+}
+
+// NewRefParserOption is an option for NewRefParser. NewRefParserOptions are only accepted
+// for the default RefParser constructor.
+type NewRefParserOption func(*newRefParserOption)
+
+type newRefParserOption struct {
+	allowSingleFileRef bool
+}
+
+// NewRefParserWithSingleFileRefAllowed sets the NewRefParser to return the single file reference
+// where applicable.
+func NewRefParserWithSingleFileRefAllowed() NewRefParserOption {
+	return func(o *newRefParserOption) {
+		o.allowSingleFileRef = true
+	}
 }
 
 // NewImageRefParser returns a new RefParser for images only.

--- a/private/buf/buffetch/format.go
+++ b/private/buf/buffetch/format.go
@@ -35,6 +35,8 @@ const (
 	formatTargz = "targz"
 	// formatZip is the zip format.
 	formatZip = "zip"
+	// formatSingleFile is the single file format
+	formatSingleFile = "file"
 )
 
 var (
@@ -54,6 +56,7 @@ var (
 	sourceFormats = []string{
 		formatDir,
 		formatGit,
+		formatSingleFile,
 		formatTar,
 		formatTargz,
 		formatZip,
@@ -62,6 +65,7 @@ var (
 	sourceFormatsNotDeprecated = []string{
 		formatDir,
 		formatGit,
+		formatSingleFile,
 		formatTar,
 		formatZip,
 	}
@@ -78,6 +82,7 @@ var (
 		formatDir,
 		formatGit,
 		formatMod,
+		formatSingleFile,
 		formatTar,
 		formatTargz,
 		formatZip,
@@ -87,6 +92,7 @@ var (
 		formatDir,
 		formatGit,
 		formatMod,
+		formatSingleFile,
 		formatTar,
 		formatZip,
 	}
@@ -99,6 +105,7 @@ var (
 		formatJSON,
 		formatJSONGZ,
 		formatMod,
+		formatSingleFile,
 		formatTar,
 		formatTargz,
 		formatZip,
@@ -110,6 +117,7 @@ var (
 		formatGit,
 		formatJSON,
 		formatMod,
+		formatSingleFile,
 		formatTar,
 		formatZip,
 	}

--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -597,6 +597,7 @@ func WithModuleFormat(format string, options ...ModuleFormatOption) RefParserOpt
 }
 
 // WithSingleFileFormat attaches the given format as a single file format.
+// The single file ref format is only allowed if the option for the parser is given. Otherwise this is a nop.
 //
 // It is up to the user to not incorrectly attach a format twice.
 func WithSingleFileFormat(format string, options ...SingleFileFormatOption) RefParserOption {

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -391,8 +391,7 @@ func (r *reader) getSingleFileBucket(
 		}
 	}
 	if terminateFileDirectoryAbsPath == "" {
-		// TODO(doria): determine the correct error to return here
-		return nil, fmt.Errorf("cannot resolve valid workspace for file reference: %s", singleFileRef.Path())
+		return nil, fmt.Errorf(`cannot resolve valid module or workspace for reference: "%s"`, singleFileRef.Path())
 	}
 	// If the terminate file exists, we need to determine the relative path from the
 	// terminateFileDirectoryAbsPath to the target singleFileRef.Path().

--- a/private/buf/buffetch/internal/single_file_ref.go
+++ b/private/buf/buffetch/internal/single_file_ref.go
@@ -1,0 +1,43 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+var (
+	_ ParsedSingleFileRef = &singleFileRef{}
+)
+
+type singleFileRef struct {
+	format string
+	path   string
+}
+
+func newSingleFileRef(format string, path string) *singleFileRef {
+	return &singleFileRef{
+		format: format,
+		path:   path,
+	}
+}
+
+func (s *singleFileRef) Format() string {
+	return s.format
+}
+
+func (s *singleFileRef) Path() string {
+	return s.path
+}
+
+func (*singleFileRef) ref()           {}
+func (*singleFileRef) bucketRef()     {}
+func (*singleFileRef) singleFileRef() {}

--- a/private/buf/buffetch/ref_parser.go
+++ b/private/buf/buffetch/ref_parser.go
@@ -389,7 +389,8 @@ func newRawRefProcessor(config *rawRefProcessorConfig) func(*internal.RawRef) er
 				compressionType = internal.CompressionTypeGzip
 			case ".git":
 				format = formatGit
-				// TODO(doria): only if the option is turned on...
+				// This only applies if the option accept `SingleFileRef` is passed in, otherwise
+				// it falls through to the `default` case.
 			case ".proto":
 				if config.allowSingleFileRef {
 					format = formatSingleFile

--- a/private/buf/buffetch/ref_parser.go
+++ b/private/buf/buffetch/ref_parser.go
@@ -72,6 +72,7 @@ func newRefParser(logger *zap.Logger) *refParser {
 			internal.WithGitFormat(formatGit),
 			internal.WithDirFormat(formatDir),
 			internal.WithModuleFormat(formatMod),
+			internal.WithSingleFileFormat(formatSingleFile),
 		),
 	}
 }
@@ -191,6 +192,8 @@ func (a *refParser) GetRef(
 		return newSourceRef(t), nil
 	case internal.ParsedModuleRef:
 		return newModuleRef(t), nil
+	case internal.SingleFileRef:
+		return newSourceRef(t), nil
 	default:
 		return nil, fmt.Errorf("unknown ParsedRef type: %T", parsedRef)
 	}
@@ -354,6 +357,8 @@ func processRawRef(rawRef *internal.RawRef) error {
 			compressionType = internal.CompressionTypeGzip
 		case ".git":
 			format = formatGit
+		case ".proto":
+			format = formatSingleFile
 		default:
 			var err error
 			format, err = assumeModuleOrDir(rawRef.Path)

--- a/private/buf/buffetch/source_ref.go
+++ b/private/buf/buffetch/source_ref.go
@@ -33,6 +33,9 @@ func newSourceRef(bucketRef internal.BucketRef) *sourceRef {
 	if dirRef, ok := bucketRef.(internal.DirRef); ok {
 		dirPath = dirRef.Path()
 	}
+	if singleFileRef, ok := bucketRef.(internal.SingleFileRef); ok {
+		dirPath = singleFileRef.Path()
+	}
 	return &sourceRef{
 		bucketRef: bucketRef,
 		dirPath:   dirPath,

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -69,6 +69,8 @@ func TestSuccess6(t *testing.T) {
 	t.Parallel()
 	testRunStdout(t, nil, 1, ``, "lint", "--input", filepath.Join("testdata", "success"))
 	testRunStdout(t, nil, 0, ``, "lint", filepath.Join("testdata", "success"))
+	testRunStdout(t, nil, 1, ``, "lint", "--input", filepath.Join("testdata", "success", "buf", "buf.proto"))
+	testRunStdout(t, nil, 0, ``, "lint", filepath.Join("testdata", "success", "buf", "buf.proto"))
 }
 
 func TestSuccessProfile1(t *testing.T) {
@@ -188,6 +190,24 @@ func TestFail5(t *testing.T) {
 		"lint",
 		filepath.Join("testdata", "fail"),
 	)
+	testRunStdout(
+		t,
+		nil,
+		1,
+		``,
+		"lint",
+		"--input",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+	)
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
+        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		"lint",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+	)
 }
 
 func TestFail6(t *testing.T) {
@@ -212,6 +232,28 @@ func TestFail6(t *testing.T) {
 		"", // stderr should be empty
 		"lint",
 		filepath.Join("testdata", "fail"),
+		"--path",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+	)
+	testRunStdout(
+		t,
+		nil,
+		1,
+		``,
+		"lint",
+		"--input",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+		"--path",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+	)
+	testRunStdoutStderr(
+		t,
+		nil,
+		1,
+		"", // stdout should be empty
+		filepath.FromSlash(`Failure: path "." is not contained within any of roots "." - note that specified paths cannot be roots, but must be contained within roots`),
+		"lint",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
 		"--path",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
 	)
@@ -268,6 +310,27 @@ func TestFail7(t *testing.T) {
 		"--path",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
 		filepath.Join("testdata"),
+		"--config",
+		`{"version":"v1","lint":{"use":["BASIC"]}}`,
+	)
+	testRunStdout(
+		t,
+		nil,
+		1,
+		``,
+		"lint",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+		"--input-config",
+		`{"version":"v1","lint":{"use":["BASIC"]}}`,
+	)
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
+        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		"lint",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
 		"--config",
 		`{"version":"v1","lint":{"use":["BASIC"]}}`,
 	)
@@ -343,6 +406,14 @@ func TestFail10(t *testing.T) {
 		"--path",
 		filepath.Join("testdata", "fail2", "buf", "buf3.proto"),
 	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		"",
+		"lint",
+		filepath.Join("testdata", "fail2", "buf", "buf3.proto"),
+	)
 }
 
 func TestFail11(t *testing.T) {
@@ -367,6 +438,14 @@ func TestFail11(t *testing.T) {
 		"--path",
 		filepath.Join("testdata", "fail2", "buf", "buf2.proto"),
 		filepath.Join("testdata"),
+	)
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`testdata/fail2/buf/buf2.proto:9:9:Field name "oneThree" should be lower_snake_case, such as "one_three".`),
+		"lint",
+		filepath.Join("testdata", "fail2", "buf", "buf2.proto"),
 	)
 }
 

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -155,7 +155,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, input)
+	ref, err := buffetch.NewRefParser(container.Logger(), buffetch.NewRefParserWithSingleFileRefAllowed()).GetRef(ctx, input)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -207,7 +207,8 @@ func run(
 		allFileAnnotations = append(allFileAnnotations, fileAnnotations...)
 	}
 
-	// TODO(doria): test the file annotations filtering here
+	// Since we are passing in the option to support `SingleFileRef`, we need to filter the annotions
+	// based on the input as well as the `--path` flags.
 	var filteredFileAnnotations []bufanalysis.FileAnnotation
 	for _, fileAnnotation := range allFileAnnotations {
 		if fileAnnotation.FileInfo() != nil {

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -206,10 +206,21 @@ func run(
 		}
 		allFileAnnotations = append(allFileAnnotations, fileAnnotations...)
 	}
-	if len(allFileAnnotations) > 0 {
+
+	// TODO(doria): test the file annotations filtering here
+	var filteredFileAnnotations []bufanalysis.FileAnnotation
+	for _, fileAnnotation := range allFileAnnotations {
+		if fileAnnotation.FileInfo() != nil {
+			if _, err := ref.PathForExternalPath(fileAnnotation.FileInfo().ExternalPath()); err == nil {
+				filteredFileAnnotations = append(filteredFileAnnotations, fileAnnotation)
+			}
+		}
+	}
+
+	if len(filteredFileAnnotations) > 0 {
 		if err := buflintconfig.PrintFileAnnotations(
 			container.Stdout(),
-			bufanalysis.DeduplicateAndSortFileAnnotations(allFileAnnotations),
+			bufanalysis.DeduplicateAndSortFileAnnotations(filteredFileAnnotations),
 			flags.ErrorFormat,
 		); err != nil {
 			return err


### PR DESCRIPTION
The purpose of this is to support use cases, such as editor plugins, where a user will need to provide a specific file as a reference and `buf` will need to resolve the valid module/workspace for linting, and then return a filtered lint result.

Some thoughts/points of discussion:

- Is the name `SingleFileRef` clear enough, or should we make it something like `SingleProtoFileRef`, so it is not conflated with our existing file ref that takes a tar/zipped file
- We may want similar reference for the other commands in the future or for the LSP, since we would want to provide a single proto file reference, but surface build errors as needed
- Currently, we fail when the user provides a single proto file reference as the input but also provides the same proto file as the `--path` flag. This is expected and I believe this behaviour to be correct, but we may want to surface a clearer error
- Currently this is a reference that is only accepted for the `lint` command and is not surfaced in the command line help. We should discuss some of the details of the user experience here

WIP:

- [ ] Add some more testing for workspaces, etc.

Ref: #493