### PR TITLE
BSR-355: use image push digest

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -175,13 +175,27 @@ func run(
 			retErr = multierr.Append(retErr, fmt.Errorf("failed to delete image %q", buildResponse.Image))
 		}
 	}()
+	machine, err := netrc.GetMachineForName(container, pluginConfig.Name.Remote())
+	if err != nil {
+		return err
+	}
+	authConfig := &bufplugindocker.RegistryAuthConfig{}
+	if machine != nil {
+		authConfig.ServerAddress = machine.Name()
+		authConfig.Username = machine.Login()
+		authConfig.Password = machine.Password()
+	}
+	pushResponse, err := client.Push(ctx, buildResponse.Image, authConfig)
+	if err != nil {
+		return err
+	}
 
 	plugin, err := bufplugin.NewPlugin(
 		pluginConfig.PluginVersion,
 		pluginConfig.Dependencies,
 		pluginConfig.Options,
 		pluginConfig.Runtime,
-		buildResponse.Digest,
+		pushResponse.Digest,
 		pluginConfig.SourceURL,
 		pluginConfig.Description,
 	)
@@ -199,7 +213,6 @@ func run(
 	var nextRevision uint32
 	// TODO: Revisit if we decide to make revision part of plugin_version
 	currentRevision, err := service.GetLatestCuratedPlugin(ctx, pluginConfig.Name.Owner(), pluginConfig.Name.Plugin(), pluginConfig.PluginVersion)
-	var currentImageDigest string
 	if err != nil {
 		if connect.CodeOf(err) != connect.CodeNotFound {
 			return err
@@ -207,23 +220,6 @@ func run(
 		nextRevision = 0
 	} else {
 		nextRevision = currentRevision.Revision + 1
-		currentImageDigest = currentRevision.ContainerImageDigest
-	}
-	if currentImageDigest != plugin.ContainerImageDigest() {
-		// Push container if digest changed from current revision
-		machine, err := netrc.GetMachineForName(container, pluginConfig.Name.Remote())
-		if err != nil {
-			return err
-		}
-		authConfig := &bufplugindocker.RegistryAuthConfig{}
-		if machine != nil {
-			authConfig.ServerAddress = machine.Name()
-			authConfig.Username = machine.Login()
-			authConfig.Password = machine.Password()
-		}
-		if _, err := client.Push(ctx, buildResponse.Image, authConfig); err != nil {
-			return err
-		}
 	}
 	curatedPlugin, err := service.CreateCuratedPlugin(
 		ctx,

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -96,7 +96,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(
 		&f.Target,
 		targetFlagName,
-		"text",
+		"",
 		"The target architecture for plugins.",
 	)
 	_ = flagSet.MarkHidden(targetFlagName)

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -243,7 +243,7 @@ func run(
 		container.Logger().Info(
 			"plugin already exists",
 			zap.String("name", pluginConfig.Name.IdentityString()),
-			zap.String("digest", buildResponse.Digest),
+			zap.String("digest", plugin.ContainerImageDigest()),
 		)
 		curatedPlugin = currentRevision
 	}

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -73,14 +73,15 @@ type BuildResponse struct {
 	// Image contains the Docker image name in the local Docker engine including the tag (i.e. plugins.buf.build/library/some-plugin:<id>, where <id> is a random id).
 	// It is created from the bufpluginconfig.Config's Name.IdentityString() and a unique id.
 	Image string
-	// Digest specifies the Docker image digest in the format <hash_algorithm>:<hash>.
+	// ImageID specifies the Docker image id in the format <hash_algorithm>:<hash>.
 	// Example: sha256:65001659f150f085e0b37b697a465a95cbfd885d9315b61960883b9ac588744e
-	Digest string
+	ImageID string
 }
 
 // PushResponse is a placeholder for data to be returned from a successful image push call.
 type PushResponse struct {
 	// Digest specifies the Docker image digest in the format <hash_algorithm>:<hash>.
+	// The digest returned from Client.Push differs from the image id returned in Client.Build.
 	Digest string
 }
 
@@ -184,8 +185,8 @@ func (d *dockerAPIClient) Build(ctx context.Context, dockerfile io.Reader, plugi
 		return nil, err
 	}
 	return &BuildResponse{
-		Image:  imageName,
-		Digest: imageInfo.ID,
+		Image:   imageName,
+		ImageID: imageInfo.ID,
 	}, nil
 }
 


### PR DESCRIPTION
Update to use the digest returned from push (instead of build) as they
don't match and remote execution fails with the build image digest.