### PR TITLE
Refactor the `WriteConfig` function for bufconfig for a generic use case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,5 +27,6 @@ require (
 	google.golang.org/genproto v0.0.0-20211104193956-4c6863e31247 // indirect
 	google.golang.org/grpc v1.43.0-dev.0.20211108191124-79e9c9571a19
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,5 @@ require (
 	google.golang.org/genproto v0.0.0-20211104193956-4c6863e31247 // indirect
 	google.golang.org/grpc v1.43.0-dev.0.20211108191124-79e9c9571a19
 	google.golang.org/protobuf v1.27.1
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1159,11 +1159,11 @@ func TestConfigInitBasic(t *testing.T) {
 		t,
 		`version: v1
 breaking:
-  use:
-  - FILE
+    use:
+        - FILE
 lint:
-  use:
-  - DEFAULT
+    use:
+        - DEFAULT
 `,
 		false,
 		"",

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1158,12 +1158,12 @@ func TestConfigInitBasic(t *testing.T) {
 	testConfigInit(
 		t,
 		`version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
-    - FILE
+  - FILE
+lint:
+  use:
+  - DEFAULT
 `,
 		false,
 		"",

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1159,11 +1159,11 @@ func TestConfigInitBasic(t *testing.T) {
 		t,
 		`version: v1
 breaking:
-    use:
-        - FILE
+  use:
+    - FILE
 lint:
-    use:
-        - DEFAULT
+  use:
+    - DEFAULT
 `,
 		false,
 		"",

--- a/private/buf/cmd/buf/command/config/configinit/configinit.go
+++ b/private/buf/cmd/buf/command/config/configinit/configinit.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
@@ -126,6 +128,23 @@ func run(
 			bufconfig.WriteConfigWithUncomment(),
 		)
 	}
+	// Need to include the default version (v1), lint config, and breaking config.
+	writeConfigOptions = append(
+		writeConfigOptions,
+		bufconfig.WriteConfigWithVersion(bufconfig.V1Version),
+	)
+	writeConfigOptions = append(
+		writeConfigOptions,
+		bufconfig.WriteConfigWithBreakingConfig(&bufbreakingconfig.Config{
+			Use: []string{"FILE"},
+		}),
+	)
+	writeConfigOptions = append(
+		writeConfigOptions,
+		bufconfig.WriteConfigWithLintConfig(&buflintconfig.Config{
+			Use: []string{"DEFAULT"},
+		}),
+	)
 	return bufconfig.WriteConfig(
 		ctx,
 		readWriteBucket,

--- a/private/buf/cmd/buf/command/config/configinit/configinit.go
+++ b/private/buf/cmd/buf/command/config/configinit/configinit.go
@@ -129,20 +129,23 @@ func run(
 		)
 	}
 	// Need to include the default version (v1), lint config, and breaking config.
+	version := bufconfig.V1Version
 	writeConfigOptions = append(
 		writeConfigOptions,
-		bufconfig.WriteConfigWithVersion(bufconfig.V1Version),
+		bufconfig.WriteConfigWithVersion(version),
 	)
 	writeConfigOptions = append(
 		writeConfigOptions,
 		bufconfig.WriteConfigWithBreakingConfig(&bufbreakingconfig.Config{
-			Use: []string{"FILE"},
+			Version: version,
+			Use:     []string{"FILE"},
 		}),
 	)
 	writeConfigOptions = append(
 		writeConfigOptions,
 		bufconfig.WriteConfigWithLintConfig(&buflintconfig.Config{
-			Use: []string{"DEFAULT"},
+			Version: version,
+			Use:     []string{"DEFAULT"},
 		}),
 	)
 	return bufconfig.WriteConfig(

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -120,6 +120,28 @@ type ExternalConfigV1 struct {
 	IgnoreUnstablePackages bool                `json:"ignore_unstable_packages,omitempty" yaml:"ignore_unstable_packages,omitempty"`
 }
 
+// ExternalConfigV1Beta1ForConfig takes a *Config and returns the v1beta1 external config representation.
+func ExternalConfigV1Beta1ForConfig(config *Config) ExternalConfigV1Beta1 {
+	return ExternalConfigV1Beta1{
+		Use:                    config.Use,
+		Except:                 config.Except,
+		Ignore:                 config.IgnoreRootPaths,
+		IgnoreOnly:             config.IgnoreIDOrCategoryToRootPaths,
+		IgnoreUnstablePackages: config.IgnoreUnstablePackages,
+	}
+}
+
+// ExternalConfigV1ForConfig takes a *Config and returns the v1 external config representation.
+func ExternalConfigV1ForConfig(config *Config) ExternalConfigV1 {
+	return ExternalConfigV1{
+		Use:                    config.Use,
+		Except:                 config.Except,
+		Ignore:                 config.IgnoreRootPaths,
+		IgnoreOnly:             config.IgnoreIDOrCategoryToRootPaths,
+		IgnoreUnstablePackages: config.IgnoreUnstablePackages,
+	}
+}
+
 // BytesForConfig takes a *Config and returns the deterministic []byte representation.
 // We use an unexported intermediary JSON form and sort all fields to ensure that the bytes
 // associated with the *Config are deterministic.

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -163,6 +163,37 @@ type ExternalConfigV1 struct {
 	AllowCommentIgnores                  bool                `json:"allow_comment_ignores,omitempty" yaml:"allow_comment_ignores,omitempty"`
 }
 
+// ExternalConfigV1Beta1ForConfig takes a *Config and returns the v1beta1 externalconfig representation.
+func ExternalConfigV1Beta1ForConfig(config *Config) ExternalConfigV1Beta1 {
+	return ExternalConfigV1Beta1{
+		Use:                                  config.Use,
+		Except:                               config.Except,
+		Ignore:                               config.IgnoreRootPaths,
+		IgnoreOnly:                           config.IgnoreIDOrCategoryToRootPaths,
+		EnumZeroValueSuffix:                  config.EnumZeroValueSuffix,
+		RPCAllowSameRequestResponse:          config.RPCAllowSameRequestResponse,
+		RPCAllowGoogleProtobufEmptyRequests:  config.RPCAllowGoogleProtobufEmptyRequests,
+		RPCAllowGoogleProtobufEmptyResponses: config.RPCAllowGoogleProtobufEmptyResponses,
+		ServiceSuffix:                        config.ServiceSuffix,
+		AllowCommentIgnores:                  config.AllowCommentIgnores,
+	}
+}
+
+// ExternalConfigV1ForConfig takes a *Config and returns the v1 externalconfig representation.
+func ExternalConfigV1ForConfig(config *Config) ExternalConfigV1 {
+	return ExternalConfigV1{
+		Use:                                  config.Use,
+		Except:                               config.Except,
+		IgnoreOnly:                           config.IgnoreIDOrCategoryToRootPaths,
+		EnumZeroValueSuffix:                  config.EnumZeroValueSuffix,
+		RPCAllowSameRequestResponse:          config.RPCAllowSameRequestResponse,
+		RPCAllowGoogleProtobufEmptyRequests:  config.RPCAllowGoogleProtobufEmptyRequests,
+		RPCAllowGoogleProtobufEmptyResponses: config.RPCAllowGoogleProtobufEmptyResponses,
+		ServiceSuffix:                        config.ServiceSuffix,
+		AllowCommentIgnores:                  config.AllowCommentIgnores,
+	}
+}
+
 // BytesForConfig takes a *Config and returns the deterministic []byte representation.
 // We use an unexported intermediary JSON form and sort all fields to ensure that the bytes
 // associated with the *Config are deterministic.

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -184,6 +184,7 @@ func ExternalConfigV1ForConfig(config *Config) ExternalConfigV1 {
 	return ExternalConfigV1{
 		Use:                                  config.Use,
 		Except:                               config.Except,
+		Ignore:                               config.IgnoreRootPaths,
 		IgnoreOnly:                           config.IgnoreIDOrCategoryToRootPaths,
 		EnumZeroValueSuffix:                  config.EnumZeroValueSuffix,
 		RPCAllowSameRequestResponse:          config.RPCAllowSameRequestResponse,

--- a/private/bufpkg/bufconfig/bufconfig.go
+++ b/private/bufpkg/bufconfig/bufconfig.go
@@ -143,6 +143,35 @@ func WriteConfigWithDependencyModuleReferences(dependencyModuleReferences ...buf
 	}
 }
 
+// WriteConfigWithBreakingConfig returns a new WriteConfigOption that sets the breaking change
+// config for the module.
+//
+// If this option is used and the version used will be consistent with the rest of the config.
+func WriteConfigWithBreakingConfig(breakingConfig *bufbreakingconfig.Config) WriteConfigOption {
+	return func(writeConfigOptions *writeConfigOptions) {
+		writeConfigOptions.breakingConfig = breakingConfig
+	}
+}
+
+// WriteConfigWithLintConfig returns a new WriteConfigOption that sets the lint config for // the module.
+//
+// If this option is used and the version used will be consistent with the rest of the config.
+func WriteConfigWithLintConfig(lintConfig *buflintconfig.Config) WriteConfigOption {
+	return func(writeConfigOptions *writeConfigOptions) {
+		writeConfigOptions.lintConfig = lintConfig
+	}
+}
+
+// WriteConfigWithVersion returns a new WriteConfigOption that sets the version of the config
+// being written.
+//
+// If this is not set, the default is v1.
+func WriteConfigWithVersion(version string) WriteConfigOption {
+	return func(writeConfigOptions *writeConfigOptions) {
+		writeConfigOptions.version = version
+	}
+}
+
 // ReadConfigOS reads the configuration from the OS or an override, if any.
 //
 // ONLY USE IN CLI TOOLS.

--- a/private/bufpkg/bufconfig/bufconfig.go
+++ b/private/bufpkg/bufconfig/bufconfig.go
@@ -165,7 +165,7 @@ func WriteConfigWithLintConfig(lintConfig *buflintconfig.Config) WriteConfigOpti
 // WriteConfigWithVersion returns a new WriteConfigOption that sets the version of the config
 // being written.
 //
-// If this is not set, the default is v1.
+// If this is not set, the default is v1beta1.
 func WriteConfigWithVersion(version string) WriteConfigOption {
 	return func(writeConfigOptions *writeConfigOptions) {
 		writeConfigOptions.version = version

--- a/private/bufpkg/bufconfig/bufconfig.go
+++ b/private/bufpkg/bufconfig/bufconfig.go
@@ -146,16 +146,16 @@ func WriteConfigWithDependencyModuleReferences(dependencyModuleReferences ...buf
 // WriteConfigWithBreakingConfig returns a new WriteConfigOption that sets the breaking change
 // config for the module.
 //
-// If this option is used and the version used will be consistent with the rest of the config.
+// If this option is used then the version used must be consistent with the rest of the config.
 func WriteConfigWithBreakingConfig(breakingConfig *bufbreakingconfig.Config) WriteConfigOption {
 	return func(writeConfigOptions *writeConfigOptions) {
 		writeConfigOptions.breakingConfig = breakingConfig
 	}
 }
 
-// WriteConfigWithLintConfig returns a new WriteConfigOption that sets the lint config for // the module.
+// WriteConfigWithLintConfig returns a new WriteConfigOption that sets the lint config for the module.
 //
-// If this option is used and the version used will be consistent with the rest of the config.
+// If this option is used then the version used must be consistent with the rest of the config.
 func WriteConfigWithLintConfig(lintConfig *buflintconfig.Config) WriteConfigOption {
 	return func(writeConfigOptions *writeConfigOptions) {
 		writeConfigOptions.lintConfig = lintConfig

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -275,19 +275,22 @@ func writeConfig(
 	var breakingConfigVersion string
 	breakingConfig := writeConfigOptions.breakingConfig
 	if breakingConfig != nil {
-		if breakingConfig.Version != version {
-			return fmt.Errorf("invalid version found for breaking config: %q", breakingConfig.Version)
+		breakingConfigVersion = breakingConfig.Version
+		if breakingConfigVersion != version {
+			return fmt.Errorf("invalid version found for breaking config: %q", breakingConfigVersion)
 		}
 		config.Breaking = breakingConfig
 	}
 	var lintConfigVersion string
 	lintConfig := writeConfigOptions.lintConfig
 	if lintConfig != nil {
-		if lintConfig.Version != version {
-			return fmt.Errorf("invalid version found for lint config: %q", breakingConfig.Version)
+		lintConfigVersion = lintConfig.Version
+		if lintConfigVersion != version {
+			return fmt.Errorf("invalid version found for lint config: %q", lintConfigVersion)
 		}
-		config.Lint = writeConfigOptions.lintConfig
+		config.Lint = lintConfig
 	}
+	// We should never hit this condition since we are already validating against `version`.
 	if breakingConfigVersion != lintConfigVersion {
 		return fmt.Errorf("breaking config version %q does not match lint config version %q", breakingConfigVersion, lintConfigVersion)
 	}

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -277,7 +277,7 @@ func writeConfig(
 	if breakingConfig != nil {
 		breakingConfigVersion = breakingConfig.Version
 		if breakingConfigVersion != version {
-			return fmt.Errorf("invalid version found for breaking config: %q", breakingConfigVersion)
+			return fmt.Errorf("version %q found for breaking config, does not match top level config version: %q", breakingConfigVersion, version)
 		}
 		config.Breaking = breakingConfig
 	}
@@ -286,7 +286,7 @@ func writeConfig(
 	if lintConfig != nil {
 		lintConfigVersion = lintConfig.Version
 		if lintConfigVersion != version {
-			return fmt.Errorf("invalid version found for lint config: %q", lintConfigVersion)
+			return fmt.Errorf("version %q found for lint config, does not match top level config version: %q", lintConfigVersion, version)
 		}
 		config.Lint = lintConfig
 	}

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -25,7 +25,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // If this is updated, make sure to update docs.buf.build TODO automate this

--- a/private/bufpkg/bufconfig/write_test.go
+++ b/private/bufpkg/bufconfig/write_test.go
@@ -76,7 +76,7 @@ func TestWriteConfigMismatchedConfigVersions(t *testing.T) {
 		}
 		err = WriteConfig(context.Background(), readWriteBucket, writeConfigOptions...)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), `invalid version found for breaking config: "v1"`)
+		require.Equal(t, err.Error(), `version "v1" found for breaking config, does not match top level config version: "v1beta1"`)
 	})
 	t.Run("invalid lint config", func(t *testing.T) {
 		storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
@@ -91,6 +91,6 @@ func TestWriteConfigMismatchedConfigVersions(t *testing.T) {
 		}
 		err = WriteConfig(context.Background(), readWriteBucket, writeConfigOptions...)
 		require.Error(t, err)
-		require.Equal(t, err.Error(), `invalid version found for lint config: "v1"`)
+		require.Equal(t, err.Error(), `version "v1" found for lint config, does not match top level config version: "v1beta1"`)
 	})
 }

--- a/private/bufpkg/bufconfig/write_test.go
+++ b/private/bufpkg/bufconfig/write_test.go
@@ -1,0 +1,96 @@
+// Copyright 2020-2021 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufconfig
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
+	"github.com/bufbuild/buf/private/pkg/storage/storageos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteConfigSuccess(t *testing.T) {
+	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
+	readWriteBucket, err := storageosProvider.NewReadWriteBucket(t.TempDir())
+	require.NoError(t, err)
+	writeConfigOptions := []WriteConfigOption{
+		WriteConfigWithVersion(V1Version),
+		WriteConfigWithBreakingConfig(&bufbreakingconfig.Config{
+			Version: V1Version,
+			Use:     []string{"FILE"},
+		}),
+		WriteConfigWithLintConfig(&buflintconfig.Config{
+			Version: V1Version,
+			Use:     []string{"DEFAULT"},
+		}),
+	}
+	err = WriteConfig(context.Background(), readWriteBucket, writeConfigOptions...)
+	require.NoError(t, err)
+	configReadObjectCloser, err := readWriteBucket.Get(context.Background(), ExternalConfigV1FilePath)
+	require.NoError(t, err)
+	configBytes, err := io.ReadAll(configReadObjectCloser)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		string(configBytes),
+		`version: v1
+breaking:
+  use:
+    - FILE
+lint:
+  use:
+    - DEFAULT
+`,
+	)
+	require.NoError(t, configReadObjectCloser.Close())
+}
+
+func TestWriteConfigMismatchedConfigVersions(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid breaking config", func(t *testing.T) {
+		storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
+		readWriteBucket, err := storageosProvider.NewReadWriteBucket(t.TempDir())
+		require.NoError(t, err)
+		writeConfigOptions := []WriteConfigOption{
+			WriteConfigWithVersion(V1Beta1Version),
+			WriteConfigWithBreakingConfig(&bufbreakingconfig.Config{
+				Version: V1Version,
+				Use:     []string{"FILE"},
+			}),
+		}
+		err = WriteConfig(context.Background(), readWriteBucket, writeConfigOptions...)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), `invalid version found for breaking config: "v1"`)
+	})
+	t.Run("invalid lint config", func(t *testing.T) {
+		storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
+		readWriteBucket, err := storageosProvider.NewReadWriteBucket(t.TempDir())
+		require.NoError(t, err)
+		writeConfigOptions := []WriteConfigOption{
+			WriteConfigWithVersion(V1Beta1Version),
+			WriteConfigWithLintConfig(&buflintconfig.Config{
+				Version: V1Version,
+				Use:     []string{"DEFAULT"},
+			}),
+		}
+		err = WriteConfig(context.Background(), readWriteBucket, writeConfigOptions...)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), `invalid version found for lint config: "v1"`)
+	})
+}

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -487,15 +487,14 @@ func ModuleToBucket(
 	if module.LintConfig() != nil {
 		lintConfigVersion = module.LintConfig().Version
 	}
-	if breakingConfigVersion != "" && lintConfigVersion != "" {
-		if breakingConfigVersion != lintConfigVersion {
-			return fmt.Errorf("breaking config version %q does not match lint config version %q", breakingConfigVersion, lintConfigVersion)
-		}
+	// If one of either breaking or lint config is non-nil, then other config will also be non-nil,
+	// even if a module does not set both configurations. An empty with the correct version
+	// will be set by the configuration getters.
+	if breakingConfigVersion != lintConfigVersion {
+		return fmt.Errorf("breaking config version %q does not match lint config version %q", breakingConfigVersion, lintConfigVersion)
+	}
+	if breakingConfigVersion != "" || lintConfigVersion != "" {
 		version = breakingConfigVersion
-	} else if breakingConfigVersion != "" {
-		version = breakingConfigVersion
-	} else if lintConfigVersion != "" {
-		version = lintConfigVersion
 	}
 	writeConfigOptions := []bufconfig.WriteConfigOption{
 		bufconfig.WriteConfigWithModuleIdentity(module.getModuleIdentity()),

--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
@@ -302,6 +303,13 @@ func TestModuleReaderCacherWithConfiguration(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 	require.Equal(t, bufmoduletesting.TestModuleDocumentation, module.Documentation())
+	// Parse config from original data
+	config, err := bufconfig.GetConfigForData(ctx, []byte(bufmoduletesting.TestModuleConfiguration))
+	require.NoError(t, err)
+	cachedConfig, err := bufconfig.GetConfigForBucket(ctx, readWriteBucket)
+	require.NoError(t, err)
+	require.Equal(t, config.Breaking, cachedConfig.Breaking)
+	require.Equal(t, config.Lint, cachedConfig.Lint)
 }
 
 func newTestDataSumBucketsAndLocker(t *testing.T) (storage.ReadWriteBucket, storage.ReadWriteBucket, filelock.Locker) {

--- a/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting.go
@@ -29,7 +29,7 @@ const (
 	// TestDigestB3WithConfiguration is a valid digest.
 	//
 	// This matches TestDataWithConfiguration.
-	TestDigestB3WithConfiguration = "b3-okxtYzp_f8B6J4-QfxM1fs49X4QX_1XlGig_RhYXCL4="
+	TestDigestB3WithConfiguration = "b3-b2gkRgE1WxTKpEfsK4ql8STGxqc6nRimCeMBGB5i2OU="
 	// TestDigestWithDocumentation is a valid test digest.
 	//
 	// This matches TestDataWithDocumentation.

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -65,7 +65,7 @@ func newModuleForProto(
 		ctx,
 		readWriteBucket,
 		dependencyModulePins,
-		nil,
+		nil, // The module identity is not stored on the proto. We rely on the layer above, (e.g. `ModuleReader`) to set this as needed.
 		protoModule.GetDocumentation(),
 		bufbreakingconfig.ConfigForProto(protoModule.GetBreakingConfig()),
 		buflintconfig.ConfigForProto(protoModule.GetLintConfig()),

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -89,6 +89,10 @@ func newModuleForBucket(
 	if err != nil {
 		return nil, err
 	}
+	// if the module config has an identity, set the module identity
+	if moduleConfig.ModuleIdentity != nil {
+		options = append(options, ModuleWithModuleIdentity(moduleConfig.ModuleIdentity))
+	}
 	return newModule(
 		ctx,
 		storage.MapReadBucket(sourceReadBucket, storage.MatchPathExt(".proto")),

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -65,6 +65,7 @@ func newModuleForProto(
 		ctx,
 		readWriteBucket,
 		dependencyModulePins,
+		nil,
 		protoModule.GetDocumentation(),
 		bufbreakingconfig.ConfigForProto(protoModule.GetBreakingConfig()),
 		buflintconfig.ConfigForProto(protoModule.GetLintConfig()),
@@ -89,14 +90,16 @@ func newModuleForBucket(
 	if err != nil {
 		return nil, err
 	}
+	var moduleIdentity bufmoduleref.ModuleIdentity
 	// if the module config has an identity, set the module identity
 	if moduleConfig.ModuleIdentity != nil {
-		options = append(options, ModuleWithModuleIdentity(moduleConfig.ModuleIdentity))
+		moduleIdentity = moduleConfig.ModuleIdentity
 	}
 	return newModule(
 		ctx,
 		storage.MapReadBucket(sourceReadBucket, storage.MatchPathExt(".proto")),
 		dependencyModulePins,
+		moduleIdentity,
 		documentation,
 		moduleConfig.Breaking,
 		moduleConfig.Lint,
@@ -110,6 +113,7 @@ func newModule(
 	// must only contain .proto files
 	sourceReadBucket storage.ReadBucket,
 	dependencyModulePins []bufmoduleref.ModulePin,
+	moduleIdentity bufmoduleref.ModuleIdentity,
 	documentation string,
 	breakingConfig *bufbreakingconfig.Config,
 	lintConfig *buflintconfig.Config,
@@ -123,6 +127,7 @@ func newModule(
 	module := &module{
 		sourceReadBucket:     sourceReadBucket,
 		dependencyModulePins: dependencyModulePins,
+		moduleIdentity:       moduleIdentity,
 		documentation:        documentation,
 		breakingConfig:       breakingConfig,
 		lintConfig:           lintConfig,


### PR DESCRIPTION
Add `WriteConfigWithBreakingConfig`, `WriteConfigWithLintConfig`, and `WriteConfigWithVersion` options for the `bufconfig.WriteConfig` function to support more generic use cases of the `WriteConfig`.
Before this change, we are only using `bufconfig.WriteConfig` in the `buf config init` command, but we now need it to write configuration structures into our module cache so that we are persisting `breaking` and `lint` config in our cache for our module structure.