### PR TITLE
Cleanup CHANGELOG.md for v1.0.0-rc9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@
 
 ## [v1.0.0-rc9] - 2021-12-15
 
-- Change message documentation for fields to be either a single field or a oneof set of fields. This is a breaking API change.
-- Use a separate repository service to for each dependency remote to resolve dependencies for `buf mod update`. Previously, we used a single repository service based on the remote
-  from the module, so it was unable to resolve dependencies from differente remotes.
+- Fix issue where `buf mod update` was unable to resolve dependencies from differente remotes.
 - Display the user-provided Buf Schema Registry remote, if specified, instead of the default within the `buf login` message.
 - Fix issue where `buf generate` fails when the same plugin was specified more than once in a single invocation.
 - Update the digest algorithm so that it encodes the `name`, `lint`, and `breaking` configuration encoded in the `buf.yaml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [v1.0.0-rc9] - 2021-12-15
 
-- Fix issue where `buf mod update` was unable to resolve dependencies from differente remotes.
+- Fix issue where `buf mod update` was unable to resolve dependencies from different remotes.
 - Display the user-provided Buf Schema Registry remote, if specified, instead of the default within the `buf login` message.
 - Fix issue where `buf generate` fails when the same plugin was specified more than once in a single invocation.
 - Update the digest algorithm so that it encodes the `name`, `lint`, and `breaking` configuration encoded in the `buf.yaml`.


### PR DESCRIPTION
This edits the first couple of points made in the `v1.0.0-rc9` release notes.

For the first point, we don't need to communicate internal API changes to our CLI users so it can be removed altogether. As for the second point, we should phrase these changes in terms of fixes and/or additions - the implementation details are irrelevant.