### PR TITLE
Update all makego dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,11 +31,14 @@ linters:
   enable:
     - govet
     - asciicheck
+    - bidichk
     - bodyclose
+    - contextcheck
     - deadcode
     - depguard
     - dogsled
     - errcheck
+    - errname
     - exportloopref
     - forbidigo
     - forcetypeassert
@@ -61,6 +64,7 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - tenv
     - typecheck
     - unconvert
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,6 @@ linters:
     - depguard
     - dogsled
     - errcheck
-    - errname
     - exportloopref
     - forbidigo
     - forcetypeassert
@@ -64,7 +63,6 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
-    - tenv
     - typecheck
     - unconvert
     - unused
@@ -97,14 +95,7 @@ issues:
     - linters:
         - gosec
       # G204 checks that exec.Command is not called with non-constants.
-      # We call exec.Command for protoc and plugin proxying, and control the arguments completely.
-      path: private/pkg/app/appproto/appprotoexec/binary_handler.go
-      text: "G204:"
-    - linters:
-        - gosec
-      # G204 checks that exec.Command is not called with non-constants.
-      # We call exec.Command for protoc and plugin proxying, and control the arguments completely.
-      path: private/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
+      path: private/pkg/command/runner.go
       text: "G204:"
     - linters:
         - wastedassign

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -1,4 +1,4 @@
-# https://github.com/jhump/protoreflect/commits/master 20211108 checked 20211108
+# https://github.com/jhump/protoreflect/commits/master 20211108 checked 2021112
 GO_GET_PKGS := $(GO_GET_PKGS) \
 	github.com/jhump/protoreflect@d551e22cd340edf9f6e515a6d3670a1f9cf7e990
 GO_ALL_REPO_PKGS := ./cmd/... ./private/...

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -1,4 +1,4 @@
-# https://github.com/jhump/protoreflect/commits/master 20211108 checked 2021112
+# https://github.com/jhump/protoreflect/commits/master 20211108 checked 20211112
 GO_GET_PKGS := $(GO_GET_PKGS) \
 	github.com/jhump/protoreflect@d551e22cd340edf9f6e515a6d3670a1f9cf7e990
 GO_ALL_REPO_PKGS := ./cmd/... ./private/...

--- a/make/go/dep_buf.mk
+++ b/make/go/dep_buf.mk
@@ -8,7 +8,7 @@ $(call _assert_var,CACHE_BIN)
 
 # Settable
 # https://github.com/bufbuild/buf/releases
-BUF_VERSION ?= v1.0.0-rc4
+BUF_VERSION ?= v1.0.0-rc8
 # Settable
 #
 # If set, this path will be installed every time someone depends on $(BUF)

--- a/make/go/dep_git_ls_files_unstaged.mk
+++ b/make/go/dep_git_ls_files_unstaged.mk
@@ -8,7 +8,7 @@ $(call _assert_var,CACHE_BIN)
 
 # Settable
 # https://github.com/bufbuild/buf/releases
-GIT_LS_FILES_UNSTAGED_VERSION ?= v1.0.0-rc3
+GIT_LS_FILES_UNSTAGED_VERSION ?= v1.0.0-rc8
 
 GIT_LS_FILES_UNSTAGED := $(CACHE_VERSIONS)/git-ls-files-unstaged/$(GIT_LS_FILES_UNSTAGED_VERSION)
 $(GIT_LS_FILES_UNSTAGED):

--- a/make/go/dep_go_fuzz.mk
+++ b/make/go/dep_go_fuzz.mk
@@ -7,8 +7,8 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/dvyukov/go-fuzz/commits/master 20210430 checked 20210521
-GO_FUZZ_VERSION ?= fca39067bc7270ea00dd1a7ce4443eba66ff58fe
+# https://github.com/dvyukov/go-fuzz/commits/master 20210914 checked 20211112
+GO_FUZZ_VERSION ?= 4980593459a186bd2a389fe4557a260cce742594
 
 GO_FUZZ := $(CACHE_VERSIONS)/go-fuzz/$(GO_FUZZ_VERSION)
 $(GO_FUZZ):

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20210619 checked 20210716
+# https://github.com/golangci/golangci-lint/releases 20211103 checked 20211112
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.41.1
+GOLANGCI_LINT_VERSION ?= v1.43.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):

--- a/make/go/dep_jq.mk
+++ b/make/go/dep_jq.mk
@@ -9,7 +9,7 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://stedolan.github.io/jq/download checked 20210521
+# https://stedolan.github.io/jq/download checked 20211112
 JQ_VERSION ?= 1.6
 
 # jq does not have an ARM release on Github so we'll use

--- a/make/go/dep_license_header.mk
+++ b/make/go/dep_license_header.mk
@@ -8,7 +8,7 @@ $(call _assert_var,CACHE_BIN)
 
 # Settable
 # https://github.com/bufbuild/buf/releases
-LICENSE_HEADER_VERSION ?= v1.0.0-rc4
+LICENSE_HEADER_VERSION ?= v1.0.0-rc8
 
 LICENSE_HEADER := $(CACHE_VERSIONS)/license-header/$(LICENSE_HEADER_VERSION)
 $(LICENSE_HEADER):

--- a/make/go/dep_minisign.mk
+++ b/make/go/dep_minisign.mk
@@ -7,7 +7,7 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/aead/minisign/commit/4b0a1d5cec55046cced3e84526660c7820b8f58c 11082021 checked 11082021
+# https://github.com/aead/minisign/commit/4b0a1d5cec55046cced3e84526660c7820b8f58c 20211108 checked 20211112
 # Contains fix for https://github.com/aead/minisign/issues/11
 MINISIGN_VERSION ?= 4b0a1d5cec55046cced3e84526660c7820b8f58c
 

--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -10,7 +10,7 @@ $(call _assert_var,CACHE_INCLUDE)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf/releases 20211028 checked 20211028
+# https://github.com/protocolbuffers/protobuf/releases 20211028 checked 20211112
 PROTOC_VERSION ?= 3.19.1
 
 # There are no protobuf releases for Darwin ARM so for

--- a/make/go/dep_protoc_gen_go.mk
+++ b/make/go/dep_protoc_gen_go.mk
@@ -7,7 +7,7 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/protocolbuffers/protobuf-go/releases 20210628 checked 20210712
+# https://github.com/protocolbuffers/protobuf-go/releases 20210628 checked 20211112
 PROTOC_GEN_GO_VERSION ?= v1.27.1
 
 GO_GET_PKGS := $(GO_GET_PKGS) \

--- a/make/go/dep_protoc_gen_go_grpc.mk
+++ b/make/go/dep_protoc_gen_go_grpc.mk
@@ -7,8 +7,8 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/grpc/grpc-go/commits/master 20211108 checked 20211108
-PROTOC_GEN_GO_GRPC_VERSION ?= 79e9c9571a1949d3abae203a127fa5d4f02fb071
+# https://github.com/grpc/grpc-go/commits/master 20211112 checked 20211112
+PROTOC_GEN_GO_GRPC_VERSION ?= cf8b64e2c5bf11e00856a29794e434460eb67b90
 
 GO_GET_PKGS := $(GO_GET_PKGS) google.golang.org/grpc@$(PROTOC_GEN_GO_GRPC_VERSION)
 

--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -43,105 +43,105 @@ func TestGitCloner(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, nil, false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, nil, false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 2", string(content), "expected the commit on local-branch to be checked out")
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
-		_, err = storage.ReadPath(context.Background(), readBucket, "submodule/test.proto")
+		_, err = storage.ReadPath(ctx, readBucket, "submodule/test.proto")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("default_submodule", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, nil, true)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, nil, true)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 2", string(content), "expected the commit on local-branch to be checked out")
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
-		content, err = storage.ReadPath(context.Background(), readBucket, "submodule/test.proto")
+		content, err = storage.ReadPath(ctx, readBucket, "submodule/test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// submodule", string(content))
 	})
 
 	t.Run("main", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, NewBranchName("main"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewBranchName("main"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 1", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("origin/main", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, NewBranchName("origin/main"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewBranchName("origin/main"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 3", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("origin/remote-branch", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, NewBranchName("origin/remote-branch"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewBranchName("origin/remote-branch"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 4", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("remote-tag", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, NewTagName("remote-tag"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewTagName("remote-tag"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 4", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("branch_and_main_ref", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 2, NewRefNameWithBranch("HEAD~", "main"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefNameWithBranch("HEAD~", "main"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 0", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("branch_and_ref", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 2, NewRefNameWithBranch("local-branch~", "local-branch"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefNameWithBranch("local-branch~", "local-branch"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 1", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
 	t.Run("HEAD", func(t *testing.T) {
 		t.Parallel()
-		readBucket := readBucketForName(t, runner, workDir, 1, NewRefName("HEAD"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewRefName("HEAD"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 2", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
@@ -149,12 +149,12 @@ func TestGitCloner(t *testing.T) {
 		t.Parallel()
 		revParseBytes, err := command.RunStdout(ctx, container, runner, "git", "-C", workDir, "rev-parse", "HEAD~")
 		require.NoError(t, err)
-		readBucket := readBucketForName(t, runner, workDir, 2, NewRefName(strings.TrimSpace(string(revParseBytes))), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName(strings.TrimSpace(string(revParseBytes))), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 1", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 
@@ -162,17 +162,17 @@ func TestGitCloner(t *testing.T) {
 		t.Parallel()
 		revParseBytes, err := command.RunStdout(ctx, container, runner, "git", "-C", originDir, "rev-parse", "remote-branch~")
 		require.NoError(t, err)
-		readBucket := readBucketForName(t, runner, workDir, 2, NewRefNameWithBranch(strings.TrimSpace(string(revParseBytes)), "origin/remote-branch"), false)
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefNameWithBranch(strings.TrimSpace(string(revParseBytes)), "origin/remote-branch"), false)
 
-		content, err := storage.ReadPath(context.Background(), readBucket, "test.proto")
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 3", string(content))
-		_, err = readBucket.Stat(context.Background(), "nonexistent")
+		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, storage.IsNotExist(err))
 	})
 }
 
-func readBucketForName(t *testing.T, runner command.Runner, path string, depth uint32, name Name, recurseSubmodules bool) storage.ReadBucket {
+func readBucketForName(ctx context.Context, t *testing.T, runner command.Runner, path string, depth uint32, name Name, recurseSubmodules bool) storage.ReadBucket {
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	cloner := NewCloner(zap.NewNop(), storageosProvider, runner, ClonerOptions{})
 	envContainer, err := app.NewEnvContainerForOS()
@@ -180,7 +180,7 @@ func readBucketForName(t *testing.T, runner command.Runner, path string, depth u
 
 	readWriteBucket := storagemem.NewReadWriteBucket()
 	err = cloner.CloneToBucket(
-		context.Background(),
+		ctx,
 		envContainer,
 		"file://"+filepath.Join(path, ".git"),
 		depth,


### PR DESCRIPTION
This updates all makego dependencies, including the newest version of `golangci-lint`. New linters that have been added are enabled where they are desired.