### PR TITLE
Do not sort in place when converting breaking and lint configs to JSON

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -169,10 +169,12 @@ type idPathsJSON struct {
 func configToJSON(config *Config) *configJSON {
 	ignoreIDPathsJSON := make([]idPathsJSON, 0, len(config.IgnoreIDOrCategoryToRootPaths))
 	for ignoreID, rootPaths := range config.IgnoreIDOrCategoryToRootPaths {
-		sort.Strings(rootPaths)
+		rootPathsCopy := make([]string, len(rootPaths))
+		copy(rootPathsCopy, rootPaths)
+		sort.Strings(rootPathsCopy)
 		ignoreIDPathsJSON = append(ignoreIDPathsJSON, idPathsJSON{
 			ID:    ignoreID,
-			Paths: rootPaths,
+			Paths: rootPathsCopy,
 		})
 	}
 	sort.Slice(ignoreIDPathsJSON, func(i, j int) bool { return ignoreIDPathsJSON[i].ID < ignoreIDPathsJSON[j].ID })

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -176,13 +176,18 @@ func configToJSON(config *Config) *configJSON {
 		})
 	}
 	sort.Slice(ignoreIDPathsJSON, func(i, j int) bool { return ignoreIDPathsJSON[i].ID < ignoreIDPathsJSON[j].ID })
-	sort.Strings(config.Use)
-	sort.Strings(config.Except)
-	sort.Strings(config.IgnoreRootPaths)
+	// We should not be sorting in place for the config structure, since it will mutate the
+	// underlying config ordering.
+	use := config.Use
+	except := config.Except
+	ignoreRootPaths := config.IgnoreRootPaths
+	sort.Strings(use)
+	sort.Strings(except)
+	sort.Strings(ignoreRootPaths)
 	return &configJSON{
-		Use:                           config.Use,
-		Except:                        config.Except,
-		IgnoreRootPaths:               config.IgnoreRootPaths,
+		Use:                           use,
+		Except:                        except,
+		IgnoreRootPaths:               ignoreRootPaths,
 		IgnoreIDOrCategoryToRootPaths: ignoreIDPathsJSON,
 		IgnoreUnstablePackages:        config.IgnoreUnstablePackages,
 		Version:                       config.Version,

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreakingconfig/bufbreakingconfig.go
@@ -178,9 +178,12 @@ func configToJSON(config *Config) *configJSON {
 	sort.Slice(ignoreIDPathsJSON, func(i, j int) bool { return ignoreIDPathsJSON[i].ID < ignoreIDPathsJSON[j].ID })
 	// We should not be sorting in place for the config structure, since it will mutate the
 	// underlying config ordering.
-	use := config.Use
-	except := config.Except
-	ignoreRootPaths := config.IgnoreRootPaths
+	use := make([]string, len(config.Use))
+	copy(use, config.Use)
+	except := make([]string, len(config.Except))
+	copy(except, config.Except)
+	ignoreRootPaths := make([]string, len(config.IgnoreRootPaths))
+	copy(ignoreRootPaths, config.IgnoreRootPaths)
 	sort.Strings(use)
 	sort.Strings(except)
 	sort.Strings(ignoreRootPaths)

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -234,13 +234,18 @@ func configToJSON(config *Config) *configJSON {
 		})
 	}
 	sort.Slice(ignoreIDPathsJSON, func(i, j int) bool { return ignoreIDPathsJSON[i].ID < ignoreIDPathsJSON[j].ID })
-	sort.Strings(config.Use)
-	sort.Strings(config.Except)
-	sort.Strings(config.IgnoreRootPaths)
+	// We should not be sorting in place for the config structure, since it will mutate the
+	// underlying config ordering.
+	use := config.Use
+	except := config.Except
+	ignoreRootPaths := config.IgnoreRootPaths
+	sort.Strings(use)
+	sort.Strings(except)
+	sort.Strings(ignoreRootPaths)
 	return &configJSON{
-		Use:                                  config.Use,
-		Except:                               config.Except,
-		IgnoreRootPaths:                      config.IgnoreRootPaths,
+		Use:                                  use,
+		Except:                               except,
+		IgnoreRootPaths:                      ignoreRootPaths,
 		IgnoreIDOrCategoryToRootPaths:        ignoreIDPathsJSON,
 		EnumZeroValueSuffix:                  config.EnumZeroValueSuffix,
 		RPCAllowSameRequestResponse:          config.RPCAllowSameRequestResponse,

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -227,10 +227,12 @@ type idPathsJSON struct {
 func configToJSON(config *Config) *configJSON {
 	ignoreIDPathsJSON := make([]idPathsJSON, 0, len(config.IgnoreIDOrCategoryToRootPaths))
 	for ignoreID, rootPaths := range config.IgnoreIDOrCategoryToRootPaths {
-		sort.Strings(rootPaths)
+		rootPathsCopy := make([]string, len(rootPaths))
+		copy(rootPathsCopy, rootPaths)
+		sort.Strings(rootPathsCopy)
 		ignoreIDPathsJSON = append(ignoreIDPathsJSON, idPathsJSON{
 			ID:    ignoreID,
-			Paths: rootPaths,
+			Paths: rootPathsCopy,
 		})
 	}
 	sort.Slice(ignoreIDPathsJSON, func(i, j int) bool { return ignoreIDPathsJSON[i].ID < ignoreIDPathsJSON[j].ID })

--- a/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
+++ b/private/bufpkg/bufcheck/buflint/buflintconfig/buflintconfig.go
@@ -236,9 +236,12 @@ func configToJSON(config *Config) *configJSON {
 	sort.Slice(ignoreIDPathsJSON, func(i, j int) bool { return ignoreIDPathsJSON[i].ID < ignoreIDPathsJSON[j].ID })
 	// We should not be sorting in place for the config structure, since it will mutate the
 	// underlying config ordering.
-	use := config.Use
-	except := config.Except
-	ignoreRootPaths := config.IgnoreRootPaths
+	use := make([]string, len(config.Use))
+	copy(use, config.Use)
+	except := make([]string, len(config.Except))
+	copy(except, config.Except)
+	ignoreRootPaths := make([]string, len(config.IgnoreRootPaths))
+	copy(ignoreRootPaths, config.IgnoreRootPaths)
 	sort.Strings(use)
 	sort.Strings(except)
 	sort.Strings(ignoreRootPaths)


### PR DESCRIPTION
Currently, we create a deterministic JSON structure for breaking and
lint configs for the `b3` digest. However, we should not be sorting
in-place when creating these structures, since it mutates the underlying
configs. Instead, we should be creating a copy.
