### PR TITLE
Use a separate repository service per remote for resolving dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Change message documentation for fields to be either a single field or a oneof set of fields. This is a breaking API change.
+- Use a separate repository service to for each dependency remote to resolve dependencies for `buf mod update`. Previously, we used a single repository service based on the remote
+  from the module, so it was unable to resolve dependencies from differente remotes.
 
 ## [v1.0.0-rc8] - 2021-11-10
 


### PR DESCRIPTION
This creates a new repository service per remote across dependencies, and then resolves dependencies based on their remote.

Fixes #729