### PR TITLE
BSR-316: add support for plugin dependencies

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -176,6 +176,7 @@ func run(
 	}
 	plugin, err := bufplugin.NewPlugin(
 		pluginConfig.PluginVersion,
+		pluginConfig.Dependencies,
 		pluginConfig.Options,
 		pluginConfig.Runtime,
 		buildResponse.Digest,
@@ -210,9 +211,9 @@ func run(
 		plugin.Version(),
 		plugin.ContainerImageDigest(),
 		bufplugin.PluginOptionsToOptionsSlice(plugin.Options()),
-		nil, // dependencies
-		"",  // sourceUrl
-		"",  // description
+		plugin.Dependencies(),
+		"", // sourceUrl
+		"", // description
 		bufplugin.PluginRuntimeToProtoRuntimeConfig(plugin.Runtime()),
 		nextRevision,
 	)

--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -26,6 +26,21 @@ type Plugin interface {
 	// Version is the version of the plugin's implementation
 	// (e.g the protoc-gen-connect-go implementation is v0.2.0).
 	Version() string
+	// Dependencies are the dependencies this plugin has on other plugins.
+	//
+	// Each dependency should be listed in the following format:
+	//
+	//   <name>:<version>-<revision>
+	//
+	// Where '<name>' is the bufpluginref.PluginIdentity of the dependency.
+	// It is required that the Remote() matches the remote of the plugin.
+	// The '<version>' is the semantic version of the dependency, and the
+	// '<revision>' is the specific numeric revision used to uniquely
+	// identify the dependency along with the version.
+	//
+	// An example of a dependency might be a 'protoc-gen-go-grpc' plugin
+	// which depends on the 'protoc-gen-go' generated code.
+	Dependencies() []string
 	// Options is the set of options available to the plugin.
 	//
 	// For now, all options are string values. This could eventually
@@ -57,11 +72,12 @@ type Plugin interface {
 // NewPlugin creates a new plugin from the given configuration and image digest.
 func NewPlugin(
 	version string,
+	dependencies []string,
 	options map[string]string,
 	runtimeConfig *bufpluginconfig.RuntimeConfig,
 	imageDigest string,
 ) (Plugin, error) {
-	return newPlugin(version, options, runtimeConfig, imageDigest)
+	return newPlugin(version, dependencies, options, runtimeConfig, imageDigest)
 }
 
 // PluginToProtoPluginLanguage determines the appropriate registryv1alpha1.PluginLanguage for the plugin.

--- a/private/bufpkg/bufplugin/bufplugin_test.go
+++ b/private/bufpkg/bufplugin/bufplugin_test.go
@@ -30,7 +30,7 @@ func TestPluginToProtoPluginLanguage(t *testing.T) {
 }
 
 func assertPluginToPluginLanguage(t testing.TB, config *bufpluginconfig.RuntimeConfig, language registryv1alpha1.PluginLanguage) {
-	plugin, err := NewPlugin("v1.0.0", nil, config, "sha256:digest")
+	plugin, err := NewPlugin("v1.0.0", nil, nil, config, "sha256:digest")
 	require.Nil(t, err)
 	assert.Equal(t, language, PluginToProtoPluginLanguage(plugin))
 }

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -53,6 +53,21 @@ type Config struct {
 	// or plugin source (e.g. Dockerfile) that would otherwise influence
 	// the plugin's behavior.
 	PluginVersion string
+	// Dependencies are the dependencies this plugin has on other plugins.
+	//
+	// Each dependency should be listed in the following format:
+	//
+	//   <name>:<version>-<revision>
+	//
+	// Where '<name>' is the bufpluginref.PluginIdentity of the dependency.
+	// It is required that the Remote() matches the remote of the plugin.
+	// The '<version>' is the semantic version of the dependency, and the
+	// '<revision>' is the specific numeric revision used to uniquely
+	// identify the dependency along with the version.
+	//
+	// An example of a dependency might be a 'protoc-gen-go-grpc' plugin
+	// which depends on the 'protoc-gen-go' generated code.
+	Dependencies []string
 	// Options is the default set of options passed into the plugin.
 	//
 	// For now, all options are string values. This could eventually
@@ -168,6 +183,7 @@ type ExternalConfig struct {
 	Version       string                `json:"version,omitempty" yaml:"version,omitempty"`
 	Name          string                `json:"name,omitempty" yaml:"name,omitempty"`
 	PluginVersion string                `json:"plugin_version,omitempty" yaml:"plugin_version,omitempty"`
+	Deps          []string              `json:"deps,omitempty" yaml:"deps,omitempty"`
 	Opts          []string              `json:"opts,omitempty" yaml:"opts,omitempty"`
 	Runtime       ExternalRuntimeConfig `json:"runtime,omitempty" yaml:"runtime,omitempty"`
 }

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -1,6 +1,8 @@
 version: v1
-name: buf.build/grpc/go
-plugin_version: v1.5.0
+name: buf.build/library/go-grpc
+plugin_version: v1.2.0
+deps:
+  - buf.build/library/go:v1.28.0-0
 opts:
   - paths=source_relative
 runtime:

--- a/private/bufpkg/bufplugin/plugin.go
+++ b/private/bufpkg/bufplugin/plugin.go
@@ -24,6 +24,7 @@ import (
 
 type plugin struct {
 	version              string
+	dependencies         []string
 	options              map[string]string
 	runtime              *bufpluginconfig.RuntimeConfig
 	containerImageDigest string
@@ -31,6 +32,7 @@ type plugin struct {
 
 func newPlugin(
 	version string,
+	dependencies []string,
 	options map[string]string,
 	runtimeConfig *bufpluginconfig.RuntimeConfig,
 	containerImageDigest string,
@@ -50,6 +52,7 @@ func newPlugin(
 	}
 	return &plugin{
 		version:              version,
+		dependencies:         dependencies,
 		options:              options,
 		runtime:              runtimeConfig,
 		containerImageDigest: containerImageDigest,
@@ -59,6 +62,11 @@ func newPlugin(
 // Version returns the plugin's version.
 func (p *plugin) Version() string {
 	return p.version
+}
+
+// Dependencies returns the plugin's dependencies on other plugins.
+func (p *plugin) Dependencies() []string {
+	return p.dependencies
 }
 
 // Options returns the plugin's options.


### PR DESCRIPTION
Update the buf.plugin.yaml configuration handling code to support
dependencies on other plugins. Update plugin push command to pass
dependencies to the BSR.