### PR TITLE
Add webhook beta command in buf cli along with create webhooks

### DIFF
--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -16,6 +16,7 @@ package buf
 
 import (
 	"context"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate"
 	"time"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
@@ -211,6 +212,13 @@ func NewRootCommand(name string) *appcmd.Command {
 											templateversionlist.NewCommand("list", builder),
 										},
 									},
+								},
+							},
+							{
+								Use:   "webhook",
+								Short: "Manage webhooks for a repository on the Buf Schema Registry.",
+								SubCommands: []*appcmd.Command{
+									webhookcreate.NewCommand("create", builder),
 								},
 							},
 						},

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -16,7 +16,6 @@ package buf
 
 import (
 	"context"
-	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate"
 	"time"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
@@ -55,6 +54,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/studioagent"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/breaking"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/build"

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package webhookcreate
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -42,7 +42,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " [flags]",
+		Use:   name,
 		Short: "Create a repository webhook.",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -1,0 +1,154 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhookcreate
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	ownerFlagName        = "owner"
+	repositoryFlagName   = "repository"
+	callbackURLFlagName  = "callback_url"
+	webhookEventFlagName = "event"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <source>",
+		Short: "Create a repository webhook.",
+		Args:  cobra.ExactArgs(0),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appflag.Container) error {
+				return run(ctx, container, flags)
+			},
+			bufcli.NewErrorInterceptor(),
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	OwnerName      string
+	RepositoryName string
+	CallbackURL    string
+	WebhookEvent   string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.WebhookEvent,
+		webhookEventFlagName,
+		"",
+		"The event type to create a webhook for. The proto enum string value is used for this input (e.g. 'WEBHOOK_EVENT_REPOSITORY_PUSH').",
+	)
+	_ = cobra.MarkFlagRequired(flagSet, webhookEventFlagName)
+	flagSet.StringVar(
+		&f.OwnerName,
+		ownerFlagName,
+		"",
+		`The owner name of the repository to create a webhook for.`,
+	)
+	_ = cobra.MarkFlagRequired(flagSet, ownerFlagName)
+	flagSet.StringVar(
+		&f.RepositoryName,
+		repositoryFlagName,
+		"",
+		"The repository name to create a webhook for.",
+	)
+	_ = cobra.MarkFlagRequired(flagSet, repositoryFlagName)
+	flagSet.StringVar(
+		&f.CallbackURL,
+		callbackURLFlagName,
+		"",
+		"The url for the webhook to callback to on a given event.",
+	)
+	_ = cobra.MarkFlagRequired(flagSet, callbackURLFlagName)
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+	flags *flags,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	input, err := bufcli.GetInputValue(container, "", ".")
+	if err != nil {
+		return err
+	}
+	storageosProvider := bufcli.NewStorageosProvider(false)
+	runner := command.NewRunner()
+	_, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
+		ctx,
+		container,
+		storageosProvider,
+		runner,
+		input,
+	)
+	if err != nil {
+		return err
+	}
+	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote := moduleIdentity.Remote()
+	service, err := apiProvider.NewWebhookService(ctx, remote)
+	if err != nil {
+		return err
+	}
+
+	var result = registryv1alpha1.WebhookEvent_WEBHOOK_EVENT_UNSPECIFIED
+	if value, ok := registryv1alpha1.WebhookEvent_value[flags.WebhookEvent]; ok {
+		result = registryv1alpha1.WebhookEvent(value)
+	}
+
+	createWebhook, err := service.CreateWebhook(
+		ctx,
+		result,
+		flags.OwnerName,
+		flags.RepositoryName,
+		flags.CallbackURL,
+	)
+	if err != nil {
+		return err
+	}
+	createWebhookResponse, err := json.MarshalIndent(createWebhook, "", "\t")
+	if err != nil {
+		return err
+	}
+	if _, err := container.Stdout().Write(createWebhookResponse); err != nil {
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -127,12 +127,10 @@ func run(
 	if err != nil {
 		return err
 	}
-
 	var result = registryv1alpha1.WebhookEvent_WEBHOOK_EVENT_UNSPECIFIED
 	if value, ok := registryv1alpha1.WebhookEvent_value[flags.WebhookEvent]; ok {
 		result = registryv1alpha1.WebhookEvent(value)
 	}
-
 	createWebhook, err := service.CreateWebhook(
 		ctx,
 		result,

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -55,10 +55,10 @@ func NewCommand(
 }
 
 type flags struct {
+	WebhookEvent   string
 	OwnerName      string
 	RepositoryName string
 	CallbackURL    string
-	WebhookEvent   string
 }
 
 func newFlags() *flags {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -128,14 +128,13 @@ func run(
 	if err != nil {
 		return err
 	}
-	value, ok := registryv1alpha1.WebhookEvent_value[flags.WebhookEvent]
-	if !ok || value == int32(registryv1alpha1.WebhookEvent_WEBHOOK_EVENT_UNSPECIFIED) {
+	event, ok := registryv1alpha1.WebhookEvent_value[flags.WebhookEvent]
+	if !ok || event == int32(registryv1alpha1.WebhookEvent_WEBHOOK_EVENT_UNSPECIFIED) {
 		return fmt.Errorf("webhook event must be specified")
 	}
-	event := registryv1alpha1.WebhookEvent(value)
 	createWebhook, err := service.CreateWebhook(
 		ctx,
-		event,
+		registryv1alpha1.WebhookEvent(event),
 		flags.OwnerName,
 		flags.RepositoryName,
 		flags.CallbackURL,

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -42,7 +42,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <source>",
+		Use:   name + " [flags]",
 		Short: "Create a repository webhook.",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(


### PR DESCRIPTION
Example usage:
```
buf beta registry webhook create \
  --owner="admin-user" \
  --repository="api" \
  --callback_url="https://bufbuild.internal/buf.alpha.webhook.v1alpha1.EventService/Event" \
  --event="WEBHOOK_EVENT_REPOSITORY_PUSH"
```