### PR TITLE
Update installation method (brew)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The [`buf`][buf] CLI is a tool for working with [Protocol Buffers][protobuf] API
 You can install `buf` using [Homebrew][brew] (macOS or Linux):
 
 ```sh
-brew install bufbuild/buf/buf
+brew tap bufbuild/buf
+brew install buf
 ```
 
 This installs:


### PR DESCRIPTION
The previous `brew install bufbuild/buf/buf` would throw an installation error because it uses HTTPS git clone. This was deprecated on August 13, 2021.

Doing the tap first and the install after solved the problem (not sure why though).

The error while trying the previous method:

```
remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
fatal: Authentication failed for 'https://github.com/buifbuild/homebrew-buf/'
Error: Failure while executing; `git clone https://github.com/buifbuild/homebrew-buf /opt/homebrew/Library/Taps/buifbuild/homebrew-buf --origin=origin --template=` exited with 128.
```