### PR TITLE
match `buf breaking` behaviour with `buf build` for workspaces

### DIFF
--- a/private/buf/bufwire/image_config.go
+++ b/private/buf/bufwire/image_config.go
@@ -38,3 +38,10 @@ func (i *imageConfig) Image() bufimage.Image {
 func (i *imageConfig) Config() *bufconfig.Config {
 	return i.config
 }
+
+func NewImageConfig(image bufimage.Image, config *bufconfig.Config) *imageConfig {
+	return &imageConfig{
+		image:  image,
+		config: config,
+	}
+}

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -919,12 +919,11 @@ func TestWorkspaceBreakingFail(t *testing.T) {
 		"build",
 		filepath.Join("testdata", "workspace", "fail", "breaking"),
 	)
-	testRunStdoutStderr(
+	testRunStdout(
 		t,
 		nil,
-		1,
-		``,
-		`Failure: input contained 1 images, whereas against contained 2 images`,
+		bufcli.ExitCodeFileAnnotation,
+		`<input>:1:1:Previously present file "rpc.proto" was deleted.`,
 		"breaking",
 		filepath.Join("testdata", "workspace", "fail", "breaking"),
 		"--against",


### PR DESCRIPTION
## Overview
One solution for #567 and also for workspace directories being altered is to treat the entire workspace as one module. This will emulate,
```shell
buf breaking --against against.bin $(buf build .)
```

## Reasoning
- `buf build` already treats a workspace as one module producing only one image. 
- This is similar to running `buf build` on two different revisions of code and testing their output for breaking change detection. 
- At a workspace level it does ensure nothing breaks even if files are moved around.

## Problem
- We will not be able to detect if files are moved amongst the directories of a workspace breaking the modules. 
- This may mislead people to believe the modules themselves didn't break whereas such a check never happens. Similar to how one might assume `buf build` when targeting a workspace will have information regarding the workspace itself.

## Implementation
We can merge all the images for both `input` and `against` respectively and use their respective configs if available. Otherwise fallback to defaults.



