### PR TITLE
Bump alpine from 3.15.1 to 3.15.2

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
   go build -ldflags "-s -w" -trimpath -o /go/bin/buf ./cmd/buf
 
-FROM --platform=${TARGETPLATFORM} alpine:3.15.1
+FROM --platform=${TARGETPLATFORM} alpine:3.15.2
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
Fixes [CVE-2022-0778](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0778)
Closes #1028 