### PR TITLE
Move `nil` checks out of `breaking` and `lint` mappers

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -76,9 +76,6 @@ func NewConfigV1(externalConfig ExternalConfigV1) *Config {
 
 // ConfigForProto returns the Config given the proto.
 func ConfigForProto(protoConfig *breakingv1.Config) *Config {
-	if protoConfig == nil {
-		return nil
-	}
 	return &Config{
 		Use:                           protoConfig.GetUseIds(),
 		Except:                        protoConfig.GetExceptIds(),
@@ -91,9 +88,6 @@ func ConfigForProto(protoConfig *breakingv1.Config) *Config {
 
 // ProtoForConfig takes a *Config and returns the proto representation.
 func ProtoForConfig(config *Config) *breakingv1.Config {
-	if config == nil {
-		return nil
-	}
 	return &breakingv1.Config{
 		UseIds:                 config.Use,
 		ExceptIds:              config.Except,

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -99,9 +99,6 @@ func NewConfigV1(externalConfig ExternalConfigV1) *Config {
 
 // ConfigForProto returns the Config given the proto.
 func ConfigForProto(protoConfig *lintv1.Config) *Config {
-	if protoConfig == nil {
-		return nil
-	}
 	return &Config{
 		Use:                                  protoConfig.GetUseIds(),
 		Except:                               protoConfig.GetExceptIds(),
@@ -119,9 +116,6 @@ func ConfigForProto(protoConfig *lintv1.Config) *Config {
 
 // ProtoForConfig takes a *Config and returns the proto representation.
 func ProtoForConfig(config *Config) *lintv1.Config {
-	if config == nil {
-		return nil
-	}
 	return &lintv1.Config{
 		UseIds:                               config.Use,
 		ExceptIds:                            config.Except,

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -25,6 +25,8 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	breakingv1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/breaking/v1"
+	lintv1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/lint/v1"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
@@ -308,12 +310,20 @@ func ModuleToProtoModule(ctx context.Context, module Module) (*modulev1alpha1.Mo
 	for i, dependencyModulePin := range dependencyModulePins {
 		protoModulePins[i] = bufmoduleref.NewProtoModulePinForModulePin(dependencyModulePin)
 	}
+	var protoBreakingConfig *breakingv1.Config
+	if module.BreakingConfig() != nil {
+		protoBreakingConfig = bufbreakingconfig.ProtoForConfig(module.BreakingConfig())
+	}
+	var protoLintConfig *lintv1.Config
+	if module.LintConfig() != nil {
+		protoLintConfig = buflintconfig.ProtoForConfig(module.LintConfig())
+	}
 	protoModule := &modulev1alpha1.Module{
 		Files:          protoModuleFiles,
 		Dependencies:   protoModulePins,
 		Documentation:  module.Documentation(),
-		BreakingConfig: bufbreakingconfig.ProtoForConfig(module.BreakingConfig()),
-		LintConfig:     buflintconfig.ProtoForConfig(module.LintConfig()),
+		BreakingConfig: protoBreakingConfig,
+		LintConfig:     protoLintConfig,
 	}
 	if err := ValidateProtoModule(protoModule); err != nil {
 		return nil, err

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -61,14 +61,22 @@ func newModuleForProto(
 	if err != nil {
 		return nil, err
 	}
+	var breakingConfig *bufbreakingconfig.Config
+	if protoModule.GetBreakingConfig() != nil {
+		breakingConfig = bufbreakingconfig.ConfigForProto(protoModule.GetBreakingConfig())
+	}
+	var lintConfig *buflintconfig.Config
+	if protoModule.GetLintConfig() != nil {
+		lintConfig = buflintconfig.ConfigForProto(protoModule.GetLintConfig())
+	}
 	return newModule(
 		ctx,
 		readWriteBucket,
 		dependencyModulePins,
 		nil, // The module identity is not stored on the proto. We rely on the layer above, (e.g. `ModuleReader`) to set this as needed.
 		protoModule.GetDocumentation(),
-		bufbreakingconfig.ConfigForProto(protoModule.GetBreakingConfig()),
-		buflintconfig.ConfigForProto(protoModule.GetLintConfig()),
+		breakingConfig,
+		lintConfig,
 		options...,
 	)
 }


### PR DESCRIPTION
A small clean-up related to #682 re: https://github.com/bufbuild/buf/pull/781#discussion_r767933162
This moves the `nil` checks to the call sites and keeps the concerns of the constructors/mappers in the `bufbreakingconfig` and `buflintconfig` packages clean.