### PR TITLE
Format default file options before custom file options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Update `buf format`'s file option order so that default
+  file options are sorted before custom options.
 - Fix `buf format` so that the output directory (if any) is
   created if and only if the input is successfully formatted.
 

--- a/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
@@ -16,6 +16,16 @@ import "google/protobuf/duration.proto"; // import-inline comment  2
 // import comment
 import "google/protobuf/timestamp.proto"; // import-inline comment
 
+// option comment 3
+option go_package = "foopb"; // option-inline comment 3
+// between-imports-and-options comment
+
+// option comment
+option java_multiple_files = true; // option-inline comment
+// option comment 4
+option java_outer_classname = "FooProto"; // option-inline comment 4
+// option comment 2
+option java_package = "com.foo"; // option-inline comment 2
 // option comment 5
 option (custom.file_option) = true; // option-inline comment 5
 // option comment 6
@@ -29,16 +39,6 @@ option (custom.file_thing_option) = {
     truth: true
   }
 }; // option-inlinecomment 6
-// option comment 3
-option go_package = "foopb"; // option-inline comment 3
-// between-imports-and-options comment
-
-// option comment
-option java_multiple_files = true; // option-inline comment
-// option comment 4
-option java_outer_classname = "FooProto"; // option-inline comment 4
-// option comment 2
-option java_package = "com.foo"; // option-inline comment 2
 
 // leading comment one1
 // leading comment one2

--- a/private/buf/bufformat/testdata/proto3/file/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/file/v1/option.golden.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "custom.proto";
+
+option cc_enable_arenas = true;
+option java_multiple_files = true;
+option (file_option) = true;

--- a/private/buf/bufformat/testdata/proto3/file/v1/option.proto
+++ b/private/buf/bufformat/testdata/proto3/file/v1/option.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "custom.proto";
+
+option (file_option) = true;
+option java_multiple_files = true;
+option cc_enable_arenas = true;


### PR DESCRIPTION
This updates the file option sorting function so that default file options are sorted before custom options. For example,

```protobuf
syntax = "proto3";

import "custom.proto";

option cc_enable_arenas = true;
option java_multiple_files = true;
option (file_option) = true;
```