### PR TITLE
Add webhook delete and list commands to beta and fixup create

### DIFF
--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -55,6 +55,8 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/studioagent"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/breaking"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/build"
@@ -219,6 +221,8 @@ func NewRootCommand(name string) *appcmd.Command {
 								Short: "Manage webhooks for a repository on the Buf Schema Registry.",
 								SubCommands: []*appcmd.Command{
 									webhookcreate.NewCommand("create", builder),
+									webhookdelete.NewCommand("delete", builder),
+									webhooklist.NewCommand("list", builder),
 								},
 							},
 						},

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -31,7 +31,7 @@ import (
 const (
 	ownerFlagName        = "owner"
 	repositoryFlagName   = "repository"
-	callbackURLFlagName  = "callback_url"
+	callbackURLFlagName  = "callback-url"
 	webhookEventFlagName = "event"
 )
 

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -100,7 +100,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Remote,
 		remoteFlagName,
 		"",
-		"The remote where the repository lives.",
+		"The remote of the repository the created webhook will belong to.",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package webhookdelete
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	webhookIDFlagName = "id"
+	remoteFlagName    = "remote"
 )
 
 // NewCommand returns a new Command
@@ -51,6 +52,7 @@ func NewCommand(
 
 type flags struct {
 	WebhookID string
+	Remote    string
 }
 
 func newFlags() *flags {
@@ -65,6 +67,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"The webhook ID to delete.",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, webhookIDFlagName)
+	flagSet.StringVar(
+		&f.Remote,
+		remoteFlagName,
+		"",
+		"The remote where the repository lives.",
+	)
+	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }
 
 func run(
@@ -73,10 +82,6 @@ func run(
 	flags *flags,
 ) error {
 	bufcli.WarnBetaCommand(ctx, container)
-	input, err := bufcli.GetInputValue(container, "", ".")
-	if err != nil {
-		return err
-	}
 	storageosProvider := bufcli.NewStorageosProvider(false)
 	runner := command.NewRunner()
 	_, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
@@ -84,7 +89,7 @@ func run(
 		container,
 		storageosProvider,
 		runner,
-		input,
+		flags.Remote,
 	)
 	if err != nil {
 		return err

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -20,7 +20,6 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
-	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -82,24 +81,11 @@ func run(
 	flags *flags,
 ) error {
 	bufcli.WarnBetaCommand(ctx, container)
-	storageosProvider := bufcli.NewStorageosProvider(false)
-	runner := command.NewRunner()
-	_, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
-		ctx,
-		container,
-		storageosProvider,
-		runner,
-		flags.Remote,
-	)
-	if err != nil {
-		return err
-	}
 	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
 	if err != nil {
 		return err
 	}
-	remote := moduleIdentity.Remote()
-	service, err := apiProvider.NewWebhookService(ctx, remote)
+	service, err := apiProvider.NewWebhookService(ctx, flags.Remote)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -71,7 +71,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Remote,
 		remoteFlagName,
 		"",
-		"The remote where the repository lives.",
+		"The remote of the repository the webhook ID belongs to.",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -1,0 +1,105 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhookdelete
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	webhookIDFlagName = "webhook_id"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name,
+		Short: "Delete a repository webhook with a webhook id.",
+		Args:  cobra.ExactArgs(0),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appflag.Container) error {
+				return run(ctx, container, flags)
+			},
+			bufcli.NewErrorInterceptor(),
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	WebhookID string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.WebhookID,
+		webhookIDFlagName,
+		"",
+		"The webhook ID to delete.",
+	)
+	_ = cobra.MarkFlagRequired(flagSet, webhookIDFlagName)
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+	flags *flags,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	input, err := bufcli.GetInputValue(container, "", ".")
+	if err != nil {
+		return err
+	}
+	storageosProvider := bufcli.NewStorageosProvider(false)
+	runner := command.NewRunner()
+	_, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
+		ctx,
+		container,
+		storageosProvider,
+		runner,
+		input,
+	)
+	if err != nil {
+		return err
+	}
+	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote := moduleIdentity.Remote()
+	service, err := apiProvider.NewWebhookService(ctx, remote)
+	if err != nil {
+		return err
+	}
+	if err := service.DeleteWebhook(ctx, flags.WebhookID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	webhookIDFlagName = "webhook_id"
+	webhookIDFlagName = "id"
 )
 
 // NewCommand returns a new Command
@@ -37,7 +37,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "Delete a repository webhook with a webhook id.",
+		Short: "Delete a repository webhook.",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package webhooklist
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -112,10 +112,16 @@ func run(
 	}
 	results, _, err := service.ListWebhooks(ctx, flags.RepositoryName, flags.OwnerName, "")
 	if err != nil {
-		if connectErr := new(connect.Error); errors.As(err, connectErr) {
-
+		if connectErr := new(connect.Error); errors.As(err, &connectErr) {
+			_, _ = container.Stdout().Write([]byte("[]"))
+			return nil
 		}
 		return err
+	}
+	if len(results) == 0 {
+		// Ignore errors for writing to stdout.
+		_, _ = container.Stdout().Write([]byte("[]"))
+		return nil
 	}
 	response, err := json.MarshalIndent(results, "", "\t")
 	if err != nil {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -80,7 +80,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Remote,
 		remoteFlagName,
 		"",
-		"The remote where the repository lives.",
+		"The remote of the owner and repository to list webhooks for.",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -1,0 +1,128 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooklist
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/bufbuild/connect-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	ownerFlagName      = "owner"
+	repositoryFlagName = "repository"
+)
+
+// NewCommand returns a new Command
+func NewCommand(
+	name string,
+	builder appflag.Builder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name,
+		Short: "List a repository webhooks.",
+		Args:  cobra.ExactArgs(0),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appflag.Container) error {
+				return run(ctx, container, flags)
+			},
+			bufcli.NewErrorInterceptor(),
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	OwnerName      string
+	RepositoryName string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.OwnerName,
+		ownerFlagName,
+		"",
+		`The owner name of the repository to list webhooks for.`,
+	)
+	_ = cobra.MarkFlagRequired(flagSet, ownerFlagName)
+	flagSet.StringVar(
+		&f.RepositoryName,
+		repositoryFlagName,
+		"",
+		"The repository name to list webhooks for.",
+	)
+	_ = cobra.MarkFlagRequired(flagSet, repositoryFlagName)
+}
+
+func run(
+	ctx context.Context,
+	container appflag.Container,
+	flags *flags,
+) error {
+	bufcli.WarnBetaCommand(ctx, container)
+	input, err := bufcli.GetInputValue(container, "", ".")
+	if err != nil {
+		return err
+	}
+	storageosProvider := bufcli.NewStorageosProvider(false)
+	runner := command.NewRunner()
+	_, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
+		ctx,
+		container,
+		storageosProvider,
+		runner,
+		input,
+	)
+	if err != nil {
+		return err
+	}
+	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	if err != nil {
+		return err
+	}
+	remote := moduleIdentity.Remote()
+	service, err := apiProvider.NewWebhookService(ctx, remote)
+	if err != nil {
+		return err
+	}
+	results, _, err := service.ListWebhooks(ctx, flags.RepositoryName, flags.OwnerName, "")
+	if err != nil {
+		if connectErr := new(connect.Error); errors.As(err, connectErr) {
+
+		}
+		return err
+	}
+	response, err := json.MarshalIndent(results, "", "\t")
+	if err != nil {
+		return err
+	}
+	if _, err := container.Stdout().Write(response); err != nil {
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "List a repository webhooks.",
+		Short: "List repository webhooks.",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -103,6 +103,10 @@ func run(
 	if err != nil {
 		return err
 	}
+	if results == nil {
+		// Ignore errors for writing to stdout.
+		_, _ = container.Stdout().Write([]byte("[]"))
+	}
 	response, err := json.MarshalIndent(results, "", "\t")
 	if err != nil {
 		return err

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -121,8 +121,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	if _, err := container.Stdout().Write(response); err != nil {
-		return err
-	}
+	// Ignore errors for writing to stdout.
+	_, _ = container.Stdout().Write(response)
 	return nil
 }


### PR DESCRIPTION
Create:
```
buf beta registry webhook create \ 
  --owner="achiu" \
  --repository="petapis" \
  --callback-url="https://bufbuild.test/buf.alpha.webhook.v1alpha1.EventService/Event" \
  --event="WEBHOOK_EVENT_REPOSITORY_PUSH" \
  --remote bufbuild.test
```
Delete:
```
buf beta registry webhook delete --id="some_id" --remote bufbuild.test
```
Listing:
```
buf beta registry webhook list --owner="achiu" --repository="petapis" --remote bufbuild.test
```