### PR TITLE
BSR-369: update plugin dependencies to a struct

### DIFF
--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -181,9 +181,15 @@ type ExternalConfig struct {
 	PluginVersion string                `json:"plugin_version,omitempty" yaml:"plugin_version,omitempty"`
 	SourceURL     string                `json:"source_url,omitempty" yaml:"source_url,omitempty"`
 	Description   string                `json:"description,omitempty" yaml:"description,omitempty"`
-	Deps          []string              `json:"deps,omitempty" yaml:"deps,omitempty"`
+	Deps          []ExternalDependency  `json:"deps,omitempty" yaml:"deps,omitempty"`
 	Opts          []string              `json:"opts,omitempty" yaml:"opts,omitempty"`
 	Runtime       ExternalRuntimeConfig `json:"runtime,omitempty" yaml:"runtime,omitempty"`
+}
+
+// ExternalDependency represents a dependency on another plugin.
+type ExternalDependency struct {
+	Plugin   string `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Revision int    `json:"revision,omitempty" yaml:"revision,omitempty"`
 }
 
 // ExternalRuntimeConfig is the external configuration for the runtime

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -37,7 +37,7 @@ func TestGetConfigForBucket(t *testing.T) {
 	require.NoError(t, err)
 	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/library/go-grpc")
 	require.NoError(t, err)
-	pluginDependency, err := bufpluginref.PluginReferenceForString("buf.build/library/go:v1.28.0", 0)
+	pluginDependency, err := bufpluginref.PluginReferenceForString("buf.build/library/go:v1.28.0", 1)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -74,7 +74,7 @@ func TestParsePluginConfigGoYAML(t *testing.T) {
 	require.NoError(t, err)
 	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.build/library/go-grpc")
 	require.NoError(t, err)
-	pluginDependency, err := bufpluginref.PluginReferenceForString("buf.build/library/go:v1.28.0", 0)
+	pluginDependency, err := bufpluginref.PluginReferenceForString("buf.build/library/go:v1.28.0", 1)
 	require.NoError(t, err)
 	require.Equal(
 		t,

--- a/private/bufpkg/bufplugin/bufpluginconfig/config.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/config.go
@@ -73,7 +73,7 @@ func newConfig(externalConfig ExternalConfig) (*Config, error) {
 	if len(externalConfig.Deps) > 0 {
 		existingDeps := make(map[string]struct{})
 		for _, dependency := range externalConfig.Deps {
-			reference, err := bufpluginref.PluginReferenceForString(dependency)
+			reference, err := bufpluginref.PluginReferenceForString(dependency.Plugin, dependency.Revision)
 			if err != nil {
 				return nil, err
 			}

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -5,7 +5,7 @@ source_url: https://github.com/grpc/grpc-go
 description: Generates Go language bindings of services in protobuf definition files for gRPC.
 deps:
   - plugin: buf.build/library/go:v1.28.0
-    revision: 0
+    revision: 1
 opts:
   - paths=source_relative
 runtime:

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go/buf.plugin.yaml
@@ -4,7 +4,8 @@ plugin_version: v1.2.0
 source_url: https://github.com/grpc/grpc-go
 description: Generates Go language bindings of services in protobuf definition files for gRPC.
 deps:
-  - buf.build/library/go:v1.28.0:0
+  - plugin: buf.build/library/go:v1.28.0
+    revision: 0
 opts:
   - paths=source_relative
 runtime:

--- a/private/bufpkg/bufplugin/bufpluginref/bufpluginref.go
+++ b/private/bufpkg/bufplugin/bufpluginref/bufpluginref.go
@@ -16,7 +16,6 @@ package bufpluginref
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -89,9 +88,9 @@ func NewPluginReference(
 
 // PluginReferenceForString returns a new PluginReference for the given string.
 //
-// This parses the path in the form remote/owner/plugin:version:revision.
-func PluginReferenceForString(reference string) (PluginReference, error) {
-	return parsePluginReference(reference)
+// This parses the path in the form remote/owner/plugin:version.
+func PluginReferenceForString(reference string, revision int) (PluginReference, error) {
+	return parsePluginReference(reference, revision)
 }
 
 func parsePluginIdentityComponents(path string) (remote string, owner string, plugin string, err error) {
@@ -118,22 +117,14 @@ func newInvalidPluginIdentityStringError(s string) error {
 	return fmt.Errorf("plugin identity %q is invalid: must be in the form remote/owner/plugin", s)
 }
 
-func parsePluginReference(reference string) (PluginReference, error) {
-	name, versionRevision, ok := strings.Cut(reference, ":")
+func parsePluginReference(reference string, revision int) (PluginReference, error) {
+	name, version, ok := strings.Cut(reference, ":")
 	if !ok {
-		return nil, fmt.Errorf("plugin references must be specified as \"<name>:<version>:<revision>\" strings")
+		return nil, fmt.Errorf("plugin references must be specified as \"<name>:<version>\" strings")
 	}
 	identity, err := PluginIdentityForString(name)
 	if err != nil {
 		return nil, err
-	}
-	version, revisionStr, ok := strings.Cut(versionRevision, ":")
-	if !ok {
-		return nil, fmt.Errorf("plugin references must be specified as \"<name>:<version>:<revision>\" strings")
-	}
-	revision, err := strconv.Atoi(revisionStr)
-	if err != nil {
-		return nil, fmt.Errorf("plugin reference %q must be specified with a numeric version", reference)
 	}
 	return NewPluginReference(identity, version, revision)
 }


### PR DESCRIPTION
Remove double ':' from plugin reference and instead split out revision
to a separate field. This will coordinate updates planned for
buf.gen.yaml with buf.plugin.yaml and also allow for revision to be
unset.