### PR TITLE
Add config validation as a part of validating proto module

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -16,6 +16,7 @@ package bufbreakingconfig
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 
 	breakingv1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/breaking/v1"
@@ -95,6 +96,21 @@ func ProtoForConfig(config *Config) *breakingv1.Config {
 		IgnoreIdPaths:          protoForIgnoreIDOrCategoryToRootPaths(config.IgnoreIDOrCategoryToRootPaths),
 		IgnoreUnstablePackages: config.IgnoreUnstablePackages,
 		Version:                config.Version,
+	}
+}
+
+// ValidateProtoConfig validates that the proto config is valid.
+func ValidateProtoConfig(protoConfig *breakingv1.Config) error {
+	// An empty config is valid.
+	if protoConfig == nil {
+		return nil
+	}
+	version := protoConfig.GetVersion()
+	switch version {
+	case v1Version, v1Beta1Version:
+		return nil
+	default:
+		return fmt.Errorf("invalid breaking config version %q provided", version)
 	}
 }
 

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -17,6 +17,7 @@ package buflintconfig
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"sort"
 	"strings"
@@ -131,6 +132,22 @@ func ProtoForConfig(config *Config) *lintv1.Config {
 	}
 }
 
+// ValidateProtoConfig validates that the proto config is valid.
+func ValidateProtoConfig(protoConfig *lintv1.Config) error {
+	// An empty config is valid.
+	if protoConfig == nil {
+		return nil
+	}
+	version := protoConfig.GetVersion()
+	switch version {
+	case v1Version, v1Beta1Version:
+		return nil
+	default:
+		return fmt.Errorf("invalid lint config version %q provided", version)
+	}
+}
+
+// ExternalConfigV1Beta1 is an external config.
 // ExternalConfigV1Beta1 is an external config.
 type ExternalConfigV1Beta1 struct {
 	Use    []string `json:"use,omitempty" yaml:"use,omitempty"`

--- a/private/bufpkg/bufconfig/bufconfig.go
+++ b/private/bufpkg/bufconfig/bufconfig.go
@@ -17,7 +17,6 @@ package bufconfig
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
@@ -219,16 +218,6 @@ func ExistingConfigFilePath(ctx context.Context, readBucket storage.ReadBucket) 
 		}
 	}
 	return "", nil
-}
-
-// ValidateVersion checks that a given version string is valid.
-func ValidateVersion(version string) error {
-	switch version {
-	case V1Version, V1Beta1Version:
-		return nil
-	default:
-		return fmt.Errorf("invalid config version %q provided", version)
-	}
 }
 
 // ExternalConfigV1Beta1 represents the on-disk representation of the Config

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -263,7 +263,7 @@ func writeConfig(
 	// This is the same default as the bufconfig getters.
 	version := V1Beta1Version
 	if writeConfigOptions.version != "" {
-		if err := ValidateVersion(writeConfigOptions.version); err != nil {
+		if err := validateVersion(writeConfigOptions.version); err != nil {
 			return err
 		}
 		version = writeConfigOptions.version
@@ -464,4 +464,13 @@ func validateWriteConfigOptions(writeConfigOptions *writeConfigOptions) error {
 		return errors.New("cannot set deps without a name for WriteConfig")
 	}
 	return nil
+}
+
+func validateVersion(version string) error {
+	switch version {
+	case V1Version, V1Beta1Version:
+		return nil
+	default:
+		return fmt.Errorf("invalid config version %q provided", version)
+	}
 }

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -119,14 +119,6 @@ func configsForProto(
 			Version: breakingConfigVersion,
 		}
 	}
-	// Finally, validate the config versions are valid. This should always pass in the case of
-	// the default values.
-	if err := bufconfig.ValidateVersion(breakingConfig.Version); err != nil {
-		return nil, nil, err
-	}
-	if err := bufconfig.ValidateVersion(lintConfig.Version); err != nil {
-		return nil, nil, err
-	}
 	return breakingConfig, lintConfig, nil
 }
 

--- a/private/bufpkg/bufmodule/validate.go
+++ b/private/bufpkg/bufmodule/validate.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 )
@@ -61,5 +63,8 @@ func ValidateProtoModule(protoModule *modulev1alpha1.Module) error {
 			return fmt.Errorf("module had invalid dependency: %v", err)
 		}
 	}
-	return nil
+	if err := bufbreakingconfig.ValidateProtoConfig(protoModule.GetBreakingConfig()); err != nil {
+		return err
+	}
+	return buflintconfig.ValidateProtoConfig(protoModule.GetLintConfig())
 }


### PR DESCRIPTION
This adds validation for the `breaking` and `lint` configs as a part of `ValidateProtoModule`.
This mostly looks at valid versions, we do not validate the rules -- this gets validated as a part of the rule builder.
`ValidateProtoModule` is also used by the push service validation layer, so once this is merged, the BSR server-side logic can be upgraded to use this same validation.