### PR TITLE
Format compound string literals across multiple lines

### DIFF
--- a/private/buf/bufformat/testdata/customoptions/options.golden.proto
+++ b/private/buf/bufformat/testdata/customoptions/options.golden.proto
@@ -8,10 +8,12 @@ import "google/protobuf/descriptor.proto";
 message Thing {
   int64 foo = 1;
   int64 bar = 2;
-  bool truth = 3;
-  Thing recursive = 4;
-  repeated int64 repeated_foo = 5;
-  repeated Thing repeated_thing = 6;
+  string baz = 3;
+  bool truth = 4;
+  Thing recursive = 5;
+  repeated int64 repeated_foo = 6;
+  repeated Thing repeated_thing = 7;
+  repeated string repeated_baz = 8;
 }
 
 extend google.protobuf.MessageOptions {

--- a/private/buf/bufformat/testdata/customoptions/options.proto
+++ b/private/buf/bufformat/testdata/customoptions/options.proto
@@ -8,10 +8,12 @@ package custom;
 message Thing {
   int64 foo = 1;
   int64 bar = 2;
-  bool truth = 3;
-  Thing recursive = 4;
-  repeated int64 repeated_foo = 5;
-  repeated Thing repeated_thing = 6;
+  string baz = 3;
+  bool truth = 4;
+  Thing recursive = 5;
+  repeated int64 repeated_foo = 6;
+  repeated Thing repeated_thing = 7;
+  repeated string repeated_baz = 8;
 }
 
 extend google.protobuf.MessageOptions {

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.golden.proto
@@ -8,7 +8,11 @@ option (list) = {
     // Trailing comment on '['.
 
     // Leading comment on compound string.
-    "one" /* One */"two" /* Two */"three" // Trailing
+    "one"
+    /* One */
+    "two"
+    /* Two */
+    "three" // Trailing
   ],
 
   values: [

--- a/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.golden.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+import "custom.proto";
+
+message Foo {
+  // one has a single compact option, so it should be written in-line.
+  string one = 1 [(custom.string_field_option) =
+    "this"
+    // Second element.
+    "is a"
+    // Third element.
+    "compound string"];
+
+    // two has multiple compact options, so it should be written across multiple lines.
+    string two = 2 [
+      deprecated = true,
+      (custom.string_field_option) =
+        "this"
+        // Second element.
+        "is a"
+        // Third element.
+        "compound string"
+    ];
+
+    // three has an array of compound string literals, but it's all in a single compact option.
+    string three = 3 [(custom.field_thing_option) = {
+      baz:
+        "One"
+        "Two"
+        "Three"
+      repeated_baz: [
+        // Firt element.
+        "this"
+        // Second element.
+        "is a"
+        // Third element.
+        "compound string" /* Trailing in array */,
+        "this" // The first element.
+        "is another" // The second element.
+        "compound string" // The last element.
+      ]
+    }];
+
+    // four has an array of compound string literals, but there are multiple compact options.
+    string four = 4 [
+      deprecated = true,
+      (custom.field_thing_option) = {
+        baz:
+          "One"
+          "Two"
+          "Three"
+        repeated_baz: [
+          // Firt element.
+          "this"
+          // Second element.
+          "is a"
+          // Third element.
+          "compound string" /* Trailing in array */,
+          "this" // The first element.
+          "is another" // The second element.
+          "compound string"
+          // Trailing comment on a newline.
+        ]
+      }
+    ];
+  }

--- a/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+import "custom.proto";
+
+message Foo {
+  // one has a single compact option, so it should be written in-line.
+  string one = 1 [(custom.string_field_option) =  "this"
+    // Second element.
+    "is a"
+    // Third element.
+    "compound string"];
+
+  // two has multiple compact options, so it should be written across multiple lines.
+  string two = 2 [
+    deprecated = true,
+    (custom.string_field_option) =  "this"
+      // Second element.
+      "is a"
+      // Third element.
+      "compound string"
+  ];
+
+  // three has an array of compound string literals, but it's all in a single compact option.
+  string three = 3 [(custom.field_thing_option) = {
+    baz: "One"
+      "Two"
+      "Three"
+    repeated_baz: [
+      // Firt element.
+      "this"
+      // Second element.
+      "is a"
+      // Third element.
+      "compound string" /* Trailing in array */,
+      "this" // The first element.
+      "is another" // The second element.
+      "compound string" // The last element.
+    ]
+  }];
+
+  // four has an array of compound string literals, but there are multiple compact options.
+  string four = 4 [
+    deprecated = true,
+    (custom.field_thing_option) = {
+      baz: "One"
+        "Two"
+        "Three"
+      repeated_baz: [
+        // Firt element.
+        "this"
+        // Second element.
+        "is a"
+        // Third element.
+        "compound string" /* Trailing in array */,
+        "this" // The first element.
+        "is another" // The second element.
+        "compound string"
+        // Trailing comment on a newline.
+      ]
+    }
+  ];
+}

--- a/private/buf/bufformat/testdata/proto3/literal/v1/literal.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/literal.golden.proto
@@ -18,6 +18,9 @@ message Foo {
     (custom.sfixed64_field_option) = -6464,
     (custom.bool_field_option) = true,
     (custom.bytes_field_option) = "bytes",
-    (custom.string_field_option) = "this" "is a" "compound string"
+    (custom.string_field_option) =
+      "this"
+      "is a"
+      "compound string"
   ];
 }

--- a/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
@@ -18,6 +18,12 @@ message Foo {
     (custom.sfixed64_field_option) = -/* Finally */6464/* After */, // Trailing
     (custom.bool_field_option) = /* Before */true/* After */, // Trailing
     (custom.bytes_field_option) = /* Before */"bytes"/* After */, // Trailing
-    (custom.string_field_option) = /* One */"this" /* Two */"is a" /* Three */"compound string"/* Trailing */
+    (custom.string_field_option) =
+      /* One */
+      "this"
+      /* Two */
+      "is a"
+      /* Three */
+      "compound string" // Trailing
   ];
 }


### PR DESCRIPTION
Fixes #1036

This updates `buf format` so that adjacent string literals are written across multiple lines. For example,

```protobuf
syntax "proto3";

package example;

import "custom.proto";

option (custom) =
  "one,"
  "two,"
  "three"
```

Note that this takes a different stance than `clang-format` - the strings are **_not_** aligned according to the first element like so:

```protobuf
syntax "proto3";

package example;

import "custom.proto";

option (custom) = "one,"
                  "two,"
                  "three"
```

The former approach is more consistent with the rest of the formatter's style, and it's actually the same style seen in GoogleAPIs (shown below).

```protobuf
option (google.api.oauth_scopes) =
  "https://www.googleapis.com/auth/analytics,"
  "https://www.googleapis.com/auth/analytics.readonly";
```