### PR TITLE
Fix private/usage for Golang 1.18

### DIFF
--- a/private/usage/usage.go
+++ b/private/usage/usage.go
@@ -31,24 +31,14 @@ func init() {
 
 func check() error {
 	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		if shouldSkip() {
-			return nil
+	if !ok || buildInfo.Main.Path == "" {
+		if !strings.HasSuffix(os.Args[0], testSuffix) && filepath.Base(os.Args[0]) != debugBin {
+			return errors.New("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects")
 		}
-		return errors.New("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects")
-	}
-	if buildInfo.Main.Path == "" {
-		if shouldSkip() {
-			return nil
-		}
-		return errors.New("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects")
+		return nil
 	}
 	if !strings.HasPrefix(buildInfo.Main.Path, "github.com/bufbuild") {
 		return fmt.Errorf("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects but was used in %s", buildInfo.Main.Path)
 	}
 	return nil
-}
-
-func shouldSkip() bool {
-	return strings.HasSuffix(os.Args[0], testSuffix) || filepath.Base(os.Args[0]) == debugBin
 }


### PR DESCRIPTION
In 1.18, https://pkg.go.dev/runtime/debug#ReadBuildInfo returns true for tests, when it returned false in 1.17. The resulting `*debug.BuildInfo` has an empty `Main.Path`, which results in a panic.