### PR TITLE
Set a default timeout in GetTestTimeout

### DIFF
--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -15,7 +15,6 @@
 package testingextended
 
 import (
-	"flag"
 	"testing"
 	"time"
 )
@@ -27,22 +26,10 @@ func SkipIfShort(t *testing.T) {
 	}
 }
 
-// GetTestTimeout returns the value of the go test -timeout flag.
+// GetTestTimeout returns the time remaining until the test times out or 10m if the test is not set to timeout.
 func GetTestTimeout(t *testing.T) time.Duration {
-	if !flag.Parsed() {
-		t.Fatal("unable to read testing timeout flag as flags have not been parsed")
+	if deadline, ok := t.Deadline(); ok {
+		return time.Until(deadline)
 	}
-
-	// default is 10m to match the default timeout for go test
-	timeout := 10 * time.Minute
-
-	// If the test.timeout flag is set, use it.
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "test.timeout" {
-			// It's fine if this panics. We expect to be in a test, and this should
-			// be covered by the Go 1 compatibility promise.
-			timeout = f.Value.(flag.Getter).Get().(time.Duration)
-		}
-	})
-	return timeout
+	return 10 * time.Minute
 }

--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -28,7 +28,7 @@ func SkipIfShort(t *testing.T) {
 
 // GetTestTimeout returns the time remaining until the test times out or 10m if the test is not set to timeout.
 func GetTestTimeout(t *testing.T) time.Duration {
-	if deadline, ok := t.Deadline(); ok {
+	if deadline, ok := t.Deadline(); ok && !deadline.IsZero() {
 		return time.Until(deadline)
 	}
 	return 10 * time.Minute

--- a/private/pkg/testingextended/testingextended.go
+++ b/private/pkg/testingextended/testingextended.go
@@ -32,7 +32,17 @@ func GetTestTimeout(t *testing.T) time.Duration {
 	if !flag.Parsed() {
 		t.Fatal("unable to read testing timeout flag as flags have not been parsed")
 	}
-	// It's fine if this panics. We expect to be in a test, and this should
-	// be covered by the Go 1 compatibility promise.
-	return flag.Lookup("test.timeout").Value.(flag.Getter).Get().(time.Duration)
+
+	// default is 10m to match the default timeout for go test
+	timeout := 10 * time.Minute
+
+	// If the test.timeout flag is set, use it.
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "test.timeout" {
+			// It's fine if this panics. We expect to be in a test, and this should
+			// be covered by the Go 1 compatibility promise.
+			timeout = f.Value.(flag.Getter).Get().(time.Duration)
+		}
+	})
+	return timeout
 }


### PR DESCRIPTION
This updates `GetTestTimeout` to return the time remaining until `t.Deadline()`. When there is no deadline it return 10 minutes.

This is needed because when running tests with goland, no `-test.timeout` is set by default.