### PR TITLE
Fix formatting edge cases

### DIFF
--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -48,6 +48,11 @@ func testFormatProto2(t *testing.T) {
 	testFormatNoDiff(t, "testdata/proto2/license/v1")
 	testFormatNoDiff(t, "testdata/proto2/message/v1")
 	testFormatNoDiff(t, "testdata/proto2/option/v1")
+
+	// TODO: Temporarily skipping this test since it's
+	// due to a bug in protocompile.
+	//
+	// testFormatNoDiff(t, "testdata/proto2/utf8/v1")
 }
 
 func testFormatProto3(t *testing.T) {

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum.golden.proto
@@ -5,9 +5,7 @@ enum Type {
   // Another trailing comment on Type.
   // A third trailing comment on Type.
 
-  TYPE_UNSPECIFIED/* Comment before '=' */ = /* Comment after '=' */0 [
-    deprecated = true
-  ];
+  TYPE_UNSPECIFIED/* Comment before '=' */ = /* Comment after '=' */0 [deprecated = true];
 
   TYPE_ONE = 1; // In-line comment on TYPE_ONE.
 

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum_trailing_comment.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum_trailing_comment.golden.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+enum Type {
+  TYPE_UNSPECIFIED = 0;
+}
+// This is a trailing comment on '}', but
+// it should remain here.
+
+// These comments are attached to the EOF.

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum_trailing_comment.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum_trailing_comment.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+enum Type {
+  TYPE_UNSPECIFIED = 0;
+}
+// This is a trailing comment on '}', but
+// it should remain here.
+
+
+
+// These comments are attached to the EOF.

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum_value_trailing_comment.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum_value_trailing_comment.golden.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+enum Foo {
+  FOO_UNSPECIFIED = 0;
+  // There are no other enum values.
+}

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum_value_trailing_comment.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum_value_trailing_comment.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+enum Foo {
+  FOO_UNSPECIFIED = 0;
+  // There are no other enum values.
+
+}

--- a/private/buf/bufformat/testdata/proto2/extend/v1/empty.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/extend/v1/empty.golden.proto
@@ -8,14 +8,10 @@ extend Foo {
   // Trailing comment on '{'.
 
   // Leading comment on value.
-  optional string value = 2 [
-    deprecated = true
-  ]; // Trailing comment on value.
+  optional string value = 2 [deprecated = true]; // Trailing comment on value.
 
   // Leading comment on Additional.
-  optional group Additional = 3 [
-    deprecated = false
-  ] {
+  optional group Additional = 3 [deprecated = false] {
     optional int64 four = 4;
     optional int64 five = 5;
   } // Trailing comment on Additional.

--- a/private/buf/bufformat/testdata/proto2/message/v1/message.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message.golden.proto
@@ -7,9 +7,7 @@ message Foo {
   option deprecated = false;
 
   // This is attached to the optional label.
-  optional string name = 1 [
-    deprecated = true
-  ];
+  optional string name = 1 [deprecated = true];
 
   repeated int64 values = 2;
 

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
@@ -20,8 +20,6 @@ message Foo {
   };
 
   // This is attached to the optional label.
-  optional string name = 1 [
-    deprecated = true
-  ];
+  optional string name = 1 [deprecated = true];
   repeated int64 values = 2;
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/multiple_nested.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/multiple_nested.golden.proto
@@ -3,9 +3,7 @@ syntax = "proto2";
 message Foo {
   option deprecated = false;
 
-  optional string name = 1/* Between the '1' and the '[' */ [
-    deprecated = true
-  ]; // In-line comment on name.
+  optional string name = 1/* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
 
   // Repeated values comment.
   repeated int64 values = 2/* Before the semiolon */;

--- a/private/buf/bufformat/testdata/proto2/message/v1/nested.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/nested.golden.proto
@@ -3,9 +3,7 @@ syntax = "proto2";
 message Foo {
   option deprecated = false;
 
-  optional string name = 1/* Between the '1' and the '[' */ [
-    deprecated = true
-  ]; // In-line comment on name.
+  optional string name = 1/* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
 
   // Repeated values comment.
   repeated int64 values = 2/* Before the semiolon */;

--- a/private/buf/bufformat/testdata/proto2/option/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option.golden.proto
@@ -47,30 +47,22 @@ message Foo {
       ctype = CORD
     ];
     // Leading comment on two.
-    required string two = 4 [
-      (custom.field_value_thing) = {}
-    ];
+    required string two = 4 [(custom.field_value_thing) = {}];
     // Leading comment on three.
-    required string three = 5 [
-      (custom.field_value_thing) = {
-        /* Empty message literal */
-      }
-    ];
+    required string three = 5 [(custom.field_value_thing) = {
+      /* Empty message literal */
+    }];
     // Leading comment on four.
-    required string four = 6 [
-      (custom.field_value_thing) = {
-        // Trailing comment on '{'.
-        // Another trailing comment on '{'.
-      }
-    ];
+    required string four = 6 [(custom.field_value_thing) = {
+      // Trailing comment on '{'.
+      // Another trailing comment on '{'.
+    }];
     // Leading comment on five.
-    required string five = 7 [
-      (custom.field_value_thing) = {
-        // Trailing comment on '{'.
+    required string five = 7 [(custom.field_value_thing) = {
+      // Trailing comment on '{'.
 
-      // Leading comment on '}'.
-      }
-    ];
+    // Leading comment on '}'.
+    }];
   }
 }
 

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_array.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_array.golden.proto
@@ -4,24 +4,22 @@ import "custom.proto";
 
 message Foo {
   message Bar {
-    string name = 1 [
-      (custom.field_thing_option) = {
-        // Trailing comment on '{'.
+    string name = 1 [(custom.field_thing_option) = {
+      // Trailing comment on '{'.
 
-        // Leading comment on repeated_foo field.
-        message_foo: [
-          // Trailing comment on array literal.
+      // Leading comment on repeated_foo field.
+      message_foo: [
+        // Trailing comment on array literal.
 
-          // Leading comment on '1'.
-          1, // Trailing comment on '1'.
-          // Leading comment on '2'.
-          2 // Trailing comment on '2'.
+        // Leading comment on '1'.
+        1, // Trailing comment on '1'.
+        // Leading comment on '2'.
+        2 // Trailing comment on '2'.
 
-        // Leading comment on ']'.
-        ]
+      // Leading comment on ']'.
+      ]
 
-      // Leading comment on '}'.
-      }
-    ];
+    // Leading comment on '}'.
+    }];
   }
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
@@ -14,23 +14,17 @@ extend .google./* identifier broken up strangely should still be accepted */prot
 }
 
 message Test {
-  optional string foo = 1 [
-    json_name = "|foo|"
-  ];
+  optional string foo = 1 [json_name = "|foo|"];
   repeated int32 array = 2;
   optional Simple s = 3;
   repeated Simple r = 4;
   map<string, int32> m = 5;
 
-  optional bytes b = 6 [
-    default = "\x00\x01\x02\x03\x04\x05\x06\afubar!"
-  ];
+  optional bytes b = 6 [default = "\x00\x01\x02\x03\x04\x05\x06\afubar!"];
 
   extensions 100 to 200;
 
-  extensions 249, 300 to 350, 500 to 550, 20000 to max [
-    (label) = "jazz"
-  ];
+  extensions 249, 300 to 350, 500 to 550, 20000 to max [(label) = "jazz"];
 
   message Nested {
     extend google.protobuf.MessageOptions {

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
@@ -17,6 +17,7 @@ message Foo {
     // Leading comment on deprecated.
     deprecated/* After deprecated */ = true,
     // Leading comment on another.
+
     (/* One */another/* Two */) = 2
   ];
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
@@ -17,7 +17,6 @@ message Foo {
     // Leading comment on deprecated.
     deprecated/* After deprecated */ = true,
     // Leading comment on another.
-
     (/* One */another/* Two */) = 2
   ];
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/single_compact_option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/single_compact_option.golden.proto
@@ -1,0 +1,5 @@
+syntax = "proto2";
+
+message Foo {
+  optional string name = 1 [deprecated = true];
+}

--- a/private/buf/bufformat/testdata/proto2/option/v1/single_compact_option.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/single_compact_option.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+
+message Foo {
+  optional string name = 1 [  deprecated = true  ];
+}

--- a/private/buf/bufformat/testdata/proto2/utf8/v1/utf8.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/utf8/v1/utf8.golden.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+enum Type {
+  // An example of strange characters in a comment: attachment���s
+  TYPE_UNSPECIFIED = 0;
+}

--- a/private/buf/bufformat/testdata/proto2/utf8/v1/utf8.proto
+++ b/private/buf/bufformat/testdata/proto2/utf8/v1/utf8.proto
@@ -1,0 +1,6 @@
+syntax = "proto2";
+
+enum Type {
+  // An example of strange characters in a comment: attachment���s
+  TYPE_UNSPECIFIED = 0;
+}

--- a/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
@@ -66,9 +66,7 @@ message One {
   c-style comment
   */
 
-  int64 one_one = 1 [
-    (custom.field_option) = true
-  ];
+  int64 one_one = 1 [(custom.field_option) = true];
   Two one_two = 2 [
     (custom.field_option) = false,
     (custom.field_thing_option) = {

--- a/private/buf/bufformat/testdata/proto3/header/v1/unused_import.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/unused_import.golden.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+// This import is unused, but it should
+// still be referenced.
+import "google/protobuf/timestamp.proto";
+
+message Foo {
+  string name = 1;
+}

--- a/private/buf/bufformat/testdata/proto3/header/v1/unused_import.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/unused_import.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+// This import is unused, but it should
+// still be referenced.
+import "google/protobuf/timestamp.proto";
+
+message Foo {
+  string name = 1;
+}

--- a/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
@@ -10,12 +10,12 @@ message Foo {
     (custom.int64_field_option) = /* Before */64/* After */, // Trailing
     (custom.uint32_field_option) = /* Before */3200/* After */, // Trailing
     (custom.uint64_field_option) = /* Before */6400/* After */, // Trailing
-    (custom.sint32_field_option) = -/* The '-' can be detached. */32 /* After 32 */, // Trailing
-    (custom.sint64_field_option) = -/* Again */64 /* After 64 */, // Trailing
+    (custom.sint32_field_option) = -/* The '-' can be detached. */32/* After 32 */, // Trailing
+    (custom.sint64_field_option) = -/* Again */64/* After 64 */, // Trailing
     (custom.fixed32_field_option) = /* Before */3232/* After */, // Trailing
     (custom.fixed64_field_option) = /* Before */6464/* After */, // Trailing
-    (custom.sfixed32_field_option) = -/* Again */3232 /* After */, // Trailing
-    (custom.sfixed64_field_option) = -/* Finally */6464 /* After */, // Trailing
+    (custom.sfixed32_field_option) = -/* Again */3232/* After */, // Trailing
+    (custom.sfixed64_field_option) = -/* Finally */6464/* After */, // Trailing
     (custom.bool_field_option) = /* Before */true/* After */, // Trailing
     (custom.bytes_field_option) = /* Before */"bytes"/* After */, // Trailing
     (custom.string_field_option) = /* One */"this" /* Two */"is a" /* Three */"compound string"/* Trailing */

--- a/private/buf/bufformat/testdata/proto3/literal/v1/special_literal.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/special_literal.golden.proto
@@ -3,14 +3,10 @@ syntax = "proto3";
 import "custom.proto";
 
 message Foo {
-  string key = 1 [
-    (custom.float_field_option) = /* Before */nan // Trailing
-  ];
+  string key = 1 [(custom.float_field_option) = /* Before */nan/* Trailing */];
   string value = 2 [
     (custom.float_field_option) = /* Before */inf/* After */, // Trailing
     (custom.bool_field_option) = false
   ];
-  string another = 3 [
-    (custom.float_field_option) =/* Before */ -/* Between */inf // Trailing
-  ];
+  string another = 3 [(custom.float_field_option) =/* Before */ -/* Between */inf/* Trailing */];
 }


### PR DESCRIPTION
This fixes a couple formatting edge cases that were caught shortly after the v1.2.0 release. The following formatting cases are adjusted:

1. Compact options with a single element are written in a single line (instead of multiple).

```protobuf
message Type {
  string name = 1 [deprecated = true];
}
```

2. If there are newlines between an element and its trailing comments, the newline is preserved.

```protobuf
message Type {
  string name = 1;
  // There are no other fields yet.
}
```

An issue was also found in `protocompile` in its ability to non-UTF8. For example,

```protobuf
syntax = "proto2";

message Type {
  // An example of strange characters in a comment: attachment���s
  TYPE_UNSPECIFIED = 0;
}
```

Again, as described [here](https://github.com/bufbuild/buf/pull/967), there are other opinions that we might adapt over time.