### PR TITLE
Fix command short description

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist/templateversionlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist/templateversionlist.go
@@ -42,7 +42,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufplugin.TemplatesPathName + "/template>",
-		Short: "List versions for the specified plugin.",
+		Short: "List versions for the specified template.",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {


### PR DESCRIPTION
This PR fixes the command description for the `buf beta registry template version list` command, which erroneously describes the command as listing _plugins_. Before:

"List versions for the specified plugin."

Now:

"List versions for the specified template."