### PR TITLE
Add --exit-code to buf format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add `--exit code` flag to `buf format` to exit with a non-zero exit code if
+  the files were not already formatted.
 
 ## [v1.2.1] - 2022-03-24
 

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1944,19 +1944,6 @@ func TestFormatDiff(t *testing.T) {
 @@ -1,13 +1,7 @@
 -
  syntax = "proto3";
- 
--
--
- package diff;
- 
--
--message   Diff  {
--
-+message Diff {
-   string content = 1;
--
--  }
-+}
 `,
 	)
 	testRunStdout(
@@ -1968,6 +1955,34 @@ func TestFormatDiff(t *testing.T) {
 		filepath.Join(tempDir, "formatted"),
 		"-d",
 	)
+}
+
+// Tests if the exit code is set for common invocations of buf format
+// with the --exit-code flag.
+func TestFormatExitCode(t *testing.T) {
+	stdout := bytes.NewBuffer(nil)
+	testRun(
+		t,
+		bufcli.ExitCodeFileAnnotation,
+		nil,
+		stdout,
+		"format",
+		filepath.Join("testdata", "format", "diff"),
+		"--exit-code",
+	)
+	assert.NotEmpty(t, stdout.String())
+	stdout = bytes.NewBuffer(nil)
+	testRun(
+		t,
+		bufcli.ExitCodeFileAnnotation,
+		nil,
+		stdout,
+		"format",
+		filepath.Join("testdata", "format", "diff"),
+		"-d",
+		"--exit-code",
+	)
+	assert.NotEmpty(t, stdout.String())
 }
 
 // Tests if the image produced by the formatted result is

--- a/private/pkg/app/appcmd/appcmdtesting/appcmdtesting.go
+++ b/private/pkg/app/appcmd/appcmdtesting/appcmdtesting.go
@@ -115,8 +115,18 @@ func RunCommandExitCode(
 	// make the use something different than the actual command
 	// to make sure that all code is binary-name-agnostic.
 	use := "test"
-	stderrCopy := bytes.NewBuffer(nil)
 	stdoutCopy := bytes.NewBuffer(nil)
+	if stdout == nil {
+		stdout = stdoutCopy
+	} else {
+		stdout = io.MultiWriter(stdout, stdoutCopy)
+	}
+	stderrCopy := bytes.NewBuffer(nil)
+	if stderr == nil {
+		stderr = stderrCopy
+	} else {
+		stderr = io.MultiWriter(stderr, stderrCopy)
+	}
 	var env map[string]string
 	if newEnv != nil {
 		env = newEnv(use)
@@ -127,8 +137,8 @@ func RunCommandExitCode(
 			app.NewContainer(
 				env,
 				stdin,
-				io.MultiWriter(stdout, stdoutCopy),
-				io.MultiWriter(stderr, stderrCopy),
+				stdout,
+				stderr,
 				append([]string{"test"}, args...)...,
 			),
 			newCommand(use),


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/1030.

This makes it so that `buf format` exits with a non-zero exit code if files were not already formatted. Common invocations:

```
# Print the diff and exit with non-zero exit code if there is a diff
$ buf format -d --exit-code
# Print nothing and exit with non-zero exit code if there is a diff
$ buf format --exit-code >/dev/null
```