### PR TITLE
Expose tracks commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   remote in the module's identity.
 - Remove `digest`, and `created_at` fields from the `buf.lock`. This will temporarily create a new commit
   when pushing the same contents to an existing repository, since the `ModulePin` has been reduced down.
+- Add `--track` flag to `buf push`
+- Update `buf beta registry commit list` to allow a track to be specified.
+- Add `buf beta registry track {list,delete}` commands.
 - Add manpages for `buf`.
 
 ## [v1.0.0-rc10] - 2021-12-16

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -185,9 +185,8 @@ func NewRootCommand(name string) *appcmd.Command {
 								},
 							},
 							{
-								Use:    "track",
-								Hidden: true, // TODO: (tracks) remove this when ready
-								Short:  "Repository track commands.",
+								Use:   "track",
+								Short: "Repository track commands.",
 								SubCommands: []*appcmd.Command{
 									tracklist.NewCommand("list", builder),
 									trackdelete.NewCommand("delete", builder),

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -80,7 +80,6 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		nil,
 		"Append the pushed module to this track. If specified multiple times, multiple tracks will be appended.",
 	)
-	_ = flagSet.MarkHidden(trackFlagName) // TODO: (tracks) remove this when ready
 	flagSet.StringSliceVarP(
 		&f.Tags,
 		tagFlagName,


### PR DESCRIPTION
This unhides `buf push --track` and `buf beta registry track`