### PR TITLE
Display correct remote in `buf login`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change message documentation for fields to be either a single field or a oneof set of fields. This is a breaking API change.
 - Use a separate repository service to for each dependency remote to resolve dependencies for `buf mod update`. Previously, we used a single repository service based on the remote
   from the module, so it was unable to resolve dependencies from differente remotes.
+- Display the user-provided Buf Schema Registry remote, if specified, instead of the default within the `buf login` message.
 
 ## [v1.0.0-rc8] - 2021-11-10
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -92,9 +92,10 @@ func run(
 	}
 	// Do not print unless we are prompting
 	if flags.Username == "" && !flags.TokenStdin {
-		loginMessage := fmt.Sprintf("Login with your Buf Schema Registry username. If you don't have a username, head over to https://%s to create one.\n\n", remote)
-		if _, err := container.Stdout().Write(
-			[]byte(loginMessage),
+		if _, err := fmt.Fprintf(
+			container.Stdout(),
+			"Login with your Buf Schema Registry username. If you don't have a username, head over to https://%s to create one.\n\n",
+			remote,
 		); err != nil {
 			return err
 		}

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -86,10 +86,15 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
+	remote := bufrpc.DefaultRemote
+	if container.NumArgs() == 1 {
+		remote = container.Arg(0)
+	}
 	// Do not print unless we are prompting
 	if flags.Username == "" && !flags.TokenStdin {
+		loginMessage := fmt.Sprintf("Login with your Buf Schema Registry username. If you don't have a username, head over to https://%s to create one.\n\n", remote)
 		if _, err := container.Stdout().Write(
-			[]byte("Login with your Buf Schema Registry username. If you don't have a username, head over to https://buf.build to create one.\n\n"),
+			[]byte(loginMessage),
 		); err != nil {
 			return err
 		}
@@ -121,10 +126,6 @@ func run(
 			}
 			return err
 		}
-	}
-	remote := bufrpc.DefaultRemote
-	if container.NumArgs() == 1 {
-		remote = container.Arg(0)
 	}
 	if err := netrc.PutMachines(
 		container,


### PR DESCRIPTION
The message displayed as part of an interactive `buf login` command
should refer to the Buf Schema Registry address that the user is
attempting to login to.