### PR TITLE
pkg/thread: add a simple test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.20.0
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect

--- a/private/pkg/thread/thread_test.go
+++ b/private/pkg/thread/thread_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thread
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+)
+
+func TestParallelizeWithImmediateCancellation(t *testing.T) {
+	// The bulk of the code relies on subtle timing that's difficult to
+	// reproduce, but we can test the most basic use case.
+	var executed atomic.Int64
+	var jobs []func(context.Context) error
+	for i := 0; i < 10; i++ {
+		jobs = append(jobs, func(_ context.Context) error {
+			executed.Inc()
+			return nil
+		})
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := Parallelize(ctx, jobs)
+	assert.Nil(t, err, "parallelize error")
+	assert.Equal(t, int64(0), executed.Load(), "jobs executed")
+}

--- a/private/pkg/thread/thread_test.go
+++ b/private/pkg/thread/thread_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestParallelizeWithImmediateCancellation(t *testing.T) {
+	t.Parallel()
 	// The bulk of the code relies on subtle timing that's difficult to
 	// reproduce, but we can test the most basic use case.
 	var executed atomic.Int64


### PR DESCRIPTION
It's difficult to test all the timing conditions in Parallelize, but we
can easily test the most basic use cases.
