### PR TITLE
Speed up the windows workflow

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,5 +1,8 @@
 name: windows
-on: push
+on:
+  push:
+  workflow_dispatch:
+
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
@@ -15,13 +18,15 @@ jobs:
         uses: WillAbides/setup-go-faster@v1.7.0
         with:
           go-version: 1.17.5
+#          ignore-local: true
       - uses: actions/cache@v2
         with:
           path: |
             ${{ steps.setup-go.outputs.GOCACHE }}
             ${{ steps.setup-go.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '/windows/**') }}
+          restore-keys: |
+            ${{ runner.os }}-buf-windows-
 #      - name: cache
 #        if: success()
 #        uses: actions/cache@v2

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -14,16 +14,16 @@ jobs:
         uses: actions/setup-go@v2.1.4 # this contains a fix for Windows file extraction
         with:
           go-version: 1.17.5
-      - name: cache
-        if: success()
-        uses: actions/cache@v2
-        with:
-          path: |
-            C:\Users\runneradmin\AppData\Local\Temp\chocolatey
-            C:\Users\runneradmin\go\pkg\mod
-          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '/windows/**') }}
-          restore-keys: |
-            ${{ runner.os }}-buf-windows-
+#      - name: cache
+#        if: success()
+#        uses: actions/cache@v2
+#        with:
+#          path: |
+#            C:\Users\runneradmin\AppData\Local\Temp\chocolatey
+#            C:\Users\runneradmin\go\pkg\mod
+#          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '/windows/**') }}
+#          restore-keys: |
+#            ${{ runner.os }}-buf-windows-
       - name: test
         if: success()
         run: ./windows/test.ps1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,6 +10,7 @@ jobs:
   test:
     env:
       GOMODCACHE: 'D:\gomodcache'
+      GOCACHE: 'D:\gocache'
     runs-on: windows-2019
     steps:
       - name: checkout

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,17 +16,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup-go
-        id: setup-go
         if: success()
         uses: WillAbides/setup-go-faster@v1.7.0
         with:
           go-version: 1.17.5
-          ignore-local: true
       - uses: actions/cache@v2
         with:
           path: |
-            ${{ steps.setup-go.outputs.GOCACHE }}
-            ${{ steps.setup-go.outputs.GOMODCACHE }}
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
           key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '.github/workflows/windows.yaml') }}
           restore-keys: |
             ${{ runner.os }}-buf-windows-

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -20,7 +20,9 @@ jobs:
         uses: WillAbides/setup-go-faster@v1.7.0
         with:
           go-version: 1.17.5
-      - uses: actions/cache@v2
+      - name: cache
+        if: success()
+        uses: actions/cache@v2
         with:
           path: |
             ${{ env.GOCACHE }}
@@ -28,16 +30,6 @@ jobs:
           key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '.github/workflows/windows.yaml') }}
           restore-keys: |
             ${{ runner.os }}-buf-windows-
-#      - name: cache
-#        if: success()
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            C:\Users\runneradmin\AppData\Local\Temp\chocolatey
-#            C:\Users\runneradmin\go\pkg\mod
-#          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '/windows/**') }}
-#          restore-keys: |
-#            ${{ runner.os }}-buf-windows-
       - name: test
         if: success()
         run: ./windows/test.ps1

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,13 +18,13 @@ jobs:
         uses: WillAbides/setup-go-faster@v1.7.0
         with:
           go-version: 1.17.5
-#          ignore-local: true
+          ignore-local: true
       - uses: actions/cache@v2
         with:
           path: |
             ${{ steps.setup-go.outputs.GOCACHE }}
             ${{ steps.setup-go.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '/windows/**') }}
+          key: ${{ runner.os }}-buf-windows2-${{ hashFiles('**/go.sum', '/windows/**') }}
           restore-keys: |
             ${{ runner.os }}-buf-windows-
 #      - name: cache

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,6 +10,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup-go
+        id: setup-go
         if: success()
         uses: WillAbides/setup-go-faster@v1.7.0
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: setup-go
         if: success()
-        uses: WillAbides/setup-go-faster@v1.7.0
+        uses: actions/setup-go@v2.1.4 # this contains a fix for Windows file extraction
         with:
           go-version: 1.17.5
       - name: cache

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ${{ steps.setup-go.outputs.GOCACHE }}
             ${{ steps.setup-go.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-buf-windows2-${{ hashFiles('**/go.sum', '.github/workflows/windows.yaml') }}
+          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', '.github/workflows/windows.yaml') }}
           restore-keys: |
             ${{ runner.os }}-buf-windows-
 #      - name: cache

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: setup-go
         if: success()
-        uses: WillAbides/setup-go-faster@v1.7
+        uses: WillAbides/setup-go-faster@v1.7.0
         with:
           go-version: 1.17.5
       - uses: actions/cache@v2

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ${{ steps.setup-go.outputs.GOCACHE }}
             ${{ steps.setup-go.outputs.GOMODCACHE }}
-          key: ${{ runner.os }}-buf-windows2-${{ hashFiles('**/go.sum', '/windows/**') }}
+          key: ${{ runner.os }}-buf-windows2-${{ hashFiles('**/go.sum', '.github/workflows/windows.yaml') }}
           restore-keys: |
             ${{ runner.os }}-buf-windows-
 #      - name: cache

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,8 +1,5 @@
 name: windows
-on:
-  push:
-  workflow_dispatch:
-
+on: push
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,9 +11,16 @@ jobs:
         uses: actions/checkout@v2
       - name: setup-go
         if: success()
-        uses: actions/setup-go@v2.1.4 # this contains a fix for Windows file extraction
+        uses: WillAbides/setup-go-faster@v1.7
         with:
           go-version: 1.17.5
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.setup-go.outputs.GOCACHE }}
+            ${{ steps.setup-go.outputs.GOMODCACHE }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 #      - name: cache
 #        if: success()
 #        uses: actions/cache@v2

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -8,6 +8,8 @@ on:
 permissions: read-all
 jobs:
   test:
+    env:
+      GOMODCACHE: 'D:\gomodcache'
     runs-on: windows-2019
     steps:
       - name: checkout

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -3,7 +3,7 @@ $protocGenGoVersion = 'v1.27.1'
 $protocGenGoGRPCVersion = '30dfb4b933a50fd366d7ed36ed4f71dbba2d382e'
 
 Invoke-WebRequest -Uri  https://github.com/protocolbuffers/protobuf/releases/download/v$protocVersion/protoc-$protocVersion-win64.zip -OutFile protoc.zip
-7z e protoc.zip
+7z x protoc.zip
 New-Item -ItemType Directory -Path C:\Users\runneradmin\protoc\bin -Force
 Move-Item -Path bin\protoc.exe -Destination C:\Users\runneradmin\protoc\bin;
 New-Item -ItemType Directory -Path C:\Users\runneradmin\protoc\lib\include\google\protobuf -Force

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -2,7 +2,7 @@ $protocVersion = '3.19.1'
 $protocGenGoVersion = 'v1.27.1'
 $protocGenGoGRPCVersion = '30dfb4b933a50fd366d7ed36ed4f71dbba2d382e'
 
-choco install --confirm curl zip
+choco install --confirm --no-progress curl zip
 curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v$protocVersion/protoc-$protocVersion-win64.zip -o protoc.zip
 unzip protoc.zip
 New-Item -ItemType Directory -Path C:\Users\runneradmin\protoc\bin -Force

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -2,8 +2,8 @@ $protocVersion = '3.19.1'
 $protocGenGoVersion = 'v1.27.1'
 $protocGenGoGRPCVersion = '30dfb4b933a50fd366d7ed36ed4f71dbba2d382e'
 
-choco install --confirm --no-progress curl zip
-curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v$protocVersion/protoc-$protocVersion-win64.zip -o protoc.zip
+choco install --confirm --no-progress zip
+Invoke-WebRequest -Uri  https://github.com/protocolbuffers/protobuf/releases/download/v$protocVersion/protoc-$protocVersion-win64.zip -OutFile protoc.zip
 unzip protoc.zip
 New-Item -ItemType Directory -Path C:\Users\runneradmin\protoc\bin -Force
 Move-Item -Path bin\protoc.exe -Destination C:\Users\runneradmin\protoc\bin;

--- a/windows/test.ps1
+++ b/windows/test.ps1
@@ -2,9 +2,8 @@ $protocVersion = '3.19.1'
 $protocGenGoVersion = 'v1.27.1'
 $protocGenGoGRPCVersion = '30dfb4b933a50fd366d7ed36ed4f71dbba2d382e'
 
-choco install --confirm --no-progress zip
 Invoke-WebRequest -Uri  https://github.com/protocolbuffers/protobuf/releases/download/v$protocVersion/protoc-$protocVersion-win64.zip -OutFile protoc.zip
-unzip protoc.zip
+7z e protoc.zip
 New-Item -ItemType Directory -Path C:\Users\runneradmin\protoc\bin -Force
 Move-Item -Path bin\protoc.exe -Destination C:\Users\runneradmin\protoc\bin;
 New-Item -ItemType Directory -Path C:\Users\runneradmin\protoc\lib\include\google\protobuf -Force


### PR DESCRIPTION
This speeds up the windows workflow by:
- moving caches to D:\ where restoring cache is much faster
- not using chocolatey to install curl and zip (or anything else)

With these changes the windows workflow typically takes between 2 and 4 minutes. Previously it took around 9 minutes.