### PR TITLE
Default to the `v1beta1` configuration in the module constructor for proto structures

### DIFF
--- a/private/bufpkg/bufconfig/bufconfig.go
+++ b/private/bufpkg/bufconfig/bufconfig.go
@@ -17,6 +17,7 @@ package bufconfig
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
@@ -218,6 +219,16 @@ func ExistingConfigFilePath(ctx context.Context, readBucket storage.ReadBucket) 
 		}
 	}
 	return "", nil
+}
+
+// ValidateVersion checks that a given version string is valid.
+func ValidateVersion(version string) error {
+	switch version {
+	case V1Version, V1Beta1Version:
+		return nil
+	default:
+		return fmt.Errorf("invalid config version %q provided", version)
+	}
 }
 
 // ExternalConfigV1Beta1 represents the on-disk representation of the Config

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -280,6 +280,11 @@ func writeConfig(
 			return fmt.Errorf("version %q found for breaking config, does not match top level config version: %q", breakingConfigVersion, version)
 		}
 		config.Breaking = breakingConfig
+	} else {
+		// Otherwise, we set a breaking config with the given version.
+		config.Breaking = &bufbreakingconfig.Config{
+			Version: version,
+		}
 	}
 	var lintConfigVersion string
 	lintConfig := writeConfigOptions.lintConfig
@@ -289,6 +294,11 @@ func writeConfig(
 			return fmt.Errorf("version %q found for lint config, does not match top level config version: %q", lintConfigVersion, version)
 		}
 		config.Lint = lintConfig
+	} else {
+		// Otherwise, we set a breaking config with the given version.
+		config.Lint = &buflintconfig.Config{
+			Version: version,
+		}
 	}
 	// We should never hit this condition since we are already validating against `version`.
 	if breakingConfigVersion != lintConfigVersion {

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -295,7 +295,7 @@ func writeConfig(
 		}
 		config.Lint = lintConfig
 	} else {
-		// Otherwise, we set a breaking config with the given version.
+		// Otherwise, we set a lint config with the given version.
 		config.Lint = &buflintconfig.Config{
 			Version: version,
 		}

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -263,7 +263,7 @@ func writeConfig(
 	// This is the same default as the bufconfig getters.
 	version := V1Beta1Version
 	if writeConfigOptions.version != "" {
-		if err := validateVersion(writeConfigOptions.version); err != nil {
+		if err := ValidateVersion(writeConfigOptions.version); err != nil {
 			return err
 		}
 		version = writeConfigOptions.version
@@ -280,11 +280,6 @@ func writeConfig(
 			return fmt.Errorf("version %q found for breaking config, does not match top level config version: %q", breakingConfigVersion, version)
 		}
 		config.Breaking = breakingConfig
-	} else {
-		// Otherwise, we set a breaking config with the given version.
-		config.Breaking = &bufbreakingconfig.Config{
-			Version: version,
-		}
 	}
 	var lintConfigVersion string
 	lintConfig := writeConfigOptions.lintConfig
@@ -294,11 +289,6 @@ func writeConfig(
 			return fmt.Errorf("version %q found for lint config, does not match top level config version: %q", lintConfigVersion, version)
 		}
 		config.Lint = lintConfig
-	} else {
-		// Otherwise, we set a lint config with the given version.
-		config.Lint = &buflintconfig.Config{
-			Version: version,
-		}
 	}
 	// We should never hit this condition since we are already validating against `version`.
 	if breakingConfigVersion != lintConfigVersion {
@@ -474,13 +464,4 @@ func validateWriteConfigOptions(writeConfigOptions *writeConfigOptions) error {
 		return errors.New("cannot set deps without a name for WriteConfig")
 	}
 	return nil
-}
-
-func validateVersion(version string) error {
-	switch version {
-	case V1Version, V1Beta1Version:
-		return nil
-	default:
-		return fmt.Errorf("invalid config version %q provided", version)
-	}
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -16,7 +16,6 @@ package bufmodulecache
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
@@ -121,6 +120,10 @@ func (m *moduleCacher) PutModule(
 	module bufmodule.Module,
 ) error {
 	modulePath := newCacheKey(modulePin)
+	digest, err := bufmodule.ModuleDigestB3(ctx, module)
+	if err != nil {
+		return err
+	}
 	dataReadWriteBucket := storage.MapReadWriteBucket(
 		m.dataReadWriteBucket,
 		storage.MapOnPrefix(modulePath),
@@ -137,18 +140,6 @@ func (m *moduleCacher) PutModule(
 		}
 	}
 	if err := bufmodule.ModuleToBucket(ctx, module, dataReadWriteBucket); err != nil {
-		return err
-	}
-	bucketModule, err := bufmodule.NewModuleForBucket(
-		ctx,
-		dataReadWriteBucket,
-		bufmodule.ModuleWithModuleIdentityAndCommit(modulePin, modulePin.Commit()),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to write module to bucket: %w", err)
-	}
-	digest, err := bufmodule.ModuleDigestB3(ctx, bucketModule)
-	if err != nil {
 		return err
 	}
 	// This will overwrite if necessary

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -61,11 +61,16 @@ func newModuleForProto(
 	if err != nil {
 		return nil, err
 	}
-	var breakingConfig *bufbreakingconfig.Config
+	// If there is no breaking and/or lint config, we want to default to the v1beta1 version
+	breakingConfig := &bufbreakingconfig.Config{
+		Version: bufconfig.V1Beta1Version,
+	}
 	if protoModule.GetBreakingConfig() != nil {
 		breakingConfig = bufbreakingconfig.ConfigForProto(protoModule.GetBreakingConfig())
 	}
-	var lintConfig *buflintconfig.Config
+	lintConfig := &buflintconfig.Config{
+		Version: bufconfig.V1Beta1Version,
+	}
 	if protoModule.GetLintConfig() != nil {
 		lintConfig = buflintconfig.ConfigForProto(protoModule.GetLintConfig())
 	}


### PR DESCRIPTION
Now that we have migrated to the `b3` digest, we are using the `breaking` and `lint` configs for the digest calculation. For remote references, we do not have any `breaking` and `lint` configs stored. Thus, when we construct the module based on the response we are receiving from the proto, we need to create the same default configurations that are created for modules from buckets without a `buf.yaml`.

Fixes: #790