### PR TITLE
testingextended: helper to get test timeout value

### DIFF
--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -34,5 +34,5 @@ func GetTestTimeout(t *testing.T) time.Duration {
 	}
 	// It's fine if this panics. We expect to be in a test, and this should
 	// be covered by the Go 1 compatability promise.
-	return flag.Lookup("timeout").Value.(testing.Getter).Get().(time.Duration)
+	return flag.Lookup("timeout").Value.(flag.Getter).Get().(time.Duration)
 }

--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -27,12 +27,12 @@ func SkipIfShort(t *testing.T) {
 	}
 }
 
-//GetTestTimeout returns the value of the go test -timeout flag.
+// GetTestTimeout returns the value of the go test -timeout flag.
 func GetTestTimeout(t *testing.T) time.Duration {
 	if !flag.Parsed() {
 		t.Fatal("unable to read testing timeout flag as flags have not been parsed")
 	}
 	// It's fine if this panics. We expect to be in a test, and this should
-	// be covered by the Go 1 compatability promise.
+	// be covered by the Go 1 compatibility promise.
 	return flag.Lookup("test.timeout").Value.(flag.Getter).Get().(time.Duration)
 }

--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -14,11 +14,25 @@
 
 package testingextended
 
-import "testing"
+import (
+	"flag"
+	"testing"
+	"time"
+)
 
 // SkipIfShort skips the test if testing.short is set.
 func SkipIfShort(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+}
+
+//GetTestTimeout returns the value of the go test -timeout flag.
+func GetTestTimeout(t *testing.T) time.Duration {
+	if !flag.Parsed() {
+		t.Fatal("unable to read testing timeout flag as flags have not been parsed")
+	}
+	// It's fine if this panics. We expect to be in a test, and this should
+	// be covered by the Go 1 compatability promise.
+	return flag.Lookup("timeout").Value.(testing.Getter).Get().(time.Duration)
 }

--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -34,5 +34,5 @@ func GetTestTimeout(t *testing.T) time.Duration {
 	}
 	// It's fine if this panics. We expect to be in a test, and this should
 	// be covered by the Go 1 compatability promise.
-	return flag.Lookup("timeout").Value.(flag.Getter).Get().(time.Duration)
+	return flag.Lookup("test.timeout").Value.(flag.Getter).Get().(time.Duration)
 }


### PR DESCRIPTION
It's useful to set go test's -timeout flag in different contexts, such
as during integration tests or when using verbose debugging or running
in a resource-constrained environment. Keeping such scenarios in mind,
it's additionally often useful to avoid internal timeouts during certain
tests by specifying a larger timeout duration. Unfortunately, this is
prone to error when the `go test` timeout exceeds the internal timeout,
which may not have been the intent of the test author, resulting in a
new, distinct and surprising failure.

Let's teach testingextended to expose `testing`'s global `timeout` flag
value so tests can refer to a duration that is guaranteed to exceed the
deadline of the test.