### PR TITLE
Remove space and new line from token

### DIFF
--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufrpc"
@@ -26,7 +27,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/netrc"
 	"github.com/bufbuild/buf/private/pkg/rpc/rpcauth"
-	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -138,7 +138,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	token = stringutil.TrimLines(token)
+	token = strings.TrimSpace(token)
 	user, err := authnService.GetCurrentUser(rpcauth.WithToken(ctx, token))
 	if err != nil {
 		// We don't want to use the default error from wrapError here if the error

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/netrc"
 	"github.com/bufbuild/buf/private/pkg/rpc/rpcauth"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -137,6 +138,7 @@ func run(
 	if err != nil {
 		return err
 	}
+	token = stringutil.TrimLines(token)
 	user, err := authnService.GetCurrentUser(rpcauth.WithToken(ctx, token))
 	if err != nil {
 		// We don't want to use the default error from wrapError here if the error

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -138,7 +138,13 @@ func run(
 	if err != nil {
 		return err
 	}
+	// Remove leading and trailing spaces from user-supplied token to avoid
+	// common input errors such as trailing new lines, as-is the case of using
+	// echo vs echo -n.
 	token = strings.TrimSpace(token)
+	if token == "" {
+		return errors.New("token cannot be empty string")
+	}
 	user, err := authnService.GetCurrentUser(rpcauth.WithToken(ctx, token))
 	if err != nil {
 		// We don't want to use the default error from wrapError here if the error


### PR DESCRIPTION
This PR adds logic to trim new lines and remove spaces from the user-supplied token.

In our docs for [CI authentication](https://docs.buf.build/bsr/authentication#ci-authentication) we have the following:

```
echo ${BUF_API_TOKEN} | buf registry --username ${BUF_USER} --token-stdin
```

Some users might be using `echo -n` and others might not. Before we added logic for validating tokens in https://github.com/bufbuild/buf/issues/861 the new line didn't matter, worst case you got an extra line in your .netrc file following the `password` field.

But now we're sending this token to the backend for validation, and `token\n` will result in an error:

```
Failure: invalid token provided
```

Again, we could tell users to `echo -n`, but to improve the user experience let's just trim the lines and spaces altogether.