### PR TITLE
add: flag to generate files for well-known types

### DIFF
--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -145,6 +145,13 @@ func GenerateWithIncludeImports() GenerateOption {
 	}
 }
 
+// GenerateWithWellKnownTypes says to also generate imports for well known types.
+func GenerateWithWellKnownTypes() GenerateOption {
+	return func(generateOptions *generateOptions) {
+		generateOptions.includeWellKnownTypes = true
+	}
+}
+
 // Config is a configuration.
 type Config struct {
 	// Required

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -92,6 +92,7 @@ func (g *generator) Generate(
 		image,
 		generateOptions.baseOutDirPath,
 		generateOptions.includeImports,
+		generateOptions.includeWellKnownTypes,
 	)
 }
 
@@ -102,6 +103,7 @@ func (g *generator) generate(
 	image bufimage.Image,
 	baseOutDirPath string,
 	includeImports bool,
+	includeWellKnownTypes bool,
 ) error {
 	if err := modifyImage(ctx, g.logger, config, image); err != nil {
 		return err
@@ -113,6 +115,7 @@ func (g *generator) generate(
 		config,
 		image,
 		includeImports,
+		includeWellKnownTypes,
 	)
 	if err != nil {
 		return err
@@ -153,6 +156,7 @@ func (g *generator) execPlugins(
 	config *Config,
 	image bufimage.Image,
 	includeImports bool,
+	includeWellKnownTypes bool,
 ) ([]*pluginpb.CodeGeneratorResponse, error) {
 	imageProvider := newImageProvider(image)
 	// Collect all of the plugin jobs so that they can be executed in parallel.
@@ -186,6 +190,7 @@ func (g *generator) execPlugins(
 					imageProvider,
 					currentPluginConfig,
 					includeImports,
+					includeWellKnownTypes,
 				)
 				if err != nil {
 					return err
@@ -232,6 +237,7 @@ func (g *generator) execLocalPlugin(
 	imageProvider *imageProvider,
 	pluginConfig *PluginConfig,
 	includeImports bool,
+	includeWellKnownTypes bool,
 ) (*pluginpb.CodeGeneratorResponse, error) {
 	pluginImages, err := imageProvider.GetImages(pluginConfig.Strategy)
 	if err != nil {
@@ -246,6 +252,7 @@ func (g *generator) execLocalPlugin(
 			pluginConfig.Opt,
 			nil,
 			includeImports,
+			includeWellKnownTypes,
 		),
 		appprotoexec.GenerateWithPluginPath(pluginConfig.Path),
 	)
@@ -450,8 +457,9 @@ func validateResponses(
 }
 
 type generateOptions struct {
-	baseOutDirPath string
-	includeImports bool
+	baseOutDirPath        string
+	includeImports        bool
+	includeWellKnownTypes bool
 }
 
 func newGenerateOptions() *generateOptions {

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -33,14 +33,15 @@ import (
 )
 
 const (
-	templateFlagName            = "template"
-	baseOutDirPathFlagName      = "output"
-	baseOutDirPathFlagShortName = "o"
-	errorFormatFlagName         = "error-format"
-	configFlagName              = "config"
-	pathsFlagName               = "path"
-	includeImportsFlagName      = "include-imports"
-	excludePathsFlagName        = "exclude-path"
+	templateFlagName              = "template"
+	baseOutDirPathFlagName        = "output"
+	baseOutDirPathFlagShortName   = "o"
+	errorFormatFlagName           = "error-format"
+	configFlagName                = "config"
+	pathsFlagName                 = "path"
+	includeImportsFlagName        = "include-imports"
+	includeWellKnownTypesFlagName = "include-well-known-types"
+	excludePathsFlagName          = "exclude-path"
 
 	// deprecated
 	inputFlagName = "input"
@@ -187,14 +188,15 @@ Insertion points are processed in the order the plugins are specified in the tem
 }
 
 type flags struct {
-	Template       string
-	BaseOutDirPath string
-	ErrorFormat    string
-	Files          []string
-	Config         string
-	Paths          []string
-	IncludeImports bool
-	ExcludePaths   []string
+	Template              string
+	BaseOutDirPath        string
+	ErrorFormat           string
+	Files                 []string
+	Config                string
+	Paths                 []string
+	IncludeImports        bool
+	IncludeWellKnownTypes bool
+	ExcludePaths          []string
 
 	// deprecated
 	Input string
@@ -217,6 +219,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		includeImportsFlagName,
 		false,
 		"Also generate all imports except for Well-Known Types.",
+	)
+	flagSet.BoolVar(
+		&f.IncludeWellKnownTypes,
+		includeWellKnownTypesFlagName,
+		false,
+		"Also generate Well-Known Types.",
 	)
 	flagSet.StringVar(
 		&f.Template,
@@ -368,6 +376,12 @@ func run(
 		generateOptions = append(
 			generateOptions,
 			bufgen.GenerateWithIncludeImports(),
+		)
+	}
+	if flags.IncludeWellKnownTypes {
+		generateOptions = append(
+			generateOptions,
+			bufgen.GenerateWithWellKnownTypes(),
 		)
 	}
 	return bufgen.NewGenerator(

--- a/private/buf/cmd/buf/command/protoc/plugin.go
+++ b/private/buf/cmd/buf/command/protoc/plugin.go
@@ -64,6 +64,7 @@ func executePlugin(
 			strings.Join(pluginInfo.Opt, ","),
 			appprotoexec.DefaultVersion,
 			false,
+			false, // maybe?
 		),
 		appprotoexec.GenerateWithPluginPath(pluginInfo.Path),
 	)

--- a/private/buf/cmd/protoc-gen-buf-lint/lint_test.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint_test.go
@@ -289,5 +289,5 @@ func testBuildCodeGeneratorRequest(
 	}
 	image, err := bufimage.NewImage(imageFiles)
 	require.NoError(t, err)
-	return bufimage.ImageToCodeGeneratorRequest(image, parameter, nil, false)
+	return bufimage.ImageToCodeGeneratorRequest(image, parameter, nil, false, false)
 }

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -357,17 +357,20 @@ func ImageToFileDescriptorProtos(image Image) []*descriptorpb.FileDescriptorProt
 //
 // All non-imports are added as files to generate.
 // If includeImports is set, all non-well-known-type imports are also added as files to generate.
+// If includeWellKnownTypes is set, well-known-type imports are also added as files to generate.
 func ImageToCodeGeneratorRequest(
 	image Image,
 	parameter string,
 	compilerVersion *pluginpb.Version,
 	includeImports bool,
+	includeWellKnownTypes bool,
 ) *pluginpb.CodeGeneratorRequest {
 	return imageToCodeGeneratorRequest(
 		image,
 		parameter,
 		compilerVersion,
 		includeImports,
+		includeWellKnownTypes,
 		nil,
 		nil,
 	)
@@ -378,17 +381,19 @@ func ImageToCodeGeneratorRequest(
 // All non-imports are added as files to generate.
 // If includeImports is set, all non-well-known-type imports are also added as files to generate.
 // If includeImports is set, only one CodeGeneratorRequest will contain any given file as a FileToGenerate.
+// If includeWellKnownTypes is set, well-known-type imports are also added as files to generate.
 func ImagesToCodeGeneratorRequests(
 	images []Image,
 	parameter string,
 	compilerVersion *pluginpb.Version,
 	includeImports bool,
+	includeWellKnownTypes bool,
 ) []*pluginpb.CodeGeneratorRequest {
 	requests := make([]*pluginpb.CodeGeneratorRequest, len(images))
 	// we don't need to track these if includeImports as false, so don't waste the time
 	var alreadyUsedPaths map[string]struct{}
 	var nonImportPaths map[string]struct{}
-	if includeImports {
+	if includeImports || includeWellKnownTypes {
 		alreadyUsedPaths = make(map[string]struct{})
 		nonImportPaths = make(map[string]struct{})
 		for _, image := range images {
@@ -405,6 +410,7 @@ func ImagesToCodeGeneratorRequests(
 			parameter,
 			compilerVersion,
 			includeImports,
+			includeWellKnownTypes,
 			alreadyUsedPaths,
 			nonImportPaths,
 		)

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/gen/data/datawkt"
 	"github.com/bufbuild/buf/private/pkg/protoversion"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -273,9 +272,6 @@ func RubyPackage(
 
 // isWellKnownType returns true if the given path is one of the well-known types.
 func isWellKnownType(ctx context.Context, imageFile bufimage.ImageFile) bool {
-	if _, err := datawkt.ReadBucket.Stat(ctx, imageFile.Path()); err == nil {
-		return true
-	}
 	return false
 }
 

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -374,6 +374,7 @@ func imageToCodeGeneratorRequest(
 	parameter string,
 	compilerVersion *pluginpb.Version,
 	includeImports bool,
+	includeWellKnownTypes bool,
 	alreadyUsedPaths map[string]struct{},
 	nonImportPaths map[string]struct{},
 ) *pluginpb.CodeGeneratorRequest {
@@ -392,6 +393,7 @@ func imageToCodeGeneratorRequest(
 			alreadyUsedPaths,
 			nonImportPaths,
 			includeImports,
+			includeWellKnownTypes,
 		) {
 			request.FileToGenerate = append(request.FileToGenerate, imageFile.Path())
 		}
@@ -404,6 +406,7 @@ func isFileToGenerate(
 	alreadyUsedPaths map[string]struct{},
 	nonImportPaths map[string]struct{},
 	includeImports bool,
+	includeWellKnownTypes bool,
 ) bool {
 	path := imageFile.Path()
 	if !imageFile.IsImport() {
@@ -414,11 +417,11 @@ func isFileToGenerate(
 		// this is a non-import in this image, we always want to generate
 		return true
 	}
-	if !includeImports {
-		// we don't want to include imports
+	if !includeImports && !datawkt.Exists(path) {
+		// we don't want to include imports; we have a seperate check for well known types
 		return false
 	}
-	if datawkt.Exists(path) {
+	if !includeWellKnownTypes && datawkt.Exists(path) {
 		// we don't want to generate wkt even if includeImports is set
 		return false
 	}


### PR DESCRIPTION
DO NOT SUBMIT

Tests are failing, but this works to generate code

Related discussion in https://github.com/bufbuild/buf/issues/795; it sounds like this is not likely to be merged, so this PR is just for record keeping.