### PR TITLE
Default to `v1` config instead of `v1beta1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Removed the `buf config migrate-v1beta1` command in favor of `buf beta migrate-v1beta1`.
 - Add `buf beta decode` command to decode message with provided image source and message type.
 - Disable `--config` flag for workspaces.
+- Move default config version from `v1beta1` to `v1`.
 
 ## [v1.0.0-rc12] - 2022-02-01
 

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -535,8 +535,7 @@ PACKAGE_NO_IMPORT_CYCLE                                    Checks that packages 
 		expectedStdout,
 		"mod",
 		"ls-lint-rules",
-		"--version",
-		"v1",
+		"--all",
 	)
 }
 
@@ -611,7 +610,8 @@ ENUM_FIRST_VALUE_ZERO             OTHER                                       Ch
 		expectedStdout,
 		"mod",
 		"ls-lint-rules",
-		"--all",
+		"--version",
+		"v1beta1",
 	)
 }
 

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -65,7 +65,7 @@ func BindLSRulesVersion(flagSet *pflag.FlagSet, addr *string, flagName string, a
 	flagSet.StringVar(
 		addr,
 		flagName,
-		"",
+		"", // do not set a default as we need to know if this is unset
 		fmt.Sprintf(
 			"List all the rules for the given configuration version. Implies --%s. Must be one of %s.",
 			allFlagName,

--- a/private/bufpkg/bufconfig/get.go
+++ b/private/bufpkg/bufconfig/get.go
@@ -47,8 +47,7 @@ func getConfigForBucket(ctx context.Context, readBucket storage.ReadBucket) (_ *
 	switch len(foundConfigFilePaths) {
 	case 0:
 		// Did not find anything, return the default.
-		// TODO: change to V1 when we make V1 the default
-		return newConfigV1Beta1(ExternalConfigV1Beta1{})
+		return newConfigV1(ExternalConfigV1{})
 	case 1:
 		readObjectCloser, err := readBucket.Get(ctx, foundConfigFilePaths[0])
 		if err != nil {

--- a/private/bufpkg/bufconfig/write.go
+++ b/private/bufpkg/bufconfig/write.go
@@ -261,7 +261,7 @@ func writeConfig(
 		return err
 	}
 	// This is the same default as the bufconfig getters.
-	version := V1Beta1Version
+	version := V1Version
 	if writeConfigOptions.version != "" {
 		if err := ValidateVersion(writeConfigOptions.version); err != nil {
 			return err

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -488,7 +488,7 @@ func ModuleToBucket(
 	}
 	// This is the default version created by bufconfig getters. The versions should be the
 	// same across lint and breaking configs.
-	version := bufconfig.V1Beta1Version
+	version := bufconfig.V1Version
 	var breakingConfigVersion string
 	if module.BreakingConfig() != nil {
 		breakingConfigVersion = module.BreakingConfig().Version

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -98,13 +98,13 @@ func configsForProto(
 	if lintConfigVersion != breakingConfigVersion {
 		return nil, nil, fmt.Errorf("mismatched breaking config version %q and lint config version %q found", breakingConfigVersion, lintConfigVersion)
 	}
-	// If there is no breaking and lint configs, we want to default to the v1beta1 version.
+	// If there is no breaking and lint configs, we want to default to the v1 version.
 	if breakingConfig == nil && lintConfig == nil {
 		breakingConfig = &bufbreakingconfig.Config{
-			Version: bufconfig.V1Beta1Version,
+			Version: bufconfig.V1Version,
 		}
 		lintConfig = &buflintconfig.Config{
-			Version: bufconfig.V1Beta1Version,
+			Version: bufconfig.V1Version,
 		}
 	} else if breakingConfig == nil {
 		// In the case that only breaking config is nil, we'll use generated an empty default config


### PR DESCRIPTION
In preparation for `v1`, we should be moving all our default configurations to `v1` instead of `v1beta1`.