### PR TITLE
Add helpers in `bufbreaking` and `buflint`

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
@@ -95,7 +95,8 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 //
 // This is used for validation purposes only.
 func GetAllRulesAndCategoriesV1() []string {
-	var allRulesAndCategories []string
+	allRulesAndCategories := make([]string, 0, len(bufbreakingv1.VersionSpec.AllCategories)+len(bufbreakingv1.VersionSpec.IDToCategories))
+
 	allRulesAndCategories = append(allRulesAndCategories, bufbreakingv1.VersionSpec.AllCategories...)
 	for id := range bufbreakingv1.VersionSpec.IDToCategories {
 		allRulesAndCategories = append(allRulesAndCategories, id)
@@ -107,7 +108,7 @@ func GetAllRulesAndCategoriesV1() []string {
 //
 // This is used for validation purposes only.
 func GetAllRulesAndCategoriesV1Beta1() []string {
-	var allRulesAndCategories []string
+	allRulesAndCategories := make([]string, 0, len(bufbreakingv1beta1.VersionSpec.AllCategories)+len(bufbreakingv1beta1.VersionSpec.IDToCategories))
 	allRulesAndCategories = append(allRulesAndCategories, bufbreakingv1beta1.VersionSpec.AllCategories...)
 	for id := range bufbreakingv1beta1.VersionSpec.IDToCategories {
 		allRulesAndCategories = append(allRulesAndCategories, id)

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
@@ -91,6 +91,30 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 	return rulesForInternalRules(internalConfig.Rules), nil
 }
 
+// GetAllRulesAndCategoriesV1 returns all rules and categories for v1 as a string slice.
+//
+// This is used for validation purposes only.
+func GetAllRulesAndCategoriesV1() []string {
+	var allRulesAndCategories []string
+	allRulesAndCategories = append(allRulesAndCategories, bufbreakingv1.VersionSpec.AllCategories...)
+	for id := range bufbreakingv1.VersionSpec.IDToCategories {
+		allRulesAndCategories = append(allRulesAndCategories, id)
+	}
+	return allRulesAndCategories
+}
+
+// GetAllRulesAndCategoriesV1Beta1 returns all rules and categories for v1beta1 as a string slice.
+//
+// This is used for validation purposes only.
+func GetAllRulesAndCategoriesV1Beta1() []string {
+	var allRulesAndCategories []string
+	allRulesAndCategories = append(allRulesAndCategories, bufbreakingv1beta1.VersionSpec.AllCategories...)
+	for id := range bufbreakingv1beta1.VersionSpec.IDToCategories {
+		allRulesAndCategories = append(allRulesAndCategories, id)
+	}
+	return allRulesAndCategories
+}
+
 func internalConfigForConfig(config *bufbreakingconfig.Config) (*internal.Config, error) {
 	var versionSpec *internal.VersionSpec
 	switch config.Version {

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -99,7 +99,8 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 //
 // This is used for validation purposes only.
 func GetAllRulesAndCategoriesV1() []string {
-	var allRulesAndCategories []string
+	allRulesAndCategories := make([]string, 0, len(buflintv1.VersionSpec.AllCategories)+len(buflintv1.VersionSpec.IDToCategories))
+
 	allRulesAndCategories = append(allRulesAndCategories, buflintv1.VersionSpec.AllCategories...)
 	for id := range buflintv1.VersionSpec.IDToCategories {
 		allRulesAndCategories = append(allRulesAndCategories, id)
@@ -111,7 +112,8 @@ func GetAllRulesAndCategoriesV1() []string {
 //
 // This is used for validation purposes only.
 func GetAllRulesAndCategoriesV1Beta1() []string {
-	var allRulesAndCategories []string
+	allRulesAndCategories := make([]string, 0, len(buflintv1beta1.VersionSpec.AllCategories)+len(buflintv1beta1.VersionSpec.IDToCategories))
+
 	allRulesAndCategories = append(allRulesAndCategories, buflintv1beta1.VersionSpec.AllCategories...)
 	for id := range buflintv1beta1.VersionSpec.IDToCategories {
 		allRulesAndCategories = append(allRulesAndCategories, id)

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -95,6 +95,30 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 	return rulesForInternalRules(internalConfig.Rules), nil
 }
 
+// GetAllRulesAndCategoriesV1 returns all rules and categories for v1 as a string slice.
+//
+// This is used for validation purposes only.
+func GetAllRulesAndCategoriesV1() []string {
+	var allRulesAndCategories []string
+	allRulesAndCategories = append(allRulesAndCategories, buflintv1.VersionSpec.AllCategories...)
+	for id := range buflintv1.VersionSpec.IDToCategories {
+		allRulesAndCategories = append(allRulesAndCategories, id)
+	}
+	return allRulesAndCategories
+}
+
+// GetAllRulesAndCategoriesV1Beta1 returns all rules and categories for v1beta1 as a string slice.
+//
+// This is used for validation purposes only.
+func GetAllRulesAndCategoriesV1Beta1() []string {
+	var allRulesAndCategories []string
+	allRulesAndCategories = append(allRulesAndCategories, buflintv1beta1.VersionSpec.AllCategories...)
+	for id := range buflintv1beta1.VersionSpec.IDToCategories {
+		allRulesAndCategories = append(allRulesAndCategories, id)
+	}
+	return allRulesAndCategories
+}
+
 func internalConfigForConfig(config *buflintconfig.Config) (*internal.Config, error) {
 	var versionSpec *internal.VersionSpec
 	switch config.Version {


### PR DESCRIPTION
Adding some helpers in `bufbreaking` and `buflint` to get the list of all categories and rules for `v1` and `v1beta1` configs. This is used to validate the rules on the server-side, so the full list of rules and categories need to be exposed from the internal layer.

Ref: #682