### PR TITLE
Upgrade to golangci-lint v1.46.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - depguard
     - dogsled
     - errcheck
+    - execinquery
     - exportloopref
     - forbidigo
     - forcetypeassert
@@ -59,6 +60,7 @@ linters:
     - nakedret
     - nilerr
     - nolintlint
+    - nosprintfhostport
     - predeclared
     - promlinter
     - rowserrcheck

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20220324 checked 20220503
+# https://github.com/golangci/golangci-lint/releases 20220517 checked 20220520
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.45.2
+GOLANGCI_LINT_VERSION ?= v1.46.2
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):

--- a/make/go/dep_protoc_gen_connect_go.mk
+++ b/make/go/dep_protoc_gen_connect_go.mk
@@ -7,8 +7,8 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/bufbuild/connect-go 20220514 checked 20220517
-CONNECT_VERSION ?= 316a3a0a4a4258b17ae9d5de86dc4327c329ca08
+# https://github.com/bufbuild/connect-go 20220518 checked 20220518
+CONNECT_VERSION ?= eaacdf55b404991aff8eca2e933c87168137b85a
 
 PROTOC_GEN_CONNECT_GO := $(CACHE_VERSIONS)/connect-go/$(CONNECT_VERSION)
 $(PROTOC_GEN_CONNECT_GO):

--- a/make/go/scripts/checknodiffgenerated.bash
+++ b/make/go/scripts/checknodiffgenerated.bash
@@ -7,9 +7,7 @@ set -euo pipefail
 STATUS_SHORT_PRE_FILE="$(mktemp)"
 STATUS_SHORT_POST_FILE="$(mktemp)"
 STATUS_SHORT_DIFF_FILE="$(mktemp)"
-trap 'rm -rf "${STATUS_SHORT_PRE_FILE}"' EXIT
-trap 'rm -rf "${STATUS_SHORT_POST_FILE}"' EXIT
-trap 'rm -rf "${STATUS_SHORT_DIFF_FILE}"' EXIT
+trap 'rm -rf "${STATUS_SHORT_PRE_FILE}" "${STATUS_SHORT_POST_FILE}" "${STATUS_SHORT_DIFF_FILE}"' EXIT
 
 git status --short > "${STATUS_SHORT_PRE_FILE}"
 "$@"


### PR DESCRIPTION
This upgrades to golangci-lint v1.46.2, which re-enables staticcheck and other key linters, as they are now compatible with Golang 1.18.