### PR TITLE
Define pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,17 +2,17 @@
   name: buf breaking
   language: golang
   entry: buf breaking
-  files: '\.proto$'
+  types: [proto]
   pass_filenames: false
 - id: buf-lint
   name: buf lint
   language: golang
   entry: buf lint
-  files: '\.proto$'
+  types: [proto]
   pass_filenames: false
 - id: buf-format
   name: buf format
   language: golang
   entry: buf format -w --exit-code
-  files: '\.proto$'
+  types: [proto]
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,18 +2,17 @@
   name: buf breaking
   language: golang
   entry: buf breaking
-  # match files ending in .proto,
-  files: &protofiles '[^/]+\.proto$'
+  files: '\.proto$'
   pass_filenames: false
 - id: buf-lint
   name: buf lint
   language: golang
   entry: buf lint
-  files: *protofiles
+  files: '\.proto$'
   pass_filenames: false
 - id: buf-format
   name: buf format
   language: golang
   entry: buf format -w --exit-code
-  files: *protofiles
+  files: '\.proto$'
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,19 @@
+- id: buf-breaking
+  name: buf breaking
+  language: golang
+  entry: buf breaking proto
+  # match files ending in .proto, .protobuf, or .pb
+  files: &protofiles '\.(?:proto(?:buf)?|pb)$'
+  pass_filenames: false
+- id: buf-lint
+  name: buf lint
+  language: golang
+  entry: buf lint
+  files: *protofiles
+  pass_filenames: false
+- id: buf-format
+  name: buf format
+  language: golang
+  entry: buf format -w --exit-code
+  files: *protofiles
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,9 @@
 - id: buf-breaking
   name: buf breaking
   language: golang
-  entry: buf breaking proto
-  # match files ending in .proto, .protobuf, or .pb
-  files: &protofiles '\.(?:proto(?:buf)?|pb)$'
+  entry: buf breaking
+  # match files ending in .proto,
+  files: &protofiles '[^/]+\.proto$'
   pass_filenames: false
 - id: buf-lint
   name: buf lint


### PR DESCRIPTION
Addresses #1077 .

---

Define official pre-commit hooks so users can reference the buf hooks directly.

For `buf lint` and `buf format`, given a standard configuration (i.e. a `buf.yaml` or `buf.work.yaml` in the repo root), zero-arg invocations should function.

```yaml
repos:
  - repo: https://github.com/bufbuild/buf
    hooks:
      - id: buf-lint
      - id: buf-format
```

Breaking change detection requires a previous version to compare against, which typically is not included in the source repository. Thus, `buf breaking` needs additional configuration to function properly.

Users with `buf.yaml` or `buf.work.yaml` not in the repo root need to specify the directory in the `args` list. Similarly, any custom arguments should be specified in the `args` list. Multiple instances can be specified if there are multiple buf yaml files that need to be run- and in this case, the `files` filter should be updated to only contain proto files contained by each yaml file.

For example[^1]:

[^1]: example courtesy of @lrewega

```yaml
repos:
  - repo: https://github.com/bufbuild/buf
    hooks:
      - id: lint
        files: ^path/to/workspace/.*\.proto$
        args: [path/to/workspace/buf.work.yaml, --error-format=json]
      - id: lint
        files: ^other/path/.*\.proto$
        args: [other/path/buf.work.yaml, --error-format=json]
```