### PR TITLE
Disable config override for workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Removed the `buf config ls-lint-rules` command in favor of `buf mod ls-lint-rules`.
 - Removed the `buf config migrate-v1beta1` command in favor of `buf beta migrate-v1beta1`.
 - Add `buf beta decode` command to decode message with provided image source and message type.
+- Disable `--config` flag for workspaces.
 
 ## [v1.0.0-rc12] - 2022-02-01
 

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -57,7 +57,7 @@ func (w *workspaceBuilder) BuildWorkspace(
 		return nil, errors.New("received a nil workspace config")
 	}
 	if configOverride != "" {
-		return nil, errors.New("the --config flag has is not compatible with workspaces")
+		return nil, errors.New("the --config flag is not compatible with workspaces")
 	}
 	// We know that if the file is actually buf.work for legacy reasons, this will be wrong,
 	// but we accept that as this shouldn't happen often anymore and this is just

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -57,7 +57,7 @@ func (w *workspaceBuilder) BuildWorkspace(
 		return nil, errors.New("received a nil workspace config")
 	}
 	if configOverride != "" {
-		return nil, errors.New("the --config flag has been disabled for workspaces")
+		return nil, errors.New("the --config flag has is not compatible with workspaces")
 	}
 	// We know that if the file is actually buf.work for legacy reasons, this will be wrong,
 	// but we accept that as this shouldn't happen often anymore and this is just

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -56,6 +56,9 @@ func (w *workspaceBuilder) BuildWorkspace(
 	if workspaceConfig == nil {
 		return nil, errors.New("received a nil workspace config")
 	}
+	if configOverride != "" {
+		return nil, errors.New("the --config flag has been disabled for workspaces")
+	}
 	// We know that if the file is actually buf.work for legacy reasons, this will be wrong,
 	// but we accept that as this shouldn't happen often anymore and this is just
 	// used for error messages.

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -241,12 +241,12 @@ func TestFail6(t *testing.T) {
 
 func TestFail7(t *testing.T) {
 	t.Parallel()
-	testRunStdout(
+	testRunStdoutStderr(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "fail/buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		"", // stdout should be empty
+		"Failure: the --config flag has been disabled for workspaces",
 		"lint",
 		"--path",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
@@ -254,12 +254,12 @@ func TestFail7(t *testing.T) {
 		"--config",
 		`{"version":"v1beta1","lint":{"use":["BASIC"]}}`,
 	)
-	testRunStdout(
+	testRunStdoutStderr(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "fail/buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		"", // stdout should be empty
+		"Failure: the --config flag has been disabled for workspaces",
 		"lint",
 		"--path",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
@@ -277,12 +277,12 @@ func TestFail7(t *testing.T) {
 		"--input-config",
 		`{"version":"v1","lint":{"use":["BASIC"]}}`,
 	)
-	testRunStdout(
+	testRunStdoutStderr(
 		t,
 		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
-        testdata/fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		1,
+		"", // stdout should be empty
+		"Failure: the --config flag has been disabled for workspaces",
 		"lint",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
 		"--config",

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -241,32 +241,6 @@ func TestFail6(t *testing.T) {
 
 func TestFail7(t *testing.T) {
 	t.Parallel()
-	testRunStdoutStderr(
-		t,
-		nil,
-		1,
-		"", // stdout should be empty
-		"Failure: the --config flag has been disabled for workspaces",
-		"lint",
-		"--path",
-		filepath.Join("testdata", "fail", "buf", "buf.proto"),
-		filepath.Join("testdata"),
-		"--config",
-		`{"version":"v1beta1","lint":{"use":["BASIC"]}}`,
-	)
-	testRunStdoutStderr(
-		t,
-		nil,
-		1,
-		"", // stdout should be empty
-		"Failure: the --config flag has been disabled for workspaces",
-		"lint",
-		"--path",
-		filepath.Join("testdata", "fail", "buf", "buf.proto"),
-		filepath.Join("testdata"),
-		"--config",
-		`{"version":"v1","lint":{"use":["BASIC"]}}`,
-	)
 	testRunStdout(
 		t,
 		nil,
@@ -282,7 +256,20 @@ func TestFail7(t *testing.T) {
 		nil,
 		1,
 		"", // stdout should be empty
-		"Failure: the --config flag has been disabled for workspaces",
+		"Failure: the --config flag is not compatible with workspaces",
+		"lint",
+		"--path",
+		filepath.Join("testdata", "fail", "buf", "buf.proto"),
+		filepath.Join("testdata"),
+		"--config",
+		`{"version":"v1beta1","lint":{"use":["BASIC"]}}`,
+	)
+	testRunStdoutStderr(
+		t,
+		nil,
+		1,
+		"", // stdout should be empty
+		"Failure: the --config flag is not compatible with workspaces",
 		"lint",
 		filepath.Join("testdata", "fail", "buf", "buf.proto"),
 		"--config",

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -166,7 +166,7 @@ func TestWorkspaceDir(t *testing.T) {
 			nil,
 			1,
 			"", // stdout should be empty
-			"Failure: the --config flag has been disabled for workspaces",
+			"Failure: the --config flag is not compatible with workspaces",
 			"lint",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 			"--config",
@@ -199,52 +199,13 @@ func TestWorkspaceDir(t *testing.T) {
 			nil,
 			1,
 			"", // stdout should be empty
-			"Failure: the --config flag has been disabled for workspaces",
-			"lint",
-			filepath.Join("testdata", "workspace", "success", baseDirPath),
-			"--config",
-			`{"version":"v1","lint": {"use": ["PACKAGE_DIRECTORY_MATCH"]}}`,
-			"--path",
-			filepath.Join("testdata", "workspace", "success", baseDirPath, "proto", "rpc.proto"),
-		)
-		testRunStdoutStderr(
-			t,
-			nil,
-			1,
-			"", // stdout should be empty
-			"Failure: the --config flag has been disabled for workspaces",
+			"Failure: the --config flag is not compatible with workspaces",
 			"lint",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 			"--config",
 			`{"version":"v1","lint": {"use": ["PACKAGE_DIRECTORY_MATCH"]}}`,
 			"--path",
 			filepath.Join("testdata", "workspace", "success", baseDirPath, "other", "proto", "request.proto"),
-		)
-		testRunStdoutStderr(
-			t,
-			nil,
-			1,
-			"", // stdout should be empty
-			"Failure: the --config flag has been disabled for workspaces",
-			"lint",
-			filepath.Join("testdata", "workspace", "success", baseDirPath),
-			"--config",
-			`{"version":"v1","lint": {"use": ["PACKAGE_DIRECTORY_MATCH"]}}`,
-			"--path",
-			filepath.Join(wd, "testdata", "workspace", "success", baseDirPath, "other", "proto", "request.proto"),
-		)
-		testRunStdoutStderr(
-			t,
-			nil,
-			1,
-			"", // stdout should be empty
-			"Failure: the --config flag has been disabled for workspaces",
-			"lint",
-			filepath.Join(wd, "testdata", "workspace", "success", baseDirPath),
-			"--config",
-			`{"version":"v1","lint": {"use": ["PACKAGE_DIRECTORY_MATCH"]}}`,
-			"--path",
-			filepath.Join(wd, "testdata", "workspace", "success", baseDirPath, "other", "proto", "request.proto"),
 		)
 	}
 }

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -161,12 +161,12 @@ func TestWorkspaceDir(t *testing.T) {
 			"--against",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 		)
-		testRunStdout(
+		testRunStdoutStderr(
 			t,
 			nil,
-			bufcli.ExitCodeFileAnnotation,
-			filepath.FromSlash(`testdata/workspace/success/`+baseDirPath+`/other/proto/request.proto:3:1:Files with package "request" must be within a directory "request" relative to root but were in directory ".".
-		    testdata/workspace/success/`+baseDirPath+`/proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".`),
+			1,
+			"", // stdout should be empty
+			"Failure: the --config flag has been disabled for workspaces",
 			"lint",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 			"--config",
@@ -194,11 +194,12 @@ func TestWorkspaceDir(t *testing.T) {
 			"--path",
 			filepath.Join("testdata", "workspace", "success", baseDirPath, "other", "proto", "request.proto"),
 		)
-		testRunStdout(
+		testRunStdoutStderr(
 			t,
 			nil,
-			bufcli.ExitCodeFileAnnotation,
-			filepath.FromSlash(`testdata/workspace/success/`+baseDirPath+`/proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".`),
+			1,
+			"", // stdout should be empty
+			"Failure: the --config flag has been disabled for workspaces",
 			"lint",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 			"--config",
@@ -206,11 +207,12 @@ func TestWorkspaceDir(t *testing.T) {
 			"--path",
 			filepath.Join("testdata", "workspace", "success", baseDirPath, "proto", "rpc.proto"),
 		)
-		testRunStdout(
+		testRunStdoutStderr(
 			t,
 			nil,
-			bufcli.ExitCodeFileAnnotation,
-			filepath.FromSlash(`testdata/workspace/success/`+baseDirPath+`/other/proto/request.proto:3:1:Files with package "request" must be within a directory "request" relative to root but were in directory ".".`),
+			1,
+			"", // stdout should be empty
+			"Failure: the --config flag has been disabled for workspaces",
 			"lint",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 			"--config",
@@ -218,11 +220,12 @@ func TestWorkspaceDir(t *testing.T) {
 			"--path",
 			filepath.Join("testdata", "workspace", "success", baseDirPath, "other", "proto", "request.proto"),
 		)
-		testRunStdout(
+		testRunStdoutStderr(
 			t,
 			nil,
-			bufcli.ExitCodeFileAnnotation,
-			filepath.FromSlash(`testdata/workspace/success/`+baseDirPath+`/other/proto/request.proto:3:1:Files with package "request" must be within a directory "request" relative to root but were in directory ".".`),
+			1,
+			"", // stdout should be empty
+			"Failure: the --config flag has been disabled for workspaces",
 			"lint",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
 			"--config",
@@ -230,13 +233,12 @@ func TestWorkspaceDir(t *testing.T) {
 			"--path",
 			filepath.Join(wd, "testdata", "workspace", "success", baseDirPath, "other", "proto", "request.proto"),
 		)
-		testRunStdout(
+		testRunStdoutStderr(
 			t,
 			nil,
-			bufcli.ExitCodeFileAnnotation,
-			filepath.FromSlash(fmt.Sprintf(`%s/testdata/workspace/success/`+baseDirPath+`/other/proto/request.proto:3:1:Files with package "request" must be within a directory "request" relative to root but were in directory ".".`,
-				wd,
-			)),
+			1,
+			"", // stdout should be empty
+			"Failure: the --config flag has been disabled for workspaces",
 			"lint",
 			filepath.Join(wd, "testdata", "workspace", "success", baseDirPath),
 			"--config",


### PR DESCRIPTION
The behaviour of the `--config` flag for workspaces is not immediately apparent to users. If a config contains [build configurations](https://docs.buf.build/configuration/v1/buf-yaml#build), for example, then that does not apply seamlessly to all modules across the workspace, and the build will error. Since this behaviour is very brittle, we have made the decision to disable the `--config` flag altogether for workspaces.