### PR TITLE
Support protocol and encoding client options based on content-type in Studio Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Support protocol and encoding client options based on content-type in Studio Agent
 
 ## [v1.6.0] - 2022-06-21
 

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -125,7 +125,9 @@ func testPlainPostHandler(t *testing.T, upstreamServer *httptest.Server) {
 		upstreamResponseHeaders := make(http.Header)
 		addProtoHeadersToGoHeader(invokeResponse.Headers, upstreamResponseHeaders)
 		addProtoHeadersToGoHeader(invokeResponse.Trailers, upstreamResponseHeaders)
+		assert.Equal(t, "", upstreamResponseHeaders.Get("grpc-status"))
 		assert.Equal(t, []byte("echo: echothis"), invokeResponse.Body)
+		assert.Equal(t, "foo-value", upstreamResponseHeaders.Get("Echo-Bar"))
 	})
 }
 

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -195,6 +195,9 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 
 		requestProto := &studiov1alpha1.InvokeRequest{
 			Target: "http://" + listener.Addr().String(),
+			Headers: goHeadersToProtoHeaders(http.Header{
+				"Content-Type": []string{"application/grpc"},
+			}),
 		}
 		requestBytes := protoMarshalBase64(t, requestProto)
 		request, err := http.NewRequest(http.MethodPost, agentServer.URL, bytes.NewReader(requestBytes))

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -223,18 +223,6 @@ func connectClientOptionsFromContentType(contentType string, requestMsgSize int)
 		return []connect.ClientOption{
 			connect.WithCodec(&bufferCodec{name: "proto"}),
 		}, nil
-	case "":
-		if requestMsgSize == 0 {
-			// For zero-length outgoing requests where the content
-			// type has not been specified, we default to gRPC + proto
-			// so any incoming response just goes into the buffer while
-			// we also allow parsing the proto error details from trailers.
-			return []connect.ClientOption{
-				connect.WithGRPC(),
-				connect.WithCodec(&bufferCodec{name: "proto"}),
-			}, nil
-		}
-		return nil, fmt.Errorf("missing Content-Type while body size is %d", requestMsgSize)
 	default:
 		return nil, fmt.Errorf("unknown Content-Type: %q", contentType)
 	}

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -141,29 +141,6 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	// Pick codec name based on outgoing headers so connect uses those.
-	var codec connect.Codec
-	switch request.Header().Get("Content-Type") {
-	case "application/grpc", "application/grpc+proto":
-		codec = &bufferCodec{name: "proto"}
-	case "application/grpc+json":
-		codec = &bufferCodec{name: "json"}
-	case "":
-		if len(request.Msg.Bytes()) == 0 {
-			// For zero-length outgoing requests where the content
-			// type has not been specified default to proto so any
-			// incoming response just goes into the buffer while we
-			// also allow parsing the proto error details from
-			// trailers.
-			codec = &bufferCodec{name: "proto"}
-			break
-		}
-		http.Error(w, fmt.Sprintf("missing Content-Type while body size is %d", len(request.Msg.Bytes())), http.StatusBadRequest)
-		return
-	default:
-		http.Error(w, fmt.Sprintf("unknown Content-Type: %q", request.Header().Get("Content-Type")), http.StatusBadRequest)
-		return
-	}
 	targetURL, err := url.Parse(envelopeRequest.GetTarget())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -179,11 +156,15 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("must specify http or https url scheme, got %q", targetURL.Scheme), http.StatusBadRequest)
 		return
 	}
+	clientOptions, err := connectClientOptionsFromContentType(request.Header().Get("Content-Type"), len(request.Msg.Bytes()))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	client := connect.NewClient[bytes.Buffer, bytes.Buffer](
 		httpClient,
 		targetURL.String(),
-		connect.WithGRPC(),
-		connect.WithCodec(codec),
+		clientOptions...,
 	)
 	// TODO: should this context be cloned to remove attached values (but keep timeout)?``
 	response, err := client.CallUnary(r.Context(), request)
@@ -220,6 +201,43 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Body:     response.Msg.Bytes(),
 		Trailers: goHeadersToProtoHeaders(response.Trailer()),
 	})
+}
+
+func connectClientOptionsFromContentType(contentType string, requestMsgSize int) ([]connect.ClientOption, error) {
+	switch contentType {
+	case "application/grpc", "application/grpc+proto":
+		return []connect.ClientOption{
+			connect.WithGRPC(),
+			connect.WithCodec(&bufferCodec{name: "proto"}),
+		}, nil
+	case "application/grpc-json":
+		return []connect.ClientOption{
+			connect.WithGRPC(),
+			connect.WithCodec(&bufferCodec{name: "json"}),
+		}, nil
+	case "application/json":
+		return []connect.ClientOption{
+			connect.WithCodec(&bufferCodec{name: "json"}),
+		}, nil
+	case "application/proto":
+		return []connect.ClientOption{
+			connect.WithCodec(&bufferCodec{name: "proto"}),
+		}, nil
+	case "":
+		if requestMsgSize == 0 {
+			// For zero-length outgoing requests where the content
+			// type has not been specified, we default to gRPC + proto
+			// so any incoming response just goes into the buffer while
+			// we also allow parsing the proto error details from trailers.
+			return []connect.ClientOption{
+				connect.WithGRPC(),
+				connect.WithCodec(&bufferCodec{name: "proto"}),
+			}, nil
+		}
+		return nil, fmt.Errorf("missing Content-Type while body size is %d", requestMsgSize)
+	default:
+		return nil, fmt.Errorf("unknown Content-Type: %q", contentType)
+	}
 }
 
 func (i *plainPostHandler) writeProtoMessage(w http.ResponseWriter, message proto.Message) {

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -210,7 +210,7 @@ func connectClientOptionsFromContentType(contentType string, requestMsgSize int)
 			connect.WithGRPC(),
 			connect.WithCodec(&bufferCodec{name: "proto"}),
 		}, nil
-	case "application/grpc-json":
+	case "application/grpc+json":
 		return []connect.ClientOption{
 			connect.WithGRPC(),
 			connect.WithCodec(&bufferCodec{name: "json"}),

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -156,7 +156,7 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("must specify http or https url scheme, got %q", targetURL.Scheme), http.StatusBadRequest)
 		return
 	}
-	clientOptions, err := connectClientOptionsFromContentType(request.Header().Get("Content-Type"), len(request.Msg.Bytes()))
+	clientOptions, err := connectClientOptionsFromContentType(request.Header().Get("Content-Type"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -203,7 +203,7 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func connectClientOptionsFromContentType(contentType string, requestMsgSize int) ([]connect.ClientOption, error) {
+func connectClientOptionsFromContentType(contentType string) ([]connect.ClientOption, error) {
 	switch contentType {
 	case "application/grpc", "application/grpc+proto":
 		return []connect.ClientOption{


### PR DESCRIPTION
Currently we are defaulting to the gRPC protocol in Studio Agent,
however, we are able to support `application/json` and `application/proto`
with the Connect protocol. This just refactors the client options so that
we are setting protocol and codec options based on the content-type.