### PR TITLE
pkg/thread: use GOMAXPROCS instead of NumCPU

### DIFF
--- a/private/pkg/thread/thread.go
+++ b/private/pkg/thread/thread.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	globalParallelism = runtime.NumCPU()
+	globalParallelism = runtime.GOMAXPROCS(0)
 	globalLock        sync.RWMutex
 )
 


### PR DESCRIPTION
In modern production environments, NumCPU is a poor estimate of the
actual parallelism available: it does consult the population count of
the cpuset mask (if any), but doesn't account for cgroups v1 or v2. Both
are commonly used in containerized environments.

The intention of this code is (I think?) to prevent us from burning
memory on initial stacks for zillions of goroutines, so we should
just use GOMAXPROCS: by definition, it's the maximum number of
goroutines that can run in parallel.
