### PR TITLE
Delete all already-deleted commands and flags

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -61,19 +61,6 @@ const (
 	// Version is the CLI version of buf.
 	Version = "1.0.0-dev"
 
-	// DeprecationMessageSuffix is the suffix that should be added to any command or flag
-	// that was deprecated and removed for v1.0.
-	DeprecationMessageSuffix = `
-
-At Buf, we take compatibility very seriously. When we say v1.0, we mean it - we hope "buf" will be
-stable on v1 for the next decade, and if there is something we want to change, it is our responsibility
-to make sure that we don't break you, not your responsibility to change because of us. We have learned
-a lot about "buf" usage in the last two years of our beta, and have deprecated flags and commands
-(including this one) as we go, but for v1.0, we have removed the deprecated items to make sure we
-have a clean setup going forward.
-
-Update your invocation for v1.0 and you'll be good to go. We apologize for any inconvenience.`
-
 	inputHTTPSUsernameEnvKey      = "BUF_INPUT_HTTPS_USERNAME"
 	inputHTTPSPasswordEnvKey      = "BUF_INPUT_HTTPS_PASSWORD"
 	inputSSHKeyFileEnvKey         = "BUF_INPUT_SSH_KEY_FILE"
@@ -217,28 +204,6 @@ If specified multiple times, the union will be taken.`,
 	)
 }
 
-// BindPathsAndDeprecatedFiles binds the paths flag and the deprecated files flag.
-//
-// We do not mark the files flag as deprecated as we now error when we hit it, and
-// print out an error message via the returned error.
-func BindPathsAndDeprecatedFiles(
-	flagSet *pflag.FlagSet,
-	pathsAddr *[]string,
-	pathsFlagName string,
-	filesAddr *[]string,
-	filesFlagName string,
-) {
-	BindPaths(flagSet, pathsAddr, pathsFlagName)
-	flagSet.StringSliceVar(
-		filesAddr,
-		filesFlagName,
-		nil,
-		`Limit to specific files.
-If specified multiple times, the union will be taken.`,
-	)
-	_ = flagSet.MarkHidden(filesFlagName)
-}
-
 // BindInputHashtag binds the input hashtag flag.
 //
 // This needs to be added to any command that has the input as the first argument.
@@ -315,15 +280,13 @@ If no argument is specified, defaults to ".".`,
 	)
 }
 
-// GetInputValue gets the first arg and errors if the deprecated flag is used.
+// GetInputValue gets the first arg.
 //
 // Also parses the special input hashtag flag that deals with the situation "buf build -#format=json".
 // The existence of 0 or 1 args should be handled by the Args field on Command.
 func GetInputValue(
 	container appflag.Container,
 	inputHashtag string,
-	deprecatedFlag string,
-	deprecatedFlagName string,
 	defaultValue string,
 ) (string, error) {
 	var arg string
@@ -344,58 +307,10 @@ func GetInputValue(
 	default:
 		return "", fmt.Errorf("only 1 argument allowed but %d arguments specified", numArgs)
 	}
-	if arg != "" && deprecatedFlag != "" {
-		return "", fmt.Errorf("cannot specify both first argument and deprecated flag --%s, use the first argument instead%s", deprecatedFlagName, DeprecationMessageSuffix)
-	}
 	if arg != "" {
 		return arg, nil
 	}
-	if deprecatedFlag != "" {
-		return "", fmt.Errorf("flag --%s is no longer supported, use the first argument instead%s", deprecatedFlagName, DeprecationMessageSuffix)
-	}
 	return defaultValue, nil
-}
-
-// GetStringFlagOrDeprecatedFlag gets the flag, or the deprecated flag.
-//
-// An error is returned if the deprecated flag is used.
-func GetStringFlagOrDeprecatedFlag(
-	flag string,
-	flagName string,
-	deprecatedFlag string,
-	deprecatedFlagName string,
-) (string, error) {
-	if flag != "" && deprecatedFlag != "" {
-		return "", fmt.Errorf("cannot specify both --%s and --%s, use --%s instead%s", flagName, deprecatedFlagName, flagName, DeprecationMessageSuffix)
-	}
-	if flag != "" {
-		return flag, nil
-	}
-	if deprecatedFlag != "" {
-		return "", fmt.Errorf("flag --%s is no longer supported, use --%s instead%s", deprecatedFlagName, flagName, DeprecationMessageSuffix)
-	}
-	return "", nil
-}
-
-// GetStringSliceFlagOrDeprecatedFlag gets the flag, or the deprecated flag.
-//
-// An error is returned if the deprecated flag is used.
-func GetStringSliceFlagOrDeprecatedFlag(
-	flag []string,
-	flagName string,
-	deprecatedFlag []string,
-	deprecatedFlagName string,
-) ([]string, error) {
-	if len(flag) > 0 && len(deprecatedFlag) > 0 {
-		return nil, fmt.Errorf("cannot specify both --%s and --%s, use --%s instead%s", flagName, deprecatedFlagName, flagName, DeprecationMessageSuffix)
-	}
-	if len(flag) > 0 {
-		return flag, nil
-	}
-	if len(deprecatedFlag) > 0 {
-		return nil, fmt.Errorf("flag --%s is no longer supported, use --%s instead%s", deprecatedFlagName, flagName, DeprecationMessageSuffix)
-	}
-	return nil, nil
 }
 
 // WarnAlphaCommand prints a warning for a alpha command unless the alphaSuppressWarningsEnvKey

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -73,31 +73,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 )
 
-const (
-	betaConfigDeprecationMessage               = `"buf beta config ..." has been moved to "buf config ...".` + bufcli.DeprecationMessageSuffix
-	betaConfigInitDeprecationMessage           = `"buf beta config init" has been moved to "buf config init".` + bufcli.DeprecationMessageSuffix
-	betaImageConvertDeprecationMessage         = `"buf beta image convert" has been moved to "buf build".` + bufcli.DeprecationMessageSuffix
-	betaModClearCacheDeprecationMessage        = `"buf beta mod clear-cache" has been moved to "buf mod clear-cache".` + bufcli.DeprecationMessageSuffix
-	betaModDeprecationMessage                  = `"buf beta mod ..." has been moved to "buf mod ...".` + bufcli.DeprecationMessageSuffix
-	betaModExportDeprecationMessage            = `"buf beta mod export" has been moved to "buf export".` + bufcli.DeprecationMessageSuffix
-	betaModInitDeprecationMessage              = `"buf beta mod init" has been moved to "buf config init".` + bufcli.DeprecationMessageSuffix
-	betaModUpdateDeprecationMessage            = `"buf beta mod update" has been moved to "buf mod update".` + bufcli.DeprecationMessageSuffix
-	betaPushDeprecationMessage                 = `"buf beta push" has been moved to "buf mod push".` + bufcli.DeprecationMessageSuffix
-	checkBreakingDeprecationMessage            = `"buf check breaking" has been moved to "buf breaking".` + bufcli.DeprecationMessageSuffix
-	checkDeprecationMessage                    = `"buf check" sub-commands are now all implemented with the top-level "buf lint" and "buf breaking" commands.` + bufcli.DeprecationMessageSuffix
-	checkLintDeprecationMessage                = `"buf check lint" has been moved to "buf lint".` + bufcli.DeprecationMessageSuffix
-	checkLsBreakingCheckersDeprecationMessage  = `"buf check ls-breaking-checkers" has been moved to "buf config ls-breaking-rules".` + bufcli.DeprecationMessageSuffix
-	checkLsLintCheckersDeprecationMessage      = `"buf check ls-lint-checkers" has been moved to "buf config ls-lint-rules".` + bufcli.DeprecationMessageSuffix
-	experimentalDeprecationMessage             = `"buf experimental" sub-commands have moved to "buf beta".` + bufcli.DeprecationMessageSuffix
-	experimentalImageConvertDeprecationMessage = `"buf experimental image convert" has been moved to "buf build".` + bufcli.DeprecationMessageSuffix
-	imageBuildDeprecationMessage               = `"buf image build" has been moved to "buf build".` + bufcli.DeprecationMessageSuffix
-	imageDeprecationMessage                    = `"buf image" sub-commands are now all implemented under the top-level "buf build" command.` + bufcli.DeprecationMessageSuffix
-	loginDeprecationMessage                    = `"buf login" has been moved to "buf registry login".` + bufcli.DeprecationMessageSuffix
-	logoutDeprecationMessage                   = `"buf logout" has been moved to "buf registry logout".` + bufcli.DeprecationMessageSuffix
-	modInitDeprecationMessage                  = `"buf mod init" has been moved to "buf config init".` + bufcli.DeprecationMessageSuffix
-	pushDeprecationMessage                     = `"buf push" has been moved to "buf mod push".` + bufcli.DeprecationMessageSuffix
-)
-
 // Main is the entrypoint to the buf CLI.
 func Main(name string) {
 	appcmd.Main(context.Background(), NewRootCommand(name))
@@ -131,7 +106,6 @@ func NewRootCommand(name string) *appcmd.Command {
 				Use:   "mod",
 				Short: "Manage Buf modules.",
 				SubCommands: []*appcmd.Command{
-					appcmd.NewDeletedCommand("init", modInitDeprecationMessage),
 					modprune.NewCommand("prune", builder),
 					modupdate.NewCommand("update", builder),
 					modopen.NewCommand("open", builder),
@@ -248,37 +222,6 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 						},
 					},
-					{
-						Use:        "config",
-						Short:      "Manage Buf module configuration.",
-						Deprecated: betaConfigDeprecationMessage,
-						Hidden:     true,
-						SubCommands: []*appcmd.Command{
-							appcmd.NewDeletedCommand("init", betaConfigInitDeprecationMessage),
-						},
-					},
-					{
-						Use:        "image",
-						Short:      "Manage Images and FileDescriptorSets.",
-						Deprecated: imageDeprecationMessage,
-						Hidden:     true,
-						SubCommands: []*appcmd.Command{
-							appcmd.NewDeletedCommand("convert", betaImageConvertDeprecationMessage),
-						},
-					},
-					{
-						Use:        "mod",
-						Short:      "Manage Buf modules.",
-						Deprecated: betaModDeprecationMessage,
-						Hidden:     true,
-						SubCommands: []*appcmd.Command{
-							appcmd.NewDeletedCommand("init", betaModInitDeprecationMessage),
-							appcmd.NewDeletedCommand("update", betaModUpdateDeprecationMessage),
-							appcmd.NewDeletedCommand("export", betaModExportDeprecationMessage),
-							appcmd.NewDeletedCommand("clear-cache", betaModClearCacheDeprecationMessage, "cc"),
-						},
-					},
-					appcmd.NewDeletedCommand("push", betaPushDeprecationMessage),
 				},
 			},
 			{
@@ -301,47 +244,6 @@ func NewRootCommand(name string) *appcmd.Command {
 									tokendelete.NewCommand("delete", builder),
 								},
 							},
-						},
-					},
-				},
-			},
-			appcmd.NewDeletedCommand("login", loginDeprecationMessage),
-			appcmd.NewDeletedCommand("logout", logoutDeprecationMessage),
-			appcmd.NewDeletedCommand("push", pushDeprecationMessage),
-			{
-				Use:        "image",
-				Short:      "Manage Images and FileDescriptorSets.",
-				Deprecated: imageDeprecationMessage,
-				Hidden:     true,
-				SubCommands: []*appcmd.Command{
-					appcmd.NewDeletedCommand("build", imageBuildDeprecationMessage),
-				},
-			},
-			{
-				Use:        "check",
-				Short:      "Run linting or breaking change detection against Buf modules.",
-				Deprecated: checkDeprecationMessage,
-				Hidden:     true,
-				SubCommands: []*appcmd.Command{
-					appcmd.NewDeletedCommand("lint", checkLintDeprecationMessage),
-					appcmd.NewDeletedCommand("breaking", checkBreakingDeprecationMessage),
-					appcmd.NewDeletedCommand("ls-lint-checkers", checkLsLintCheckersDeprecationMessage),
-					appcmd.NewDeletedCommand("ls-breaking-checkers", checkLsBreakingCheckersDeprecationMessage),
-				},
-			},
-			{
-				Use:        "experimental",
-				Short:      "Experimental commands. Unstable and likely to change.",
-				Deprecated: experimentalDeprecationMessage,
-				Hidden:     true,
-				SubCommands: []*appcmd.Command{
-					{
-						Use:        "image",
-						Short:      "Manage Images and FileDescriptorSets.",
-						Deprecated: imageDeprecationMessage,
-						Hidden:     true,
-						SubCommands: []*appcmd.Command{
-							appcmd.NewDeletedCommand("convert", experimentalImageConvertDeprecationMessage),
 						},
 					},
 				},

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -43,17 +43,6 @@ const (
 	againstConfigFlagName     = "against-config"
 	excludePathsFlagName      = "exclude-path"
 	disableSymlinksFlagName   = "disable-symlinks"
-
-	// deprecated
-	inputFlagName = "input"
-	// deprecated
-	inputConfigFlagName = "input-config"
-	// deprecated
-	againstInputFlagName = "against-input"
-	// deprecated
-	againstInputConfigFlagName = "against-input-config"
-	// deprecated
-	filesFlagName = "file"
 )
 
 // NewCommand returns a new Command.
@@ -87,17 +76,6 @@ type flags struct {
 	AgainstConfig     string
 	ExcludePaths      []string
 	DisableSymlinks   bool
-
-	// deprecated
-	Input string
-	// deprecated
-	InputConfig string
-	// deprecated
-	AgainstInput string
-	// deprecated
-	AgainstInputConfig string
-	// deprecated
-	Files []string
 	// special
 	InputHashtag string
 }
@@ -107,7 +85,7 @@ func newFlags() *flags {
 }
 
 func (f *flags) Bind(flagSet *pflag.FlagSet) {
-	bufcli.BindPathsAndDeprecatedFiles(flagSet, &f.Paths, pathsFlagName, &f.Files, filesFlagName)
+	bufcli.BindPaths(flagSet, &f.Paths, pathsFlagName)
 	bufcli.BindInputHashtag(flagSet, &f.InputHashtag)
 	bufcli.BindExcludePaths(flagSet, &f.ExcludePaths, excludePathsFlagName)
 	bufcli.BindDisableSymlinks(flagSet, &f.DisableSymlinks, disableSymlinksFlagName)
@@ -158,45 +136,6 @@ Overrides --%s.`,
 		"",
 		`The file or data to use to configure the against source, module, or image.`,
 	)
-
-	// deprecated, but not marked as deprecated as we return error if this is used
-	flagSet.StringVar(
-		&f.Input,
-		inputFlagName,
-		"",
-		fmt.Sprintf(
-			`The source or Image to check for breaking changes. Must be one of format %s.`,
-			buffetch.AllFormatsString,
-		),
-	)
-	_ = flagSet.MarkHidden(inputFlagName)
-	// deprecated, but not marked as deprecated as we return error if this is used
-	flagSet.StringVar(
-		&f.InputConfig,
-		inputConfigFlagName,
-		"",
-		`The file or data to use for configuration.`,
-	)
-	_ = flagSet.MarkHidden(inputConfigFlagName)
-	// deprecated, but not marked as deprecated as we return error if this is used
-	flagSet.StringVar(
-		&f.AgainstInput,
-		againstInputFlagName,
-		"",
-		fmt.Sprintf(
-			`Required. The source or Image to check against. Must be one of format %s.`,
-			buffetch.AllFormatsString,
-		),
-	)
-	_ = flagSet.MarkHidden(againstInputFlagName)
-	// deprecated, but not marked as deprecated as we return error if this is used
-	flagSet.StringVar(
-		&f.AgainstInputConfig,
-		againstInputConfigFlagName,
-		"",
-		`The file or data to use to configure the against source or Image.`,
-	)
-	_ = flagSet.MarkHidden(againstInputConfigFlagName)
 }
 
 func run(
@@ -204,49 +143,13 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
+	if flags.Against == "" {
+		return appcmd.NewInvalidArgumentErrorf("required flag %q not set", againstFlagName)
+	}
 	if err := bufcli.ValidateErrorFormatFlag(flags.ErrorFormat, errorFormatFlagName); err != nil {
 		return err
 	}
-	input, err := bufcli.GetInputValue(container, flags.InputHashtag, flags.Input, inputFlagName, ".")
-	if err != nil {
-		return err
-	}
-	inputConfig, err := bufcli.GetStringFlagOrDeprecatedFlag(
-		flags.Config,
-		configFlagName,
-		flags.InputConfig,
-		inputConfigFlagName,
-	)
-	if err != nil {
-		return err
-	}
-	againstInput, err := bufcli.GetStringFlagOrDeprecatedFlag(
-		flags.Against,
-		againstFlagName,
-		flags.AgainstInput,
-		againstInputFlagName,
-	)
-	if err != nil {
-		return err
-	}
-	againstInputConfig, err := bufcli.GetStringFlagOrDeprecatedFlag(
-		flags.AgainstConfig,
-		againstConfigFlagName,
-		flags.AgainstInputConfig,
-		againstInputConfigFlagName,
-	)
-	if err != nil {
-		return err
-	}
-	if againstInput == "" {
-		return appcmd.NewInvalidArgumentErrorf("required flag %q not set", againstFlagName)
-	}
-	paths, err := bufcli.GetStringSliceFlagOrDeprecatedFlag(
-		flags.Paths,
-		pathsFlagName,
-		flags.Files,
-		filesFlagName,
-	)
+	input, err := bufcli.GetInputValue(container, flags.InputHashtag, ".")
 	if err != nil {
 		return err
 	}
@@ -273,8 +176,8 @@ func run(
 		ctx,
 		container,
 		ref,
-		inputConfig,
-		paths,              // we filter checks for files
+		flags.Config,
+		flags.Paths,        // we filter checks for files
 		flags.ExcludePaths, // we exclude these paths
 		false,              // files specified must exist on the main input
 		false,              // we must include source info for this side of the check
@@ -294,14 +197,14 @@ func run(
 	}
 	// TODO: this doesn't actually work because we're using the same file paths for both sides
 	// if the roots change, then we're torched
-	externalPaths := paths
+	externalPaths := flags.Paths
 	if flags.LimitToInputFiles {
 		externalPaths, err = getExternalPathsForImages(imageConfigs, flags.ExcludeImports)
 		if err != nil {
 			return err
 		}
 	}
-	againstRef, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, againstInput)
+	againstRef, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, flags.Against)
 	if err != nil {
 		return err
 	}
@@ -309,7 +212,7 @@ func run(
 		ctx,
 		container,
 		againstRef,
-		againstInputConfig,
+		flags.AgainstConfig,
 		externalPaths,      // we filter checks for files
 		flags.ExcludePaths, // we exclude these paths
 		true,               // files are allowed to not exist on the against input

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -111,7 +111,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	input, err := bufcli.GetInputValue(container, flags.InputHashtag, "", "", ".")
+	input, err := bufcli.GetInputValue(container, flags.InputHashtag, ".")
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -36,11 +36,6 @@ const (
 	errorFormatFlagName     = "error-format"
 	includeImportsFlagName  = "include-imports"
 	disableSymlinksFlagName = "disable-symlinks"
-
-	// deprecated
-	inputFlagName = "input"
-	// deprecated
-	inputConfigFlagName = "input-config"
 )
 
 // NewCommand returns a new Command.
@@ -70,11 +65,6 @@ type flags struct {
 	ErrorFormat     string
 	IncludeImports  bool
 	DisableSymlinks bool
-
-	// deprecated
-	Input string
-	// deprecated
-	InputConfig string
 	// special
 	InputHashtag string
 }
@@ -91,15 +81,6 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		asImportPathsFlagName,
 		false,
 		"Strip local directory paths and print filepaths as they are imported.",
-	)
-	flagSet.StringVar(
-		&f.Input,
-		inputFlagName,
-		"",
-		fmt.Sprintf(
-			`The source or Image to list files from. Must be one of format %s.`,
-			buffetch.AllFormatsString,
-		),
 	)
 	flagSet.StringVar(
 		&f.Config,
@@ -122,15 +103,6 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		false,
 		"Include imports.",
 	)
-
-	// deprecated, but not marked as deprecated as we return error if this is used
-	flagSet.StringVar(
-		&f.InputConfig,
-		inputConfigFlagName,
-		"",
-		`The file or data to use for configuration.`,
-	)
-	_ = flagSet.MarkHidden(inputConfigFlagName)
 }
 
 func run(
@@ -138,16 +110,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	input, err := bufcli.GetInputValue(container, flags.InputHashtag, flags.Input, inputFlagName, ".")
-	if err != nil {
-		return err
-	}
-	inputConfig, err := bufcli.GetStringFlagOrDeprecatedFlag(
-		flags.Config,
-		configFlagName,
-		flags.InputConfig,
-		inputConfigFlagName,
-	)
+	input, err := bufcli.GetInputValue(container, flags.InputHashtag, ".")
 	if err != nil {
 		return err
 	}
@@ -174,7 +137,7 @@ func run(
 		ctx,
 		container,
 		ref,
-		inputConfig,
+		flags.Config,
 		flags.IncludeImports,
 	)
 	if err != nil {

--- a/private/buf/cmd/buf/command/mod/modopen/modopen.go
+++ b/private/buf/cmd/buf/command/mod/modopen/modopen.go
@@ -51,7 +51,7 @@ func run(
 	ctx context.Context,
 	container appflag.Container,
 ) error {
-	directoryInput, err := bufcli.GetInputValue(container, "", "", "", ".")
+	directoryInput, err := bufcli.GetInputValue(container, "", ".")
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -55,7 +55,7 @@ func run(
 	ctx context.Context,
 	container appflag.Container,
 ) error {
-	directoryInput, err := bufcli.GetInputValue(container, "", "", "", ".")
+	directoryInput, err := bufcli.GetInputValue(container, "", ".")
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -88,7 +88,7 @@ func run(
 	container appflag.Container,
 	flags *flags,
 ) error {
-	directoryInput, err := bufcli.GetInputValue(container, "", "", "", ".")
+	directoryInput, err := bufcli.GetInputValue(container, "", ".")
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -108,7 +108,7 @@ func run(
 	if err := bufcli.ValidateErrorFormatFlag(flags.ErrorFormat, errorFormatFlagName); err != nil {
 		return err
 	}
-	source, err := bufcli.GetInputValue(container, flags.InputHashtag, "", "", ".")
+	source, err := bufcli.GetInputValue(container, flags.InputHashtag, ".")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is basically a code cleanup pass. In [v1.0.0-rc1](https://github.com/bufbuild/buf/releases/tag/v1.0.0-rc1), we made all of these commands and flags error, so this PR functionally is a no-op, but it cleans up the codebase going forward. After about five months, we can move from custom errors to normal not found errors.