### PR TITLE
Fix image construction non-determinism

### DIFF
--- a/private/bufpkg/bufimage/image_test.go
+++ b/private/bufpkg/bufimage/image_test.go
@@ -97,3 +97,43 @@ func TestMergeImagesWithDuplicateFile(t *testing.T) {
 	_, err = MergeImages(firstImage, secondImage)
 	require.Error(t, err)
 }
+
+func TestMergeImagesOrdered(t *testing.T) {
+	t.Parallel()
+	firstProtoImage := &imagev1.Image{
+		File: []*imagev1.ImageFile{
+			{
+				Syntax: proto.String("proto3"),
+				Name:   proto.String("a.proto"),
+			},
+			{
+				Syntax: proto.String("proto3"),
+				Name:   proto.String("b.proto"),
+			},
+		},
+	}
+	secondProtoImage := &imagev1.Image{
+		File: []*imagev1.ImageFile{
+			{
+				Syntax: proto.String("proto3"),
+				Name:   proto.String("c.proto"),
+			},
+			{
+				Syntax: proto.String("proto3"),
+				Name:   proto.String("d.proto"),
+			},
+		},
+	}
+
+	firstImage, err := NewImageForProto(firstProtoImage)
+	require.NoError(t, err)
+	secondImage, err := NewImageForProto(secondProtoImage)
+	require.NoError(t, err)
+	image, err := MergeImages(firstImage, secondImage)
+	require.NoError(t, err)
+	var paths []string
+	for _, imageFile := range image.Files() {
+		paths = append(paths, imageFile.Path())
+	}
+	assert.Equal(t, []string{"a.proto", "b.proto", "c.proto", "d.proto"}, paths)
+}


### PR DESCRIPTION
Fixes #793

The workspace is processed deterministically (in the order specified by the `buf.work.yaml`), but the order was not preserved when the images are merged in [MergeImages](https://github.com/bufbuild/buf/blob/b87ac6eb1d295e39f6595d89f10b0adee51cc774/private/bufpkg/bufimage/bufimage.go#L141) because we use a `map` to handle duplicates. Now we preserve the order by adding the files in the same order they were provided.