### PR TITLE
Add buf push --vcs-check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,12 @@ issues:
       text: "G101:"
     - linters:
         - gosec
+      # G101 checks for hardcoded credentials, and the variables named "*Token*
+      # trip this off.
+      path: private/buf/cmd/buf/command/push/vcscheck.go
+      text: "G101:"
+    - linters:
+        - gosec
       # G204 checks that exec.Command is not called with non-constants.
       path: private/pkg/command/runner.go
       text: "G204:"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gofrs/flock v0.8.1
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-cmp v0.5.7
+	github.com/google/go-github/v42 v42.0.0
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a
 	github.com/jhump/protoreflect v1.11.1-0.20220213155251-0c2aedc66cf4
 	github.com/klauspost/compress v1.14.2
@@ -21,6 +22,7 @@ require (
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/tools v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bradleyfalzon/ghinstallation/v2 v2.0.3/go.mod h1:tlgi+JWCXnKFx/Y4WtnDbZEINo31N5bcvnCoqieefmk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -125,6 +126,7 @@ github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZg
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -175,6 +177,11 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-github/v39 v39.0.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
+github.com/google/go-github/v42 v42.0.0 h1:YNT0FwjPrEysRkLIiKuEfSvBPCGKphW5aS5PxwaoLec=
+github.com/google/go-github/v42 v42.0.0/go.mod h1:jgg/jvyI0YlDOM1/ps6XYh04HNQ3vKf0CVko62/EhRg=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -390,6 +397,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -488,6 +496,7 @@ golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -685,6 +694,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/private/buf/cmd/buf/command/push/vcscheck.go
+++ b/private/buf/cmd/buf/command/push/vcscheck.go
@@ -1,0 +1,192 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package push
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
+	"github.com/bufbuild/buf/private/pkg/app"
+	"github.com/bufbuild/buf/private/pkg/github"
+	"github.com/bufbuild/buf/private/pkg/rpc"
+)
+
+type checkType int
+
+const (
+	checkTypeNone checkType = iota + 1
+	checkTypeGithub
+)
+
+var checkTypeStrings = map[checkType]string{
+	checkTypeNone:   "none",
+	checkTypeGithub: "github",
+}
+
+var stringToCheckType = map[string]checkType{
+	"none":   checkTypeNone,
+	"github": checkTypeGithub,
+}
+
+var allCheckTypeStrings = []string{
+	"none",
+	"github",
+}
+
+const (
+	githubTokenEnvKey      = "GITHUB_TOKEN"
+	githubRepositoryEnvKey = "GITHUB_REPOSITORY"
+	githubAPIURLEnvKey     = "GITHUB_API_URL"
+)
+
+func (g checkType) String() string {
+	got, ok := checkTypeStrings[g]
+	if !ok {
+		return fmt.Sprintf("unknown(%d)", g)
+	}
+	return got
+}
+
+// githubCheck is a vcs check that uses the github api to prevent pushing outdated commits to BSR.
+//
+// It requires:
+//  - environment variable GITHUB_REPOSITORY is set with the github repository name in the format "owner/repository"
+// 	- environment variable GITHUB_TOKEN is set with a github token with access to the repository
+// 	- exactly one element of tags is a git commit hash (called taggedGitCommit below)
+//
+// It errors if the head of any track
+//   1. has a different digest from module
+//     and
+//   2. is not already tagged with taggedGitCommit
+//     and
+//   3. has no tags that represent a git commit that is behind taggedGitCommit in the github repository
+//     and
+//	 4. has one or more tags that represent git commits that are ahead of taggedGitCommit in the github repository
+func githubCheck(
+	ctx context.Context,
+	envContainer app.EnvContainer,
+	apiProvider registryv1alpha1apiclient.Provider,
+	module bufmodule.Module,
+	moduleIdentity bufmoduleref.ModuleIdentity,
+	tags []string,
+	tracks []string,
+) error {
+	digest, err := bufmodule.ModuleDigestB1(ctx, module)
+	if err != nil {
+		return err
+	}
+	var taggedGitCommit string
+	for _, tag := range tags {
+		if !maybeGitCommit(tag) {
+			continue
+		}
+		if taggedGitCommit != "" {
+			return fmt.Errorf("exactly one tag must be a 40 character git commit hash when --vcs-check=github")
+		}
+		taggedGitCommit = tag
+	}
+	if taggedGitCommit == "" {
+		return fmt.Errorf("exactly one tag must be a 40 character git commit hash when --vcs-check=github")
+	}
+	repositoryCommitService, err := apiProvider.NewRepositoryCommitService(ctx, moduleIdentity.Remote())
+	if err != nil {
+		return err
+	}
+	token := envContainer.Env(githubTokenEnvKey)
+	if token == "" {
+		return fmt.Errorf("environment variable %s must be set when --vcs-check=github", githubTokenEnvKey)
+	}
+	githubRepository := envContainer.Env(githubRepositoryEnvKey)
+	if githubRepository == "" {
+		return fmt.Errorf("environment variable %s must be set when --vcs-check=github", githubRepositoryEnvKey)
+	}
+	// baseURL is optional
+	baseURL := envContainer.Env(githubAPIURLEnvKey)
+	userAgent := fmt.Sprintf("buf/%s", bufcli.Version)
+	githubClient, err := github.NewClient(ctx, token, userAgent, baseURL, githubRepository)
+	if err != nil {
+		return err
+	}
+	for _, track := range tracks {
+		trackHead, err := repositoryCommitService.GetRepositoryCommitByReference(
+			ctx,
+			moduleIdentity.Owner(),
+			moduleIdentity.Repository(),
+			track,
+		)
+		if err != nil {
+			if rpc.GetErrorCode(err) == rpc.ErrorCodeNotFound {
+				// It's always ok to push to a new track
+				continue
+			}
+			return err
+		}
+		if trackHead.Digest == digest {
+			// It's always ok to push to a track with the same digest
+			continue
+		}
+		diverged := false
+		behind := false
+		ahead := false
+		identical := false
+		for _, tag := range trackHead.Tags {
+			if !maybeGitCommit(tag.Name) {
+				continue
+			}
+			status, err := githubClient.CompareCommits(ctx, tag.Name, taggedGitCommit)
+			if err != nil {
+				if github.IsNotFoundError(err) {
+					// It can't be an ancestor of a commit that doesn't exist.
+					continue
+				}
+				return err
+			}
+			switch status {
+			case github.CompareCommitsStatusDiverged:
+				diverged = true
+			case github.CompareCommitsStatusBehind:
+				behind = true
+			case github.CompareCommitsStatusAhead:
+				ahead = true
+			case github.CompareCommitsStatusIdentical:
+				identical = true
+			}
+		}
+		if ahead || identical {
+			// It's ok to push if the new commit is ahead of or the same as any tagged git commit...even if it is behind
+			// other tagged git commits.
+			continue
+		}
+		if diverged || behind {
+			return fmt.Errorf("not pushing because %s is behind the head of %s", taggedGitCommit, track)
+		}
+		// Tracks with no tagged git commits are ok to push.
+	}
+	return nil
+}
+
+// maybeGitCommit returns true if the string is 40 characters long and only contains hexadecimal characters.
+func maybeGitCommit(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}

--- a/private/pkg/github/github.go
+++ b/private/pkg/github/github.go
@@ -1,0 +1,83 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v42/github"
+)
+
+type CompareCommitsStatus int
+
+// The possible values for returned from githubClient.CompareCommits.
+// see https://stackoverflow.com/a/23969867
+const (
+	CompareCommitsStatusDiverged CompareCommitsStatus = iota + 1
+	CompareCommitsStatusIdentical
+	CompareCommitsStatusAhead
+	CompareCommitsStatusBehind
+)
+
+var compareCommitStatusStrings = map[CompareCommitsStatus]string{
+	CompareCommitsStatusDiverged:  "diverged",
+	CompareCommitsStatusIdentical: "identical",
+	CompareCommitsStatusAhead:     "ahead",
+	CompareCommitsStatusBehind:    "behind",
+}
+
+var stringsToCompareCommitStatus = map[string]CompareCommitsStatus{
+	"diverged":  CompareCommitsStatusDiverged,
+	"identical": CompareCommitsStatusIdentical,
+	"ahead":     CompareCommitsStatusAhead,
+	"behind":    CompareCommitsStatusBehind,
+}
+
+func (s CompareCommitsStatus) String() string {
+	got, ok := compareCommitStatusStrings[s]
+	if !ok {
+		return fmt.Sprintf("unknown(%d)", s)
+	}
+	return got
+}
+
+type Client interface {
+	// CompareCommits compares two commits and returns the status of head relative to base.
+	CompareCommits(ctx context.Context, base string, head string) (CompareCommitsStatus, error)
+}
+
+// NewClient returns a new github client.
+// baseURL is optional and defaults to https://api.github.com/.
+func NewClient(
+	ctx context.Context,
+	githubToken string,
+	userAgent string,
+	baseURL string,
+	repository string,
+) (Client, error) {
+	return newGithubClient(ctx, githubToken, userAgent, baseURL, repository)
+}
+
+// IsNotFoundError returns true if the error is a *github.ErrorResponse with a 404 status code.
+func IsNotFoundError(err error) bool {
+	var errorResponse *github.ErrorResponse
+	if !errors.As(err, &errorResponse) {
+		return false
+	}
+	return errorResponse.Response.StatusCode == http.StatusNotFound
+}

--- a/private/pkg/github/githubclient.go
+++ b/private/pkg/github/githubclient.go
@@ -1,0 +1,98 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/google/go-github/v42/github"
+	"golang.org/x/oauth2"
+)
+
+type githubClient struct {
+	client *github.Client
+	owner  string
+	repo   string
+}
+
+func newGithubClient(
+	ctx context.Context,
+	githubToken string,
+	userAgent string,
+	baseURL string,
+	repository string,
+) (*githubClient, error) {
+	goGithubClient, err := newGoGithubClient(ctx, githubToken, userAgent, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	ownerAndRepo := strings.Split(repository, "/")
+	if len(ownerAndRepo) != 2 {
+		return nil, fmt.Errorf("invalid repository: %s", repository)
+	}
+	return &githubClient{
+		client: goGithubClient,
+		owner:  ownerAndRepo[0],
+		repo:   ownerAndRepo[1],
+	}, nil
+}
+
+func (c *githubClient) CompareCommits(ctx context.Context, base string, head string) (CompareCommitsStatus, error) {
+	comp, _, err := c.client.Repositories.CompareCommits(ctx, c.owner, c.repo, base, head, nil)
+	if err != nil {
+		return 0, err
+	}
+	status, ok := stringsToCompareCommitStatus[comp.GetStatus()]
+	if !ok {
+		return 0, fmt.Errorf("unknown CompareCommitsStatus: %s", comp.GetStatus())
+	}
+	return status, nil
+}
+
+func newGoGithubClient(
+	ctx context.Context,
+	token string,
+	userAgent string,
+	baseURL string,
+) (*github.Client, error) {
+	if token == "" {
+		return nil, fmt.Errorf("github token is empty")
+	}
+	client := github.NewClient(
+		oauth2.NewClient(
+			ctx,
+			oauth2.StaticTokenSource(
+				&oauth2.Token{
+					AccessToken: token,
+				},
+			),
+		),
+	)
+	var err error
+	if baseURL != "" {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		client.BaseURL, err = url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse base url: %w", err)
+		}
+	}
+	client.UserAgent = userAgent
+	return client, nil
+}

--- a/private/pkg/github/githubclient_test.go
+++ b/private/pkg/github/githubclient_test.go
@@ -1,0 +1,123 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-github/v42/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const (
+	testGithubToken      = "githubToken"
+	testGithubRepository = "owner/repo"
+	testUserAgent        = "userAgent"
+)
+
+func TestCompareCommits(t *testing.T) {
+	assertRequestHeaders := func(t *testing.T, r *http.Request) {
+		assert.Equal(t, fmt.Sprintf("Bearer %s", testGithubToken), r.Header.Get("Authorization"))
+		assert.Equal(t, testUserAgent, r.Header.Get("User-Agent"))
+		assert.Equal(t, "GET", r.Method)
+	}
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		server := newTestServer(t)
+		server.addHandler("/repos/owner/repo/compare/foo...bar", func(w http.ResponseWriter, r *http.Request) {
+			assertRequestHeaders(t, r)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"ahead_by":  1,
+				"behind_by": 2,
+				"status":    CompareCommitsStatusDiverged.String(),
+			})
+			assert.NoError(t, err)
+		})
+		client := server.client(ctx)
+		status, err := client.CompareCommits(ctx, "foo", "bar")
+		require.NoError(t, err)
+		assert.Equal(t, CompareCommitsStatusDiverged, status)
+	})
+
+	t.Run("404", func(t *testing.T) {
+		ctx := context.Background()
+		server := newTestServer(t)
+		server.handlers["/repos/owner/repo/compare/foo...bar"] = func(w http.ResponseWriter, r *http.Request) {
+			assertRequestHeaders(t, r)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			err := json.NewEncoder(w).Encode(map[string]interface{}{
+				"message":           "Not Found",
+				"documentation_url": "https://developer.github.com/v3/repos/commits/#compare-two-commits",
+			})
+			assert.NoError(t, err)
+		}
+		client := server.client(ctx)
+		_, err := client.CompareCommits(ctx, "foo", "bar")
+		require.Error(t, err)
+		errorResponse, ok := err.(*github.ErrorResponse)
+		require.True(t, ok)
+		require.Equal(t, http.StatusNotFound, errorResponse.Response.StatusCode)
+	})
+}
+
+type testServer struct {
+	t        *testing.T
+	handlers map[string]http.HandlerFunc
+	server   *httptest.Server
+}
+
+func newTestServer(t *testing.T) *testServer {
+	ts := &testServer{
+		t:        t,
+		handlers: map[string]http.HandlerFunc{},
+	}
+	ts.server = httptest.NewTLSServer(ts)
+	t.Cleanup(ts.server.Close)
+	return ts
+}
+
+func (t *testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	handler, ok := t.handlers[r.URL.Path]
+	if !ok {
+		t.t.Errorf("unexpected request: %s", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	handler(w, r)
+}
+
+func (t *testServer) client(ctx context.Context) *githubClient {
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, t.server.Client())
+	client, err := newGithubClient(ctx, testGithubToken, testUserAgent, t.server.URL, testGithubRepository)
+	assert.Equal(t.t, nil, err)
+	return client
+}
+
+func (t *testServer) addHandler(path string, handler http.HandlerFunc) {
+	if t.handlers == nil {
+		t.handlers = make(map[string]http.HandlerFunc)
+	}
+	t.handlers[path] = handler
+}

--- a/private/pkg/github/usage.gen.go
+++ b/private/pkg/github/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package github
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This adds a `--vcs-check` flag to `buf push` with two values "github" and "none". Of course "none" does nothing.

`--vcs-check=github` is meant to be used by `buf-push-action` to prevent out-of-order runs from overwriting the latest BSR commit with something older, however it can also be used outside of `buf-push-action`.

`--vcs-check=github` requires:
  - Exactly one `--tag` is a git commit. There can be more tag values set, but only one can be a 40 character hex string.
  - Environment variables `GITHUB_TOKEN` and `GITHUB_REPOSITORY` are set.
  - If using GitHub Enterprise Server `GITHUB_API_URL` must be set.

`--vcs-check=github` will block the push if all the following conditions are met for the head of any track being pushed:
  - It has a different digest from the module being pushed.
  - It is not already tagged with the same git commit tag specified by `--tag`.
  - It is not tagged with any git commit hashes that are behind the git commit tag specified by `--tag`.
  - It is tagged with one or more git commit hashes that are ahead of the git commit tag specified by `--tag`.

Another option is adding `--vcs-check=git` which would do the same checks using the local git repository. I opted to start with the github api because it is more straight-forward to run from a github action where you have to deal with shallow clones that will prevent the checks from working.
