### PR TITLE
Fix build scripts and re-enable private usage check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix build scripts to avoid using the `command-line-arguments` pseudo-package
+  when building binaries and re-introduce checking for proper usage of private
+  packages.
 
 ## [v1.1.1] - 2022-03-21
 

--- a/make/buf/scripts/brew.sh
+++ b/make/buf/scripts/brew.sh
@@ -19,8 +19,8 @@ mkdir -p "${OUT_DIR}/share/zsh/site-functions"
 mkdir -p "${OUT_DIR}/share/man/man1"
 
 for binary in buf protoc-gen-buf-breaking protoc-gen-buf-lint; do
-  echo go build -ldflags \"-s -w\" -trimpath -o \"${OUT_DIR}/bin/${binary}\" \"cmd/${binary}/main.go\"
-  go build -ldflags "-s -w" -trimpath -o "${OUT_DIR}/bin/${binary}" "cmd/${binary}/main.go"
+  echo go build -ldflags \"-s -w\" -trimpath -o \"${OUT_DIR}/bin/${binary}\" \"./cmd/${binary}\"
+  go build -ldflags "-s -w" -trimpath -o "${OUT_DIR}/bin/${binary}" "./cmd/${binary}"
 done
 echo \"${OUT_DIR}/bin/buf\" completion bash \> \"${OUT_DIR}/etc/bash_completion.d/buf\"
 "${OUT_DIR}/bin/buf" completion bash > "${OUT_DIR}/etc/bash_completion.d/buf"

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -97,7 +97,7 @@ for os in Darwin Linux Windows; do
       protoc-gen-buf-breaking \
       protoc-gen-buf-lint; do
       CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
-        go build -a -ldflags "-s -w" -trimpath -o "${dir}/bin/${binary}${extension}" "${DIR}/cmd/${binary}/main.go"
+        go build -a -ldflags "-s -w" -trimpath -o "${dir}/bin/${binary}${extension}" "${DIR}/cmd/${binary}"
       cp "${dir}/bin/${binary}${extension}" "${binary}-${os}-${arch}${extension}"
     done
   done

--- a/private/usage/usage.go
+++ b/private/usage/usage.go
@@ -25,12 +25,11 @@ import (
 
 const debugBinPrefix = "__debug_bin"
 
-// TODO: remove until we are able to find a workaround for BuildInfo, details at https://github.com/bufbuild/buf/issues/1013
-// func init() {
-// if err := check(); err != nil {
-// 	panic(err.Error())
-// }
-// }
+func init() {
+	if err := check(); err != nil {
+		panic(err.Error())
+	}
+}
 
 func check() error {
 	buildInfo, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
A change introduced in go 1.18, [CL 339170][0], altered
`runtime/debug.BuildInfo` details for the `command-line-arguments`
pseudo-package, which represents file arguments provided to tools such
as `go build` or `go run`. As such, it's no longer possible to determine
the package name associated with the `main` function when the file it's
defined in is passed as a file argument. Let's avoid
`command-line-arguments` altogether by changing how we build binaries,
instead referring to `main` packages using package path syntax.

Now that we can determine the package path of the `main` function again,
re-introduce invoking `private/usage.check` in `private`'s `init()`.

See also #1013 and https://github.com/bufbuild/homebrew-buf/issues/8

[0]: https://go-review.googlesource.com/c/go/+/339170/