### PR TITLE
registry login: handle context cancel (SIGINT)

### DIFF
--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -87,10 +87,10 @@ func run(
 	flags *flags,
 ) error {
 	errc := make(chan error)
-	defer close(errc)
 
 	go func() {
 		errc <- inner(container, flags)
+		close(errc)
 	}()
 
 	select {

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -109,7 +109,14 @@ func run(
 	case err := <-errc:
 		return err
 	case <-ctx.Done():
-		return ctx.Err()
+		ctxErr := ctx.Err()
+		if errors.Is(ctxErr, context.Canceled) {
+			if _, err := fmt.Fprintln(container.Stdout()); err != nil {
+				return err
+			}
+			return nil
+		}
+		return ctxErr
 	}
 }
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -86,6 +86,25 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
+	errc := make(chan error)
+	defer close(errc)
+
+	go func() {
+		errc <- inner(container, flags)
+	}()
+
+	select {
+	case err := <-errc:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func inner(
+	container appflag.Container,
+	flags *flags,
+) error {
 	remote := bufrpc.DefaultRemote
 	if container.NumArgs() == 1 {
 		remote = container.Arg(0)

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -100,13 +100,13 @@ func run(
 	// Note that this does not gracefully handle the case where the terminal is
 	// in no-echo mode, as is the case when prompting for a password
 	// interactively.
-	errc := make(chan error, 1)
+	errC := make(chan error, 1)
 	go func() {
-		errc <- inner(container, flags)
-		close(errc)
+		errC <- inner(container, flags)
+		close(errC)
 	}()
 	select {
-	case err := <-errc:
+	case err := <-errC:
 		return err
 	case <-ctx.Done():
 		ctxErr := ctx.Err()

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -110,7 +110,10 @@ func run(
 		return err
 	case <-ctx.Done():
 		ctxErr := ctx.Err()
+		// Otherwise we will print "Failure: context canceled".
 		if errors.Is(ctxErr, context.Canceled) {
+			// Otherwise the next terminal line will be on the same line as the
+			// last output from buf.
 			if _, err := fmt.Fprintln(container.Stdout()); err != nil {
 				return err
 			}


### PR DESCRIPTION
If a user sends a SIGINT to `buf`, the top-level application context is
cancelled and signal masks are reset. However, during an interactive
login the context is not respected; for example, it takes _two_ SIGINTs
to interrupt the process.

Ideally we could just trigger an I/O timeout by setting the deadline on
stdin, but when stdin is connected to a terminal the underlying fd is in
blocking mode making it ineligible. As changing the mode of stdin is
dangerous, this change takes an alternate approach of simply returning
early.

Note that this does not gracefully handle the case where the terminal is
in no-echo mode, as is the case when prompting for a password
interactively.