### PR TITLE
[WIP / do not merge] Better support for remote plugins in buf.gen.yaml

### DIFF
--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -132,8 +132,9 @@ func newConfigV1(externalConfig ExternalConfigV1, id string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		if plugin.Remote != "" {
-			// Always use StrategyAll for remote plugins
+			// Always use StrategyAll for remote plugins.
 			strategy = StrategyAll
 		}
 		opt, err := encoding.InterfaceSliceOrStringToCommaSepString(plugin.Opt)

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
 	"github.com/bufbuild/buf/private/bufpkg/bufremoteplugin"
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
@@ -132,7 +133,7 @@ func newConfigV1(externalConfig ExternalConfigV1, id string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		if plugin.Remote != "" {
+		if _, err := bufpluginref.PluginReferenceForString(plugin.Name); plugin.Remote != "" || err == nil {
 			// Always use StrategyAll for remote plugins
 			strategy = StrategyAll
 		}

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -132,9 +132,8 @@ func newConfigV1(externalConfig ExternalConfigV1, id string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		if plugin.Remote != "" {
-			// Always use StrategyAll for remote plugins.
+			// Always use StrategyAll for remote plugins
 			strategy = StrategyAll
 		}
 		opt, err := encoding.InterfaceSliceOrStringToCommaSepString(plugin.Opt)

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -418,6 +418,34 @@ func TestReadConfigV1(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, successConfig, config)
 
+	successConfig = &Config{
+		PluginConfigs: []*PluginConfig{
+			{
+				Name:     "buf.build/library/go:v1.5.0",
+				Out:      "buf.build/library/go",
+				Strategy: StrategyAll,
+			},
+		},
+	}
+	readBucket, err = storagemem.NewReadBucket(nil)
+	require.NoError(t, err)
+	config, err = ReadConfig(ctx, provider, readBucket, ReadConfigWithOverride(filepath.Join("testdata", "v1", "shorthand_gen_success1.yaml")))
+	require.NoError(t, err)
+	require.Equal(t, successConfig, config)
+	data, err = os.ReadFile(filepath.Join("testdata", "v1", "shorthand_gen_success1.yaml"))
+	require.NoError(t, err)
+	config, err = ReadConfig(ctx, provider, readBucket, ReadConfigWithOverride(string(data)))
+	require.NoError(t, err)
+	require.Equal(t, successConfig, config)
+	config, err = ReadConfig(ctx, provider, readBucket, ReadConfigWithOverride(filepath.Join("testdata", "v1", "shorthand_gen_success1.json")))
+	require.NoError(t, err)
+	require.Equal(t, successConfig, config)
+	data, err = os.ReadFile(filepath.Join("testdata", "v1", "shorthand_gen_success1.json"))
+	require.NoError(t, err)
+	config, err = ReadConfig(ctx, provider, readBucket, ReadConfigWithOverride(string(data)))
+	require.NoError(t, err)
+	require.Equal(t, successConfig, config)
+
 	testReadConfigError(t, provider, readBucket, filepath.Join("testdata", "v1", "go_gen_error1.yaml"))
 	testReadConfigError(t, provider, readBucket, filepath.Join("testdata", "v1", "go_gen_error2.yaml"))
 	testReadConfigError(t, provider, readBucket, filepath.Join("testdata", "v1", "go_gen_error3.yaml"))

--- a/private/buf/bufgen/testdata/v1/shorthand_gen_success1.json
+++ b/private/buf/bufgen/testdata/v1/shorthand_gen_success1.json
@@ -1,0 +1,6 @@
+{
+  "version": "v1",
+  "plugins": [
+    "buf.build/library/go:v1.5.0"
+  ]
+}

--- a/private/buf/bufgen/testdata/v1/shorthand_gen_success1.yaml
+++ b/private/buf/bufgen/testdata/v1/shorthand_gen_success1.yaml
@@ -1,0 +1,3 @@
+version: v1
+plugins:
+  - buf.build/library/go:v1.5.0

--- a/private/bufpkg/bufplugin/bufpluginref/bufpluginref_test.go
+++ b/private/bufpkg/bufplugin/bufpluginref/bufpluginref_test.go
@@ -69,3 +69,46 @@ func TestPluginIdentityForStringError(t *testing.T) {
 		})
 	}
 }
+
+func TestPluginReferenceForString(t *testing.T) {
+	t.Parallel()
+	expectedPluginReference, err := NewPluginReference("foo.com", "barr", "baz", "v1")
+	require.NoError(t, err)
+	require.Equal(t, "foo.com/barr/baz:v1", expectedPluginReference.String())
+	pluginReference, err := PluginReferenceForString("foo.com/barr/baz:v1")
+	require.NoError(t, err)
+	require.Equal(t, expectedPluginReference, pluginReference)
+}
+
+func TestPluginReferenceForStringError(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name  string
+		Input string
+	}{
+		{
+			Name:  "Plugin without a remote",
+			Input: "/barr/baz:v1",
+		},
+		{
+			Name:  "Plugin without an owner",
+			Input: "foo.com//baz:v1",
+		},
+		{
+			Name:  "Plugin without a plugin name",
+			Input: "foo.com/barr/:v1",
+		},
+		{
+			Name:  "Plugin without a reference",
+			Input: "foo.com/barr/baz:",
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+			_, err := PluginReferenceForString(testCase.Input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/private/bufpkg/bufplugin/bufpluginref/plugin_reference.go
+++ b/private/bufpkg/bufplugin/bufpluginref/plugin_reference.go
@@ -1,0 +1,88 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpluginref
+
+import "errors"
+
+type pluginReference struct {
+	remote    string
+	owner     string
+	plugin    string
+	reference string
+}
+
+func newPluginReference(
+	remote string,
+	owner string,
+	plugin string,
+	reference string,
+) (*pluginReference, error) {
+	pluginReference := &pluginReference{
+		remote:    remote,
+		owner:     owner,
+		plugin:    plugin,
+		reference: reference,
+	}
+	if err := validatePluginReference(pluginReference); err != nil {
+		return nil, err
+	}
+	return pluginReference, nil
+}
+
+func (m *pluginReference) Remote() string {
+	return m.remote
+}
+
+func (m *pluginReference) Owner() string {
+	return m.owner
+}
+
+func (m *pluginReference) Plugin() string {
+	return m.plugin
+}
+
+func (m *pluginReference) Reference() string {
+	return m.reference
+}
+
+func (m *pluginReference) IdentityString() string {
+	return m.remote + "/" + m.owner + "/" + m.plugin
+}
+
+func (m *pluginReference) String() string {
+	return m.remote + "/" + m.owner + "/" + m.plugin + ":" + m.reference
+}
+
+func (*pluginReference) isPluginIdentity()  {}
+func (*pluginReference) isPluginReference() {}
+
+func validatePluginReference(pluginReference PluginReference) error {
+	if pluginReference == nil {
+		return errors.New("plugin reference is required")
+	}
+	if err := validateRemote(pluginReference.Remote()); err != nil {
+		return err
+	}
+	if pluginReference.Owner() == "" {
+		return errors.New("owner name is required")
+	}
+	if pluginReference.Plugin() == "" {
+		return errors.New("plugin name is required")
+	}
+	if pluginReference.Reference() == "" {
+		return errors.New("reference is required")
+	}
+	return nil
+}


### PR DESCRIPTION
## Background

Now that the `buf.plugin.yaml` is defined and (soon) able to be pushed to the BSR, this extends the `buf.gen.yaml` syntax so that it can recognize and interact with these plugins. The new plugin path representation omit the `/plugins/` path element so that fully-qualified plugin names look like any other ordinary BSR resource:

```yaml 
version: v1
plugins:
  - buf.build/library/java:v21.1.0-1
```

This syntax leverages a custom `{json,yaml}.Unmarshaler` implementation so that it implicitly assigns the above configuration to the following:

```yaml
version: v1
plugins:
  - name: buf.build/library/java:v21.1.0-1
    out: buf.build/library/java
    strategy: all
```

This is supported for both YAML and JSON so you can even run the following:

```sh
$ buf generate --template '{"version": "v1", "plugins": ["buf.build/library/java:v21.1.0-1"]}'
```

## Open Questions

The current proposal is up for debate - we need to consider a few things before moving forward here.

1. What should the default `out` value be? The fully-qualified representation makes it so that two plugins with the same base name don't collide (e.g. `buf.build/protocolbuffers/java` vs `buf.build/grpc/java`), but it makes the generated code path far more verbose:

```sh
.
└── buf.build
    └── protocolbuffers
        └── java
            └── buf
                └── alpha
                    └── breaking
                       └── v1
                           └── ConfigOuterClass.java
```

To be clear, the alternative is to map the shorthand representation to the following:

```yaml
version: v1
plugins:
  - name: buf.build/library/java:v21.1.0-1
    out: java
    strategy: all
```

No matter what we decide, the user will be able to override the default behavior by explicitly specifying the `out` key (as demonstrated above). **This might suggest that we use the shorthand name by default, and only instruct users to override it if they have conflicts.**

2. Should we instead use the `remote` key? In the current proposal, we now overload the `name` key so that it can either be a local binary (discoverable on the user's `PATH`), or a fully-qualified `bufpluginref.PluginReference`. We previously used the separate `remote` key to distinguish the two, but we can easily do this by adapting the `name` like so. In this case, we are effectively deprecating the `remote` key and pushing users towards using the `name` key in general, but we might actually want to continue leaning into the `remote` key for clarity.

3. This proposes that we continue to use the `buf.alpha.registrypublic.v1alpha1.PluginService/GeneratePlugins` endpoint to generate code for the plugins defined by a `buf.plugin.yaml`. Looking at the interface we have today, we should be able to do so - it will just require changes on the server-side to account for the `buf.plugin.yaml`, but we have all the parameters we need in its current state. See [this](https://github.com/bufbuild/buf/blob/8d2cea2f9d911a7e5355a3187e598384af78e860/proto/buf/alpha/registry/v1alpha1/generate.proto#L71) for details.

TL;DR Putting this up early so that we have an interface to experiment with for plugins produced with a `buf.plugin.yaml`. There's a few open questions, but this will unlock other development/experimentation for now.

Note that we **should not** merge this until we're ready for it to be in our users' hands. In other words, we need to be mindful of compatibility here.