### PR TITLE
Add user-facing buf.plugin.yaml

### DIFF
--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -1,0 +1,205 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bufpluginconfig defines the buf.plugin.yaml file.
+package bufpluginconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+	"github.com/bufbuild/buf/private/pkg/encoding"
+	"github.com/bufbuild/buf/private/pkg/storage"
+)
+
+const (
+	// ExternalConfigFilePath is the default configuration file path for v1.
+	ExternalConfigFilePath = "buf.plugin.yaml"
+	// V1Version is the version string used to indicate the v1 version of the buf.plugin.yaml file.
+	V1Version = "v1"
+)
+
+var (
+	// AllConfigFilePaths are all acceptable config file paths without overrides.
+	//
+	// These are in the order we should check.
+	AllConfigFilePaths = []string{
+		ExternalConfigFilePath,
+	}
+)
+
+// Config is the plugin config.
+type Config struct {
+	// Name is the name of the plugin (e.g. 'buf.build/protocolbuffers/go').
+	Name bufpluginref.PluginIdentity
+	// Options is the set of options available to the plugin.
+	//
+	// For now, all options are string values. This could eventually
+	// support other types (like JSON Schema and Terraform variables),
+	// where strings are the default value unless otherwise specified.
+	//
+	// Note that some legacy plugins don't always express their options
+	// as key value pairs. For example, protoc-gen-java has an option
+	// that can be passed like so:
+	//
+	//  java_opt=annotate_code
+	//
+	// In those cases, the option value in this map will be set to
+	// the empty string, and the option will be propagated to the
+	// compiler without the '=' delimiter.
+	Options map[string]string
+	// Runtime is the runtime configuration, which lets the user specify
+	// runtime dependencies, and other metadata that applies to a specific
+	// remote generation registry (e.g. the Go module proxy, NPM registry,
+	// etc).
+	Runtime *RuntimeConfig
+}
+
+// RuntimeConfig is the configuration for the runtime of a plugin.
+//
+// Only one field will be set.
+type RuntimeConfig struct {
+	Go      *GoRuntimeConfig
+	NPM     *NPMRuntimeConfig
+	Archive *ArchiveRuntimeConfig
+}
+
+// GoRuntimeConfig is the runtime configuration for a Go plugin.
+type GoRuntimeConfig struct {
+	MinVersion string
+	Deps       []string
+}
+
+// NPMRuntimeConfig is the runtime configuration for a JavaScript NPM plugin.
+type NPMRuntimeConfig struct {
+	Deps []string
+}
+
+// ArchiveRuntimeConfig is the runtime configuration for a plugin that can be downloaded
+// as an archive instead of a language-specific registry.
+type ArchiveRuntimeConfig struct {
+	Deps []string
+}
+
+// GetConfigForBucket gets the Config for the YAML data at ConfigFilePath.
+//
+// If the data is of length 0, returns the default config.
+func GetConfigForBucket(ctx context.Context, readBucket storage.ReadBucket) (*Config, error) {
+	return getConfigForBucket(ctx, readBucket)
+}
+
+// GetConfigForData gets the Config for the given JSON or YAML data.
+//
+// If the data is of length 0, returns the default config.
+func GetConfigForData(ctx context.Context, data []byte) (*Config, error) {
+	return getConfigForData(ctx, data)
+}
+
+// ExistingConfigFilePath checks if a configuration file exists, and if so, returns the path
+// within the ReadBucket of this configuration file.
+//
+// Returns empty string and no error if no configuration file exists.
+func ExistingConfigFilePath(ctx context.Context, readBucket storage.ReadBucket) (string, error) {
+	for _, configFilePath := range AllConfigFilePaths {
+		exists, err := storage.Exists(ctx, readBucket, configFilePath)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			return configFilePath, nil
+		}
+	}
+	return "", nil
+}
+
+// ParseConfig parses the file at the given path as a Config.
+func ParseConfig(config string) (*Config, error) {
+	var data []byte
+	var err error
+	switch filepath.Ext(config) {
+	case ".json", ".yaml", ".yml":
+		data, err = os.ReadFile(config)
+		if err != nil {
+			return nil, fmt.Errorf("could not read file: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("invalid extension %s, must be .json, .yaml or .yml", filepath.Ext(config))
+	}
+	var externalConfig ExternalConfig
+	if err := encoding.UnmarshalJSONOrYAMLStrict(data, &externalConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal plugin config: %w", err)
+	}
+	switch externalConfig.Version {
+	case V1Version:
+		return newConfig(externalConfig)
+	}
+	return nil, fmt.Errorf("invalid plugin configuration version: must be one of %v", AllConfigFilePaths)
+}
+
+// ExternalConfig represents the on-disk representation
+// of the plugin configuration at version v1.
+type ExternalConfig struct {
+	Version string                `json:"version,omitempty" yaml:"version,omitempty"`
+	Name    string                `json:"name,omitempty" yaml:"name,omitempty"`
+	Opts    []string              `json:"opts,omitempty" yaml:"opts,omitempty"`
+	Runtime ExternalRuntimeConfig `json:"runtime,omitempty" yaml:"runtime,omitempty"`
+}
+
+// ExternalRuntimeConfig is the external configuration for the runtime
+// of a plugin.
+type ExternalRuntimeConfig struct {
+	Go      ExternalGoRuntimeConfig      `json:"go,omitempty" yaml:"go,omitempty"`
+	NPM     ExternalNPMRuntimeConfig     `json:"npm,omitempty" yaml:"npm,omitempty"`
+	Archive ExternalArchiveRuntimeConfig `json:"archive,omitempty" yaml:"archive,omitempty"`
+}
+
+// ExternalGoRuntimeConfig is the external runtime configuration for a Go plugin.
+type ExternalGoRuntimeConfig struct {
+	// The minimum Go version required by the plugin.
+	MinVersion string   `json:"min_version,omitempty" yaml:"min_version,omitempty"`
+	Deps       []string `json:"deps,omitempty" yaml:"deps,omitempty"`
+}
+
+// IsEmpty returns true if the configuration is empty.
+func (e ExternalGoRuntimeConfig) IsEmpty() bool {
+	return e.MinVersion == "" && len(e.Deps) == 0
+}
+
+// ExternalNPMRuntimeConfig is the external runtime configuration for a JavaScript NPM plugin.
+type ExternalNPMRuntimeConfig struct {
+	Deps []string `json:"deps,omitempty" yaml:"deps,omitempty"`
+}
+
+// IsEmpty returns true if the configuration is empty.
+func (e ExternalNPMRuntimeConfig) IsEmpty() bool {
+	return len(e.Deps) == 0
+}
+
+// ExternalArchiveRuntimeConfig is the external runtime configuration for a plugin that can be
+// downloaded as an archive instead of a language-specific registry.
+type ExternalArchiveRuntimeConfig struct {
+	Deps []string `json:"deps,omitempty" yaml:"deps,omitempty"`
+}
+
+// IsEmpty returns true if the configuration is empty.
+func (e ExternalArchiveRuntimeConfig) IsEmpty() bool {
+	return len(e.Deps) == 0
+}
+
+type externalConfigVersion struct {
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+}

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -1,0 +1,160 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginconfig
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+	"github.com/bufbuild/buf/private/pkg/storage/storageos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConfigForBucket(t *testing.T) {
+	t.Parallel()
+	storageosProvider := storageos.NewProvider()
+	readWriteBucket, err := storageosProvider.NewReadWriteBucket(filepath.Join("testdata", "success", "archive"))
+	require.NoError(t, err)
+	pluginConfig, err := GetConfigForBucket(context.Background(), readWriteBucket)
+	require.NoError(t, err)
+	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/protocolbuffers/java")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		&Config{
+			Name: pluginIdentity,
+			Runtime: &RuntimeConfig{
+				Archive: &ArchiveRuntimeConfig{
+					Deps: []string{
+						"io.grpc:grpc-protobuf:v1.46.0",
+						"io.grpc:grpc-netty-shaded:v1.46.0",
+						"io.grpc:grpc-stub:v1.46.0",
+						"io.grpc:grpc-okhttp:v1.46.0",
+					},
+				},
+			},
+		},
+		pluginConfig,
+	)
+}
+
+func TestParsePluginConfigArchiveYAML(t *testing.T) {
+	t.Parallel()
+	pluginConfig, err := ParseConfig(filepath.Join("testdata", "success", "archive", "buf.plugin.yaml"))
+	require.NoError(t, err)
+	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/protocolbuffers/java")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		&Config{
+			Name: pluginIdentity,
+			Runtime: &RuntimeConfig{
+				Archive: &ArchiveRuntimeConfig{
+					Deps: []string{
+						"io.grpc:grpc-protobuf:v1.46.0",
+						"io.grpc:grpc-netty-shaded:v1.46.0",
+						"io.grpc:grpc-stub:v1.46.0",
+						"io.grpc:grpc-okhttp:v1.46.0",
+					},
+				},
+			},
+		},
+		pluginConfig,
+	)
+}
+
+func TestParsePluginConfigGoYAML(t *testing.T) {
+	t.Parallel()
+	pluginConfig, err := ParseConfig(filepath.Join("testdata", "success", "go", "buf.plugin.yaml"))
+	require.NoError(t, err)
+	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/grpc/go")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		&Config{
+			Name: pluginIdentity,
+			Options: map[string]string{
+				"paths": "source_relative",
+			},
+			Runtime: &RuntimeConfig{
+				Go: &GoRuntimeConfig{
+					MinVersion: "v1.18",
+					Deps: []string{
+						"google.golang.org/grpc:v1.32.0",
+					},
+				},
+			},
+		},
+		pluginConfig,
+	)
+}
+
+func TestParsePluginConfigNPMYAML(t *testing.T) {
+	t.Parallel()
+	pluginConfig, err := ParseConfig(filepath.Join("testdata", "success", "npm", "buf.plugin.yaml"))
+	require.NoError(t, err)
+	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/protocolbuffers/js")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		&Config{
+			Name: pluginIdentity,
+			Options: map[string]string{
+				"paths": "source_relative",
+			},
+			Runtime: &RuntimeConfig{
+				NPM: &NPMRuntimeConfig{
+					Deps: []string{
+						"grpc-web:v1.3.1",
+						"@types/google-protobuf:v3.15.6",
+					},
+				},
+			},
+		},
+		pluginConfig,
+	)
+}
+
+func TestParsePluginConfigOptionsYAML(t *testing.T) {
+	t.Parallel()
+	pluginConfig, err := ParseConfig(filepath.Join("testdata", "success", "options", "buf.plugin.yaml"))
+	require.NoError(t, err)
+	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/protocolbuffers/java")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		&Config{
+			Name: pluginIdentity,
+			Options: map[string]string{
+				"annotate_code": "",
+			},
+		},
+		pluginConfig,
+	)
+}
+
+func TestParsePluginConfigMultipleRuntimeLangYAML(t *testing.T) {
+	t.Parallel()
+	_, err := ParseConfig(filepath.Join("testdata", "failure", "invalid-multiple-languages.yaml"))
+	require.Error(t, err)
+}
+
+func TestParsePluginConfigEmptyVersionYAML(t *testing.T) {
+	t.Parallel()
+	_, err := ParseConfig(filepath.Join("testdata", "failure", "invalid-empty-version.yaml"))
+	require.Error(t, err)
+}

--- a/private/bufpkg/bufplugin/bufpluginconfig/config.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/config.go
@@ -1,0 +1,191 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginconfig
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+	// Note that the semver package we're using conforms to the
+	// support SemVer syntax found in the go.mod file. This means
+	// that runtime dependencies will need to specify the 'v' prefix
+	// in their semantic version even if it isn't directly applicable
+	// to that runtime environment (e.g. NPM).
+	//
+	// We'll use this for now so that runtime dependencies are
+	// consistent across each runtime configuration, but we might need
+	// to change this later.
+	"golang.org/x/mod/semver"
+)
+
+func newConfig(externalConfig ExternalConfig) (*Config, error) {
+	pluginIdentity, err := bufpluginref.PluginIdentityForString(externalConfig.Name)
+	if err != nil {
+		return nil, err
+	}
+	var options map[string]string
+	if len(externalConfig.Opts) > 0 {
+		// We only want to create a non-nil map if the user
+		// actually specified any options.
+		options = make(map[string]string)
+	}
+	for _, option := range externalConfig.Opts {
+		split := strings.Split(option, "=")
+		if len(split) > 2 {
+			return nil, errors.New(`plugin options must be specified as "<key>=<value>" strings`)
+		}
+		if len(split) == 1 {
+			// Some plugins don't actually specify the '=' delimiter
+			// (e.g. protoc-gen-java's java_opt=annotate_code). To
+			// support these legacy options, we map the key to an empty
+			// string value.
+			//
+			// This means that plugin options with an explicit
+			// 'something=""' option are actually passed in as
+			// --something (omitting the explicit "" entirely).
+			//
+			// This behavior might need to change depending on if
+			// there are valid use cases here, but we eventually
+			// want to support structured options as key, value
+			// pairs so we enforce this implicit behavior for now.
+			split = append(split, "")
+		}
+		key, value := split[0], split[1]
+		if _, ok := options[key]; ok {
+			return nil, fmt.Errorf("plugin option %q was specified more than once", key)
+		}
+		options[key] = value
+	}
+	runtimeConfig, err := newRuntimeConfig(externalConfig.Runtime)
+	if err != nil {
+		return nil, err
+	}
+	return &Config{
+		Name:    pluginIdentity,
+		Options: options,
+		Runtime: runtimeConfig,
+	}, nil
+}
+
+func newRuntimeConfig(externalRuntimeConfig ExternalRuntimeConfig) (*RuntimeConfig, error) {
+	var (
+		isArchiveEmpty = externalRuntimeConfig.Archive.IsEmpty()
+		isGoEmpty      = externalRuntimeConfig.Go.IsEmpty()
+		isNPMEmpty     = externalRuntimeConfig.NPM.IsEmpty()
+	)
+	if isArchiveEmpty && isGoEmpty && isNPMEmpty {
+		// It's possible that the plugin doesn't have any runtime dependencies.
+		return nil, nil
+	}
+	if isArchiveEmpty && isGoEmpty && !isNPMEmpty {
+		npmRuntimeConfig, err := newNPMRuntimeConfig(externalRuntimeConfig.NPM)
+		if err != nil {
+			return nil, err
+		}
+		return &RuntimeConfig{
+			NPM: npmRuntimeConfig,
+		}, nil
+	}
+	if isArchiveEmpty && !isGoEmpty && isNPMEmpty {
+		goRuntimeConfig, err := newGoRuntimeConfig(externalRuntimeConfig.Go)
+		if err != nil {
+			return nil, err
+		}
+		return &RuntimeConfig{
+			Go: goRuntimeConfig,
+		}, nil
+	}
+	if !isArchiveEmpty && isGoEmpty && isNPMEmpty {
+		archiveRuntimeConfig, err := newArchiveRuntimeConfig(externalRuntimeConfig.Archive)
+		if err != nil {
+			return nil, err
+		}
+		return &RuntimeConfig{
+			Archive: archiveRuntimeConfig,
+		}, nil
+	}
+	// If we made it this far, that means the config specifies multiple
+	// runtime languages.
+	//
+	// We might eventually want to support multiple runtime configuration
+	// (e.g. 'go' and 'archive'), but it's safe to start with an error for
+	// now.
+	return nil, fmt.Errorf("%s configuration contains multiple runtime languages", ExternalConfigFilePath)
+}
+
+func newNPMRuntimeConfig(externalNPMRuntimeConfig ExternalNPMRuntimeConfig) (*NPMRuntimeConfig, error) {
+	if err := validateRuntimeDeps(externalNPMRuntimeConfig.Deps); err != nil {
+		return nil, err
+	}
+	return &NPMRuntimeConfig{
+		Deps: externalNPMRuntimeConfig.Deps,
+	}, nil
+}
+
+func newGoRuntimeConfig(externalGoRuntimeConfig ExternalGoRuntimeConfig) (*GoRuntimeConfig, error) {
+	if err := validateRuntimeDeps(externalGoRuntimeConfig.Deps); err != nil {
+		return nil, err
+	}
+	// The best we can do is verify that the minimum version
+	// is a valid semantic version, just like we do for the
+	// runtime dependencies.
+	//
+	// This will not actually verify that the go version is
+	// in the valid set. It's impossible to capture the
+	// real set of valid identifiers at any given time (for
+	// an old version of the buf CLI) without reaching out to
+	// some external source at runtime.
+	//
+	// Note that this ensures the user's configuration specifies
+	// a 'v' prefix in the version (e.g. v1.18) even though the
+	// minimum version is rendered without it in the go.mod.
+	if externalGoRuntimeConfig.MinVersion != "" && !semver.IsValid(externalGoRuntimeConfig.MinVersion) {
+		return nil, fmt.Errorf("the go minimum version %q must be a valid semantic version", externalGoRuntimeConfig.MinVersion)
+	}
+	return &GoRuntimeConfig{
+		MinVersion: externalGoRuntimeConfig.MinVersion,
+		Deps:       externalGoRuntimeConfig.Deps,
+	}, nil
+}
+
+func newArchiveRuntimeConfig(externalArchiveRuntimeConfig ExternalArchiveRuntimeConfig) (*ArchiveRuntimeConfig, error) {
+	if err := validateRuntimeDeps(externalArchiveRuntimeConfig.Deps); err != nil {
+		return nil, err
+	}
+	return &ArchiveRuntimeConfig{
+		Deps: externalArchiveRuntimeConfig.Deps,
+	}, nil
+}
+
+func validateRuntimeDeps(dependencies []string) error {
+	seen := make(map[string]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		split := strings.Split(dependency, ":")
+		if len(split) < 2 {
+			return fmt.Errorf(`runtime dependency %q must be specified as "<name>:<version>"`, dependency)
+		}
+		name, version := strings.Join(split[:len(split)-1], ":"), split[len(split)-1]
+		if _, ok := seen[name]; ok {
+			return fmt.Errorf("runtime dependency %q was specified more than once", name)
+		}
+		if !semver.IsValid(version) {
+			return fmt.Errorf("runtime dependency %q does not have a valid semantic version", dependency)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}

--- a/private/bufpkg/bufplugin/bufpluginconfig/get.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/get.go
@@ -1,0 +1,125 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginconfig
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/bufbuild/buf/private/pkg/encoding"
+	"github.com/bufbuild/buf/private/pkg/storage"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
+	"go.opencensus.io/trace"
+	"go.uber.org/multierr"
+)
+
+func getConfigForBucket(ctx context.Context, readBucket storage.ReadBucket) (_ *Config, retErr error) {
+	ctx, span := trace.StartSpan(ctx, "get_plugin_config")
+	defer span.End()
+	// This will be in the order of precedence.
+	var foundConfigFilePaths []string
+	// Go through all valid config file paths and see which ones are present.
+	// If none are present, return the default config.
+	// If multiple are present, error.
+	for _, configFilePath := range AllConfigFilePaths {
+		exists, err := storage.Exists(ctx, readBucket, configFilePath)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			foundConfigFilePaths = append(foundConfigFilePaths, configFilePath)
+		}
+	}
+	switch len(foundConfigFilePaths) {
+	case 0:
+		// Did not find anything, return the default.
+		return newConfig(ExternalConfig{})
+	case 1:
+		readObjectCloser, err := readBucket.Get(ctx, foundConfigFilePaths[0])
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			retErr = multierr.Append(retErr, readObjectCloser.Close())
+		}()
+		data, err := io.ReadAll(readObjectCloser)
+		if err != nil {
+			return nil, err
+		}
+		return getConfigForDataInternal(
+			ctx,
+			encoding.UnmarshalYAMLNonStrict,
+			encoding.UnmarshalYAMLStrict,
+			data,
+			readObjectCloser.ExternalPath(),
+		)
+	default:
+		return nil, fmt.Errorf("only one plugin file can exist but found multiple plugin files: %s", stringutil.SliceToString(foundConfigFilePaths))
+	}
+}
+
+func getConfigForData(ctx context.Context, data []byte) (*Config, error) {
+	_, span := trace.StartSpan(ctx, "get_plugin_config_for_data")
+	defer span.End()
+	return getConfigForDataInternal(
+		ctx,
+		encoding.UnmarshalJSONOrYAMLNonStrict,
+		encoding.UnmarshalJSONOrYAMLStrict,
+		data,
+		"Plugin configuration data",
+	)
+}
+
+func getConfigForDataInternal(
+	ctx context.Context,
+	unmarshalNonStrict func([]byte, interface{}) error,
+	unmarshalStrict func([]byte, interface{}) error,
+	data []byte,
+	id string,
+) (*Config, error) {
+	var externalConfigVersion externalConfigVersion
+	if err := unmarshalNonStrict(data, &externalConfigVersion); err != nil {
+		return nil, err
+	}
+	if err := validateExternalConfigVersion(externalConfigVersion, id); err != nil {
+		return nil, err
+	}
+	var externalConfig ExternalConfig
+	if err := unmarshalStrict(data, &externalConfig); err != nil {
+		return nil, err
+	}
+	return newConfig(externalConfig)
+}
+
+func validateExternalConfigVersion(externalConfigVersion externalConfigVersion, id string) error {
+	switch externalConfigVersion.Version {
+	case "":
+		return fmt.Errorf(
+			`%s has no version set. Please add "version: %s"`,
+			id,
+			V1Version,
+		)
+	case V1Version:
+		return nil
+	default:
+		return fmt.Errorf(
+			`%s has an invalid "version: %s" set. Please add "version: %s"`,
+			id,
+			externalConfigVersion.Version,
+			V1Version,
+		)
+	}
+}

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-empty-version.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-empty-version.yaml
@@ -1,0 +1,2 @@
+version:
+name: buf.build/protocolbuffers/go

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-multiple-languages.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-multiple-languages.yaml
@@ -1,0 +1,10 @@
+version: v1
+name: buf.build/protocolbuffers/go
+opts:
+  - paths=source_relative
+runtime:
+  npm:
+    deps:
+      - "@types/google-protobuf:v3.15.6"
+  go:
+    min_version: 1.18

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/archive/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/archive/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/protocolbuffers/java
+runtime:
+  archive:
+    deps:
+      - "io.grpc:grpc-protobuf:v1.46.0"
+      - "io.grpc:grpc-netty-shaded:v1.46.0"
+      - "io.grpc:grpc-stub:v1.46.0"
+      - "io.grpc:grpc-okhttp:v1.46.0"

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/grpc/go
+opts:
+  - paths=source_relative
+runtime:
+  go:
+    min_version: v1.18
+    deps:
+      - "google.golang.org/grpc:v1.32.0"

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/npm/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/npm/buf.plugin.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: buf.build/protocolbuffers/js
+opts:
+  - paths=source_relative
+runtime:
+  npm:
+    deps:
+      - "grpc-web:v1.3.1"
+      - "@types/google-protobuf:v3.15.6"

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/options/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/options/buf.plugin.yaml
@@ -1,0 +1,4 @@
+version: v1
+name: buf.build/protocolbuffers/java
+opts:
+  - annotate_code

--- a/private/bufpkg/bufplugin/bufpluginconfig/usage.gen.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package bufpluginconfig
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/bufpkg/bufplugin/bufpluginref/bufpluginref.go
+++ b/private/bufpkg/bufplugin/bufpluginref/bufpluginref.go
@@ -1,0 +1,80 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginref
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PluginIdentity is a plugin identity.
+//
+// It just contains remote, owner, plugin.
+type PluginIdentity interface {
+	Remote() string
+	Owner() string
+	Plugin() string
+
+	// IdentityString is the string remote/owner/plugin.
+	IdentityString() string
+
+	// Prevents this type from being implemented by
+	// another package.
+	isPluginIdentity()
+}
+
+// NewPluginIdentity returns a new PluginIdentity.
+func NewPluginIdentity(
+	remote string,
+	owner string,
+	plugin string,
+) (PluginIdentity, error) {
+	return newPluginIdentity(remote, owner, plugin)
+}
+
+// PluginIdentityForString returns a new PluginIdentity for the given string.
+//
+// This parses the path in the form remote/owner/plugin.
+func PluginIdentityForString(path string) (PluginIdentity, error) {
+	remote, owner, plugin, err := parsePluginIdentityComponents(path)
+	if err != nil {
+		return nil, err
+	}
+	return NewPluginIdentity(remote, owner, plugin)
+}
+
+func parsePluginIdentityComponents(path string) (remote string, owner string, plugin string, err error) {
+	slashSplit := strings.Split(path, "/")
+	if len(slashSplit) != 3 {
+		return "", "", "", newInvalidPluginIdentityStringError(path)
+	}
+	remote = strings.TrimSpace(slashSplit[0])
+	if remote == "" {
+		return "", "", "", newInvalidPluginIdentityStringError(path)
+	}
+	owner = strings.TrimSpace(slashSplit[1])
+	if owner == "" {
+		return "", "", "", newInvalidPluginIdentityStringError(path)
+	}
+	plugin = strings.TrimSpace(slashSplit[2])
+	if plugin == "" {
+		return "", "", "", newInvalidPluginIdentityStringError(path)
+	}
+	return remote, owner, plugin, nil
+}
+
+func newInvalidPluginIdentityStringError(s string) error {
+	return fmt.Errorf("plugin identity %q is invalid: must be in the form remote/owner/plugin", s)
+}

--- a/private/bufpkg/bufplugin/bufpluginref/bufpluginref_test.go
+++ b/private/bufpkg/bufplugin/bufpluginref/bufpluginref_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginref
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginIdentityForString(t *testing.T) {
+	t.Parallel()
+	expectedPluginIdentity, err := NewPluginIdentity("foo.com", "bar", "baz")
+	require.NoError(t, err)
+	assert.Equal(t, "foo.com", expectedPluginIdentity.Remote())
+	assert.Equal(t, "bar", expectedPluginIdentity.Owner())
+	assert.Equal(t, "baz", expectedPluginIdentity.Plugin())
+	pluginIdentity, err := PluginIdentityForString("foo.com/bar/baz")
+	require.NoError(t, err)
+	assert.Equal(t, expectedPluginIdentity, pluginIdentity)
+}
+
+func TestPluginIdentityForStringError(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name  string
+		Input string
+	}{
+		{
+			Name:  "no remote",
+			Input: "/bar",
+		},
+		{
+			Name:  "no owner",
+			Input: "foo.com",
+		},
+		{
+			Name:  "empty owner",
+			Input: "foo.com//baz",
+		},
+		{
+			Name:  "no plugin",
+			Input: "foo.com/bar",
+		},
+		{
+			Name:  "empty plugin",
+			Input: "foo.com/bar/",
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+			_, err := PluginIdentityForString(testCase.Input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/private/bufpkg/bufplugin/bufpluginref/plugin_identity.go
+++ b/private/bufpkg/bufplugin/bufpluginref/plugin_identity.go
@@ -1,0 +1,88 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginref
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bufbuild/buf/private/pkg/netextended"
+)
+
+type pluginIdentity struct {
+	remote string
+	owner  string
+	plugin string
+}
+
+func newPluginIdentity(
+	remote string,
+	owner string,
+	plugin string,
+) (*pluginIdentity, error) {
+	pluginIdentity := &pluginIdentity{
+		remote: remote,
+		owner:  owner,
+		plugin: plugin,
+	}
+	if err := validatePluginIdentity(pluginIdentity); err != nil {
+		return nil, err
+	}
+	return pluginIdentity, nil
+}
+
+func (m *pluginIdentity) Remote() string {
+	return m.remote
+}
+
+func (m *pluginIdentity) Owner() string {
+	return m.owner
+}
+
+func (m *pluginIdentity) Plugin() string {
+	return m.plugin
+}
+
+func (m *pluginIdentity) IdentityString() string {
+	return m.remote + "/" + m.owner + "/" + m.plugin
+}
+
+func (*pluginIdentity) isPluginIdentity() {}
+
+func validatePluginIdentity(pluginIdentity PluginIdentity) error {
+	if pluginIdentity == nil {
+		return errors.New("plugin identity is required")
+	}
+	if err := validateRemote(pluginIdentity.Remote()); err != nil {
+		return err
+	}
+	if pluginIdentity.Owner() == "" {
+		return errors.New("owner name is required")
+	}
+	if pluginIdentity.Plugin() == "" {
+		return errors.New("plugin name is required")
+	}
+	return nil
+}
+
+func validateRemote(remote string) error {
+	if remote == "" {
+		return errors.New("remote name is required")
+	}
+	if _, err := netextended.ValidateHostname(remote); err != nil {
+		return fmt.Errorf("invalid remote %q: %w", remote, err)
+	}
+	return nil
+}

--- a/private/bufpkg/bufplugin/bufpluginref/usage.gen.go
+++ b/private/bufpkg/bufplugin/bufpluginref/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package bufpluginref
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This adds a simple version of the `buf.plugin.yaml`. Some fields (e.g. `deps`, better `opts`, etc) are not included for now, but they will be added later on.

```yaml
version: v1
name: buf.build/grpc/go
opts:
  - paths=source_relative
runtime:
  go:
    min_version: v1.18
    deps:
      - "google.golang.org/grpc:v1.32.0"
```

This takes some inspiration from the [bufpluginconfig](https://github.com/bufbuild/buf/blob/main/private/bufpkg/bufpluginconfig/bufpluginconfig.go) package that already exists, but adapts some of the keys and internal implementation so that we separate the `ExternalConfig` from the internal `Config` representation. There are a couple things to consider with this one:

**Structured options**

Not all plugin options are expressed as key, value pairs. For example, `protoc-gen-java` has [an option](https://github.com/protocolbuffers/protobuf/issues/42) that are simple strings, just like we see in command line flags (e.g. `--dry-run`).

For now, we handle these cases by mapping the key (the option name) to an empty string value. This is susceptible to break down if there's ever a case that we need to explicitly specify the empty string as a value though. I imagine that we might change this later on (options are just free-form strings in the `buf.gen.yaml`), but this gives us something to work on top of for the time being - comments are left in-line.

**Runtime dependencies**

Runtime dependencies aren’t easily expressed in the same format across the board. Some output formats produce dependency names with ‘:’ (e.g. Java for Gradle/Maven) and ‘@‘ (e.g. JS and TS). It's also unclear how archive runtime dependencies can be reliably used in a generic fashion - the dependency format will be directly influenced by the target that's being produced.

For now, we can always treat the final ‘:’ element as the version, and trust that the user expressed their dependency in the format that they need. Then, it’s up to the registry (e.g. Go proxy, NPM registry, etc) to recognize this runtime dependency and act accordingly. All of this should be validated in the planned server-side unit test / verification (if possible).