### PR TITLE
Enum parents and leading dot consistency across protosource

### DIFF
--- a/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
@@ -707,7 +707,7 @@ func checkRPCRequestResponseUnique(
 		for _, method := range allFullNameToMethod {
 			if method.InputTypeName() == method.OutputTypeName() {
 				// if we allow both empty requests and responses, we do not want to add a FileAnnotation
-				if !(method.InputTypeName() == ".google.protobuf.Empty" && allowGoogleProtobufEmptyRequests && allowGoogleProtobufEmptyResponses) {
+				if !(method.InputTypeName() == "google.protobuf.Empty" && allowGoogleProtobufEmptyRequests && allowGoogleProtobufEmptyResponses) {
 					add(
 						method,
 						method.Location(),
@@ -744,7 +744,7 @@ func checkRPCRequestResponseUnique(
 		}
 		// if the request or response type is google.protobuf.Empty and we allow this for requests or responses,
 		// we have to do a harder check
-		if requestResponseType == ".google.protobuf.Empty" && (allowGoogleProtobufEmptyRequests || allowGoogleProtobufEmptyResponses) {
+		if requestResponseType == "google.protobuf.Empty" && (allowGoogleProtobufEmptyRequests || allowGoogleProtobufEmptyResponses) {
 			// if both requests and responses can be google.protobuf.Empty, then do not add any error
 			// else, we check
 			if !(allowGoogleProtobufEmptyRequests && allowGoogleProtobufEmptyResponses) {
@@ -752,10 +752,10 @@ func checkRPCRequestResponseUnique(
 				var requestMethods []protosource.Method
 				var responseMethods []protosource.Method
 				for _, method := range fullNameToMethod {
-					if method.InputTypeName() == ".google.protobuf.Empty" {
+					if method.InputTypeName() == "google.protobuf.Empty" {
 						requestMethods = append(requestMethods, method)
 					}
-					if method.OutputTypeName() == ".google.protobuf.Empty" {
+					if method.OutputTypeName() == "google.protobuf.Empty" {
 						responseMethods = append(responseMethods, method)
 					}
 				}
@@ -830,7 +830,7 @@ func checkRPCRequestStandardName(add addFunc, method protosource.Method, allowGo
 		return errors.New("method.Service() is nil")
 	}
 	name := method.InputTypeName()
-	if allowGoogleProtobufEmptyRequests && name == ".google.protobuf.Empty" {
+	if allowGoogleProtobufEmptyRequests && name == "google.protobuf.Empty" {
 		return nil
 	}
 	if strings.Contains(name, ".") {
@@ -878,7 +878,7 @@ func checkRPCResponseStandardName(add addFunc, method protosource.Method, allowG
 		return errors.New("method.Service() is nil")
 	}
 	name := method.OutputTypeName()
-	if allowGoogleProtobufEmptyResponses && name == ".google.protobuf.Empty" {
+	if allowGoogleProtobufEmptyResponses && name == "google.protobuf.Empty" {
 		return nil
 	}
 	if strings.Contains(name, ".") {

--- a/private/pkg/protosource/enum.go
+++ b/private/pkg/protosource/enum.go
@@ -23,6 +23,7 @@ type enum struct {
 	allowAliasPath     []int32
 	reservedEnumRanges []EnumRange
 	reservedNames      []ReservedName
+	parent             Message
 }
 
 func newEnum(
@@ -30,12 +31,14 @@ func newEnum(
 	optionExtensionDescriptor optionExtensionDescriptor,
 	allowAlias bool,
 	allowAliasPath []int32,
+	parent Message,
 ) *enum {
 	return &enum{
 		namedDescriptor:           namedDescriptor,
 		optionExtensionDescriptor: optionExtensionDescriptor,
 		allowAlias:                allowAlias,
 		allowAliasPath:            allowAliasPath,
+		parent:                    parent,
 	}
 }
 
@@ -65,6 +68,10 @@ func (e *enum) ReservedTagRanges() []TagRange {
 
 func (e *enum) ReservedNames() []ReservedName {
 	return e.reservedNames
+}
+
+func (e *enum) Parent() Message {
+	return e.parent
 }
 
 func (e *enum) addValue(value EnumValue) {

--- a/private/pkg/protosource/file.go
+++ b/private/pkg/protosource/file.go
@@ -16,6 +16,7 @@ package protosource
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -295,6 +296,7 @@ func newFile(inputFile InputFile) (*file, error) {
 			enumIndex,
 			nil,
 			nil,
+			nil,
 		)
 		if err != nil {
 			return nil, err
@@ -349,6 +351,7 @@ func (f *file) populateEnum(
 	nestedMessageIndexes []int,
 	// all message names leading to this enum
 	nestedMessageNames []string,
+	parent Message,
 ) (Enum, error) {
 	enumNamedDescriptor, err := newNamedDescriptor(
 		newLocationDescriptor(
@@ -369,6 +372,7 @@ func (f *file) populateEnum(
 		),
 		enumDescriptorProto.GetOptions().GetAllowAlias(),
 		getEnumAllowAliasPath(enumIndex, nestedMessageIndexes...),
+		parent,
 	)
 
 	for enumValueIndex, enumValueDescriptorProto := range enumDescriptorProto.GetValue() {
@@ -536,8 +540,8 @@ func (f *file) populateMessage(
 			int(fieldDescriptorProto.GetNumber()),
 			label,
 			typ,
-			fieldDescriptorProto.GetTypeName(),
-			fieldDescriptorProto.GetExtendee(),
+			strings.TrimPrefix(fieldDescriptorProto.GetTypeName(), "."),
+			strings.TrimPrefix(fieldDescriptorProto.GetExtendee(), "."),
 			oneof,
 			fieldDescriptorProto.GetProto3Optional(),
 			fieldDescriptorProto.GetJsonName(),
@@ -609,8 +613,8 @@ func (f *file) populateMessage(
 			int(fieldDescriptorProto.GetNumber()),
 			label,
 			typ,
-			fieldDescriptorProto.GetTypeName(),
-			fieldDescriptorProto.GetExtendee(),
+			strings.TrimPrefix(fieldDescriptorProto.GetTypeName(), "."),
+			strings.TrimPrefix(fieldDescriptorProto.GetExtendee(), "."),
 			oneof,
 			fieldDescriptorProto.GetProto3Optional(),
 			fieldDescriptorProto.GetJsonName(),
@@ -682,6 +686,7 @@ func (f *file) populateMessage(
 			// TODO we should refactor get.*Path messages to be more consistent
 			append([]int{topLevelMessageIndex}, nestedMessageIndexes...),
 			append(nestedMessageNames, message.Name()),
+			message,
 		)
 		if err != nil {
 			return nil, err
@@ -749,8 +754,8 @@ func (f *file) populateService(
 				methodDescriptorProto.GetOptions(),
 			),
 			service,
-			methodDescriptorProto.GetInputType(),
-			methodDescriptorProto.GetOutputType(),
+			strings.TrimPrefix(methodDescriptorProto.GetInputType(), "."),
+			strings.TrimPrefix(methodDescriptorProto.GetOutputType(), "."),
 			methodDescriptorProto.GetClientStreaming(),
 			methodDescriptorProto.GetServerStreaming(),
 			getMethodInputTypePath(serviceIndex, methodIndex),
@@ -811,8 +816,8 @@ func (f *file) populateExtension(
 		int(fieldDescriptorProto.GetNumber()),
 		label,
 		typ,
-		fieldDescriptorProto.GetTypeName(),
-		fieldDescriptorProto.GetExtendee(),
+		strings.TrimPrefix(fieldDescriptorProto.GetTypeName(), "."),
+		strings.TrimPrefix(fieldDescriptorProto.GetExtendee(), "."),
 		nil,
 		fieldDescriptorProto.GetProto3Optional(),
 		fieldDescriptorProto.GetJsonName(),

--- a/private/pkg/protosource/message.go
+++ b/private/pkg/protosource/message.go
@@ -47,6 +47,7 @@ func newMessage(
 	return &message{
 		namedDescriptor:                  namedDescriptor,
 		optionExtensionDescriptor:        optionExtensionDescriptor,
+		parent:                           parent,
 		isMapEntry:                       isMapEntry,
 		messageSetWireFormat:             messageSetWireFormat,
 		noStandardDescriptorAccessor:     noStandardDescriptorAccessor,

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -305,6 +305,9 @@ type Enum interface {
 
 	AllowAlias() bool
 	AllowAliasLocation() Location
+
+	// Will return nil if this is a top-level Enum
+	Parent() Message
 }
 
 // EnumValue is an enum value descriptor.
@@ -730,7 +733,7 @@ func NumberToMessageField(message Message) (map[int]Field, error) {
 		numberToMessageField[number] = messageField
 	}
 	for _, messageField := range message.Extensions() {
-		if messageField.Extendee() != "."+message.FullName() {
+		if messageField.Extendee() != message.FullName() {
 			// TODO: ideally we want this field to be returned when
 			// the Extendee message is passed into some function,
 			// need to investigate what index is necessary for that.


### PR DESCRIPTION
- Trim leading dots from Extendee, TypeName, InputType & OutputType for consistency when using protosource. 

  I took a look if this could use `protosource.Message`'s on which we could get their `FullName()`, but I think that requires a much larger refactor (and probably discussion). To make it so that I don't have `strings.TrimPrefix` throughout the image filtering code, doing it here seems most clean.
- Add `Parent` to enums, as enums may be nested in messages.

I'll add the partial image PR on top of this soon (https://github.com/bufbuild/buf/pull/949), separating this out as it also touches other code like lint.