### PR TITLE
Upgrade `buf` version to `v1.0.0-rc11` for Github Actions

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v0.7.0
         if: success()
         with:
-          version: 0.56.0
+          version: 1.0.0-rc11
       - uses: bufbuild/buf-lint-action@v1.0.0
         if: success()
         with:
@@ -23,7 +23,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v0.7.0
         if: success()
         with:
-          version: 0.56.0
+          version: 1.0.0-rc11
       - uses: bufbuild/buf-breaking-action@v1.0.0
         if: success()
         with:
@@ -40,7 +40,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v0.7.0
         if: success()
         with:
-          version: 0.56.0
+          version: 1.0.0-rc11
       - uses: bufbuild/buf-push-action@v1.0.0
         if: success()
         with:


### PR DESCRIPTION
We've been running our Github Actions on `0.56.0`, upgraading everything up to `v1.0.0-rc11`, our most recent version, to keep our dogfooding processes up-to-date.﻿
