### PR TITLE
Add buf push --track

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -28,9 +28,13 @@ import (
 )
 
 const (
+	// MainTrack is the name of the track created for every repository.
+	// This is the default track used if no track is specified.
+	MainTrack = "main"
+
 	// MainBranch is the name of the branch created for every repository.
 	// This is the default branch used if no branch or commit is specified.
-	MainBranch = "main"
+	MainBranch = MainTrack
 )
 
 // FileInfo contains module file info.


### PR DESCRIPTION
This adds a `--track` option to `buf push`. When set, the module will be appended to the track(s) specified. Otherwise the module will be appended to the main track.