### PR TITLE
Adds cert server to buf from buf/core

### DIFF
--- a/private/pkg/cert/certserver/certserver.go
+++ b/private/pkg/cert/certserver/certserver.go
@@ -1,0 +1,58 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certserver
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/bufbuild/buf/private/pkg/app/appname"
+)
+
+// ExternalServerTLSConfig allows users to configure TLS on the server side.
+type ExternalServerTLSConfig struct {
+	Use                string `json:"use,omitempty" yaml:"use,omitempty"`
+	ServerCertFilePath string `json:"server_cert_file_path,omitempty" yaml:"server_cert_file_path,omitempty"`
+	ServerKeyFilePath  string `json:"server_key_file_path,omitempty" yaml:"server_key_file_path,omitempty"`
+}
+
+// NewServerTLSConfig creates a new *tls.Config from the ExternalTLSConfig
+//
+// The default is to use a local TLS config at ${configDirPath}/tls/{cert,key}.pem.
+func NewServerTLSConfig(
+	container appname.Container,
+	externalServerTLSConfig ExternalServerTLSConfig,
+) (*tls.Config, error) {
+	switch t := strings.ToLower(strings.TrimSpace(externalServerTLSConfig.Use)); t {
+	case "local", "":
+		serverCertFilePath := externalServerTLSConfig.ServerCertFilePath
+		if serverCertFilePath == "" {
+			serverCertFilePath = filepath.Join(container.ConfigDirPath(), "tls", "cert.pem")
+		}
+		serverKeyFilePath := externalServerTLSConfig.ServerKeyFilePath
+		if serverKeyFilePath == "" {
+			serverKeyFilePath = filepath.Join(container.ConfigDirPath(), "tls", "key.pem")
+		}
+		return newServerTLSConfigFromFiles(serverCertFilePath, serverKeyFilePath)
+	case "system":
+		return newServerSystemTLSConfig(), nil
+	case "false":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown tls.use: %q", t)
+	}
+}

--- a/private/pkg/cert/certserver/usage.gen.go
+++ b/private/pkg/cert/certserver/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package certserver
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/pkg/cert/certserver/util.go
+++ b/private/pkg/cert/certserver/util.go
@@ -1,0 +1,59 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certserver
+
+import (
+	"crypto/tls"
+	"os"
+)
+
+// newServerTLSConfigFromFiles creates a new tls.Config from a server certificate file and a server key file.
+func newServerTLSConfigFromFiles(serverCertFile string, serverKeyFile string) (*tls.Config, error) {
+	certPEMBlock, err := os.ReadFile(serverCertFile)
+	if err != nil {
+		return nil, err
+	}
+	keyPEMBlock, err := os.ReadFile(serverKeyFile)
+	if err != nil {
+		return nil, err
+	}
+	return newServerTLSConfigFromData(certPEMBlock, keyPEMBlock)
+}
+
+// newServerTLSConfigFromData creates a new tls.Config from server certificate data and server key data.
+func newServerTLSConfigFromData(serverCertData []byte, serverKeyData []byte) (*tls.Config, error) {
+	certificate, err := tls.X509KeyPair(serverCertData, serverKeyData)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{certificate},
+	}, nil
+}
+
+// newServerSystemTLSConfig creates a new tls.Config that uses the system cert pool for verifying
+// server certificates.
+func newServerSystemTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// An empty TLS config will use the system certificate pool
+		// when verifying the servers certificate. This is because
+		// not setting any RootCAs will set `x509.VerifyOptions.Roots`
+		// to nil, which triggers the loading of system certs (including
+		// on Windows somehow) within (*x509.Certificate).Verify.
+		RootCAs: nil,
+	}
+}


### PR DESCRIPTION
This adds the `private/pkg/cert/certserver` package to this repo.  This package is a wholesale copy from the `certserver` located in `buf/core`.  The `certserver` in `buf/core` will be removed in a followup PR.

This is needed for configuration when building Connect clients.