### PR TITLE
handle name collision of request and response fields in generation

### DIFF
--- a/private/bufpkg/bufprotoplugin/cmd/protoc-gen-go-api/main.go
+++ b/private/bufpkg/bufprotoplugin/cmd/protoc-gen-go-api/main.go
@@ -48,11 +48,7 @@ func handle(helper protogenutil.NamedHelper, plugin *protogen.Plugin, file *prot
 			if err := protogenutil.ValidateMethodUnary(method); err != nil {
 				return err
 			}
-			requestParameterStrings, err := protogenutil.GetParameterStrings(g, method.Input.Fields)
-			if err != nil {
-				return err
-			}
-			responseParameterStrings, err := protogenutil.GetParameterStrings(g, method.Output.Fields)
+			requestParameterStrings, responseParameterStrings, err := protogenutil.GetRequestAndResponseParameterStrings(g, method.Input.Fields, method.Output.Fields)
 			if err != nil {
 				return err
 			}

--- a/private/bufpkg/bufprotoplugin/cmd/protoc-gen-go-apiclientgrpc/main.go
+++ b/private/bufpkg/bufprotoplugin/cmd/protoc-gen-go-apiclientgrpc/main.go
@@ -192,11 +192,7 @@ func generateServiceFile(helper protogenutil.NamedHelper, plugin *protogen.Plugi
 			if err := protogenutil.ValidateMethodUnary(method); err != nil {
 				return err
 			}
-			requestParameterStrings, err := protogenutil.GetParameterStrings(g, method.Input.Fields)
-			if err != nil {
-				return err
-			}
-			responseParameterStrings, err := protogenutil.GetParameterStrings(g, method.Output.Fields)
+			requestParameterStrings, responseParameterStrings, err := protogenutil.GetRequestAndResponseParameterStrings(g, method.Input.Fields, method.Output.Fields)
 			if err != nil {
 				return err
 			}

--- a/private/pkg/protogenutil/protogenutil.go
+++ b/private/pkg/protogenutil/protogenutil.go
@@ -412,9 +412,13 @@ func GetRequestAndResponseParameterStrings(
 			return nil, nil, err
 		}
 		fieldName := GetUnexportGoName(field.GoName)
-		if _, ok := fieldNames[fieldName]; ok {
+		for {
+			if _, ok := fieldNames[fieldName]; !ok {
+				break
+			}
 			fieldName = fieldName + "Response"
 		}
+		fieldNames[fieldName] = struct{}{}
 		responseParameterStrings[i] = fieldName + ` ` + fieldGoType
 	}
 	return requestParameterStrings, responseParameterStrings, nil


### PR DESCRIPTION
This is to handle name collision of request and response fields in `protoc-gen-go-api` and `protoc-gen-go-apiclientgrpc`,
for example, if both request and response have fields `payload`, the response field is now named as `payloadResponse`. 

Alternatively, we can just name the field to `_`, as this will be safer to prevent other collision (e.g. there might be another field called `payloadResponse` already) but the interface generated will have unclear argument names.