### PR TITLE
DISCUSS: Do not override existing token in the bufcli Context Modifier

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -547,7 +547,9 @@ func NewContextModifierProvider(
 		}
 		return func(ctx context.Context) context.Context {
 			ctx = bufrpc.WithOutgoingCLIVersionHeader(ctx, Version)
-			if token != "" {
+			// Only set the token if there is no existing token on the context.
+			// This allows requests to override the token at the call site as needed.
+			if token != "" && !rpcauth.ExistingToken(ctx) {
 				return rpcauth.WithToken(ctx, token)
 			}
 			return ctx

--- a/private/pkg/rpc/rpcauth/rpcauth.go
+++ b/private/pkg/rpc/rpcauth/rpcauth.go
@@ -60,6 +60,14 @@ func WithToken(ctx context.Context, token string) context.Context {
 	return ctx
 }
 
+// ExistingToken returns true if a token is already set on the context and false otherwise.
+func ExistingToken(ctx context.Context) bool {
+	if token := rpc.GetOutgoingHeader(ctx, authenticationHeader); token != "" {
+		return true
+	}
+	return false
+}
+
 // GetTokenFromHeader gets the current authentication token, if
 // there is one.
 func GetTokenFromHeader(ctx context.Context) (string, error) {


### PR DESCRIPTION
Fixes #934

For `buf registry login`, we make a call out to `GetCurrentUser` with the token provided in order to check the validity of the token. However, the `bufcli` has a context modifier that will use an existing token in the `.netrc` or set to `BUF_TOKEN` in the request unless those are both unset. This change will prevent the context modifier from overriding a token that has already been set on the context.