### PR TITLE
Delete usage of os.Rename

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,9 @@ linters-settings:
       - '^exec\.Cmd$'
       - '^exec\.Command$'
       - '^exec\.CommandContext$'
+      # os.Rename does not work across filesystem boundaries
+      # See https://github.com/bufbuild/buf/issues/639
+      - '^os\.Rename$'
       # Ban debug statements
       - '^fmt\.Print'
       - '^log\.'


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/639

The original idea was that we wanted to make sure the file write happened without error before touching the original file, but we don't really need this level of guarantee here, and arguably (1) writing to a small file and having a failure is extremely unlikely (2) rename could have it's own issues.
