### PR TITLE
Support multiple insertion points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Upgrade to `protoc` 3.19.1 support.
+- Fix issue with `buf generate` where multiple insertion points are defined in the same file.
 
 ## [v1.0.0-rc6] - 2021-10-20
 

--- a/private/buf/cmd/buf/command/generate/testdata/insertion_point/test.txt
+++ b/private/buf/cmd/buf/command/generate/testdata/insertion_point/test.txt
@@ -11,5 +11,13 @@
 				
 		//     @@protoc_insertion_point(example)
 		//
-		// Note that all text should be added above the insertion point.
+		// The 'other' insertion point is also included so that we verify
+		// multiple insertion points can be written in a single invocation.
+		//
+		
+					// Include this comment on the 'other' insertion point.
+				
+		//   @@protoc_insertion_point(other)
+		//
+		// Note that all text should be added above the insertion points.
 		

--- a/private/buf/cmd/buf/command/generate/testdata/nested_insertion_point/gen/proto/insertion/test.txt
+++ b/private/buf/cmd/buf/command/generate/testdata/nested_insertion_point/gen/proto/insertion/test.txt
@@ -11,5 +11,13 @@
 				
 		//     @@protoc_insertion_point(example)
 		//
-		// Note that all text should be added above the insertion point.
+		// The 'other' insertion point is also included so that we verify
+		// multiple insertion points can be written in a single invocation.
+		//
+		
+					// Include this comment on the 'other' insertion point.
+				
+		//   @@protoc_insertion_point(other)
+		//
+		// Note that all text should be added above the insertion points.
 		

--- a/private/buf/cmd/buf/command/protoc/internal/protoc-gen-insertion-point-receiver/main.go
+++ b/private/buf/cmd/buf/command/protoc/internal/protoc-gen-insertion-point-receiver/main.go
@@ -43,7 +43,12 @@ func handle(
 		//
 		//     @@protoc_insertion_point(example)
 		//
-		// Note that all text should be added above the insertion point.
+		// The 'other' insertion point is also included so that we verify
+		// multiple insertion points can be written in a single invocation.
+		//
+		//   @@protoc_insertion_point(other)
+		//
+		// Note that all text should be added above the insertion points.
 		`),
 		},
 	)

--- a/private/buf/cmd/buf/command/protoc/internal/protoc-gen-insertion-point-writer/main.go
+++ b/private/buf/cmd/buf/command/protoc/internal/protoc-gen-insertion-point-writer/main.go
@@ -33,7 +33,7 @@ func handle(
 	responseWriter appproto.ResponseBuilder,
 	request *pluginpb.CodeGeneratorRequest,
 ) error {
-	return responseWriter.AddFile(
+	if err := responseWriter.AddFile(
 		&pluginpb.CodeGeneratorResponse_File{
 			Name:           proto.String("test.txt"),
 			InsertionPoint: proto.String("example"),
@@ -44,5 +44,19 @@ func handle(
 			// And don't forget the windows newline literal (\r\n).
 		`),
 		},
-	)
+	); err != nil {
+		return err
+	}
+	if err := responseWriter.AddFile(
+		&pluginpb.CodeGeneratorResponse_File{
+			Name:           proto.String("test.txt"),
+			InsertionPoint: proto.String("other"),
+			Content: proto.String(`
+			// Include this comment on the 'other' insertion point.
+		`),
+		},
+	); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes #702 

We were guarding against duplicate files, but did not take into account whether or not the file contained an insertion point. The insertion point test was adapted to match the test case demonstrated in #702.