### PR TITLE
Fix content-type to application/proto in webhook docs

### DIFF
--- a/private/gen/proto/api/buf/alpha/registry/v1alpha1/registryv1alpha1api/webhook.pb.go
+++ b/private/gen/proto/api/buf/alpha/registry/v1alpha1/registryv1alpha1api/webhook.pb.go
@@ -24,7 +24,8 @@ import (
 // WebhookService exposes the functionality for a caller to
 // create/delete/list Webhooks for a given repository event.
 type WebhookService interface {
-	// Create a webhook, subscribes to a given repository event for a callback URL invocation.
+	// Create a webhook, subscribes to a given repository event for a callback URL
+	// invocation.
 	CreateWebhook(
 		ctx context.Context,
 		webhookEvent v1alpha1.WebhookEvent,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/webhook.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/webhook.pb.go
@@ -29,7 +29,8 @@ type webhookServiceClient struct {
 	client registryv1alpha1connect.WebhookServiceClient
 }
 
-// Create a webhook, subscribes to a given repository event for a callback URL invocation.
+// Create a webhook, subscribes to a given repository event for a callback URL
+// invocation.
 func (s *webhookServiceClient) CreateWebhook(
 	ctx context.Context,
 	webhookEvent v1alpha1.WebhookEvent,

--- a/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/webhook.connect.go
+++ b/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/webhook.connect.go
@@ -41,7 +41,8 @@ const (
 
 // WebhookServiceClient is a client for the buf.alpha.registry.v1alpha1.WebhookService service.
 type WebhookServiceClient interface {
-	// Create a webhook, subscribes to a given repository event for a callback URL invocation.
+	// Create a webhook, subscribes to a given repository event for a callback URL
+	// invocation.
 	CreateWebhook(context.Context, *connect_go.Request[v1alpha1.CreateWebhookRequest]) (*connect_go.Response[v1alpha1.CreateWebhookResponse], error)
 	// Delete a webhook removes the event subscription.
 	DeleteWebhook(context.Context, *connect_go.Request[v1alpha1.DeleteWebhookRequest]) (*connect_go.Response[v1alpha1.DeleteWebhookResponse], error)
@@ -102,7 +103,8 @@ func (c *webhookServiceClient) ListWebhooks(ctx context.Context, req *connect_go
 // WebhookServiceHandler is an implementation of the buf.alpha.registry.v1alpha1.WebhookService
 // service.
 type WebhookServiceHandler interface {
-	// Create a webhook, subscribes to a given repository event for a callback URL invocation.
+	// Create a webhook, subscribes to a given repository event for a callback URL
+	// invocation.
 	CreateWebhook(context.Context, *connect_go.Request[v1alpha1.CreateWebhookRequest]) (*connect_go.Response[v1alpha1.CreateWebhookResponse], error)
 	// Delete a webhook removes the event subscription.
 	DeleteWebhook(context.Context, *connect_go.Request[v1alpha1.DeleteWebhookRequest]) (*connect_go.Response[v1alpha1.DeleteWebhookResponse], error)

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/webhook.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/webhook.pb.go
@@ -448,10 +448,11 @@ type Webhook struct {
 	RepositoryName string `protobuf:"bytes,5,opt,name=repository_name,json=repositoryName,proto3" json:"repository_name,omitempty"`
 	// The webhook repository owner name.
 	OwnerName string `protobuf:"bytes,6,opt,name=owner_name,json=ownerName,proto3" json:"owner_name,omitempty"`
-	// The subscriber's callback URL where notifications are delivered.
-	// Currently we only support Connect-powered backends with application/protobuf as the content type.
-	// Make sure that your URL ends with `/buf.alpha.webhook.v1alpha1.EventService/Event`.
-	// For more information about Connect see `https://connect.build`.
+	// The subscriber's callback URL where notifications are delivered. Currently
+	// we only support Connect-powered backends with application/proto as the
+	// content type. Make sure that your URL ends with
+	// "/buf.alpha.webhook.v1alpha1.EventService/Event". For more information
+	// about Connect, see https://connect.build.
 	CallbackUrl string `protobuf:"bytes,7,opt,name=callback_url,json=callbackUrl,proto3" json:"callback_url,omitempty"`
 }
 

--- a/proto/buf/alpha/registry/v1alpha1/webhook.proto
+++ b/proto/buf/alpha/registry/v1alpha1/webhook.proto
@@ -21,7 +21,8 @@ import "google/protobuf/timestamp.proto";
 // WebhookService exposes the functionality for a caller to
 // create/delete/list Webhooks for a given repository event.
 service WebhookService {
-  // Create a webhook, subscribes to a given repository event for a callback URL invocation.
+  // Create a webhook, subscribes to a given repository event for a callback URL
+  // invocation.
   rpc CreateWebhook(CreateWebhookRequest) returns (CreateWebhookResponse) {}
   // Delete a webhook removes the event subscription.
   rpc DeleteWebhook(DeleteWebhookRequest) returns (DeleteWebhookResponse) {}
@@ -104,9 +105,10 @@ message Webhook {
   string repository_name = 5;
   // The webhook repository owner name.
   string owner_name = 6;
-  // The subscriber's callback URL where notifications are delivered.
-  // Currently we only support Connect-powered backends with application/protobuf as the content type.
-  // Make sure that your URL ends with `/buf.alpha.webhook.v1alpha1.EventService/Event`.
-  // For more information about Connect see `https://connect.build`.
+  // The subscriber's callback URL where notifications are delivered. Currently
+  // we only support Connect-powered backends with application/proto as the
+  // content type. Make sure that your URL ends with
+  // "/buf.alpha.webhook.v1alpha1.EventService/Event". For more information
+  // about Connect, see https://connect.build.
   string callback_url = 7;
 }


### PR DESCRIPTION
The docs at https://connect.build/docs/protocol describe `application/proto`,
not `application/protobuf`.  Some minor spacing edits too.