### PR TITLE
Add `nil` check for `ConfigForProto` for `breaking` and `lint` configs

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -76,6 +76,9 @@ func NewConfigV1(externalConfig ExternalConfigV1) *Config {
 
 // ConfigForProto returns the Config given the proto.
 func ConfigForProto(protoConfig *breakingv1.Config) *Config {
+	if protoConfig == nil {
+		return nil
+	}
 	return &Config{
 		Use:                           protoConfig.GetUseIds(),
 		Except:                        protoConfig.GetExceptIds(),

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -99,6 +99,9 @@ func NewConfigV1(externalConfig ExternalConfigV1) *Config {
 
 // ConfigForProto returns the Config given the proto.
 func ConfigForProto(protoConfig *lintv1.Config) *Config {
+	if protoConfig == nil {
+		return nil
+	}
 	return &Config{
 		Use:                                  protoConfig.GetUseIds(),
 		Except:                               protoConfig.GetExceptIds(),
@@ -116,6 +119,9 @@ func ConfigForProto(protoConfig *lintv1.Config) *Config {
 
 // ProtoForConfig takes a *Config and returns the proto representation.
 func ProtoForConfig(config *Config) *lintv1.Config {
+	if config == nil {
+		return nil
+	}
 	return &lintv1.Config{
 		UseIds:                               config.Use,
 		ExceptIds:                            config.Except,


### PR DESCRIPTION
As a part of #682, we are encoding the modules, but we need to have a `nil` check for mappers for the `Config` structures from the proto structures. Remote references stored in the BSR will not have configs stored and this needs to handle the `nil` case seamlessly.

As a follow-up, tests in `core` will need to be added with unmarshalling references from the `DownloadService`.