### PR TITLE
use GetRepositoryCommitByReference for module resolver

### DIFF
--- a/private/bufpkg/bufapimodule/bufapimodule.go
+++ b/private/bufpkg/bufapimodule/bufapimodule.go
@@ -33,7 +33,7 @@ func NewModuleReader(
 // NewModuleResolver returns a new ModuleResolver backed by the resolve service.
 func NewModuleResolver(
 	logger *zap.Logger,
-	resolveServiceProvider registryv1alpha1apiclient.ResolveServiceProvider,
+	repositoryCommitServiceProvider registryv1alpha1apiclient.RepositoryCommitServiceProvider,
 ) bufmodule.ModuleResolver {
-	return newModuleResolver(logger, resolveServiceProvider)
+	return newModuleResolver(logger, repositoryCommitServiceProvider)
 }

--- a/private/bufpkg/bufapimodule/module_resolver.go
+++ b/private/bufpkg/bufapimodule/module_resolver.go
@@ -61,7 +61,7 @@ func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmo
 		moduleReference.Remote(),
 		moduleReference.Owner(),
 		moduleReference.Repository(),
-		bufmoduleref.Main,
+		"",
 		repositoryCommit.Name,
 		repositoryCommit.CreateTime.AsTime(),
 	)


### PR DESCRIPTION
Use GetRepositoryCommitByReference instead of GetModulePins for module resolver.

We expect the `resolveService` is only be used for dependency resolving, for something that looks up the commit by a reference we can use a more generic and straightforward endpoint `repositoryCommitService.GetRepositoryCommitByReference`.