### PR TITLE
Add dependency commits to `b3` digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add `default`, `except` and `override` to `java_package_prefix`.
+- Add dependency commits as a part of the `b3` digest.
 
 ## [v1.0.0-rc11] - 2022-01-18
 

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -406,7 +406,7 @@ func ModuleDigestB3(ctx context.Context, module Module) (string, error) {
 	// but we only want to use commit as part of the sort order, so we make a copy of
 	// the slice and sort it by commit
 	for _, dependencyModulePin := range copyModulePinsSortedByOnlyCommit(module.DependencyModulePins()) {
-		if _, err := hash.Write([]byte(dependencyModulePin.IdentityString())); err != nil {
+		if _, err := hash.Write([]byte(dependencyModulePin.IdentityString() + ":" + dependencyModulePin.Commit())); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
Commits should be a part of the `b3` digest, otherwise changes where only dependencies are updated will not be detected.
Note this will create a cache invalidation when first run/upgraded since it's a digest change.