### PR TITLE
registry login: suppress bug report message on EOF

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -685,6 +685,10 @@ func promptUser(container app.Container, prompt string, isPassword bool) (string
 		if isPassword {
 			data, err := term.ReadPassword(int(file.Fd()))
 			if err != nil {
+				// If the user submitted an EOF (e.g. via ^D) then we
+				// should not treat it as an internal error; returning
+				// the error directly makes it more clear as to
+				// why the command failed.
 				if errors.Is(err, io.EOF) {
 					return "", err
 				}


### PR DESCRIPTION
A user entering EOF (^D) when prompted does not warrant filing a bug
report.