### PR TITLE
BSR-374: start initial revision at 1

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -217,7 +217,7 @@ func run(
 		if connect.CodeOf(err) != connect.CodeNotFound {
 			return err
 		}
-		nextRevision = 0
+		nextRevision = 1
 	} else {
 		nextRevision = currentRevision.Revision + 1
 	}


### PR DESCRIPTION
When creating plugins, start initial revisions at 1 instead of 0.