### PR TITLE
Remove `branch` from `buf.lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `default`, `except` and `override` to `java_package_prefix`.
 - Add dependency commits as a part of the `b3` digest.
 - Upgrade to `protoc` 3.19.4 support.
+- Remove `branch` field from `buf.lock`.
 
 ## [v1.0.0-rc11] - 2022-01-18
 

--- a/private/bufpkg/buflock/buflock.go
+++ b/private/bufpkg/buflock/buflock.go
@@ -43,7 +43,6 @@ type Dependency struct {
 	Remote     string
 	Owner      string
 	Repository string
-	Branch     string
 	Commit     string
 }
 
@@ -88,7 +87,6 @@ func DependencyForExternalConfigDependencyV1(dep ExternalConfigDependencyV1) Dep
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
-		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }
@@ -101,7 +99,6 @@ func ExternalConfigDependencyV1ForDependency(dep Dependency) ExternalConfigDepen
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
-		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }
@@ -124,7 +121,6 @@ func DependencyForExternalConfigDependencyV1Beta1(dep ExternalConfigDependencyV1
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
-		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }
@@ -137,7 +133,6 @@ func ExternalConfigDependencyV1Beta1ForDependency(dep Dependency) ExternalConfig
 		Remote:     dep.Remote,
 		Owner:      dep.Owner,
 		Repository: dep.Repository,
-		Branch:     dep.Branch,
 		Commit:     dep.Commit,
 	}
 }

--- a/private/bufpkg/buflock/buflock_test.go
+++ b/private/bufpkg/buflock/buflock_test.go
@@ -43,7 +43,6 @@ func testReadConfig(t *testing.T, version string) {
 				Remote:     "bufbuild.test",
 				Owner:      "acme",
 				Repository: "weather",
-				Branch:     "main",
 				Commit:     "e9191fcdc2294e2f8f3b82c528fc90a8",
 			},
 		},
@@ -73,14 +72,12 @@ func TestWriteReadConfig(t *testing.T) {
 				Remote:     "buf.build",
 				Owner:      "test1",
 				Repository: "foob1",
-				Branch:     "main",
 				Commit:     bufmoduletesting.TestCommit,
 			},
 			{
 				Remote:     "buf.build",
 				Owner:      "test2",
 				Repository: "foob2",
-				Branch:     "main", // Can't import bufmodule here without causing an import cycle
 				Commit:     bufmoduletesting.TestCommit,
 			},
 		},
@@ -119,14 +116,12 @@ func TestParseV1Beta1Config(t *testing.T) {
 				Remote:     "buf.build",
 				Owner:      "test1",
 				Repository: "foob1",
-				Branch:     "main",
 				Commit:     bufmoduletesting.TestCommit,
 			},
 			{
 				Remote:     "buf.build",
 				Owner:      "test2",
 				Repository: "foob2",
-				Branch:     "main", // Can't import bufmodule here without causing an import cycle
 				Commit:     bufmoduletesting.TestCommit,
 			},
 		},

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -416,7 +416,7 @@ func DependencyModulePinsForBucket(
 			dep.Remote,
 			dep.Owner,
 			dep.Repository,
-			dep.Branch,
+			"",
 			dep.Commit,
 			"",
 			time.Time{},
@@ -454,7 +454,6 @@ func PutDependencyModulePinsToBucket(
 				Remote:     pin.Remote(),
 				Owner:      pin.Owner(),
 				Repository: pin.Repository(),
-				Branch:     pin.Branch(),
 				Commit:     pin.Commit(),
 			},
 		)


### PR DESCRIPTION
Now that we've merged and deployed a change to the server-side to return the full `ModulePin` structure for dependencies, we can safely remove the `branch` field from the `buf.lock` without breaking backwards compatibility for older clients.

It should be noted that if a user downgrades their client, they would need to clear their cache (since the digest has not changed, but there is client-side validation for the `branch` field in older clients), but otherwise this is backwards compatible.

Refs #777 