### PR TITLE
Change capitalization of image and managed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,8 +555,8 @@ buf check breaking proto --against .git#branch=master,subdir=proto
 
 ## [v0.18.0] - 2020-06-22
 
-- Handle custom options when marshalling JSON Images (#87).
-- Add `buf experimental image convert` command to convert to/from binary/JSON Images (#87).
+- Handle custom options when marshalling JSON images (#87).
+- Add `buf experimental image convert` command to convert to/from binary/JSON images (#87).
 
 ## [v0.17.0] - 2020-06-17
 
@@ -574,7 +574,7 @@ buf check breaking proto --against .git#branch=master,subdir=proto
 
 ## [v0.14.0] - 2020-05-30
 
-- Add `--file` flag to `buf image build` to only add specific files and their imports to outputted Images. To exclude imports, use `--exclude-imports`.
+- Add `--file` flag to `buf image build` to only add specific files and their imports to outputted images. To exclude imports, use `--exclude-imports`.
 - Add `zip` as a source format. Buf can now read `zip` files, either locally or remotely, for image building, linting, and breaking change detection.
 - Add `zstd` as a compression format. Buf can now read and write Image files that are compressed using zstandard, and can read tarballs compressed with zstandard.
 - Deprecated: The formats `bingz, jsongz, targz` are now deprecated. Instead, use `format=bin,compression=gzip`, `format=json,compression=gzip`, or `format=tar,compression=gzip`. The formats `bingz, jsongz, targz` will continue to work forever and will not be broken, but will print a deprecation warning and we recommend updating. Automatic file extension parsing continues to work the same as well.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [`buf`][buf] CLI is a tool for working with [Protocol Buffers][protobuf] API
 - A [breaking change detector][breaking_usage] that enforces compatibility at the sourfce code or wire level.
 - A [generator][generate_usage] that invokes your protoc plugins based on a configurable [template][templates].
   A [`protoc` replacement][protoc] that uses Buf's [high-performance Protobuf compiler][compiler].
-- A configurable file [builder][build_usage] that produces [Images], our extension of Protobuf's native [FileDescriptorSets][filedescriptorset].
+- A configurable file [builder][build_usage] that produces [images], our extension of Protobuf's native [FileDescriptorSets][filedescriptorset].
 
 ## Installation
 
@@ -90,7 +90,7 @@ While `buf`'s [core features][features] should cover most use cases, we've inclu
 * **Fine-grained rule configuration** for [linting][lint.rules] and [breaking change][breaking.rules]. While we do have recommended defaults, you can always select the exact set of rules that your use case requires, with [40 lint rules][lint.rules] and [53 breaking change rules][breaking.rules] available.
 * **Configurable error formats** for CLI output. `buf` outputs information in `file:line:column:message` form by default for each lint error and breaking change it encounters, but you can also select JSON and, in the near future, JUnit output.
 * **Editor integration** driven by `buf`'s granular error output. We currently provide linting integrations for both [Vim and Visual Studio Code][ide] but we plan to support other editors, such as Emacs and [JetBrains IDEs][jetbrains] like IntelliJ and GoLand, in the future.
-* **Universal Input targeting**. But enables you to perform actions like linting and breaking change detection not just against local `.proto` files but also against a broad range of other [Inputs], such as tarballs and ZIP files, remote Git repositories, and pre-built [Image][images] files.
+* **Universal Input targeting**. But enables you to perform actions like linting and breaking change detection not just against local `.proto` files but also against a broad range of other [Inputs], such as tarballs and ZIP files, remote Git repositories, and pre-built [image][images] files.
 * **Speed**. Buf's internal Protobuf compiler compiles your Protobuf sources using all available cores without compromising deterministic output, which is considerably faster than [`protoc`][protoc]. This allows for near-instantaneous feedback, which is of special importance for features like [editor integration][id].
 
 ## Next steps

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -166,7 +166,7 @@ func BindAsFileDescriptorSet(flagSet *pflag.FlagSet, addr *bool, flagName string
 		flagName,
 		false,
 		`Output as a google.protobuf.FileDescriptorSet instead of an image.
-Note that images are wire-compatible with FileDescriptorSets, however this flag will strip
+Note that images are wire compatible with FileDescriptorSets, but this flag strips
 the additional metadata added for Buf usage.`,
 	)
 }

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -202,7 +202,7 @@ func BindPaths(
 		pathsFlagName,
 		nil,
 		`Limit to specific files or directories, for example "proto/a/a.proto" or "proto/a".
-If specified multiple times, the union will be taken.`,
+If specified multiple times, the union is taken.`,
 	)
 }
 
@@ -233,7 +233,7 @@ func BindExcludePaths(
 		excludePathsFlagName,
 		nil,
 		`Exclude specific files or directories, for example "proto/a/a.proto" or "proto/a".
-If specified multiple times, the union will be taken.`,
+If specified multiple times, the union is taken.`,
 	)
 }
 
@@ -665,7 +665,7 @@ func promptUser(container app.Container, prompt string, isPassword bool) (string
 			// have another attempt.
 			if _, err := fmt.Fprintln(
 				container.Stdout(),
-				"An answer was not provided; please try again.",
+				"No answer was provided. Please try again.",
 			); err != nil {
 				return "", NewInternalError(err)
 			}
@@ -800,7 +800,7 @@ func NewImageForSource(
 }
 
 // ParseSourceAndType returns the moduleReference and typeName from the source and type provided by the user.
-// When source is not provided, we assume the type is a fully-qualified path to the type and try to parse it.
+// When source is not provided, we assume the type is a fully qualified path to the type and try to parse it.
 // Otherwise, if both source and type are provided, the type must be a valid Protobuf identifier (e.g. weather.v1.Units).
 func ParseSourceAndType(
 	ctx context.Context,
@@ -818,7 +818,7 @@ func ParseSourceAndType(
 	}
 	moduleReference, moduleTypeName, err := parseFullyQualifiedPath(typeName)
 	if err != nil {
-		return "", "", appcmd.NewInvalidArgumentErrorf("if source is not provided, the type need to be a fully-qualified path that includes the module reference, failed to parse the type: %v", err)
+		return "", "", appcmd.NewInvalidArgumentErrorf("if a source isn't provided, the type needs to be a fully qualified path that includes the module reference; failed to parse the type: %v", err)
 	}
 	return moduleReference, moduleTypeName, nil
 }
@@ -906,10 +906,10 @@ func checkExistingCacheDirs(baseCacheDirPath string, dirPaths ...string) error {
 			return err
 		}
 		if !fileInfo.IsDir() {
-			return fmt.Errorf("Expected %q to be a directory. This is used for buf's cache. The base cache directory %q can be overridden by setting the $BUF_CACHE_DIR environment variable.", dirPath, baseCacheDirPath)
+			return fmt.Errorf("Expected %q to be a directory. This is used for buf's cache. You can override the base cache directory %q by setting the $BUF_CACHE_DIR environment variable.", dirPath, baseCacheDirPath)
 		}
 		if fileInfo.Mode().Perm()&0700 != 0700 {
-			return fmt.Errorf("Expected %q to be a writeable directory. This is used for buf's cache. The base cache directory %q can be overridden by setting the $BUF_CACHE_DIR environment variable.", dirPath, baseCacheDirPath)
+			return fmt.Errorf("Expected %q to be a writeable directory. This is used for buf's cache. You can override the base cache directory %q by setting the $BUF_CACHE_DIR environment variable.", dirPath, baseCacheDirPath)
 		}
 	}
 	return nil

--- a/private/buf/bufcli/bufcli_test.go
+++ b/private/buf/bufcli/bufcli_test.go
@@ -45,10 +45,10 @@ func TestParseSourceAndType(t *testing.T) {
 	})
 	t.Run("fail with module name", func(t *testing.T) {
 		_, _, err := bufcli.ParseSourceAndType(ctx, "", "buf.test/testuser/testrepo")
-		assert.EqualError(t, err, `if source is not provided, the type need to be a fully-qualified path that includes the module reference, failed to parse the type: "buf.test/testuser/testrepo" is not a valid fully qualified path`)
+		assert.EqualError(t, err, `if a source isn't provided, the type needs to be a fully qualified path that includes the module reference; failed to parse the type: "buf.test/testuser/testrepo" is not a valid fully qualified path`)
 	})
 	t.Run("fail with type name", func(t *testing.T) {
 		_, _, err := bufcli.ParseSourceAndType(ctx, "", "buf.v1.Foo")
-		assert.EqualError(t, err, `if source is not provided, the type need to be a fully-qualified path that includes the module reference, failed to parse the type: "buf.v1.Foo" is not a valid fully qualified path`)
+		assert.EqualError(t, err, `if a source isn't provided, the type needs to be a fully qualified path that includes the module reference; failed to parse the type: "buf.v1.Foo" is not a valid fully qualified path`)
 	})
 }

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -194,7 +194,7 @@ func (p *PluginConfig) PluginName() string {
 	return ""
 }
 
-// ManagedConfig is the Managed Mode configuration.
+// ManagedConfig is the managed mode configuration.
 type ManagedConfig struct {
 	CcEnableArenas        *bool
 	JavaMultipleFiles     *bool
@@ -276,7 +276,7 @@ type ExternalPluginConfigV1 struct {
 	Strategy string      `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }
 
-// ExternalManagedConfigV1 is an external Managed Mode configuration.
+// ExternalManagedConfigV1 is an external managed mode configuration.
 //
 // Only use outside of this package for testing.
 type ExternalManagedConfigV1 struct {

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -195,7 +195,7 @@ func validateExternalConfigV1(externalConfig ExternalConfigV1, id string) error 
 
 func newManagedConfigV1(externalManagedConfig ExternalManagedConfigV1) (*ManagedConfig, error) {
 	if !externalManagedConfig.Enabled && !externalManagedConfig.IsEmpty() {
-		return nil, errors.New("Managed Mode options are set, but 'managed.enabled: true' is not set")
+		return nil, errors.New("managed mode options are set but 'managed.enabled: true' is not set")
 	}
 	if !externalManagedConfig.Enabled {
 		return nil, nil

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -322,7 +322,7 @@ func (g *generator) execRemotePlugin(
 	return responses[0], nil
 }
 
-// modifyImage modifies the image according to the given configuration (i.e. Managed Mode).
+// modifyImage modifies the image according to the given configuration (i.e. managed mode).
 func modifyImage(
 	ctx context.Context,
 	logger *zap.Logger,

--- a/private/buf/bufwire/module_config_reader.go
+++ b/private/buf/bufwire/module_config_reader.go
@@ -624,7 +624,7 @@ func (m *moduleConfigReader) getModuleConfig(
 				// This also may be nil.
 				//
 				// This is particularly useful for the GoPackage modifier used in
-				// Managed Mode, which supports module-specific overrides.
+				// managed mode, which supports module-specific overrides.
 				bufmodulebuild.WithModuleIdentity(moduleConfig.ModuleIdentity),
 			}
 			bucketRelPaths := make([]string, len(externalDirOrFilePaths))

--- a/private/buf/bufwork/bufwork.go
+++ b/private/buf/bufwork/bufwork.go
@@ -145,7 +145,7 @@ func BuildOptionsForWorkspaceDirectory(
 		// This also may be nil.
 		//
 		// This is particularly useful for the GoPackage modifier used in
-		// Managed Mode, which supports module-specific overrides.
+		// managed mode, which supports module-specific overrides.
 		bufmodulebuild.WithModuleIdentity(moduleConfig.ModuleIdentity),
 	}
 	if len(externalDirOrFilePaths) == 0 && len(externalExcludeDirOrFilePaths) == 0 {

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -54,7 +54,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <input> --against <against-input>",
 		Short: "Verify that the input location has no breaking changes compared to the against location.",
-		Long:  bufcli.GetInputLong(`the source, module, or Image to check for breaking changes`),
+		Long:  bufcli.GetInputLong(`the source, module, or image to check for breaking changes`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
@@ -126,7 +126,7 @@ Overrides --%s.`,
 		againstFlagName,
 		"",
 		fmt.Sprintf(
-			`Required. The source, module, or Image to check against. Must be one of format %s.`,
+			`Required. The source, module, or image to check against. Must be one of format %s.`,
 			buffetch.AllFormatsString,
 		),
 	)

--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -50,7 +50,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Build all Protobuf files from the specified input and output an Image.",
+		Short: "Build all Protobuf files from the specified input and output a Buf image.",
 		Long:  bufcli.GetInputLong(`the source or module to build or image to convert`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
@@ -104,7 +104,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		outputFlagShortName,
 		app.DevNullFilePath,
 		fmt.Sprintf(
-			`The output location for the built Image. Must be one of format %s.`,
+			`The output location for the built image. Must be one of format %s.`,
 			buffetch.ImageFormatsString,
 		),
 	)


### PR DESCRIPTION
This is a nit and should _not_ set back the 1.0 release. But I think that now is a good time to effect standardization across CLI, docs, blog, etc. Happy to discuss if there are strong objections to this, but I do think that it's a good practice to introduce capitalization only for _products_, not technical terms.