### PR TITLE
Add sentinel error definitions for user errors on image filter

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -156,6 +156,10 @@ func TestTypesFromMainModule(t *testing.T) {
 
 	_, err = ImageFilteredByTypes(image, "dependency.Dep")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrImageFilterTypeIsImport)
+	_, err = ImageFilteredByTypes(image, "nonexisting")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrImageFilterTypeNotFound)
 }
 
 func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedFile string) {


### PR DESCRIPTION
These need to be detectable in the API to decide if the error should be
returned to the user or wrapped.