### PR TITLE
BSR-316: support sourceURL and description

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -181,6 +181,8 @@ func run(
 		pluginConfig.Options,
 		pluginConfig.Runtime,
 		buildResponse.Digest,
+		pluginConfig.SourceURL,
+		pluginConfig.Description,
 	)
 	if err != nil {
 		return err
@@ -213,8 +215,8 @@ func run(
 		plugin.ContainerImageDigest(),
 		bufplugin.PluginOptionsToOptionsSlice(plugin.Options()),
 		bufplugin.PluginReferencesToCuratedProtoPluginReferences(plugin.Dependencies()),
-		"", // sourceUrl
-		"", // description
+		plugin.SourceURL(),
+		plugin.Description(),
 		bufplugin.PluginRuntimeToProtoRuntimeConfig(plugin.Runtime()),
 		nextRevision,
 	)

--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -27,6 +27,12 @@ type Plugin interface {
 	// Version is the version of the plugin's implementation
 	// (e.g the protoc-gen-connect-go implementation is v0.2.0).
 	Version() string
+	// SourceURL is an optional attribute used to specify where the source
+	// for the plugin can be found.
+	SourceURL() string
+	// Description is an optional attribute to provide a more detailed
+	// description for the plugin.
+	Description() string
 	// Dependencies are the dependencies this plugin has on other plugins.
 	//
 	// An example of a dependency might be a 'protoc-gen-go-grpc' plugin
@@ -67,8 +73,10 @@ func NewPlugin(
 	options map[string]string,
 	runtimeConfig *bufpluginconfig.RuntimeConfig,
 	imageDigest string,
+	sourceURL string,
+	description string,
 ) (Plugin, error) {
-	return newPlugin(version, dependencies, options, runtimeConfig, imageDigest)
+	return newPlugin(version, dependencies, options, runtimeConfig, imageDigest, sourceURL, description)
 }
 
 // PluginToProtoPluginLanguage determines the appropriate registryv1alpha1.PluginLanguage for the plugin.

--- a/private/bufpkg/bufplugin/bufplugin_test.go
+++ b/private/bufpkg/bufplugin/bufplugin_test.go
@@ -30,7 +30,7 @@ func TestPluginToProtoPluginLanguage(t *testing.T) {
 }
 
 func assertPluginToPluginLanguage(t testing.TB, config *bufpluginconfig.RuntimeConfig, language registryv1alpha1.PluginLanguage) {
-	plugin, err := NewPlugin("v1.0.0", nil, nil, config, "sha256:digest")
+	plugin, err := NewPlugin("v1.0.0", nil, nil, config, "sha256:digest", "", "")
 	require.Nil(t, err)
 	assert.Equal(t, language, PluginToProtoPluginLanguage(plugin))
 }

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -53,6 +53,12 @@ type Config struct {
 	// or plugin source (e.g. Dockerfile) that would otherwise influence
 	// the plugin's behavior.
 	PluginVersion string
+	// SourceURL is an optional attribute used to specify where the source
+	// for the plugin can be found.
+	SourceURL string
+	// Description is an optional attribute to provide a more detailed
+	// description for the plugin.
+	Description string
 	// Dependencies are the dependencies this plugin has on other plugins.
 	//
 	// An example of a dependency might be a 'protoc-gen-go-grpc' plugin
@@ -173,6 +179,8 @@ type ExternalConfig struct {
 	Version       string                `json:"version,omitempty" yaml:"version,omitempty"`
 	Name          string                `json:"name,omitempty" yaml:"name,omitempty"`
 	PluginVersion string                `json:"plugin_version,omitempty" yaml:"plugin_version,omitempty"`
+	SourceURL     string                `json:"source_url,omitempty" yaml:"source_url,omitempty"`
+	Description   string                `json:"description,omitempty" yaml:"description,omitempty"`
 	Deps          []string              `json:"deps,omitempty" yaml:"deps,omitempty"`
 	Opts          []string              `json:"opts,omitempty" yaml:"opts,omitempty"`
 	Runtime       ExternalRuntimeConfig `json:"runtime,omitempty" yaml:"runtime,omitempty"`

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -45,6 +45,8 @@ func TestGetConfigForBucket(t *testing.T) {
 		&Config{
 			Name:          pluginIdentity,
 			PluginVersion: "v1.2.0",
+			SourceURL:     "https://github.com/grpc/grpc-go",
+			Description:   "Generates Go language bindings of services in protobuf definition files for gRPC.",
 			Dependencies: []bufpluginref.PluginReference{
 				pluginDependency,
 			},
@@ -80,6 +82,8 @@ func TestParsePluginConfigGoYAML(t *testing.T) {
 		&Config{
 			Name:          pluginIdentity,
 			PluginVersion: "v1.2.0",
+			SourceURL:     "https://github.com/grpc/grpc-go",
+			Description:   "Generates Go language bindings of services in protobuf definition files for gRPC.",
 			Dependencies: []bufpluginref.PluginReference{
 				pluginDependency,
 			},

--- a/private/bufpkg/bufplugin/bufpluginconfig/config.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/config.go
@@ -97,6 +97,8 @@ func newConfig(externalConfig ExternalConfig) (*Config, error) {
 		Options:       options,
 		Dependencies:  dependencies,
 		Runtime:       runtimeConfig,
+		SourceURL:     externalConfig.SourceURL,
+		Description:   externalConfig.Description,
 	}, nil
 }
 

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -1,6 +1,8 @@
 version: v1
 name: buf.build/library/go-grpc
 plugin_version: v1.2.0
+source_url: https://github.com/grpc/grpc-go
+description: Generates Go language bindings of services in protobuf definition files for gRPC.
 deps:
   - buf.build/library/go:v1.28.0:0
 opts:

--- a/private/bufpkg/bufplugin/plugin.go
+++ b/private/bufpkg/bufplugin/plugin.go
@@ -29,7 +29,11 @@ type plugin struct {
 	options              map[string]string
 	runtime              *bufpluginconfig.RuntimeConfig
 	containerImageDigest string
+	sourceURL            string
+	description          string
 }
+
+var _ Plugin = (*plugin)(nil)
 
 func newPlugin(
 	version string,
@@ -37,6 +41,8 @@ func newPlugin(
 	options map[string]string,
 	runtimeConfig *bufpluginconfig.RuntimeConfig,
 	containerImageDigest string,
+	sourceURL string,
+	description string,
 ) (*plugin, error) {
 	if version == "" {
 		return nil, errors.New("plugin version is required")
@@ -57,6 +63,8 @@ func newPlugin(
 		options:              options,
 		runtime:              runtimeConfig,
 		containerImageDigest: containerImageDigest,
+		sourceURL:            sourceURL,
+		description:          description,
 	}, nil
 }
 
@@ -83,4 +91,12 @@ func (p *plugin) Runtime() *bufpluginconfig.RuntimeConfig {
 // ContainerImageDigest returns the plugin's image digest.
 func (p *plugin) ContainerImageDigest() string {
 	return p.containerImageDigest
+}
+
+func (p *plugin) SourceURL() string {
+	return p.sourceURL
+}
+
+func (p *plugin) Description() string {
+	return p.description
 }


### PR DESCRIPTION
Update the plugin configuration to support sourceURL and description
attributes. Pass along the new configuration in the CreateCuratedPlugin
call so it can be persisted in the BSR.