### PR TITLE
BSR-322: gracefully handle plugin exists

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 )
 
 const (
@@ -217,7 +218,16 @@ func run(
 		nextRevision,
 	)
 	if err != nil {
-		return err
+		if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			return err
+		}
+		// Plugin with the same image digest and metadata already exists
+		container.Logger().Info(
+			"plugin already exists",
+			zap.String("name", pluginConfig.Name.IdentityString()),
+			zap.String("digest", buildResponse.Digest),
+		)
+		curatedPlugin = currentRevision
 	}
 	return bufprint.NewCuratedPluginPrinter(container.Stdout()).PrintCuratedPlugin(ctx, format, curatedPlugin)
 }


### PR DESCRIPTION
When a plugin already exists with the same metadata and image digest in
the BSR, we should handle the error more gracefully (it doesn't really
indicate an error).