### PR TITLE
Add tls config to client

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -552,8 +552,13 @@ func NewConfig(container appflag.Container) (*bufapp.Config, error) {
 
 // NewRegistryProvider creates a new registryv1alpha1apiclient.Provider.
 func NewRegistryProvider(ctx context.Context, container appflag.Container) (registryv1alpha1apiclient.Provider, error) {
+	config, err := NewConfig(container)
+	if err != nil {
+		return nil, err
+	}
 	client := http2client.NewClient(
 		http2client.WithObservability(),
+		http2client.WithTLSConfig(config.TLS),
 	)
 	options := []bufapiclient.RegistryProviderOption{
 		bufapiclient.RegistryProviderWithGRPC(),


### PR DESCRIPTION
This re-adds `NewConfig` and passes the `config.TLS` to the http client.

https://github.com/bufbuild/buf/commit/97f8a3e15a40d7ba14f4bd961e7f3479b4ce826d#diff-73cbaebe6766a371dfca1849d8942ec87a6e1e7b808634e5d97a3d146599770aL821-L824