### PR TITLE
Check user provided token during `buf registry login`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Check that the user provided a valid token when running `buf registry login`.
 
 ## [v1.0.0-rc12] - 2022-02-01
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -147,7 +147,7 @@ func run(
 		return errors.New("no user found for provided token")
 	}
 	if user.Username != username {
-		return fmt.Errorf("token user does not match username provided: %s", username)
+		return fmt.Errorf("the username associated with that token (%s) does not match the username provided (%s)", user.Username, username)
 	}
 	if err := netrc.PutMachines(
 		container,


### PR DESCRIPTION
Check the token and username provided when calling `buf registry login`.
If the token is invalid, we return an error and if the user resolved from the token does not match the username provided, we return an error.

Fixes: #861