### PR TITLE
Print a special error message if too many files are opened during generation

### DIFF
--- a/private/pkg/app/appproto/appprotoexec/binary_handler.go
+++ b/private/pkg/app/appproto/appprotoexec/binary_handler.go
@@ -70,9 +70,10 @@ func (h *binaryHandler) Handle(
 	cmd.Stdin = bytes.NewReader(requestData)
 	cmd.Stdout = responseBuffer
 	cmd.Stderr = container.Stderr()
+
 	if err := cmd.Run(); err != nil {
 		// TODO: strip binary path as well?
-		return err
+		return handlePotentialTooManyFilesError(err)
 	}
 	response := &pluginpb.CodeGeneratorResponse{}
 	if err := protoencoding.NewWireUnmarshaler(nil).Unmarshal(responseBuffer.Bytes(), response); err != nil {

--- a/private/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
+++ b/private/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
@@ -135,7 +135,7 @@ func (h *protocProxyHandler) Handle(
 	if err := cmd.Run(); err != nil {
 		// TODO: strip binary path as well?
 		// We don't know if this is a system error or plugin error, so we assume system error
-		return err
+		return handlePotentialTooManyFilesError(err)
 	}
 	if featureProto3Optional {
 		responseWriter.SetFeatureProto3Optional()

--- a/private/pkg/app/appproto/appprotoexec/util.go
+++ b/private/pkg/app/appproto/appprotoexec/util.go
@@ -1,0 +1,46 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appprotoexec
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// handlePotentialTooManyFilesError checks if the error is a result of too many files
+// being open, and if so, modifies the output error with a help message.
+//
+// This could potentially go in osextended, but we want to provide a specific help
+// message referencing StrategyAll, so it is simplest to just put this here for now.
+func handlePotentialTooManyFilesError(err error) error {
+	if isTooManyFilesError(err) {
+		return fmt.Errorf("%w: %s", err, tooManyFilesHelpMessage)
+	}
+	return err
+}
+
+func isTooManyFilesError(err error) bool {
+	var syscallError *os.SyscallError
+	if errors.As(err, &syscallError) {
+		// This may not actually be correct on other platforms, however the worst cast
+		// is that we just don't provide the additional help message.
+		//
+		// Note that syscallError.Syscall has both equalled "pipe" and "fork/exec" in testing, but
+		// we don't match on this as this could be particularly prone to being platform-specific.
+		return syscallError.Err != nil && syscallError.Err.Error() == "too many open files"
+	}
+	return false
+}

--- a/private/pkg/app/appproto/appprotoexec/util_darwin.go
+++ b/private/pkg/app/appproto/appprotoexec/util_darwin.go
@@ -1,0 +1,20 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+// +build darwin
+
+package appprotoexec
+
+const tooManyFilesHelpMessage = `This is commonly caused by the maximum file limut being too low. On Mac, the default is 256, which is very low. Run "ulimit -n" to check your file limit. If this happened on generation, setting "strategy: all" for each configured plugin in your buf.gen.yaml can mitigate the issue if you are unable to change your file limit.`

--- a/private/pkg/app/appproto/appprotoexec/util_undarwin.go
+++ b/private/pkg/app/appproto/appprotoexec/util_undarwin.go
@@ -1,0 +1,20 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin
+// +build !darwin
+
+package appprotoexec
+
+const tooManyFilesHelpMessage = `This is commonly caused by the maximum file limut being too low. Run "ulimit -n" to check your file limit. If this happened on generation, setting "strategy: all" for each configured plugin in your buf.gen.yaml can mitigate the issue if you are unable to change your file limit.`


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/636 somewhat.

This prints a special warning if too many files are opened when invoking plugins. We can't control how many files these plugins open directly, although we could later have special logic that limits the amount of parallel execs depending on the file limit. Users should adjust their limits, especially as Mac's limits are so low.