### PR TITLE
Update golangci-lint to v1.44.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,8 +33,10 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - errcheck
@@ -50,6 +52,7 @@ linters:
     - gosimple
     - gosec
     - govet
+    - grouper
     - importas
     - ineffassign
     - makezero
@@ -110,3 +113,11 @@ issues:
     - linters:
         - gochecknoinits
       path: private/usage/usage.go
+      # we actually want to embed a context here
+    - linters:
+        - containedctx
+      path: private/bufpkg/bufmodule/bufmoduleprotoparse/path_resolver.go
+      # we actually want to embed a context here
+    - linters:
+        - containedctx
+      path: private/pkg/transport/grpc/grpcclient/client_conn_provider.go

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,7 +7,7 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20211103 checked 20211112
+# https://github.com/golangci/golangci-lint/releases 20220125 checked 20220215
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
 GOLANGCI_LINT_VERSION ?= v1.44.0
 

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -9,7 +9,7 @@ $(call _assert_var,CACHE_BIN)
 # Settable
 # https://github.com/golangci/golangci-lint/releases 20211103 checked 20211112
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.43.0
+GOLANGCI_LINT_VERSION ?= v1.44.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):

--- a/private/pkg/rpc/headers.go
+++ b/private/pkg/rpc/headers.go
@@ -31,7 +31,12 @@ type incomingHeadersContextKey struct{}
 // If the key is unset, this returns the empty string.
 func GetIncomingHeader(ctx context.Context, key string) string {
 	if contextValue := ctx.Value(incomingHeadersContextKey{}); contextValue != nil {
-		return contextValue.(map[string]string)[normalizeHeaderKey(key)]
+		value, ok := contextValue.(map[string]string)[normalizeHeaderKey(key)]
+		if !ok {
+			// Unreachable
+			return ""
+		}
+		return value
 	}
 	return ""
 }
@@ -45,7 +50,12 @@ func GetIncomingHeader(ctx context.Context, key string) string {
 // If the key is unset, this returns the empty string.
 func GetOutgoingHeader(ctx context.Context, key string) string {
 	if contextValue := ctx.Value(outgoingHeadersContextKey{}); contextValue != nil {
-		return contextValue.(map[string]string)[normalizeHeaderKey(key)]
+		value, ok := contextValue.(map[string]string)[normalizeHeaderKey(key)]
+		if !ok {
+			// Unreachable
+			return ""
+		}
+		return value
 	}
 	return ""
 }

--- a/private/pkg/rpc/rpcauth/rpcauth.go
+++ b/private/pkg/rpc/rpcauth/rpcauth.go
@@ -49,7 +49,8 @@ func GetUser(ctx context.Context) (*User, bool) {
 	}
 	// This is the only package where we can set this context key, so
 	// this is guaranteed to be of this type if it exists.
-	return userValue.(*User), true
+	user, ok := userValue.(*User)
+	return user, ok
 }
 
 // WithToken adds the token to the context via a header.


### PR DESCRIPTION
This updates `golangic-lint` to `v1.44.0` and addresses some of the issues with the `forcetypeassert` plugin that were previously uncaught (they were caught in the upgrade).

There have been several new linters added in this release:
- [containdctx](https://github.com/sivchari/containedctx)
- [decorder](https://gitlab.com/bosi/decorder)
- [errchkjson](https://github.com/breml/errchkjson)
- [grouper](https://github.com/leonklingele/grouper)
- [maintidx](https://github.com/yagipy/maintidx)

I don't think we want to add any of them - the `errchkjson` one is interesting, but we actually encourage that we check all of our errors so it's not really useful in our case.
