### PR TITLE
Merge http clients for ease of use

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -54,7 +54,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
-	"github.com/bufbuild/buf/private/pkg/transport/http2client"
+	"github.com/bufbuild/buf/private/pkg/transport/http/httpclient"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"golang.org/x/term"
@@ -586,9 +586,9 @@ func newRegistryProviderWithOptions(container appflag.Container, opts ...bufapic
 	if err != nil {
 		return nil, err
 	}
-	client := http2client.NewClient(
-		http2client.WithObservability(),
-		http2client.WithTLSConfig(config.TLS),
+	client := httpclient.NewClient(
+		httpclient.WithObservability(),
+		httpclient.WithTLSConfig(config.TLS),
 	)
 	options := []bufapiclient.RegistryProviderOption{
 		bufapiclient.RegistryProviderWithAddressMapper(func(address string) string {

--- a/private/pkg/transport/http/httpclient/client.go
+++ b/private/pkg/transport/http/httpclient/client.go
@@ -24,10 +24,11 @@ import (
 )
 
 type clientOptions struct {
-	tlsConfig     *tls.Config
-	observability bool
-	proxy         Proxy
-	h2c           bool
+	tlsConfig       *tls.Config
+	observability   bool
+	proxy           Proxy
+	interceptorFunc ClientInterceptorFunc
+	h2c             bool
 }
 
 func newClient(options ...ClientOption) *http.Client {
@@ -51,6 +52,9 @@ func newClient(options ...ClientOption) *http.Client {
 			TLSClientConfig: opts.tlsConfig,
 			Proxy:           opts.proxy,
 		}
+	}
+	if opts.interceptorFunc != nil {
+		roundTripper = opts.interceptorFunc(roundTripper)
 	}
 	if opts.observability {
 		roundTripper = observability.NewHTTPTransport(roundTripper)

--- a/private/pkg/transport/http/httpclient/httpclient.go
+++ b/private/pkg/transport/http/httpclient/httpclient.go
@@ -16,12 +16,8 @@ package httpclient
 
 import (
 	"crypto/tls"
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-
-	"go.uber.org/multierr"
 )
 
 // NewClient returns a new Client.
@@ -90,23 +86,4 @@ type Proxy func(req *http.Request) (*url.URL, error)
 // with other ClientOptions.
 func NewClientWithTransport(transport http.RoundTripper) *http.Client {
 	return newClientWithTransport(transport)
-}
-
-// GetResponseBody reads and closes the response body.
-func GetResponseBody(client *http.Client, request *http.Request) (_ []byte, retErr error) {
-	response, err := client.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		retErr = multierr.Append(retErr, response.Body.Close())
-	}()
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got HTTP status code %d", response.StatusCode)
-	}
-	data, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("could not read HTTP response: %v", err)
-	}
-	return data, nil
 }

--- a/private/pkg/transport/http/httpclient/httpclient.go
+++ b/private/pkg/transport/http/httpclient/httpclient.go
@@ -32,6 +32,9 @@ func NewClient(options ...ClientOption) *http.Client {
 // ClientOption is an option for a new Client.
 type ClientOption func(*clientOptions)
 
+// ClientInterceptorFunc is a function that wraps a RoundTripper with any interceptors
+type ClientInterceptorFunc func(http.RoundTripper) http.RoundTripper
+
 // WithTLSConfig returns a new ClientOption to use the tls.Config.
 //
 // The default is to use no TLS.
@@ -66,6 +69,13 @@ func WithH2C() ClientOption {
 func WithProxy(proxyFunc Proxy) ClientOption {
 	return func(opts *clientOptions) {
 		opts.proxy = proxyFunc
+	}
+}
+
+// WithInterceptorFunc returns a new ClientOption to use a given interceptor.
+func WithInterceptorFunc(interceptorFunc ClientInterceptorFunc) ClientOption {
+	return func(opts *clientOptions) {
+		opts.interceptorFunc = interceptorFunc
 	}
 }
 

--- a/private/pkg/transport/http/httpclient/httpclient.go
+++ b/private/pkg/transport/http/httpclient/httpclient.go
@@ -49,6 +49,9 @@ func NewClient(options ...ClientOption) Client {
 // ClientOption is an option for a new Client.
 type ClientOption func(*client)
 
+// ClientInterceptorFunc is a function that wraps a RoundTripper with any interceptors
+type ClientInterceptorFunc func(http.RoundTripper) http.RoundTripper
+
 // ClientWithTLSConfig returns a new ClientOption to use the tls.Config.
 //
 // The default is to use no TLS.
@@ -75,6 +78,13 @@ func ClientWithObservability() ClientOption {
 func ClientWithProxy(proxyFunc Proxy) ClientOption {
 	return func(client *client) {
 		client.proxy = proxyFunc
+	}
+}
+
+// ClientWithInterceptorFunc returns a new ClientOption to use a given interceptor.
+func ClientWithInterceptorFunc(interceptorFunc ClientInterceptorFunc) ClientOption {
+	return func(client *client) {
+		client.interceptorFunc = interceptorFunc
 	}
 }
 

--- a/private/pkg/transport/http/httpclient/httpclient.go
+++ b/private/pkg/transport/http/httpclient/httpclient.go
@@ -71,6 +71,8 @@ func ClientWithObservability() ClientOption {
 	}
 }
 
+// ClientWithH2C returns a new ClientOption that allows dialing
+// h2c (cleartext) servers.
 func ClientWithH2C() ClientOption {
 	return func(client *client) {
 		client.h2c = true

--- a/private/pkg/transport/http/httpclient/httpclient.go
+++ b/private/pkg/transport/http/httpclient/httpclient.go
@@ -71,6 +71,12 @@ func ClientWithObservability() ClientOption {
 	}
 }
 
+func ClientWithH2C() ClientOption {
+	return func(client *client) {
+		client.h2c = true
+	}
+}
+
 // WithProxy returns a new ClientOption to use
 // a proxy.
 //

--- a/private/pkg/transport/http/httpclient/httpclient_test.go
+++ b/private/pkg/transport/http/httpclient/httpclient_test.go
@@ -37,7 +37,7 @@ func TestProxy(t *testing.T) {
 	require.NoError(t, err)
 	client := NewClient(
 		// setup the client to proxy all requests to the proxy server
-		ClientWithProxy(http.ProxyURL(proxyURL)),
+		WithProxy(http.ProxyURL(proxyURL)),
 	)
 
 	req, err := http.NewRequest("GET", "http://www.example.com", nil)


### PR DESCRIPTION
This merges the two http clients in `buf` into one client that handles all the concerns.

The previous `http2client` was created to be able to use cleartext because the `http2.Transport` struct was the only way to configure `AllowHTTP`.  Therefore, users needed to use the `http2client` if they wanted cleartext and the regular `httpclient` for everything else.  

This essentially takes what both clients were doing and combines them into one interface.  If a callsite requests H2C, then the client will use `http2.Transport` with `AllowHTTP`.  For all other client constructions, the regular `http` client is used.  

Finally, instead of returning a struct with a nested `http.Client`, this simply returns the client straightaway.  The previous implementation only seemed to have the wrapping struct for use with functional parameters.  These properties were not used anywhere other than during construction of the client.  This allows us to simplify all the callsites to use a straight-forward `*http.Client` rather than an unnecessary custom `httpclient.Client` type.

If/when this PR is merged, this obviates the need for the `http2client` altogether and that package can be deleted.  Its usages will be refactored to use this `httpclient` interface.