### PR TITLE
golangci-lint: remove duplicated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters-settings:
         alias: registryv1alpha1
 linters:
   enable:
-    - govet
     - asciicheck
     - bidichk
     - bodyclose
@@ -47,8 +46,8 @@ linters:
     - goimports
     - gomodguard
     - goprintffuncname
-    - gosimple
     - gosec
+    - gosimple
     - govet
     - importas
     - ineffassign


### PR DESCRIPTION
We have `govet` listed twice. This commit pipes the list through `sort
-u`, so we should have a nice clean list now.
