### PR TITLE
Clean-up `WriteConfig` function

### DIFF
--- a/private/buf/cmd/buf/command/config/configinit/configinit.go
+++ b/private/buf/cmd/buf/command/config/configinit/configinit.go
@@ -136,17 +136,21 @@ func run(
 	)
 	writeConfigOptions = append(
 		writeConfigOptions,
-		bufconfig.WriteConfigWithBreakingConfig(&bufbreakingconfig.Config{
-			Version: version,
-			Use:     []string{"FILE"},
-		}),
+		bufconfig.WriteConfigWithBreakingConfig(
+			&bufbreakingconfig.Config{
+				Version: version,
+				Use:     []string{"FILE"},
+			},
+		),
 	)
 	writeConfigOptions = append(
 		writeConfigOptions,
-		bufconfig.WriteConfigWithLintConfig(&buflintconfig.Config{
-			Version: version,
-			Use:     []string{"DEFAULT"},
-		}),
+		bufconfig.WriteConfigWithLintConfig(
+			&buflintconfig.Config{
+				Version: version,
+				Use:     []string{"DEFAULT"},
+			},
+		),
 	)
 	return bufconfig.WriteConfig(
 		ctx,

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -339,8 +339,8 @@ func writeExternalConfig(
 			Breaking: externalBreakingConfig,
 			Lint:     externalLintConfig,
 		}
-		var buffer bytes.Buffer
-		encoder := yaml.NewEncoder(&buffer)
+		buffer := bytes.NewBuffer(nil)
+		encoder := yaml.NewEncoder(buffer)
 		encoder.SetIndent(2)
 		if err := encoder.Encode(externalConfig); err != nil {
 			return err
@@ -362,8 +362,8 @@ func writeExternalConfig(
 			Breaking: externalBreakingConfig,
 			Lint:     externalLintConfig,
 		}
-		var buffer bytes.Buffer
-		encoder := yaml.NewEncoder(&buffer)
+		buffer := bytes.NewBuffer(nil)
+		encoder := yaml.NewEncoder(buffer)
 		encoder.SetIndent(2)
 		if err := encoder.Encode(externalConfig); err != nil {
 			return err

--- a/private/bufpkg/bufconfig/write_test.go
+++ b/private/bufpkg/bufconfig/write_test.go
@@ -31,14 +31,18 @@ func TestWriteConfigSuccess(t *testing.T) {
 	require.NoError(t, err)
 	writeConfigOptions := []WriteConfigOption{
 		WriteConfigWithVersion(V1Version),
-		WriteConfigWithBreakingConfig(&bufbreakingconfig.Config{
-			Version: V1Version,
-			Use:     []string{"FILE"},
-		}),
-		WriteConfigWithLintConfig(&buflintconfig.Config{
-			Version: V1Version,
-			Use:     []string{"DEFAULT"},
-		}),
+		WriteConfigWithBreakingConfig(
+			&bufbreakingconfig.Config{
+				Version: V1Version,
+				Use:     []string{"FILE"},
+			},
+		),
+		WriteConfigWithLintConfig(
+			&buflintconfig.Config{
+				Version: V1Version,
+				Use:     []string{"DEFAULT"},
+			},
+		),
 	}
 	err = WriteConfig(context.Background(), readWriteBucket, writeConfigOptions...)
 	require.NoError(t, err)


### PR DESCRIPTION
This is a follow-up to address post-merge comments on #766.﻿
