### PR TITLE
Update to pass make with Golang 1.19

### DIFF
--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -789,10 +789,11 @@ type GetBucketOption func(*getBucketOptions)
 //
 // The terminateFileNames are expected to be valid and have no slashes.
 // Example of terminateFileNames:
-// 	[][]string{
-// 		[]string{"buf.work.yaml", "buf.work"},
-// 		[]string{"buf.yaml", "buf.mod"},
-// 	}.
+//
+//	[][]string{
+//		[]string{"buf.work.yaml", "buf.work"},
+//		[]string{"buf.yaml", "buf.mod"},
+//	}.
 func WithGetBucketTerminateFileNames(terminateFileNames [][]string) GetBucketOption {
 	return func(getBucketOptions *getBucketOptions) {
 		getBucketOptions.terminateFileNames = terminateFileNames

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -145,16 +145,15 @@ func (f *formatter) writeFile(fileNode *ast.FileNode) {
 //
 // For example,
 //
-//  syntax = "proto3";
+//	syntax = "proto3";
 //
-//  package acme.v1.weather;
+//	package acme.v1.weather;
 //
-//  import "acme/payment/v1/payment.proto";
-//  import "google/type/datetime.proto";
+//	import "acme/payment/v1/payment.proto";
+//	import "google/type/datetime.proto";
 //
-//  option cc_enable_arenas = true;
-//  option optimize_for = SPEED;
-//
+//	option cc_enable_arenas = true;
+//	option optimize_for = SPEED;
 func (f *formatter) writeFileHeader(fileNode *ast.FileNode) {
 	var (
 		packageNode *ast.PackageNode
@@ -263,8 +262,7 @@ func (f *formatter) writeFileTypes(fileNode *ast.FileNode) {
 //
 // For example,
 //
-//  syntax = "proto3";
-//
+//	syntax = "proto3";
 func (f *formatter) writeSyntax(syntaxNode *ast.SyntaxNode) {
 	f.writeStart(syntaxNode.Keyword)
 	f.Space()
@@ -278,8 +276,7 @@ func (f *formatter) writeSyntax(syntaxNode *ast.SyntaxNode) {
 //
 // For example,
 //
-//  package acme.weather.v1;
-//
+//	package acme.weather.v1;
 func (f *formatter) writePackage(packageNode *ast.PackageNode) {
 	f.writeStart(packageNode.Keyword)
 	f.Space()
@@ -291,8 +288,7 @@ func (f *formatter) writePackage(packageNode *ast.PackageNode) {
 //
 // For example,
 //
-//  import "google/protobuf/descriptor.proto";
-//
+//	import "google/protobuf/descriptor.proto";
 func (f *formatter) writeImport(importNode *ast.ImportNode) {
 	// We don't use f.writeStart here because the imports are sorted
 	// and potentially changed order.
@@ -340,8 +336,7 @@ func (f *formatter) writeFileOption(optionNode *ast.OptionNode) {
 //
 // For example,
 //
-//  option go_package = "github.com/foo/bar";
-//
+//	option go_package = "github.com/foo/bar";
 func (f *formatter) writeOption(optionNode *ast.OptionNode) {
 	f.writeOptionPrefix(optionNode)
 	if optionNode.Semicolon != nil {
@@ -366,11 +361,10 @@ func (f *formatter) writeOption(optionNode *ast.OptionNode) {
 //
 // For example,
 //
-//  [
-//    deprecated = true,
-//    json_name = "something" // Trailing comment on the last element.
-//  ]
-//
+//	[
+//	  deprecated = true,
+//	  json_name = "something" // Trailing comment on the last element.
+//	]
 func (f *formatter) writeLastCompactOption(optionNode *ast.OptionNode) {
 	f.writeOptionPrefix(optionNode)
 	f.writeLineEnd(optionNode.Val)
@@ -381,8 +375,7 @@ func (f *formatter) writeLastCompactOption(optionNode *ast.OptionNode) {
 //
 // For example,
 //
-//  deprecated =
-//
+//	deprecated =
 func (f *formatter) writeOptionPrefix(optionNode *ast.OptionNode) {
 	if optionNode.Keyword != nil {
 		// Compact options don't have the keyword.
@@ -407,10 +400,9 @@ func (f *formatter) writeOptionPrefix(optionNode *ast.OptionNode) {
 //
 // For example,
 //
-//  go_package
-//  (custom.thing)
-//  (custom.thing).bridge.(another.thing)
-//
+//	go_package
+//	(custom.thing)
+//	(custom.thing).bridge.(another.thing)
 func (f *formatter) writeOptionName(optionNameNode *ast.OptionNameNode) {
 	for i := 0; i < len(optionNameNode.Parts); i++ {
 		if i == 0 {
@@ -442,25 +434,24 @@ func (f *formatter) writeOptionName(optionNameNode *ast.OptionNameNode) {
 //
 // For example,
 //
-//  message Foo {
-//    option deprecated = true;
-//    reserved 50 to 100;
-//    extensions 150 to 200;
+//	message Foo {
+//	  option deprecated = true;
+//	  reserved 50 to 100;
+//	  extensions 150 to 200;
 //
-//    message Bar {
-//      string name = 1;
-//    }
-//    enum Baz {
-//      BAZ_UNSPECIFIED = 0;
-//    }
-//    extend Bar {
-//      string value = 2;
-//    }
+//	  message Bar {
+//	    string name = 1;
+//	  }
+//	  enum Baz {
+//	    BAZ_UNSPECIFIED = 0;
+//	  }
+//	  extend Bar {
+//	    string value = 2;
+//	  }
 //
-//    Bar bar = 1;
-//    Baz baz = 2;
-//  }
-//
+//	  Bar bar = 1;
+//	  Baz baz = 2;
+//	}
 func (f *formatter) writeMessage(messageNode *ast.MessageNode) {
 	var elementWriterFunc func()
 	if len(messageNode.Decls) != 0 {
@@ -487,16 +478,16 @@ func (f *formatter) writeMessage(messageNode *ast.MessageNode) {
 // writeMessageLiteral writes a message literal.
 //
 // For example,
-//  {
-//    foo: 1
-//    foo: 2
-//    foo: 3
-//    bar: <
-//      name:"abc"
-//      id:123
-//    >
-//  }
 //
+//	{
+//	  foo: 1
+//	  foo: 2
+//	  foo: 3
+//	  bar: <
+//	    name:"abc"
+//	    id:123
+//	  >
+//	}
 func (f *formatter) writeMessageLiteral(messageLiteralNode *ast.MessageLiteralNode) {
 	var elementWriterFunc func()
 	if len(messageLiteralNode.Elements) > 0 {
@@ -536,9 +527,8 @@ func (f *formatter) writeMessageLiteralForArray(
 //
 // For example,
 //
-//  foo: 1
-//  foo: 2
-//
+//	foo: 1
+//	foo: 2
 func (f *formatter) writeMessageLiteralElements(messageLiteralNode *ast.MessageLiteralNode) {
 	for i := 0; i < len(messageLiteralNode.Elements); i++ {
 		if i > 0 {
@@ -573,8 +563,7 @@ func (f *formatter) writeMessageFieldWithSeparator(messageFieldNode *ast.Message
 //
 // For example,
 //
-//  foo:"bar"
-//
+//	foo:"bar"
 func (f *formatter) writeMessageFieldPrefix(messageFieldNode *ast.MessageFieldNode) {
 	// The comments need to be written as a multiline comment above
 	// the message field name.
@@ -607,13 +596,12 @@ func (f *formatter) writeMessageFieldPrefix(messageFieldNode *ast.MessageFieldNo
 //
 // For example,
 //
-//  enum Foo {
-//    option deprecated = true;
-//    reserved 1 to 5;
+//	enum Foo {
+//	  option deprecated = true;
+//	  reserved 1 to 5;
 //
-//    FOO_UNSPECIFIED = 0;
-//  }
-//
+//	  FOO_UNSPECIFIED = 0;
+//	}
 func (f *formatter) writeEnum(enumNode *ast.EnumNode) {
 	var elementWriterFunc func()
 	if len(enumNode.Decls) > 0 {
@@ -642,10 +630,9 @@ func (f *formatter) writeEnum(enumNode *ast.EnumNode) {
 //
 // For example,
 //
-//  FOO_UNSPECIFIED = 1 [
-//    deprecated = true
-//  ];
-//
+//	FOO_UNSPECIFIED = 1 [
+//	  deprecated = true
+//	];
 func (f *formatter) writeEnumValue(enumValueNode *ast.EnumValueNode) {
 	f.writeStart(enumValueNode.Name)
 	f.Space()
@@ -664,11 +651,10 @@ func (f *formatter) writeEnumValue(enumValueNode *ast.EnumValueNode) {
 //
 // For example,
 //
-//  repeated string name = 1 [
-//    deprecated = true,
-//    json_name = "name"
-//  ];
-//
+//	repeated string name = 1 [
+//	  deprecated = true,
+//	  json_name = "name"
+//	];
 func (f *formatter) writeField(fieldNode *ast.FieldNode) {
 	// We need to handle the comments for the field label specially since
 	// a label might not be defined, but it has the leading comments attached
@@ -741,9 +727,9 @@ func (f *formatter) writeFieldReference(fieldReferenceNode *ast.FieldReferenceNo
 //
 // For example,
 //
-//  extend google.protobuf.FieldOptions {
-//    bool redacted = 33333;
-//  }
+//	extend google.protobuf.FieldOptions {
+//	  bool redacted = 33333;
+//	}
 func (f *formatter) writeExtend(extendNode *ast.ExtendNode) {
 	var elementWriterFunc func()
 	if len(extendNode.Decls) > 0 {
@@ -771,11 +757,10 @@ func (f *formatter) writeExtend(extendNode *ast.ExtendNode) {
 //
 // For example,
 //
-//  service FooService {
-//    option deprecated = true;
+//	service FooService {
+//	  option deprecated = true;
 //
-//    rpc Foo(FooRequest) returns (FooResponse) {};
-//
+//	  rpc Foo(FooRequest) returns (FooResponse) {};
 func (f *formatter) writeService(serviceNode *ast.ServiceNode) {
 	var elementWriterFunc func()
 	if len(serviceNode.Decls) > 0 {
@@ -804,10 +789,9 @@ func (f *formatter) writeService(serviceNode *ast.ServiceNode) {
 //
 // For example,
 //
-//  rpc Foo(FooRequest) returns (FooResponse) {
-//    option deprecated = true;
-//  };
-//
+//	rpc Foo(FooRequest) returns (FooResponse) {
+//	  option deprecated = true;
+//	};
 func (f *formatter) writeRPC(rpcNode *ast.RPCNode) {
 	var elementWriterFunc func()
 	if len(rpcNode.Decls) > 0 {
@@ -860,13 +844,12 @@ func (f *formatter) writeRPCType(rpcTypeNode *ast.RPCTypeNode) {
 //
 // For example,
 //
-//  oneof foo {
-//    option deprecated = true;
+//	oneof foo {
+//	  option deprecated = true;
 //
-//    string name = 1;
-//    int number = 2;
-//  }
-//
+//	  string name = 1;
+//	  int number = 2;
+//	}
 func (f *formatter) writeOneOf(oneOfNode *ast.OneOfNode) {
 	var elementWriterFunc func()
 	if len(oneOfNode.Decls) > 0 {
@@ -894,14 +877,13 @@ func (f *formatter) writeOneOf(oneOfNode *ast.OneOfNode) {
 //
 // For example,
 //
-//  optional group Key = 4 [
-//    deprecated = true,
-//    json_name = "key"
-//  ] {
-//    optional uint64 id = 1;
-//    optional string name = 2;
-//  }
-//
+//	optional group Key = 4 [
+//	  deprecated = true,
+//	  json_name = "key"
+//	] {
+//	  optional uint64 id = 1;
+//	  optional string name = 2;
+//	}
 func (f *formatter) writeGroup(groupNode *ast.GroupNode) {
 	var elementWriterFunc func()
 	if len(groupNode.Decls) > 0 {
@@ -948,10 +930,9 @@ func (f *formatter) writeGroup(groupNode *ast.GroupNode) {
 //
 // For example,
 //
-//  extensions 5-10, 100 to max [
-//    deprecated = true
-//  ];
-//
+//	extensions 5-10, 100 to max [
+//	  deprecated = true
+//	];
 func (f *formatter) writeExtensionRange(extensionRangeNode *ast.ExtensionRangeNode) {
 	f.writeStart(extensionRangeNode.Keyword)
 	f.Space()
@@ -974,8 +955,7 @@ func (f *formatter) writeExtensionRange(extensionRangeNode *ast.ExtensionRangeNo
 //
 // For example,
 //
-//  reserved 5-10, 100 to max;
-//
+//	reserved 5-10, 100 to max;
 func (f *formatter) writeReserved(reservedNode *ast.ReservedNode) {
 	f.writeStart(reservedNode.Keyword)
 	// Either names or ranges will be set, but never both.
@@ -1024,11 +1004,10 @@ func (f *formatter) writeRange(rangeNode *ast.RangeNode) {
 //
 // For example,
 //
-//  [
-//    deprecated = true,
-//    json_name = "something"
-//  ]
-//
+//	[
+//	  deprecated = true,
+//	  json_name = "something"
+//	]
 func (f *formatter) writeCompactOptions(compactOptionsNode *ast.CompactOptionsNode) {
 	if len(compactOptionsNode.Options) == 1 {
 		// If there's only a single compact option without comments, we can write it in-line.
@@ -1097,11 +1076,10 @@ func (f *formatter) writeCompactOptions(compactOptionsNode *ast.CompactOptionsNo
 //
 // For example,
 //
-//  [
-//    "foo",
-//    "bar"
-//  ]
-//
+//	[
+//	  "foo",
+//	  "bar"
+//	]
 func (f *formatter) writeArrayLiteral(arrayLiteralNode *ast.ArrayLiteralNode) {
 	var elementWriterFunc func()
 	if len(arrayLiteralNode.Elements) > 0 {
@@ -1144,14 +1122,14 @@ func (f *formatter) writeArrayLiteral(arrayLiteralNode *ast.ArrayLiteralNode) {
 //
 // For example,
 //
-//  option (value) = /* In-line comment for '-42' */ -42;
+//	option (value) = /* In-line comment for '-42' */ -42;
 //
-//  option (thing) = {
-//    values: [
-//      // Leading comment on -42.
-//      -42, // Trailing comment on -42.
-//    ]
-//  }
+//	option (thing) = {
+//	  values: [
+//	    // Leading comment on -42.
+//	    -42, // Trailing comment on -42.
+//	  ]
+//	}
 //
 // The lastElement boolean is used to signal whether or not the composite value
 // should be written as the last element (i.e. it doesn't have a trailing comma).
@@ -1319,11 +1297,10 @@ func (f *formatter) writeCompoundIdent(compoundIdentNode *ast.CompoundIdentNode)
 //
 // For example,
 //
-//  message Foo {
-//    // These are comments attached to bar.
-//    bar.v1.Bar bar = 1;
-//  }
-//
+//	message Foo {
+//	  // These are comments attached to bar.
+//	  bar.v1.Bar bar = 1;
+//	}
 func (f *formatter) writeCompountIdentForFieldName(compoundIdentNode *ast.CompoundIdentNode) {
 	if compoundIdentNode.LeadingDot != nil {
 		f.writeStart(compoundIdentNode.LeadingDot)
@@ -1345,10 +1322,9 @@ func (f *formatter) writeCompountIdentForFieldName(compoundIdentNode *ast.Compou
 //
 // For example,
 //
-//  optional
-//  repeated
-//  required
-//
+//	optional
+//	repeated
+//	required
 func (f *formatter) writeFieldLabel(fieldLabel ast.FieldLabel) {
 	f.WriteString(fieldLabel.Val)
 }
@@ -1362,10 +1338,9 @@ func (f *formatter) writeBoolLiteral(boolLiteralNode *ast.BoolLiteralNode) {
 //
 // For example,
 //
-//  "one,"
-//  "two,"
-//  "three"
-//
+//	"one,"
+//	"two,"
+//	"three"
 func (f *formatter) writeCompoundStringLiteral(compoundStringLiteralNode *ast.CompoundStringLiteralNode) {
 	f.In()
 	for _, child := range compoundStringLiteralNode.Children() {
@@ -1387,11 +1362,10 @@ func (f *formatter) writeCompoundStringLiteral(compoundStringLiteralNode *ast.Co
 //
 // For example,
 //
-//  option (custom) =
-//    "one,"
-//    "two,"
-//    "three";
-//
+//	option (custom) =
+//	  "one,"
+//	  "two,"
+//	  "three";
 func (f *formatter) writeCompoundStringLiteralForSingleOption(compoundStringLiteralNode *ast.CompoundStringLiteralNode) {
 	f.In()
 	for i, child := range compoundStringLiteralNode.Children() {
@@ -1643,24 +1617,24 @@ func (f *formatter) writeNode(node ast.Node) {
 //
 // For example,
 //
-//  // Leading comment on 'message'.
-//  // Spread across multiple lines.
-//  message /* This is a trailing comment on 'message' */ Foo {}
+//	// Leading comment on 'message'.
+//	// Spread across multiple lines.
+//	message /* This is a trailing comment on 'message' */ Foo {}
 //
 // Newlines are preserved, so that any logical grouping of elements
 // is maintained in the formatted result.
 //
 // For example,
 //
-//  // Type represents a set of different types.
-//  enum Type {
-//    // Unspecified is the naming convention for default enum values.
-//    TYPE_UNSPECIFIED = 0;
+//	// Type represents a set of different types.
+//	enum Type {
+//	  // Unspecified is the naming convention for default enum values.
+//	  TYPE_UNSPECIFIED = 0;
 //
-//    // The following elements are the real values.
-//    TYPE_ONE = 1;
-//    TYPE_TWO = 2;
-//  }
+//	  // The following elements are the real values.
+//	  TYPE_ONE = 1;
+//	  TYPE_TWO = 2;
+//	}
 //
 // Start nodes are always indented according to the formatter's
 // current level of indentation (e.g. nested messages, fields, etc).
@@ -1743,9 +1717,8 @@ func (f *formatter) writeStart(node ast.Node) {
 //
 // For example,
 //
-//  // This is a leading comment on the syntax keyword.
-//  syntax = /* This is a leading comment on 'proto3' */" proto3";
-//
+//	// This is a leading comment on the syntax keyword.
+//	syntax = /* This is a leading comment on 'proto3' */" proto3";
 func (f *formatter) writeInline(node ast.Node) {
 	if _, ok := node.(ast.CompositeNode); ok {
 		// We only want to write comments for terminal nodes.
@@ -1779,12 +1752,11 @@ func (f *formatter) writeInline(node ast.Node) {
 //
 // For example,
 //
-//  message Foo {
-//    string bar = 1;
+//	message Foo {
+//	  string bar = 1;
 //
-//  // Leading comment on '}'.
-//  } // Trailing comment on '}.
-//
+//	// Leading comment on '}'.
+//	} // Trailing comment on '}.
 func (f *formatter) writeBodyEnd(node ast.Node) {
 	if _, ok := node.(ast.CompositeNode); ok {
 		// We only want to write comments for terminal nodes.
@@ -1824,14 +1796,13 @@ func (f *formatter) writeBodyEnd(node ast.Node) {
 //
 // For example,
 //
-//  message Foo {
-//    string bar = 1 [
-//      deprecated = true
+//	message Foo {
+//	  string bar = 1 [
+//	    deprecated = true
 //
-//    // Leading comment on ']'.
-//    ] /* Trailing comment on ']' */ ;
-//  }
-//
+//	  // Leading comment on ']'.
+//	  ] /* Trailing comment on ']' */ ;
+//	}
 func (f *formatter) writeBodyEndInline(node ast.Node) {
 	if _, ok := node.(ast.CompositeNode); ok {
 		// We only want to write comments for terminal nodes.
@@ -1862,9 +1833,8 @@ func (f *formatter) writeBodyEndInline(node ast.Node) {
 //
 // For example,
 //
-//  // This is a leading comment on the syntax keyword.
-//  syntax = " proto3" /* This is a leading comment on the ';'; // This is a trailing comment on the ';'.
-//
+//	// This is a leading comment on the syntax keyword.
+//	syntax = " proto3" /* This is a leading comment on the ';'; // This is a trailing comment on the ';'.
 func (f *formatter) writeLineEnd(node ast.Node) {
 	if _, ok := node.(ast.CompositeNode); ok {
 		// We only want to write comments for terminal nodes.
@@ -1891,10 +1861,9 @@ func (f *formatter) writeLineEnd(node ast.Node) {
 //
 // For example,
 //
-//  // This is a comment spread across
-//  // multiple lines.
-//  message Foo {}
-//
+//	// This is a comment spread across
+//	// multiple lines.
+//	message Foo {}
 func (f *formatter) writeMultilineComments(comments ast.Comments) {
 	var previousComment ast.Comment
 	for i := 0; i < comments.Len(); i++ {
@@ -1932,18 +1901,17 @@ func (f *formatter) writeMultilineComments(comments ast.Comments) {
 //
 // For example, given the following:
 //
-//  extend . google. // in-line comment
-//   protobuf .
-//    ExtensionRangeOptions {
-//     optional string label = 20000;
-//    }
+//	extend . google. // in-line comment
+//	 protobuf .
+//	  ExtensionRangeOptions {
+//	   optional string label = 20000;
+//	  }
 //
 // The formatted result is shown below:
 //
-//  extend .google.protobuf./* in-line comment */ExtensionRangeOptions {
-//    optional string label = 20000;
-//  }
-//
+//	extend .google.protobuf./* in-line comment */ExtensionRangeOptions {
+//	  optional string label = 20000;
+//	}
 func (f *formatter) writeInlineComments(comments ast.Comments) {
 	for i := 0; i < comments.Len(); i++ {
 		if i > 0 {
@@ -1968,12 +1936,11 @@ func (f *formatter) writeInlineComments(comments ast.Comments) {
 //
 // For example,
 //
-//  enum Type {
-//    TYPE_UNSPECIFIED = 0;
-//  }
-//  // This comment is attached to the '}'
-//  // So is this one.
-//
+//	enum Type {
+//	  TYPE_UNSPECIFIED = 0;
+//	}
+//	// This comment is attached to the '}'
+//	// So is this one.
 func (f *formatter) writeTrailingEndComments(comments ast.Comments) {
 	for i := 0; i < comments.Len(); i++ {
 		comment := comments.Index(i)
@@ -2010,10 +1977,9 @@ func (f *formatter) startsWithNewline(info ast.NodeInfo) bool {
 //
 // For example,
 //
-//  message Foo {
-//    string name = 1; // Like this.
-//  }
-//
+//	message Foo {
+//	  string name = 1; // Like this.
+//	}
 func (f *formatter) hasTrailingComment(node ast.Node) bool {
 	if node == nil {
 		return false

--- a/private/buf/bufwork/bufwork.go
+++ b/private/buf/bufwork/bufwork.go
@@ -29,27 +29,27 @@
 // `import "acme/payment/v2/payment.proto";` from the acme/pet/v1/pet.proto file
 // will suffice as long as the buf.work.yaml file exists.
 //
-//   // buf.work.yaml
-//   version: v1
-//   directories:
-//     - paymentapis
-//     - petapis
+//	// buf.work.yaml
+//	version: v1
+//	directories:
+//	  - paymentapis
+//	  - petapis
 //
-//   $ tree
-//   .
-//   ├── buf.work.yaml
-//   ├── paymentapis
-//   │   ├── acme
-//   │   │   └── payment
-//   │   │       └── v2
-//   │   │           └── payment.proto
-//   │   └── buf.yaml
-//   └── petapis
-//       ├── acme
-//       │   └── pet
-//       │       └── v1
-//       │           └── pet.proto
-//       └── buf.yaml
+//	$ tree
+//	.
+//	├── buf.work.yaml
+//	├── paymentapis
+//	│   ├── acme
+//	│   │   └── payment
+//	│   │       └── v2
+//	│   │           └── payment.proto
+//	│   └── buf.yaml
+//	└── petapis
+//	    ├── acme
+//	    │   └── pet
+//	    │       └── v1
+//	    │           └── pet.proto
+//	    └── buf.yaml
 //
 // Note that inputs MUST NOT overlap with any of the directories defined in the buf.work.yaml
 // file. For example, it's not possible to build input "paymentapis/acme" since the image

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -223,9 +223,9 @@ func validateWorkspaceDirectoryNonEmpty(
 // overlap in either direction. The last argument is only used for
 // error reporting.
 //
-//  validateInputOverlap("foo", "bar", "buf.work.yaml")     -> OK
-//  validateInputOverlap("foo/bar", "foo", "buf.work.yaml") -> NOT OK
-//  validateInputOverlap("foo", "foo/bar", "buf.work.yaml") -> NOT OK
+//	validateInputOverlap("foo", "bar", "buf.work.yaml")     -> OK
+//	validateInputOverlap("foo/bar", "foo", "buf.work.yaml") -> NOT OK
+//	validateInputOverlap("foo", "foo/bar", "buf.work.yaml") -> NOT OK
 func validateInputOverlap(
 	workspaceDirectory string,
 	targetSubDirPath string,

--- a/private/buf/cmd/buf/command/alpha/protoc/flags_unix.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/flags_unix.go
@@ -22,12 +22,12 @@ package protoc
 // This is always true in unix, and is true if the path is not absolute in windows.
 // This is needed because i.e.:
 //
-//   # unix
-//   --go_out=opt:foo/bar
-//   --go_out=foo/bar
-//   # windows
-//   --go_out=opt:C:\foo\bar
-//   --go_out=C:\foo\bar
+//	# unix
+//	--go_out=opt:foo/bar
+//	--go_out=foo/bar
+//	# windows
+//	--go_out=opt:C:\foo\bar
+//	--go_out=C:\foo\bar
 //
 // protoc uses : in both unix and windows to separate the opt and out, but in windows,
 // if a full path is given, then we don't want it interpreted as something we should split.

--- a/private/buf/cmd/buf/command/alpha/protoc/flags_windows.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/flags_windows.go
@@ -26,12 +26,12 @@ import (
 // This is always true in unix, and is true if the path is not absolute in windows.
 // This is needed because i.e.:
 //
-//   # unix
-//   --go_out=opt:foo/bar
-//   --go_out=foo/bar
-//   # windows
-//   --go_out=opt:C:\foo\bar
-//   --go_out=C:\foo\bar
+//	# unix
+//	--go_out=opt:foo/bar
+//	--go_out=foo/bar
+//	# windows
+//	--go_out=opt:C:\foo\bar
+//	--go_out=C:\foo\bar
 //
 // protoc uses : in both unix and windows to separate the opt and out, but in windows,
 // if a full path is given, then we don't want it interpreted as something we should split.

--- a/private/bufpkg/bufanalysis/bufanalysis.go
+++ b/private/bufpkg/bufanalysis/bufanalysis.go
@@ -159,13 +159,13 @@ func NewFileAnnotation(
 //
 // The order of sorting is:
 //
-//   ExternalPath
-//   StartLine
-//   StartColumn
-//   Type
-//   Message
-//   EndLine
-//   EndColumn
+//	ExternalPath
+//	StartLine
+//	StartColumn
+//	Type
+//	Message
+//	EndLine
+//	EndColumn
 func SortFileAnnotations(fileAnnotations []FileAnnotation) {
 	sort.Stable(sortFileAnnotations(fileAnnotations))
 }

--- a/private/bufpkg/bufcheck/buflint/internal/buflintv1/buflintv1.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintv1/buflintv1.go
@@ -34,45 +34,45 @@ import "github.com/bufbuild/buf/private/bufpkg/bufcheck/internal"
 // is shown below:
 //
 // Removed:
-//  * FILE_LAYOUT
-//  * PACKAGE_AFFINITY
-//  * SENSIBLE
-//  * STYLE_BASIC
-//  * STYLE_DEFAULT
-//  * OTHER
+//   - FILE_LAYOUT
+//   - PACKAGE_AFFINITY
+//   - SENSIBLE
+//   - STYLE_BASIC
+//   - STYLE_DEFAULT
+//   - OTHER
 //
 // Thus, the only remaining categories are:
 //
 // Categories:
-//  * MINIMAL
-//  * BASIC
-//  * DEFAULT
-//  * COMMENTS
-//  * UNARY_RPC
+//   - MINIMAL
+//   - BASIC
+//   - DEFAULT
+//   - COMMENTS
+//   - UNARY_RPC
 //
 // The rules included in the MINIMAL lint category have also been adjusted.
 // The difference is shown below:
 //
 // Removed:
-//  * ENUM_NO_ALLOW_ALIAS
-//  * FIELD_NO_DESCRIPTOR
-//  * IMPORT_NO_PUBLIC
-//  * IMPORT_NO_WEAK
-//  * PACKAGE_SAME_CSHARP_NAMESPACE
-//  * PACKAGE_SAME_GO_PACKAGE
-//  * PACKAGE_SAME_JAVA_MULTIPLE_FILES
-//  * PACKAGE_SAME_JAVA_PACKAGE
-//  * PACKAGE_SAME_PHP_NAMESPACE
-//  * PACKAGE_SAME_RUBY_PACKAGE
-//  * PACKAGE_SAME_SWIFT_PREFIX
+//   - ENUM_NO_ALLOW_ALIAS
+//   - FIELD_NO_DESCRIPTOR
+//   - IMPORT_NO_PUBLIC
+//   - IMPORT_NO_WEAK
+//   - PACKAGE_SAME_CSHARP_NAMESPACE
+//   - PACKAGE_SAME_GO_PACKAGE
+//   - PACKAGE_SAME_JAVA_MULTIPLE_FILES
+//   - PACKAGE_SAME_JAVA_PACKAGE
+//   - PACKAGE_SAME_PHP_NAMESPACE
+//   - PACKAGE_SAME_RUBY_PACKAGE
+//   - PACKAGE_SAME_SWIFT_PREFIX
 //
 // With these changes applied, the final result of MINIMAL is:
 //
 // MINIMAL:
-//  * DIRECTORY_SAME_PACKAGE
-//  * PACKAGE_DEFINED
-//  * PACKAGE_DIRECTORY_MATCH
-//  * PACKAGE_SAME_DIRECTORY
+//   - DIRECTORY_SAME_PACKAGE
+//   - PACKAGE_DEFINED
+//   - PACKAGE_DIRECTORY_MATCH
+//   - PACKAGE_SAME_DIRECTORY
 var VersionSpec = &internal.VersionSpec{
 	RuleBuilders:      v1RuleBuilders,
 	DefaultCategories: v1DefaultCategories,

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -76,10 +76,10 @@ func NewFileOptionSweeper() Sweeper {
 // they are provided. This is particularly useful for constructing a modifier
 // from its initial 'nil' value.
 //
-//  var modifier Modifier
-//  if config.JavaMultipleFiles {
-//    modifier = Merge(modifier, JavaMultipleFiles)
-//  }
+//	var modifier Modifier
+//	if config.JavaMultipleFiles {
+//	  modifier = Merge(modifier, JavaMultipleFiles)
+//	}
 func Merge(left Modifier, right Modifier) Modifier {
 	if left == nil {
 		return right
@@ -226,10 +226,10 @@ func GoPackageImportPathForFile(imageFile bufimage.ImageFile, importPathPrefix s
 // ObjcClassPrefix returns a Modifier that sets the objc_class_prefix file option
 // according to the package name. It is set to the uppercase first letter of each package sub-name,
 // not including the package version, with the following rules:
-//  * If the resulting abbreviation is 2 characters, add "X".
-//  * If the resulting abbreviation is 1 character, add "XX".
-//  * If the resulting abbreviation is "GPB", change it to "GPX".
-//    "GPB" is reserved by Google for the Protocol Buffers implementation.
+//   - If the resulting abbreviation is 2 characters, add "X".
+//   - If the resulting abbreviation is 1 character, add "XX".
+//   - If the resulting abbreviation is "GPB", change it to "GPX".
+//     "GPB" is reserved by Google for the Protocol Buffers implementation.
 func ObjcClassPrefix(
 	logger *zap.Logger,
 	sweeper Sweeper,

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -85,60 +85,61 @@ func FreeMessageRangeStrings(
 // descriptor is needed to accurately and completely describe that descriptor.
 // For the follwing types that includes:
 //
-//    Messages
-//     - messages & enums referenced in fields
-//     - proto2 extension declarations for this field
-//     - custom options for the message, its fields, and the file in which the
-//       message is defined
-//     - the parent message if this message is a nested definition
+//	Messages
+//	 - messages & enums referenced in fields
+//	 - proto2 extension declarations for this field
+//	 - custom options for the message, its fields, and the file in which the
+//	   message is defined
+//	 - the parent message if this message is a nested definition
 //
-//    Enums
-//     - Custom options used in the enum, enum values, and the file
-//       in which the message is defined
-//     - the parent message if this message is a nested definition
+//	Enums
+//	 - Custom options used in the enum, enum values, and the file
+//	   in which the message is defined
+//	 - the parent message if this message is a nested definition
 //
-//    Services
-//     - request & response types referenced in methods
-//     - custom options for the service, its methods, and the file
-//       in which the message is defined
+//	Services
+//	 - request & response types referenced in methods
+//	 - custom options for the service, its methods, and the file
+//	   in which the message is defined
 //
 // As an example, consider the following proto structure:
 //
-//   --- foo.proto ---
-//   package pkg;
-//   message Foo {
-//     optional Bar bar = 1;
-//     extensions 2 to 3;
-//   }
-//   message Bar { ... }
-//   message Baz {
-//     other.Qux qux = 1 [(other.my_option).field = "buf"];
-//   }
-//   --- baz.proto ---
-//   package other;
-//   extend Foo {
-//     optional Qux baz = 2;
-//   }
-//   message Qux{ ... }
-//   message Quux{ ... }
-//   extend google.protobuf.FieldOptions {
-//     optional Quux my_option = 51234;
-//   }
+//	--- foo.proto ---
+//	package pkg;
+//	message Foo {
+//	  optional Bar bar = 1;
+//	  extensions 2 to 3;
+//	}
+//	message Bar { ... }
+//	message Baz {
+//	  other.Qux qux = 1 [(other.my_option).field = "buf"];
+//	}
+//	--- baz.proto ---
+//	package other;
+//	extend Foo {
+//	  optional Qux baz = 2;
+//	}
+//	message Qux{ ... }
+//	message Quux{ ... }
+//	extend google.protobuf.FieldOptions {
+//	  optional Quux my_option = 51234;
+//	}
 //
 // A filtered image for type `pkg.Foo` would include
-//   files:      [foo.proto, bar.proto]
-//   messages:   [pkg.Foo, pkg.Bar, other.Qux]
-//   extensions: [other.baz]
+//
+//	files:      [foo.proto, bar.proto]
+//	messages:   [pkg.Foo, pkg.Bar, other.Qux]
+//	extensions: [other.baz]
 //
 // A filtered image for type `pkg.Bar` would include
-//   files:      [foo.proto]
-//   messages:   [pkg.Bar]
 //
-//  A filtered image for type `pkg.Baz` would include
-//   files:      [foo.proto, bar.proto]
-//   messages:   [pkg.Baz, other.Quux, other.Qux]
-//   extensions: [other.my_option]
+//	 files:      [foo.proto]
+//	 messages:   [pkg.Bar]
 //
+//	A filtered image for type `pkg.Baz` would include
+//	 files:      [foo.proto, bar.proto]
+//	 messages:   [pkg.Baz, other.Quux, other.Qux]
+//	 extensions: [other.my_option]
 func ImageFilteredByTypes(image bufimage.Image, types ...string) (bufimage.Image, error) {
 	imageIndex, err := newImageIndexForImage(image)
 	if err != nil {

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -17,7 +17,7 @@ package bufimageutil
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"sort"
 	"testing"
 
@@ -209,7 +209,7 @@ func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedF
 
 	expectedReader, err := bucket.Get(ctx, expectedFile)
 	require.NoError(t, err)
-	expected, err := ioutil.ReadAll(expectedReader)
+	expected, err := io.ReadAll(expectedReader)
 	require.NoError(t, err)
 	assert.Equal(t, string(expected), string(generated))
 

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -63,13 +63,18 @@ type ModuleFile interface {
 // Terminology:
 //
 // Targets (Modules and ModuleFileSets):
-//   Just the files specified to build. This will either be sources, or will be specific files
-//   within sources, ie this is a subset of Sources. The difference between Targets and Sources happens
-//   when i.e. the --path flag is used.
+//
+//	Just the files specified to build. This will either be sources, or will be specific files
+//	within sources, ie this is a subset of Sources. The difference between Targets and Sources happens
+//	when i.e. the --path flag is used.
+//
 // Sources (Modules and ModuleFileSets):
-//   The files with no dependencies. This is a superset of Targets and subset of All.
+//
+//	The files with no dependencies. This is a superset of Targets and subset of All.
+//
 // All (ModuleFileSets only):
-//   All files including dependencies. This is a superset of Sources.
+//
+//	All files including dependencies. This is a superset of Sources.
 type Module interface {
 	// TargetFileInfos gets all FileInfos specified as target files. This is either
 	// all the FileInfos belonging to the module, or those specified by ModuleWithTargetPaths().
@@ -334,11 +339,11 @@ func ModuleToProtoModule(ctx context.Context, module Module) (*modulev1alpha1.Mo
 // ModuleDigestB1 returns the b1 digest for the Module.
 //
 // To create the module digest (SHA256):
-// 	1. For every file in the module (sorted lexicographically by path):
-// 		a. Add the file path
-//		b. Add the file contents
-// 	2. Add the dependency hashes (sorted lexicographically by the string representation)
-//	3. Produce the final digest by URL-base64 encoding the summed bytes and prefixing it with the digest prefix
+//  1. For every file in the module (sorted lexicographically by path):
+//     a. Add the file path
+//     b. Add the file contents
+//  2. Add the dependency hashes (sorted lexicographically by the string representation)
+//  3. Produce the final digest by URL-base64 encoding the summed bytes and prefixing it with the digest prefix
 func ModuleDigestB1(ctx context.Context, module Module) (string, error) {
 	hash := sha256.New()
 	// DependencyModulePins returns these sorted
@@ -392,14 +397,14 @@ func ModuleDigestB1(ctx context.Context, module Module) (string, error) {
 // ModuleDigestB3 returns the b3 digest for the Module.
 //
 // To create the module digest (SHA256):
-// 	1. For every file in the module (sorted lexicographically by path):
-// 		a. Add the file path
-// 		b. Add the file contents
-// 	2. Add the dependency's module identity and commit ID (sorted lexicographically by commit ID)
-// 	3. Add the module identity if available.
-// 	4. Add the module documentation if available.
-// 	5. Add the breaking and lint configurations if available.
-// 	6. Produce the final digest by URL-base64 encoding the summed bytes and prefixing it with the digest prefix
+//  1. For every file in the module (sorted lexicographically by path):
+//     a. Add the file path
+//     b. Add the file contents
+//  2. Add the dependency's module identity and commit ID (sorted lexicographically by commit ID)
+//  3. Add the module identity if available.
+//  4. Add the module documentation if available.
+//  5. Add the breaking and lint configurations if available.
+//  6. Produce the final digest by URL-base64 encoding the summed bytes and prefixing it with the digest prefix
 func ModuleDigestB3(ctx context.Context, module Module) (string, error) {
 	hash := sha256.New()
 	// We do not want to change the sort order as the rest of the codebase relies on it,

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -86,7 +86,7 @@ func testPlainPostHandler(t *testing.T, upstreamServer *httptest.Server) {
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, "https://example.buf.build", response.Header.Get("Access-Control-Allow-Origin"))
-	responseBytes, err := ioutil.ReadAll(response.Body)
+	responseBytes, err := io.ReadAll(response.Body)
 	assert.NoError(t, err)
 	invokeResponse := &studiov1alpha1.InvokeResponse{}
 	protoUnmarshalBase64(t, responseBytes, invokeResponse)
@@ -141,7 +141,7 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, response.StatusCode)
-		responseBytes, err := ioutil.ReadAll(response.Body)
+		responseBytes, err := io.ReadAll(response.Body)
 		assert.NoError(t, err)
 		invokeResponse := &studiov1alpha1.InvokeResponse{}
 		protoUnmarshalBase64(t, responseBytes, invokeResponse)

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/textproto"
@@ -103,7 +103,7 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "", http.StatusUnsupportedMediaType)
 		return
 	}
-	bodyBytes, err := ioutil.ReadAll(
+	bodyBytes, err := io.ReadAll(
 		base64.NewDecoder(
 			i.B64Encoding,
 			http.MaxBytesReader(w, r.Body, i.MaxMessageSizeBytes),

--- a/private/gen/proto/api/buf/alpha/registry/v1alpha1/registryv1alpha1api/resolve.pb.go
+++ b/private/gen/proto/api/buf/alpha/registry/v1alpha1/registryv1alpha1api/resolve.pb.go
@@ -49,13 +49,13 @@ type LocalResolveService interface {
 	//
 	// We want this for two reasons:
 	//
-	// 1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
-	//    While we could just do this in GetModulePins by being aware of what our remote is
-	//    (something we probably still need to know, DNS problems aside, which are more
-	//    theoretical), this helps.
-	// 2. Having a separate method makes us able to say "do not make decisions about what
-	//    wins between competing pins for the same repo". This should only be done in
-	//    GetModulePins, not in this function, i.e. only done at the top level.
+	//  1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
+	//     While we could just do this in GetModulePins by being aware of what our remote is
+	//     (something we probably still need to know, DNS problems aside, which are more
+	//     theoretical), this helps.
+	//  2. Having a separate method makes us able to say "do not make decisions about what
+	//     wins between competing pins for the same repo". This should only be done in
+	//     GetModulePins, not in this function, i.e. only done at the top level.
 	GetLocalModulePins(
 		ctx context.Context,
 		localModuleReferences []*v1alpha11.LocalModuleReference,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/resolve.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/resolve.pb.go
@@ -71,13 +71,13 @@ type localResolveServiceClient struct {
 //
 // We want this for two reasons:
 //
-// 1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
-//    While we could just do this in GetModulePins by being aware of what our remote is
-//    (something we probably still need to know, DNS problems aside, which are more
-//    theoretical), this helps.
-// 2. Having a separate method makes us able to say "do not make decisions about what
-//    wins between competing pins for the same repo". This should only be done in
-//    GetModulePins, not in this function, i.e. only done at the top level.
+//  1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
+//     While we could just do this in GetModulePins by being aware of what our remote is
+//     (something we probably still need to know, DNS problems aside, which are more
+//     theoretical), this helps.
+//  2. Having a separate method makes us able to say "do not make decisions about what
+//     wins between competing pins for the same repo". This should only be done in
+//     GetModulePins, not in this function, i.e. only done at the top level.
 func (s *localResolveServiceClient) GetLocalModulePins(
 	ctx context.Context,
 	localModuleReferences []*v1alpha11.LocalModuleReference,

--- a/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
+++ b/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
@@ -124,13 +124,13 @@ type LocalResolveServiceClient interface {
 	//
 	// We want this for two reasons:
 	//
-	// 1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
-	//    While we could just do this in GetModulePins by being aware of what our remote is
-	//    (something we probably still need to know, DNS problems aside, which are more
-	//    theoretical), this helps.
-	// 2. Having a separate method makes us able to say "do not make decisions about what
-	//    wins between competing pins for the same repo". This should only be done in
-	//    GetModulePins, not in this function, i.e. only done at the top level.
+	//  1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
+	//     While we could just do this in GetModulePins by being aware of what our remote is
+	//     (something we probably still need to know, DNS problems aside, which are more
+	//     theoretical), this helps.
+	//  2. Having a separate method makes us able to say "do not make decisions about what
+	//     wins between competing pins for the same repo". This should only be done in
+	//     GetModulePins, not in this function, i.e. only done at the top level.
 	GetLocalModulePins(context.Context, *connect_go.Request[v1alpha1.GetLocalModulePinsRequest]) (*connect_go.Response[v1alpha1.GetLocalModulePinsResponse], error)
 }
 
@@ -171,13 +171,13 @@ type LocalResolveServiceHandler interface {
 	//
 	// We want this for two reasons:
 	//
-	// 1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
-	//    While we could just do this in GetModulePins by being aware of what our remote is
-	//    (something we probably still need to know, DNS problems aside, which are more
-	//    theoretical), this helps.
-	// 2. Having a separate method makes us able to say "do not make decisions about what
-	//    wins between competing pins for the same repo". This should only be done in
-	//    GetModulePins, not in this function, i.e. only done at the top level.
+	//  1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
+	//     While we could just do this in GetModulePins by being aware of what our remote is
+	//     (something we probably still need to know, DNS problems aside, which are more
+	//     theoretical), this helps.
+	//  2. Having a separate method makes us able to say "do not make decisions about what
+	//     wins between competing pins for the same repo". This should only be done in
+	//     GetModulePins, not in this function, i.e. only done at the top level.
 	GetLocalModulePins(context.Context, *connect_go.Request[v1alpha1.GetLocalModulePinsRequest]) (*connect_go.Response[v1alpha1.GetLocalModulePinsResponse], error)
 }
 

--- a/private/pkg/app/appproto/appproto.go
+++ b/private/pkg/app/appproto/appproto.go
@@ -261,7 +261,7 @@ func NewResponseBuilder(container app.StderrContainer) ResponseBuilder {
 // and returns the leading whitespace substring, if any,
 // respecting utf-8 encoding.
 //
-//  leadingWhitespace("\u205F   foo ") -> "\u205F   "
+//	leadingWhitespace("\u205F   foo ") -> "\u205F   "
 func leadingWhitespace(buf []byte) []byte {
 	leadingSize := 0
 	iterBuf := buf

--- a/private/pkg/app/appproto/appprotoexec/appprotoexec.go
+++ b/private/pkg/app/appproto/appprotoexec/appprotoexec.go
@@ -110,11 +110,11 @@ func GenerateWithPluginPath(pluginPath string) GenerateOption {
 //
 // protocPath and pluginPath are optional.
 //
-// - If the plugin path is set, this returns a new binary handler for that path.
-// - If the plugin path is unset, this does exec.LookPath for a binary named protoc-gen-pluginName,
-//   and if one is found, a new binary handler is returned for this.
-// - Else, if the name is in ProtocProxyPluginNames, this returns a new protoc proxy handler.
-// - Else, this returns error.
+//   - If the plugin path is set, this returns a new binary handler for that path.
+//   - If the plugin path is unset, this does exec.LookPath for a binary named protoc-gen-pluginName,
+//     and if one is found, a new binary handler is returned for this.
+//   - Else, if the name is in ProtocProxyPluginNames, this returns a new protoc proxy handler.
+//   - Else, this returns error.
 func NewHandler(
 	logger *zap.Logger,
 	storageosProvider storageos.Provider,

--- a/private/pkg/storage/diff.go
+++ b/private/pkg/storage/diff.go
@@ -80,9 +80,11 @@ func DiffWithExternalPathPrefixes(
 
 // DiffWithTransform returns a DiffOption that adds a transform function. The transform function will be run on each
 // file being compared before it is diffed. transform takes the arguments:
-//  side: one or two whether it is the first or second item in the diff
-//  filename: the filename including path
-//  content: the file content.
+//
+//	side: one or two whether it is the first or second item in the diff
+//	filename: the filename including path
+//	content: the file content.
+//
 // transform returns a string that is the transformed content of filename.
 func DiffWithTransform(
 	transform func(side string, filename string, content []byte) []byte,

--- a/private/pkg/stringutil/stringutil.go
+++ b/private/pkg/stringutil/stringutil.go
@@ -177,7 +177,7 @@ func SliceToHumanString(s []string) string {
 	}
 }
 
-// SliceToHumanStringQuoted prints the slice as `"e1", "e2", and "e3"``.
+// SliceToHumanStringQuoted prints the slice as `"e1", "e2", and "e3"“.
 func SliceToHumanStringQuoted(s []string) string {
 	switch len(s) {
 	case 0:

--- a/private/pkg/stringutil/stringutil.go
+++ b/private/pkg/stringutil/stringutil.go
@@ -177,7 +177,7 @@ func SliceToHumanString(s []string) string {
 	}
 }
 
-// SliceToHumanStringQuoted prints the slice as `"e1", "e2", and "e3"“.
+// SliceToHumanStringQuoted prints the slice as `"e1", "e2", and "e3"`.
 func SliceToHumanStringQuoted(s []string) string {
 	switch len(s) {
 	case 0:

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -62,13 +62,13 @@ service LocalResolveService {
   //
   // We want this for two reasons:
   //
-  // 1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
-  //    While we could just do this in GetModulePins by being aware of what our remote is
-  //    (something we probably still need to know, DNS problems aside, which are more
-  //    theoretical), this helps.
-  // 2. Having a separate method makes us able to say "do not make decisions about what
-  //    wins between competing pins for the same repo". This should only be done in
-  //    GetModulePins, not in this function, i.e. only done at the top level.
+  //  1. It makes it easy to say "we know we're looking for owner/repo on this specific remote".
+  //     While we could just do this in GetModulePins by being aware of what our remote is
+  //     (something we probably still need to know, DNS problems aside, which are more
+  //     theoretical), this helps.
+  //  2. Having a separate method makes us able to say "do not make decisions about what
+  //     wins between competing pins for the same repo". This should only be done in
+  //     GetModulePins, not in this function, i.e. only done at the top level.
   rpc GetLocalModulePins(GetLocalModulePinsRequest) returns (GetLocalModulePinsResponse);
 }
 


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/SNruPJUSFz0/m/8QKkkMpJAAAJ

- `gofmt` has changed to deal with comments, this now formats the comments.
- `io/ioutil` is now a failing check with `staticcheck` - `ioutil.ReadAll` was deprecated and replaced with `io.ReadAll` in 1.16.

Otherwise, we're Golang 1.19 ready!