### PR TITLE
Change `Use` text for `buf breaking`

### DIFF
--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -52,7 +52,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " --against against-input <input>",
+		Use:   name + " <input> --against <against-input>",
 		Short: "Verify that the input location has no breaking changes compared to the against location.",
 		Long:  bufcli.GetInputLong(`the source, module, or Image to check for breaking changes`),
 		Args:  cobra.MaximumNArgs(1),


### PR DESCRIPTION
This strikes me as more intuitive and also more in line with the `Short` description.
