### PR TITLE
Add plugin_version to buf.plugin.yaml

### DIFF
--- a/private/buf/cmd/buf/command/beta/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/plugin/pluginpush/pluginpush.go
@@ -147,6 +147,7 @@ func run(
 	// to the BSR.
 	//
 	//  plugin, err := bufplugin.NewPlugin(
+	//    pluginConfig.PluginVersion(),
 	//    pluginConfig.Options(),
 	//    pluginConfig.Runtime(),
 	//    imageDigest,

--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -20,6 +20,9 @@ import (
 
 // Plugin represents a plugin defined by a buf.plugin.yaml.
 type Plugin interface {
+	// Version is the version of the plugin's implementation
+	// (e.g the protoc-gen-connect-go implementation is v0.2.0).
+	Version() string
 	// Options is the set of options available to the plugin.
 	//
 	// For now, all options are string values. This could eventually
@@ -50,9 +53,10 @@ type Plugin interface {
 
 // NewPlugin creates a new plugin from the given configuration and image digest.
 func NewPlugin(
+	version string,
 	options map[string]string,
 	runtimeConfig *bufpluginconfig.RuntimeConfig,
 	imageDigest string,
 ) (Plugin, error) {
-	return newPlugin(options, runtimeConfig, imageDigest)
+	return newPlugin(version, options, runtimeConfig, imageDigest)
 }

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -46,6 +46,13 @@ var (
 type Config struct {
 	// Name is the name of the plugin (e.g. 'buf.build/protocolbuffers/go').
 	Name bufpluginref.PluginIdentity
+	// PluginVersion is the version of the plugin's implementation
+	// (e.g the protoc-gen-connect-go implementation is v0.2.0).
+	//
+	// This excludes any other details found in the buf.plugin.yaml
+	// or plugin source (e.g. Dockerfile) that would otherwise influence
+	// the plugin's behavior.
+	PluginVersion string
 	// Options is the default set of options passed into the plugin.
 	//
 	// For now, all options are string values. This could eventually
@@ -158,10 +165,11 @@ func ParseConfig(config string) (*Config, error) {
 // ExternalConfig represents the on-disk representation
 // of the plugin configuration at version v1.
 type ExternalConfig struct {
-	Version string                `json:"version,omitempty" yaml:"version,omitempty"`
-	Name    string                `json:"name,omitempty" yaml:"name,omitempty"`
-	Opts    []string              `json:"opts,omitempty" yaml:"opts,omitempty"`
-	Runtime ExternalRuntimeConfig `json:"runtime,omitempty" yaml:"runtime,omitempty"`
+	Version       string                `json:"version,omitempty" yaml:"version,omitempty"`
+	Name          string                `json:"name,omitempty" yaml:"name,omitempty"`
+	PluginVersion string                `json:"plugin_version,omitempty" yaml:"plugin_version,omitempty"`
+	Opts          []string              `json:"opts,omitempty" yaml:"opts,omitempty"`
+	Runtime       ExternalRuntimeConfig `json:"runtime,omitempty" yaml:"runtime,omitempty"`
 }
 
 // ExternalRuntimeConfig is the external configuration for the runtime

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -36,7 +36,8 @@ func TestGetConfigForBucket(t *testing.T) {
 	require.Equal(
 		t,
 		&Config{
-			Name: pluginIdentity,
+			Name:          pluginIdentity,
+			PluginVersion: "v1.5.0",
 			Options: map[string]string{
 				"paths": "source_relative",
 			},
@@ -65,7 +66,8 @@ func TestParsePluginConfigGoYAML(t *testing.T) {
 	require.Equal(
 		t,
 		&Config{
-			Name: pluginIdentity,
+			Name:          pluginIdentity,
+			PluginVersion: "v1.5.0",
 			Options: map[string]string{
 				"paths": "source_relative",
 			},
@@ -94,7 +96,8 @@ func TestParsePluginConfigNPMYAML(t *testing.T) {
 	require.Equal(
 		t,
 		&Config{
-			Name: pluginIdentity,
+			Name:          pluginIdentity,
+			PluginVersion: "v1.0.0",
 			Options: map[string]string{
 				"paths": "source_relative",
 			},
@@ -126,7 +129,8 @@ func TestParsePluginConfigOptionsYAML(t *testing.T) {
 	require.Equal(
 		t,
 		&Config{
-			Name: pluginIdentity,
+			Name:          pluginIdentity,
+			PluginVersion: "v2.0.0",
 			Options: map[string]string{
 				"annotate_code": "",
 			},

--- a/private/bufpkg/bufplugin/bufpluginconfig/config.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/config.go
@@ -29,6 +29,13 @@ func newConfig(externalConfig ExternalConfig) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	pluginVersion := externalConfig.PluginVersion
+	if pluginVersion == "" {
+		return nil, errors.New("a plugin_version is required")
+	}
+	if !semver.IsValid(pluginVersion) {
+		return nil, fmt.Errorf("plugin_version %q must be a valid semantic version", externalConfig.PluginVersion)
+	}
 	var options map[string]string
 	if len(externalConfig.Opts) > 0 {
 		// We only want to create a non-nil map if the user
@@ -67,9 +74,10 @@ func newConfig(externalConfig ExternalConfig) (*Config, error) {
 		return nil, err
 	}
 	return &Config{
-		Name:    pluginIdentity,
-		Options: options,
-		Runtime: runtimeConfig,
+		Name:          pluginIdentity,
+		PluginVersion: pluginVersion,
+		Options:       options,
+		Runtime:       runtimeConfig,
 	}, nil
 }
 

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-empty-plugin-version.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-empty-plugin-version.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/protocolbuffers/go

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-empty-version.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-empty-version.yaml
@@ -1,2 +1,3 @@
 version:
 name: buf.build/protocolbuffers/go
+plugin_version: v1.5.0

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-multiple-languages.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-multiple-languages.yaml
@@ -1,5 +1,6 @@
 version: v1
 name: buf.build/protocolbuffers/go
+plugin_version: v1.5.0
 opts:
   - paths=source_relative
 runtime:

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-plugin-version.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/failure/invalid-plugin-version.yaml
@@ -1,0 +1,3 @@
+version: v1
+name: buf.build/protocolbuffers/go
+plugin_version: foo

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -1,5 +1,6 @@
 version: v1
 name: buf.build/grpc/go
+plugin_version: v1.5.0
 opts:
   - paths=source_relative
 runtime:

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/npm/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/npm/buf.plugin.yaml
@@ -1,5 +1,6 @@
 version: v1
 name: buf.build/protocolbuffers/js
+plugin_version: v1.0.0
 opts:
   - paths=source_relative
 runtime:

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/options/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/options/buf.plugin.yaml
@@ -1,4 +1,5 @@
 version: v1
 name: buf.build/protocolbuffers/java
+plugin_version: v2.0.0
 opts:
   - annotate_code


### PR DESCRIPTION
This adds the `plugin_version` key to the `buf.plugin.yaml` file. This requires that users specify the version of the underlying plugin implementation (e.g. the `protoc-gen-connect-go` binary has a version of `v0.2.0`).