### PR TITLE
CLI support for plugin and template deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Upgrade to `protoc` 3.19.2 support.
+- Add `buf beta registry plugin deprecate`, `buf beta registry plugin undeprecate`, `buf beta registry template deprecate` and `buf beta registry template undeprecate`.
 
 ## [v1.0.0-rc10] - 2021-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Upgrade to `protoc` 3.19.2 support.
-- Add `buf beta registry plugin deprecate`, `buf beta registry plugin undeprecate`, `buf beta registry template deprecate` and `buf beta registry template undeprecate`.
+- Add `buf beta registry {plugin,template} {deprecate,undeprecate}`
 
 ## [v1.0.0-rc10] - 2021-12-16
 

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -294,6 +294,21 @@ func (g *generator) execRemotePlugin(
 	if len(responses) != 1 {
 		return nil, fmt.Errorf("unexpected number of responses received, got %d, wanted %d", len(responses), 1)
 	}
+	pluginService, err := g.registryProvider.NewPluginService(ctx, remote)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create plugin service for remote %q: %w", remote, err)
+	}
+	plugin, err := pluginService.GetPlugin(ctx, owner, name)
+	if err != nil {
+		return nil, err
+	}
+	if plugin.Deprecated {
+		warnMsg := fmt.Sprintf(`Plugin "%s/%s/%s" is deprecated`, remote, owner, name)
+		if plugin.DeprecationMessage != "" {
+			warnMsg = fmt.Sprintf("%s: %s", warnMsg, plugin.DeprecationMessage)
+		}
+		g.logger.Sugar().Warn(warnMsg)
+	}
 	return responses[0], nil
 }
 

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -30,7 +30,9 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/organization/organizationget"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete"
@@ -207,6 +209,8 @@ func NewRootCommand(name string) *appcmd.Command {
 									plugincreate.NewCommand("create", builder),
 									pluginlist.NewCommand("list", builder),
 									plugindelete.NewCommand("delete", builder),
+									plugindeprecate.NewCommand("deprecate", builder),
+									pluginundeprecate.NewCommand("undeprecate", builder),
 									{
 										Use:   "version",
 										Short: "Plugin version commands.",

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -44,7 +44,9 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/tag/taglist"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templatecreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templatedelete"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templatelist"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/breaking"
@@ -227,6 +229,8 @@ func NewRootCommand(name string) *appcmd.Command {
 									templatecreate.NewCommand("create", builder),
 									templatelist.NewCommand("list", builder),
 									templatedelete.NewCommand("delete", builder),
+									templatedeprecate.NewCommand("deprecate", builder),
+									templateundeprecate.NewCommand("undeprecate", builder),
 									{
 										Use:   "version",
 										Short: "Template version commands.",

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
@@ -1,0 +1,99 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugindeprecate
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	internal "github.com/bufbuild/buf/private/bufpkg/bufplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/rpc"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	messageFlagName = "message"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <buf.build/owner/" + internal.PluginsPathName + "/plugin>",
+		Short: "Deprecate a plugin by name.",
+		Args:  cobra.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appflag.Container) error {
+				return run(ctx, container, flags)
+			},
+			bufcli.NewErrorInterceptor(),
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	Message string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.Message,
+		messageFlagName,
+		"",
+		`The deprecation message to display with deprecation warnings.`,
+	)
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+	flags *flags,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	pluginPath := container.Arg(0)
+	if pluginPath == "" {
+		return appcmd.NewInvalidArgumentError("a plugin path must be specified")
+	}
+	registryProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote, owner, name, err := internal.ParsePluginPath(pluginPath)
+	if err != nil {
+		return err
+	}
+	pluginService, err := registryProvider.NewPluginService(ctx, remote)
+	if err != nil {
+		return err
+	}
+	if err := pluginService.DeprecatePlugin(ctx, owner, name, flags.Message); err != nil {
+		if rpc.GetErrorCode(err) == rpc.ErrorCodeNotFound {
+			return bufcli.NewPluginNotFoundError(owner, name)
+		}
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
-	internal "github.com/bufbuild/buf/private/bufpkg/bufplugin"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -37,7 +37,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/" + internal.PluginsPathName + "/plugin>",
+		Use:   name + " <buf.build/owner/" + bufplugin.PluginsPathName + "/plugin>",
 		Short: "Deprecate a plugin by name.",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
@@ -81,7 +81,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	remote, owner, name, err := internal.ParsePluginPath(pluginPath)
+	remote, owner, name, err := bufplugin.ParsePluginPath(pluginPath)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package plugindeprecate
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
@@ -1,0 +1,69 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pluginundeprecate
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	internal "github.com/bufbuild/buf/private/bufpkg/bufplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/rpc"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	return &appcmd.Command{
+		Use:   name + " <buf.build/owner/" + internal.PluginsPathName + "/plugin>",
+		Short: "Undeprecate a plugin by name.",
+		Args:  cobra.ExactArgs(1),
+		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
+	}
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	pluginPath := container.Arg(0)
+	if pluginPath == "" {
+		return appcmd.NewInvalidArgumentError("a plugin path must be specified")
+	}
+	registryProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote, owner, name, err := internal.ParsePluginPath(pluginPath)
+	if err != nil {
+		return err
+	}
+	pluginService, err := registryProvider.NewPluginService(ctx, remote)
+	if err != nil {
+		return err
+	}
+	if err := pluginService.UndeprecatePlugin(ctx, owner, name); err != nil {
+		if rpc.GetErrorCode(err) == rpc.ErrorCodeNotFound {
+			return bufcli.NewPluginNotFoundError(owner, name)
+		}
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
-	internal "github.com/bufbuild/buf/private/bufpkg/bufplugin"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/rpc"
@@ -31,7 +31,7 @@ func NewCommand(
 	builder appflag.Builder,
 ) *appcmd.Command {
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/" + internal.PluginsPathName + "/plugin>",
+		Use:   name + " <buf.build/owner/" + bufplugin.PluginsPathName + "/plugin>",
 		Short: "Undeprecate a plugin by name.",
 		Args:  cobra.ExactArgs(1),
 		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
@@ -51,7 +51,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	remote, owner, name, err := internal.ParsePluginPath(pluginPath)
+	remote, owner, name, err := bufplugin.ParsePluginPath(pluginPath)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package pluginundeprecate
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
@@ -1,0 +1,99 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templatedeprecate
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/rpc"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	messageFlagName = "message"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <buf.build/owner/" + bufplugin.TemplatesPathName + "/template>",
+		Short: "Deprecate a template by name.",
+		Args:  cobra.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appflag.Container) error {
+				return run(ctx, container, flags)
+			},
+			bufcli.NewErrorInterceptor(),
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	Message string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.Message,
+		messageFlagName,
+		"",
+		`The deprecation message to display with deprecation warnings.`,
+	)
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+	flags *flags,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	templatePath := container.Arg(0)
+	if templatePath == "" {
+		return appcmd.NewInvalidArgumentError("a template path must be specified")
+	}
+	registryProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote, owner, name, err := bufplugin.ParseTemplatePath(templatePath)
+	if err != nil {
+		return err
+	}
+	pluginService, err := registryProvider.NewPluginService(ctx, remote)
+	if err != nil {
+		return err
+	}
+	if err := pluginService.DeprecateTemplate(ctx, owner, name, flags.Message); err != nil {
+		if rpc.GetErrorCode(err) == rpc.ErrorCodeNotFound {
+			return bufcli.NewTemplateNotFoundError(owner, name)
+		}
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package templatedeprecate
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/templateundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/templateundeprecate.go
@@ -1,0 +1,69 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templateundeprecate
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/rpc"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	return &appcmd.Command{
+		Use:   name + " <buf.build/owner/" + bufplugin.TemplatesPathName + "/template>",
+		Short: "Undeprecate a template by name.",
+		Args:  cobra.ExactArgs(1),
+		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
+	}
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	templatePath := container.Arg(0)
+	if templatePath == "" {
+		return appcmd.NewInvalidArgumentError("a template path must be specified")
+	}
+	registryProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote, owner, name, err := bufplugin.ParseTemplatePath(templatePath)
+	if err != nil {
+		return err
+	}
+	pluginService, err := registryProvider.NewPluginService(ctx, remote)
+	if err != nil {
+		return err
+	}
+	if err := pluginService.UndeprecateTemplate(ctx, owner, name); err != nil {
+		if rpc.GetErrorCode(err) == rpc.ErrorCodeNotFound {
+			return bufcli.NewTemplateNotFoundError(owner, name)
+		}
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package templateundeprecate
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
will also include warning message when user is using deprecated plugin/template in this PR

### Plugin

To deprecate a plugin: 
`buf beta registry plugin deprecate buf.build/owner/plugins/plugin [--message "please use buf.build/owner/plugins/newplugin"]`

To undeprecate a plugin:
`buf beta registry plugin undeprecate buf.build/owner/plugins/plugin`

When you run `buf generate` with a deprecated remote plugin in your `buf.gen.yaml`, you will get a warning message:
`WARN    Plugin "buf.build/owner/plugins/plugin" is deprecated: please use buf.build/owner/plugins/newplugin`

