### PR TITLE
Temporarily remove `check` from `init` in private usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Temporarily remove private usage check on private packages to unbreak Homebrew releases.
+- Remove check for proper usage of private packages due to a breaking change made in the Golang standard library in 1.18.
 
 ## [v1.1.0] - 2022-03-01
 - Add `--type` flag to the `build` command to create filtered images containing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Temporarily remove private usage check on private packages to unbreak Homebrew releases.
 
 ## [v1.1.0] - 2022-03-01
 - Add `--type` flag to the `build` command to create filtered images containing

--- a/private/usage/usage.go
+++ b/private/usage/usage.go
@@ -26,9 +26,10 @@ import (
 const debugBinPrefix = "__debug_bin"
 
 func init() {
-	if err := check(); err != nil {
-		panic(err.Error())
-	}
+	// TODO: remove until we are able to find a workaround for BuildInfo, details at https://github.com/bufbuild/buf/issues/1013
+	// if err := check(); err != nil {
+	// 	panic(err.Error())
+	// }
 }
 
 func check() error {

--- a/private/usage/usage.go
+++ b/private/usage/usage.go
@@ -25,12 +25,12 @@ import (
 
 const debugBinPrefix = "__debug_bin"
 
-func init() {
-	// TODO: remove until we are able to find a workaround for BuildInfo, details at https://github.com/bufbuild/buf/issues/1013
-	// if err := check(); err != nil {
-	// 	panic(err.Error())
-	// }
-}
+// TODO: remove until we are able to find a workaround for BuildInfo, details at https://github.com/bufbuild/buf/issues/1013
+// func init() {
+// if err := check(); err != nil {
+// 	panic(err.Error())
+// }
+// }
 
 func check() error {
 	buildInfo, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
This is currently breaking our Homebrew build: https://github.com/bufbuild/buf/issues/1013
Once this is merged, we will make a `v1.1.1` release.