### PR TITLE
Fix validation for duplicate plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use a separate repository service to for each dependency remote to resolve dependencies for `buf mod update`. Previously, we used a single repository service based on the remote
   from the module, so it was unable to resolve dependencies from differente remotes.
 - Display the user-provided Buf Schema Registry remote, if specified, instead of the default within the `buf login` message.
+- Fix issue where `buf generate` fails when the same plugin was specified more than once in a single invocation.
 - Update the digest algorithm so that it encodes the `name`, `lint`, and `breaking` configuration encoded in the `buf.yaml`.
   When this change is deployed, users will observe the following:
   - Users on `v0.43.0` or before will notice mismatched digest errors similar to the one described in https://github.com/bufbuild/buf/issues/661.

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -439,6 +439,7 @@ func validateResponses(
 			appproto.NewPluginResponse(
 				response,
 				pluginConfig.PluginName(),
+				pluginConfig.Out,
 			),
 		)
 	}

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -155,6 +155,22 @@ func TestProtoFileRefIncludePackageFiles(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGenerateDuplicatePlugins(t *testing.T) {
+	tempDirPath := t.TempDir()
+	testRunSuccess(
+		t,
+		"--output",
+		tempDirPath,
+		"--template",
+		filepath.Join("testdata", "duplicate_plugins", "buf.gen.yaml"),
+		filepath.Join("testdata", "duplicate_plugins"),
+	)
+	_, err := os.Stat(filepath.Join(tempDirPath, "foo", "a", "v1", "A.java"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(tempDirPath, "bar", "a", "v1", "A.java"))
+	require.NoError(t, err)
+}
+
 func TestOutputWithPathEqualToExclude(t *testing.T) {
 	tempDirPath := t.TempDir()
 	testRunStdoutStderr(

--- a/private/buf/cmd/buf/command/generate/testdata/duplicate_plugins/a.proto
+++ b/private/buf/cmd/buf/command/generate/testdata/duplicate_plugins/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package a.v1;
+
+message Foo {}

--- a/private/buf/cmd/buf/command/generate/testdata/duplicate_plugins/buf.gen.yaml
+++ b/private/buf/cmd/buf/command/generate/testdata/duplicate_plugins/buf.gen.yaml
@@ -1,0 +1,8 @@
+# The same plugin can be executed more than once, as long as they are written
+# to different output directories.
+version: v1
+plugins:
+  - name: java
+    out: foo
+  - name: java
+    out: bar

--- a/private/buf/cmd/buf/command/protoc/protoc.go
+++ b/private/buf/cmd/buf/command/protoc/protoc.go
@@ -206,7 +206,7 @@ func run(
 			if err != nil {
 				return err
 			}
-			pluginResponses = append(pluginResponses, appproto.NewPluginResponse(response, pluginName))
+			pluginResponses = append(pluginResponses, appproto.NewPluginResponse(response, pluginName, pluginInfo.Out))
 		}
 		if err := appproto.ValidatePluginResponses(pluginResponses); err != nil {
 			return err

--- a/private/pkg/app/appproto/appproto.go
+++ b/private/pkg/app/appproto/appproto.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"unicode"
 	"unicode/utf8"
 
@@ -178,13 +179,19 @@ func WriteResponseWithInsertionPointReadBucket(
 type PluginResponse struct {
 	Response   *pluginpb.CodeGeneratorResponse
 	PluginName string
+	PluginOut  string
 }
 
 // NewPluginResponse retruns a new *PluginResponse.
-func NewPluginResponse(response *pluginpb.CodeGeneratorResponse, pluginName string) *PluginResponse {
+func NewPluginResponse(
+	response *pluginpb.CodeGeneratorResponse,
+	pluginName string,
+	pluginOut string,
+) *PluginResponse {
 	return &PluginResponse{
 		Response:   response,
 		PluginName: pluginName,
+		PluginOut:  pluginOut,
 	}
 }
 
@@ -198,7 +205,7 @@ func ValidatePluginResponses(pluginResponses []*PluginResponse) error {
 				// to files that already exist.
 				continue
 			}
-			fileName := file.GetName()
+			fileName := filepath.Join(pluginResponse.PluginOut, file.GetName())
 			if pluginName, ok := seen[fileName]; ok {
 				return fmt.Errorf(
 					"file %q was generated multiple times: once by plugin %q and again by plugin %q",


### PR DESCRIPTION
Fixes #774

Note that this does _not_ fix the equivalent behavior for `buf protoc` yet. The solution is more nuanced there because the implementation strongly assumes that there can only one `_out` per plugin. At an initial glance, `buf protoc` will require more significant refactors in order to get this working. For reference, check it out [here](https://github.com/bufbuild/buf/blob/0786cea8690ed81cdd1f5b31b9b5c0529ffdab74/private/buf/cmd/buf/command/protoc/flags.go#L356).

We will follow-up with larger refactors to `buf protoc`, but it's left for a follow-up so that we focus on the user issue at hand.