### PR TITLE
Add missing NewErrorInterceptor to repository undeprecate

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
@@ -32,7 +32,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 		Use:   name + " <buf.build/owner/repository>",
 		Short: "Undeprecate a repository.",
 		Args:  cobra.ExactArgs(1),
-		Run:   builder.NewRunFunc(run),
+		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
 	}
 }
 


### PR DESCRIPTION
I left this off when adding undeprecate.