### PR TITLE
Add `bazel` extensions to license header

### DIFF
--- a/private/pkg/licenseheader/licenseheader.go
+++ b/private/pkg/licenseheader/licenseheader.go
@@ -79,6 +79,8 @@ All rights reserved.`,
 		".sql":   "---",
 		".ts":    "//",
 		".tsx":   "//",
+		".bazel": "#",
+		".bzl":   "#",
 	}
 )
 


### PR DESCRIPTION
Adds `.bazel` and `.bzl`