### PR TITLE
Fix multiple request issue listing repositories

### DIFF
--- a/private/buf/bufprint/bufprint.go
+++ b/private/buf/bufprint/bufprint.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
@@ -87,11 +86,10 @@ type RepositoryPrinter interface {
 
 // NewRepositoryPrinter returns a new RepositoryPrinter.
 func NewRepositoryPrinter(
-	apiProvider registryv1alpha1apiclient.Provider,
 	address string,
 	writer io.Writer,
 ) RepositoryPrinter {
-	return newRepositoryPrinter(apiProvider, address, writer)
+	return newRepositoryPrinter(address, writer)
 }
 
 // RepositoryBranchPrinter is a repository branch printer.

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -127,7 +127,6 @@ func run(
 		return err
 	}
 	return bufprint.NewRepositoryPrinter(
-		apiProvider,
 		moduleIdentity.Remote(),
 		container.Stdout(),
 	).PrintRepository(ctx, format, repository)

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
@@ -101,7 +101,6 @@ func run(
 		return err
 	}
 	return bufprint.NewRepositoryPrinter(
-		apiProvider,
 		moduleIdentity.Remote(),
 		container.Stdout(),
 	).PrintRepository(ctx, format, repository)

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
@@ -121,7 +121,6 @@ func run(
 		return err
 	}
 	return bufprint.NewRepositoryPrinter(
-		apiProvider,
 		remote,
 		container.Stdout(),
 	).PrintRepositories(ctx, format, nextPageToken, repositories...)


### PR DESCRIPTION
This fixes an n+1 issue where `buf beta registry repository list` was doing a separate API request for each repository in the result set.