### PR TITLE
fix connection upgrade for Docker tests

### DIFF
--- a/private/bufpkg/bufplugin/bufplugindocker/registry_auth_config_test.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/registry_auth_config_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestRegistryAuthMarshalJSON(t *testing.T) {
+	t.Parallel()
 	auth := RegistryAuthConfig{
 		Username:      "someuser",
 		Password:      "somepass",
@@ -38,6 +39,7 @@ func TestRegistryAuthMarshalJSON(t *testing.T) {
 }
 
 func TestRegistryAuthToFromHeader(t *testing.T) {
+	t.Parallel()
 	auth := RegistryAuthConfig{
 		Username:      "someuser",
 		Password:      "somepass",


### PR DESCRIPTION
Currently, the Docker tests are occassionally hitting a 10s delay on
shutdown when closing the buildkit session. This appears to be due to
incorrect logic when upgrading the connection from HTTP/1.1 to HTTP/2.
The Docker client API doesn't send the required HTTP2-Settings header
and so the h2c handler doesn't upgrade the connection properly.
    
Update the Docker engine implementation for tests to correctly upgrade
to a H2C connection, fixing the delay on close.
    
Update some additional tests in this package to support parallel
execution.