### PR TITLE
Change ENUM_ZERO_VALUE_SUFFIX to match the full value name

### DIFF
--- a/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
@@ -245,7 +245,8 @@ func checkEnumZeroValueSuffix(add addFunc, enumValue protosource.EnumValue, suff
 		return nil
 	}
 	name := enumValue.Name()
-	if !strings.HasSuffix(name, suffix) {
+	expectedName := fieldToUpperSnakeCase(enumValue.Enum().Name()) + suffix
+	if name != expectedName {
 		add(
 			enumValue,
 			enumValue.NameLocation(),
@@ -254,9 +255,9 @@ func checkEnumZeroValueSuffix(add addFunc, enumValue protosource.EnumValue, suff
 			[]protosource.Location{
 				enumValue.Enum().Location(),
 			},
-			"Enum zero value name %q should be suffixed with %q.",
+			"Enum zero value name %q should be %q.",
 			name,
-			suffix,
+			expectedName,
 		)
 	}
 	return nil


### PR DESCRIPTION
Change ENUM_ZERO_VALUE_SUFFIX to match the full value name, instead of only checking the suffix.

Previously no lint rule would catch a zero value with "stuff in the middle", eg `TYPE_NAME_OTHER_STUFF_UNSPECIFIED`.