### PR TITLE
Allow execution of debug builds

### DIFF
--- a/private/usage/usage.go
+++ b/private/usage/usage.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 )
 
+const debugBinPrefix = "__debug_bin"
+
 func init() {
 	if err := check(); err != nil {
 		panic(err.Error())
@@ -32,7 +34,8 @@ func init() {
 func check() error {
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok || buildInfo.Main.Path == "" {
-		if !strings.HasSuffix(os.Args[0], testSuffix) && filepath.Base(os.Args[0]) != debugBin {
+		// Detect and allow *.test and __debug_bin files.
+		if !strings.HasSuffix(os.Args[0], testSuffix) && !strings.HasPrefix(filepath.Base(os.Args[0]), debugBinPrefix) {
 			return errors.New("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects")
 		}
 		return nil

--- a/private/usage/usage.go
+++ b/private/usage/usage.go
@@ -34,7 +34,7 @@ func init() {
 func check() error {
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok || buildInfo.Main.Path == "" {
-		// Detect and allow *.test and __debug_bin files.
+		// Detect and allow *.test and __debug_bin* files.
 		if !strings.HasSuffix(os.Args[0], testSuffix) && !strings.HasPrefix(filepath.Base(os.Args[0]), debugBinPrefix) {
 			return errors.New("github.com/bufbuild/buf/private code must only be imported by github.com/bufbuild projects")
 		}

--- a/private/usage/usage_unix.go
+++ b/private/usage/usage_unix.go
@@ -17,7 +17,4 @@
 
 package usage
 
-const (
-	testSuffix = ".test"
-	debugBin   = "__debug_bin"
-)
+const testSuffix = ".test"

--- a/private/usage/usage_windows.go
+++ b/private/usage/usage_windows.go
@@ -17,7 +17,4 @@
 
 package usage
 
-const (
-	testSuffix = ".test.exe"
-	debugBin   = "__debug_bin.exe"
-)
+const testSuffix = ".test.exe"


### PR DESCRIPTION
It seems that recently the name pattern used for Go's debug builds change, so our existing mitigation strategy is not sufficient. I have seen names in the shape of `/var/folders/ss/92w9dtp15l38qgbjgpvg4f580000gn/T/__debug_bin3790439195`, so this new check should handle both.

Since we're checking by name prefix of the last part of the executable, we no longer need to differentiate it between Windows and other platforms.