### PR TITLE
prefix 'plugins.' when building/publishing images

### DIFF
--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
 	"github.com/docker/docker/api/types"
@@ -32,6 +33,9 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+// pluginsImagePrefix is used to prefix all image names with the correct path for pushing to the OCI registry.
+const pluginsImagePrefix = "plugins."
 
 // Client is a small abstraction over a Docker API client, providing the basic APIs we need to build plugins.
 // It ensures that we pass the appropriate parameters to build images (i.e. platform 'linux/amd64').
@@ -111,6 +115,9 @@ func (d *dockerAPIClient) Build(ctx context.Context, dockerfile io.Reader, plugi
 
 	buildID := stringid.GenerateRandomID()
 	imageName := pluginConfig.Name.IdentityString() + ":" + buildID
+	if !strings.HasPrefix(imageName, pluginsImagePrefix) {
+		imageName = pluginsImagePrefix + imageName
+	}
 	eg.Go(func() (retErr error) {
 		defer func() {
 			if err := buildkitSession.Close(); err != nil {

--- a/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
@@ -46,6 +46,7 @@ import (
 const (
 	examplePluginIdentity = "buf.build/library/go"
 	dockerVersion         = "1.41"
+	pluginsImagePrefix    = "plugins."
 )
 
 var (
@@ -66,7 +67,7 @@ func TestBuildSuccess(t *testing.T) {
 	require.Nilf(t, err, "failed to build docker plugin")
 	assert.Truef(
 		t,
-		strings.HasPrefix(response.Image, examplePluginIdentity+":"),
+		strings.HasPrefix(response.Image, pluginsImagePrefix+examplePluginIdentity+":"),
 		"image name should begin with: %q, found: %q",
 		examplePluginIdentity,
 		response.Image,


### PR DESCRIPTION
We should prefix 'plugins.' to the image tag when building locally and
publishing (to ensure we publish to the proper OCI registry subdomain).