### PR TITLE
Remove `digest`, and `created_at` fields from the `buf.lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add `buf beta registry {plugin,template} {deprecate,undeprecate}`.
 - Add warning when using enterprise dependencies without specifying a enterprise
   remote in the module's identity.
+- Remove `branch`, `digest`, and `created_at` fields from the `buf.lock`. This will create
+  when pushing the same contents to an existing repository, since the `ModulePin` has been reduced down.
 
 ## [v1.0.0-rc10] - 2021-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `buf beta registry {plugin,template} {deprecate,undeprecate}`.
 - Add warning when using enterprise dependencies without specifying a enterprise
   remote in the module's identity.
-- Remove `branch`, `digest`, and `created_at` fields from the `buf.lock`. This will create
+- Remove `branch`, `digest`, and `created_at` fields from the `buf.lock`. This will temporarily create a new commit
   when pushing the same contents to an existing repository, since the `ModulePin` has been reduced down.
 
 ## [v1.0.0-rc10] - 2021-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `buf beta registry {plugin,template} {deprecate,undeprecate}`.
 - Add warning when using enterprise dependencies without specifying a enterprise
   remote in the module's identity.
-- Remove `branch`, `digest`, and `created_at` fields from the `buf.lock`. This will temporarily create a new commit
+- Remove `digest`, and `created_at` fields from the `buf.lock`. This will temporarily create a new commit
   when pushing the same contents to an existing repository, since the `ModulePin` has been reduced down.
 
 ## [v1.0.0-rc10] - 2021-12-16

--- a/private/bufpkg/buflock/buflock.go
+++ b/private/bufpkg/buflock/buflock.go
@@ -43,10 +43,7 @@ type Dependency struct {
 	Remote     string
 	Owner      string
 	Repository string
-	Branch     string
 	Commit     string
-	Digest     string
-	CreateTime time.Time
 }
 
 // ReadConfig reads the lock file at ExternalConfigFilePath relative
@@ -84,6 +81,28 @@ type ExternalConfigDependencyV1 struct {
 	CreateTime time.Time `json:"create_time,omitempty" yaml:"create_time,omitempty"`
 }
 
+// DependencyForExternalConfigDependencyV1 returns the Dependency representation of a ExternalConfigDependencyV1.
+func DependencyForExternalConfigDependencyV1(dep ExternalConfigDependencyV1) Dependency {
+	return Dependency{
+		Remote:     dep.Remote,
+		Owner:      dep.Owner,
+		Repository: dep.Repository,
+		Commit:     dep.Commit,
+	}
+}
+
+// ExternalConfigDependencyV1ForDependency returns the ExternalConfigDependencyV1 of a Dependency.
+//
+// Note, some fields will be their empty value since not all values are available on the Dependency.
+func ExternalConfigDependencyV1ForDependency(dep Dependency) ExternalConfigDependencyV1 {
+	return ExternalConfigDependencyV1{
+		Remote:     dep.Remote,
+		Owner:      dep.Owner,
+		Repository: dep.Repository,
+		Commit:     dep.Commit,
+	}
+}
+
 // ExternalConfigDependencyV1Beta1 represents a single dependency within
 // the v1beta1 lock file.
 type ExternalConfigDependencyV1Beta1 struct {
@@ -94,6 +113,28 @@ type ExternalConfigDependencyV1Beta1 struct {
 	Commit     string    `json:"commit,omitempty" yaml:"commit,omitempty"`
 	Digest     string    `json:"digest,omitempty" yaml:"digest,omitempty"`
 	CreateTime time.Time `json:"create_time,omitempty" yaml:"create_time,omitempty"`
+}
+
+// DepedencyForExternalConfigDependencyV1Beta1 returns the Dependency representation of a ExternalConfigDependencyV1Beta1.
+func DependencyForExternalConfigDependencyV1Beta1(dep ExternalConfigDependencyV1Beta1) Dependency {
+	return Dependency{
+		Remote:     dep.Remote,
+		Owner:      dep.Owner,
+		Repository: dep.Repository,
+		Commit:     dep.Commit,
+	}
+}
+
+// ExternalConfigDependencyV1Beta1ForDependency returns the ExternalConfigDependencyV1Beta1 of a Dependency.
+//
+// Note, some fields will be their empty value since not all values are available on the Dependency.
+func ExternalConfigDependencyV1Beta1ForDependency(dep Dependency) ExternalConfigDependencyV1Beta1 {
+	return ExternalConfigDependencyV1Beta1{
+		Remote:     dep.Remote,
+		Owner:      dep.Owner,
+		Repository: dep.Repository,
+		Commit:     dep.Commit,
+	}
 }
 
 // ExternalConfigVersion defines the subset of all lock

--- a/private/bufpkg/buflock/buflock.go
+++ b/private/bufpkg/buflock/buflock.go
@@ -43,6 +43,7 @@ type Dependency struct {
 	Remote     string
 	Owner      string
 	Repository string
+	Branch     string
 	Commit     string
 }
 
@@ -87,6 +88,7 @@ func DependencyForExternalConfigDependencyV1(dep ExternalConfigDependencyV1) Dep
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
+		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }
@@ -99,6 +101,7 @@ func ExternalConfigDependencyV1ForDependency(dep Dependency) ExternalConfigDepen
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
+		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }
@@ -121,6 +124,7 @@ func DependencyForExternalConfigDependencyV1Beta1(dep ExternalConfigDependencyV1
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
+		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }
@@ -133,6 +137,7 @@ func ExternalConfigDependencyV1Beta1ForDependency(dep Dependency) ExternalConfig
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
+		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }

--- a/private/bufpkg/buflock/buflock_test.go
+++ b/private/bufpkg/buflock/buflock_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
@@ -45,9 +44,6 @@ func testReadConfig(t *testing.T, version string) {
 				Owner:      "acme",
 				Repository: "weather",
 				Commit:     "e9191fcdc2294e2f8f3b82c528fc90a8",
-				Digest:     bufmoduletesting.TestDigest,
-				Branch:     "main",
-				CreateTime: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 		},
 	}
@@ -77,18 +73,12 @@ func TestWriteReadConfig(t *testing.T) {
 				Owner:      "test1",
 				Repository: "foob1",
 				Commit:     bufmoduletesting.TestCommit,
-				Digest:     bufmoduletesting.TestDigest,
-				Branch:     "barr",
-				CreateTime: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			{
 				Remote:     "buf.build",
 				Owner:      "test2",
 				Repository: "foob2",
 				Commit:     bufmoduletesting.TestCommit,
-				Digest:     bufmoduletesting.TestDigest,
-				Branch:     "main", // Can't import bufmodule here without causing an import cycle
-				CreateTime: time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
 		},
 	}
@@ -127,18 +117,12 @@ func TestParseV1Beta1Config(t *testing.T) {
 				Owner:      "test1",
 				Repository: "foob1",
 				Commit:     bufmoduletesting.TestCommit,
-				Digest:     bufmoduletesting.TestDigest,
-				Branch:     "barr",
-				CreateTime: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			{
 				Remote:     "buf.build",
 				Owner:      "test2",
 				Repository: "foob2",
 				Commit:     bufmoduletesting.TestCommit,
-				Digest:     bufmoduletesting.TestDigest,
-				Branch:     "main", // Can't import bufmodule here without causing an import cycle
-				CreateTime: time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
 		},
 	}
@@ -149,8 +133,8 @@ func TestParseV1Beta1Config(t *testing.T) {
 	})
 	v1beta1Config := &buflock.ExternalConfigV1Beta1{
 		Deps: []buflock.ExternalConfigDependencyV1Beta1{
-			buflock.ExternalConfigDependencyV1Beta1(testConfig.Dependencies[0]),
-			buflock.ExternalConfigDependencyV1Beta1(testConfig.Dependencies[1]),
+			buflock.ExternalConfigDependencyV1Beta1ForDependency(testConfig.Dependencies[0]),
+			buflock.ExternalConfigDependencyV1Beta1ForDependency(testConfig.Dependencies[1]),
 		},
 	}
 	err = encoding.NewYAMLEncoder(writeObjectCloser).Encode(v1beta1Config)
@@ -187,7 +171,7 @@ func TestParseIncompleteConfig(t *testing.T) {
 	configBytes, err := encoding.MarshalYAML(&buflock.ExternalConfigV1{
 		Version: buflock.V1Version,
 		Deps: []buflock.ExternalConfigDependencyV1{
-			buflock.ExternalConfigDependencyV1(testConfig.Dependencies[0]),
+			buflock.ExternalConfigDependencyV1ForDependency(testConfig.Dependencies[0]),
 		},
 	})
 	require.NoError(t, err)

--- a/private/bufpkg/buflock/buflock_test.go
+++ b/private/bufpkg/buflock/buflock_test.go
@@ -43,6 +43,7 @@ func testReadConfig(t *testing.T, version string) {
 				Remote:     "bufbuild.test",
 				Owner:      "acme",
 				Repository: "weather",
+				Branch:     "main",
 				Commit:     "e9191fcdc2294e2f8f3b82c528fc90a8",
 			},
 		},
@@ -72,12 +73,14 @@ func TestWriteReadConfig(t *testing.T) {
 				Remote:     "buf.build",
 				Owner:      "test1",
 				Repository: "foob1",
+				Branch:     "main",
 				Commit:     bufmoduletesting.TestCommit,
 			},
 			{
 				Remote:     "buf.build",
 				Owner:      "test2",
 				Repository: "foob2",
+				Branch:     "main", // Can't import bufmodule here without causing an import cycle
 				Commit:     bufmoduletesting.TestCommit,
 			},
 		},
@@ -116,12 +119,14 @@ func TestParseV1Beta1Config(t *testing.T) {
 				Remote:     "buf.build",
 				Owner:      "test1",
 				Repository: "foob1",
+				Branch:     "main",
 				Commit:     bufmoduletesting.TestCommit,
 			},
 			{
 				Remote:     "buf.build",
 				Owner:      "test2",
 				Repository: "foob2",
+				Branch:     "main", // Can't import bufmodule here without causing an import cycle
 				Commit:     bufmoduletesting.TestCommit,
 			},
 		},

--- a/private/bufpkg/buflock/lock_file.go
+++ b/private/bufpkg/buflock/lock_file.go
@@ -43,7 +43,7 @@ func readConfig(ctx context.Context, readBucket storage.ReadBucket) (_ *Config, 
 		}
 		config := &Config{}
 		for _, dep := range externalConfig.Deps {
-			config.Dependencies = append(config.Dependencies, Dependency(dep))
+			config.Dependencies = append(config.Dependencies, DependencyForExternalConfigDependencyV1Beta1(dep))
 		}
 		return config, nil
 	case V1Version:
@@ -53,7 +53,7 @@ func readConfig(ctx context.Context, readBucket storage.ReadBucket) (_ *Config, 
 		}
 		config := &Config{}
 		for _, dep := range externalConfig.Deps {
-			config.Dependencies = append(config.Dependencies, Dependency(dep))
+			config.Dependencies = append(config.Dependencies, DependencyForExternalConfigDependencyV1(dep))
 		}
 		return config, nil
 	default:
@@ -67,7 +67,7 @@ func writeConfig(ctx context.Context, writeBucket storage.WriteBucket, config *C
 		Deps:    make([]ExternalConfigDependencyV1, 0, len(config.Dependencies)),
 	}
 	for _, dep := range config.Dependencies {
-		externalConfig.Deps = append(externalConfig.Deps, ExternalConfigDependencyV1(dep))
+		externalConfig.Deps = append(externalConfig.Deps, ExternalConfigDependencyV1ForDependency(dep))
 	}
 	configBytes, err := encoding.MarshalYAML(&externalConfig)
 	if err != nil {

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -412,10 +412,10 @@ func DependencyModulePinsForBucket(
 			dep.Remote,
 			dep.Owner,
 			dep.Repository,
-			dep.Branch,
+			"",
 			dep.Commit,
-			dep.Digest,
-			dep.CreateTime,
+			"",
+			time.Time{},
 		)
 		if err != nil {
 			return nil, err
@@ -450,10 +450,7 @@ func PutDependencyModulePinsToBucket(
 				Remote:     pin.Remote(),
 				Owner:      pin.Owner(),
 				Repository: pin.Repository(),
-				Branch:     pin.Branch(),
 				Commit:     pin.Commit(),
-				Digest:     pin.Digest(),
-				CreateTime: pin.CreateTime(),
 			},
 		)
 	}

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -416,7 +416,7 @@ func DependencyModulePinsForBucket(
 			dep.Remote,
 			dep.Owner,
 			dep.Repository,
-			"",
+			MainBranch,
 			dep.Commit,
 			"",
 			time.Time{},

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -454,6 +454,7 @@ func PutDependencyModulePinsToBucket(
 				Remote:     pin.Remote(),
 				Owner:      pin.Owner(),
 				Repository: pin.Repository(),
+				Branch:     pin.Branch(),
 				Commit:     pin.Commit(),
 			},
 		)

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -416,7 +416,7 @@ func DependencyModulePinsForBucket(
 			dep.Remote,
 			dep.Owner,
 			dep.Repository,
-			MainBranch,
+			dep.Branch,
 			dep.Commit,
 			"",
 			time.Time{},


### PR DESCRIPTION
This PR removes the writing of `branch`, `digest`, and `created_at` fields into the `buf.lock`.
This also means that we will not be reading those values out of future `buf.lock`, so those values will be the `nil`/zero values for the module pin sent to the server-side. This means, that if the server-side is still on the `b1` digest (which it currently is), a new commit will be written with a client that includes this change. If the server-side digest is migrated to `b3`, then this change does not present any issues.