### PR TITLE
add lang key to buf.plugin.yaml go config

### DIFF
--- a/private/bufpkg/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufpluginconfig/bufpluginconfig.go
@@ -45,6 +45,8 @@ type Runtime struct {
 
 // GoConfig is the configuration for a Go plugin.
 type GoConfig struct {
+	// The minimum Go version required by the plugin.
+	Lang string `json:"lang" yaml:"lang"`
 	Deps []struct {
 		Module  string `json:"module" yaml:"module"`
 		Version string `json:"version" yaml:"version"`

--- a/private/bufpkg/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufpluginconfig/bufpluginconfig_test.go
@@ -75,6 +75,7 @@ func TestParsePluginConfigGoYAML(t *testing.T) {
 			Deps:    []string{"java:v1.21.0"},
 			Runtime: Runtime{
 				Go: &GoConfig{
+					Lang: "1.18",
 					Deps: []struct {
 						Module  string `json:"module" yaml:"module"`
 						Version string `json:"version" yaml:"version"`

--- a/private/bufpkg/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -5,6 +5,7 @@ deps:
   - java:v1.21.0
 runtime:
   go:
+    lang: 1.18
     deps:
       - module: "google.golang.org/grpc"
         version: v1.32.0


### PR DESCRIPTION
add lang key for go version in buf.plugin.yaml to allow for go minimum version selection

[BSR-226](https://linear.app/bufbuild/issue/BSR-226/connect-go-plugin-and-requires-go118-go-mod)