### PR TITLE
Add a nil check for `terminateFileProvider`

### DIFF
--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -402,11 +402,9 @@ func (r *reader) getBucketRootPathAndRelativePath(
 	// priority file.
 	var terminateFileDirectoryAbsPath string
 	// Get the highest priority file found and use it as the terminate file directory path.
-	if terminateFileProvider != nil {
-		terminateFiles := terminateFileProvider.GetTerminateFiles()
-		if len(terminateFiles) != 0 {
-			terminateFileDirectoryAbsPath = terminateFiles[0].Path()
-		}
+	terminateFiles := terminateFileProvider.GetTerminateFiles()
+	if len(terminateFiles) != 0 {
+		terminateFileDirectoryAbsPath = terminateFiles[0].Path()
 	}
 	if terminateFileDirectoryAbsPath != "" {
 		// If the terminate file exists, we need to determine the relative path from the


### PR DESCRIPTION
We need to add a `nil` check for the `terminateFileProvider`, since there is not always
a `terminateFile` file found. This is caught through testing in our private repository.

#668 has been opened for better testing outside of our repository context, which will always
have a terminate file (our workspace configuration at the top level of our repository).

This has been run against our private repository and fixes the issue.
