### PR TITLE
add hidden target argument for local arm64 dev

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -41,6 +41,7 @@ const (
 	formatFlagName          = "format"
 	errorFormatFlagName     = "error-format"
 	disableSymlinksFlagName = "disable-symlinks"
+	targetFlagName          = "target"
 )
 
 // NewCommand returns a new Command.
@@ -68,6 +69,7 @@ type flags struct {
 	Format          string
 	ErrorFormat     string
 	DisableSymlinks bool
+	Target          string
 }
 
 func newFlags() *flags {
@@ -91,6 +93,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
+	flagSet.StringVar(
+		&f.Target,
+		targetFlagName,
+		"text",
+		"The target architecture for plugins.",
+	)
+	_ = flagSet.MarkHidden(targetFlagName)
 }
 
 func run(
@@ -147,7 +156,13 @@ func run(
 		retErr = multierr.Append(retErr, client.Close())
 	}()
 
-	buildResponse, err := client.Build(ctx, dockerfile, pluginConfig, bufplugindocker.WithConfigDirPath(container.ConfigDirPath()))
+	buildResponse, err := client.Build(
+		ctx,
+		dockerfile,
+		pluginConfig,
+		bufplugindocker.WithConfigDirPath(container.ConfigDirPath()),
+		bufplugindocker.WithTarget(flags.Target),
+	)
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -61,6 +61,13 @@ func WithConfigDirPath(path string) BuildOption {
 	}
 }
 
+// WithTarget is a BuildOption which sets the target architecture (used for local testing on arm64).
+func WithTarget(target string) BuildOption {
+	return func(options *buildOptions) {
+		options.target = target
+	}
+}
+
 // BuildResponse returns details of a successful image build call.
 type BuildResponse struct {
 	// Image contains the Docker image name in the local Docker engine including the tag (i.e. plugins.buf.build/library/some-plugin:<id>, where <id> is a random id).
@@ -125,9 +132,13 @@ func (d *dockerAPIClient) Build(ctx context.Context, dockerfile io.Reader, plugi
 			}
 		}()
 
+		target := params.target
+		if len(target) == 0 {
+			target = "linux/amd64"
+		}
 		response, err := d.cli.ImageBuild(ctx, dockerContext, types.ImageBuildOptions{
 			Tags:     []string{imageName},
-			Platform: "linux/amd64",
+			Platform: target,
 			Labels: map[string]string{
 				"build.buf.plugins.config.remote": pluginConfig.Name.Remote(),
 				"build.buf.plugins.config.owner":  pluginConfig.Name.Owner(),
@@ -267,4 +278,5 @@ func WithVersion(version string) ClientOption {
 
 type buildOptions struct {
 	configDirPath string
+	target        string
 }


### PR DESCRIPTION
In order to support building images on M1 for local development and testing, add a hidden `--target` CLI argument which can be used to override the default architecture.