### PR TITLE
Remove compile term from public text

### DIFF
--- a/private/buf/cmd/buf/command/alpha/protoc/errors.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/errors.go
@@ -94,7 +94,7 @@ func newDescriptorSetInNotSupportedError() error {
 	return fmt.Errorf(
 		`--%s is not supported by buf.
 
-Buf will work with cross-repository imports Buf Schema Registry, which will be based on source files, not pre-compiled images.
+Buf will work with cross-repository imports Buf Schema Registry, which will be based on source files, not pre-built Images.
 We think this is a much safer option that leads to less errors and more consistent results.
 
 Please email us at support@buf.build if this is a need for your organization.`,

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -140,7 +140,7 @@ $ buf generate --template buf.gen.yaml .
 # --template also takes YAML or JSON data as input, so it can be used without a file
 $ buf generate --template '{"version":"v1","plugins":[{"name":"go","out":"gen/go"}]}'
 
-# download the repository, compile it, and generate per the bar.yaml template
+# download the repository and generate code stubs per the bar.yaml template
 $ buf generate --template bar.yaml https://github.com/foo/bar.git
 
 # generate to the bar/ directory, prepending bar/ to the out directives in the template


### PR DESCRIPTION
Just a small nit. The build vs. compile distinction is likely to produce confusion. Fortunately, "compile" is barely used here in the CLI but it's nonetheless worthwhile to remove it.