### PR TITLE
Update protoc version handling

### DIFF
--- a/private/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
+++ b/private/pkg/app/appproto/appprotoexec/protoc_proxy_handler.go
@@ -109,8 +109,7 @@ func (h *protocProxyHandler) Handle(
 		fmt.Sprintf("--descriptor_set_in=%s", descriptorFilePath),
 		fmt.Sprintf("--%s_out=%s", h.pluginName, tmpDir.AbsPath()),
 	}
-	featureProto3Optional := getFeatureProto3Optional(protocVersion)
-	if featureProto3Optional {
+	if getExperimentalAllowProto3Optional(protocVersion) {
 		args = append(
 			args,
 			// this flag may be deleted someday
@@ -144,7 +143,7 @@ func (h *protocProxyHandler) Handle(
 		// We don't know if this is a system error or plugin error, so we assume system error
 		return handlePotentialTooManyFilesError(err)
 	}
-	if featureProto3Optional {
+	if getFeatureProto3Optional(protocVersion) {
 		responseWriter.SetFeatureProto3Optional()
 	}
 	// no need for symlinks here, and don't want to support

--- a/private/pkg/app/appproto/appprotoexec/version.go
+++ b/private/pkg/app/appproto/appprotoexec/version.go
@@ -46,44 +46,58 @@ func parseVersionForCLIVersion(value string) (_ *pluginpb.Version, retErr error)
 	// protoc always starts with "libprotoc "
 	value = strings.TrimPrefix(value, "libprotoc ")
 	split := strings.Split(value, ".")
-	if len(split) != 3 {
-		return nil, errors.New("more than three components split by '.'")
+	if len(split) != 2 && len(split) != 3 {
+		return nil, fmt.Errorf("%d components split by '.'", len(split))
 	}
 	major, err := strconv.ParseInt(split[0], 10, 32)
 	if err != nil {
 		return nil, err
 	}
-	minor, err := strconv.ParseInt(split[1], 10, 32)
-	if err != nil {
-		return nil, err
-	}
-	patchSplit := strings.Split(split[2], "-")
-	patch, err := strconv.ParseInt(patchSplit[0], 10, 32)
-	if err != nil {
-		return nil, err
-	}
 	var suffix string
-	switch len(patchSplit) {
+	restSplit := strings.SplitN(split[len(split)-1], "-", 2)
+	lastNumber, err := strconv.ParseInt(restSplit[0], 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	switch len(restSplit) {
 	case 1:
 	case 2:
-		suffix = patchSplit[1]
+		suffix = restSplit[1]
 	default:
 		return nil, errors.New("more than two patch components split by '-'")
+	}
+	var minor int64
+	var patch int64
+	switch len(split) {
+	case 2:
+		minor = lastNumber
+	case 3:
+		minor, err = strconv.ParseInt(split[1], 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		patch = lastNumber
 	}
 	return newVersion(int32(major), int32(minor), int32(patch), suffix), nil
 }
 
 func versionString(version *pluginpb.Version) string {
-	value := fmt.Sprintf("%d.%d.%d", version.GetMajor(), version.GetMinor(), version.GetPatch())
+	var value string
+	if version.GetMajor() <= 3 || version.GetPatch() != 0 {
+		value = fmt.Sprintf("%d.%d.%d", version.GetMajor(), version.GetMinor(), version.GetPatch())
+	} else {
+		value = fmt.Sprintf("%d.%d", version.GetMajor(), version.GetMinor())
+	}
 	if version.Suffix != nil {
 		value = value + "-" + version.GetSuffix()
 	}
 	return value
 }
 
-func getFeatureProto3Optional(version *pluginpb.Version) bool {
+// Should I set the --experimental_allow_proto3_optional flag?
+func getExperimentalAllowProto3Optional(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {
-		return true
+		return false
 	}
 	if version.GetMajor() != 3 {
 		return false
@@ -91,12 +105,31 @@ func getFeatureProto3Optional(version *pluginpb.Version) bool {
 	return version.GetMinor() > 11 && version.GetMinor() < 15
 }
 
+// Should I notify that I am OK with the proto3 optional feature?
+func getFeatureProto3Optional(version *pluginpb.Version) bool {
+	if version.GetSuffix() == "buf" {
+		return true
+	}
+	if version.GetMajor() < 3 {
+		return false
+	}
+	if version.GetMajor() == 3 {
+		return version.GetMinor() > 11
+	}
+	// version.GetMajor() > 3
+	return true
+}
+
 func getKotlinSupported(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {
 		return true
 	}
-	if version.GetMajor() != 3 {
+	if version.GetMajor() < 3 {
 		return false
 	}
-	return version.GetMinor() > 16
+	if version.GetMajor() == 3 {
+		return version.GetMinor() > 16
+	}
+	// version.GetMajor() > 3
+	return true
 }

--- a/private/pkg/app/appproto/appprotoexec/version_test.go
+++ b/private/pkg/app/appproto/appprotoexec/version_test.go
@@ -25,22 +25,42 @@ func TestVersionString(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "3.11.1-buf", versionString(newVersion(3, 11, 1, "buf")))
 	assert.Equal(t, "3.15.0", versionString(newVersion(3, 15, 0, "")))
+	assert.Equal(t, "21.0", versionString(newVersion(21, 0, 0, "")))
+	assert.Equal(t, "21.1", versionString(newVersion(21, 1, 0, "")))
+	assert.Equal(t, "21.1-rc-1", versionString(newVersion(21, 1, 0, "rc-1")))
+	assert.Equal(t, "21.1.1", versionString(newVersion(21, 1, 1, "")))
+	assert.Equal(t, "21.1.1-rc-1", versionString(newVersion(21, 1, 1, "rc-1")))
+}
+
+func TestGetExperimentalAllowProto3Optional(t *testing.T) {
+	t.Parallel()
+	assert.False(t, getExperimentalAllowProto3Optional(newVersion(2, 12, 4, "")))
+	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 11, 1, "buf")))
+	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 11, 4, "")))
+	assert.True(t, getExperimentalAllowProto3Optional(newVersion(3, 12, 1, "")))
+	assert.True(t, getExperimentalAllowProto3Optional(newVersion(3, 14, 1, "")))
+	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 14, 1, "buf")))
+	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 15, 0, "")))
+	assert.False(t, getExperimentalAllowProto3Optional(newVersion(21, 0, 0, "")))
 }
 
 func TestGetFeatureProto3Optional(t *testing.T) {
 	t.Parallel()
+	assert.False(t, getFeatureProto3Optional(newVersion(2, 12, 4, "")))
+	assert.False(t, getFeatureProto3Optional(newVersion(3, 11, 4, "")))
 	assert.True(t, getFeatureProto3Optional(newVersion(3, 11, 1, "buf")))
 	assert.True(t, getFeatureProto3Optional(newVersion(3, 12, 1, "")))
 	assert.True(t, getFeatureProto3Optional(newVersion(3, 14, 1, "")))
-	assert.False(t, getFeatureProto3Optional(newVersion(3, 11, 4, "")))
-	assert.False(t, getFeatureProto3Optional(newVersion(2, 12, 4, "")))
-	assert.False(t, getFeatureProto3Optional(newVersion(3, 15, 0, "")))
+	assert.True(t, getFeatureProto3Optional(newVersion(3, 15, 0, "")))
+	assert.True(t, getFeatureProto3Optional(newVersion(21, 0, 0, "")))
 }
 
 func TestGetKotlinSupported(t *testing.T) {
 	t.Parallel()
 	assert.True(t, getKotlinSupported(newVersion(3, 11, 1, "buf")))
 	assert.True(t, getKotlinSupported(newVersion(3, 17, 4, "")))
+	assert.True(t, getKotlinSupported(newVersion(21, 1, 0, "")))
+	assert.True(t, getKotlinSupported(newVersion(21, 1, 0, "buf")))
 	assert.False(t, getKotlinSupported(newVersion(3, 12, 1, "")))
 	assert.False(t, getKotlinSupported(newVersion(3, 14, 1, "")))
 }
@@ -49,9 +69,17 @@ func TestParseVersionForCLIVersion(t *testing.T) {
 	t.Parallel()
 	testParseVersionForCLIVersionSuccess(t, "libprotoc 3.14.0", newVersion(3, 14, 0, ""))
 	testParseVersionForCLIVersionSuccess(t, "libprotoc 3.14.0-rc1", newVersion(3, 14, 0, "rc1"))
+	testParseVersionForCLIVersionSuccess(t, "libprotoc 3.14.0-rc-1", newVersion(3, 14, 0, "rc-1"))
 	testParseVersionForCLIVersionSuccess(t, "3.14.0", newVersion(3, 14, 0, ""))
 	testParseVersionForCLIVersionSuccess(t, "3.14.0-rc1", newVersion(3, 14, 0, "rc1"))
 	testParseVersionForCLIVersionSuccess(t, "3.14.0-buf", newVersion(3, 14, 0, "buf"))
+	testParseVersionForCLIVersionSuccess(t, "libprotoc 21.1", newVersion(21, 1, 0, ""))
+	testParseVersionForCLIVersionSuccess(t, "libprotoc 21.1-rc1", newVersion(21, 1, 0, "rc1"))
+	testParseVersionForCLIVersionSuccess(t, "libprotoc 21.1-rc-1", newVersion(21, 1, 0, "rc-1"))
+	testParseVersionForCLIVersionSuccess(t, "21.1", newVersion(21, 1, 0, ""))
+	testParseVersionForCLIVersionSuccess(t, "21.1-rc1", newVersion(21, 1, 0, "rc1"))
+	testParseVersionForCLIVersionSuccess(t, "21.1-rc-1", newVersion(21, 1, 0, "rc-1"))
+	testParseVersionForCLIVersionSuccess(t, "21.1-buf", newVersion(21, 1, 0, "buf"))
 	testParseVersionForCLIVersionError(t, "libprotoc3.14.0")
 	testParseVersionForCLIVersionError(t, "libprotoc 3.14.0.1")
 }


### PR DESCRIPTION
The github.com/protocolbuffers/protobuf library versioning is changing:

- https://github.com/protocolbuffers/protobuf/releases/tag/v21.0-rc1
- https://developers.google.com/protocol-buffers/docs/news/2022-05-06

As such, our current version parsing scheme is broken. This updates the version parsing scheme to account for this, as well as fixes a few bugs:

- We needed to split the handling of whether to set the `--experimental_allow_proto3_optional` flag from whether or not a response should say it handles proto3 `optionals`. This splits that handling.
- Suffixes with a `-` in them, such as `rc-1`, were not properly handled.