### PR TITLE
BSR-379: document version can be optional

### DIFF
--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/plugin_curation.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/plugin_curation.pb.go
@@ -1066,7 +1066,8 @@ type GetLatestCuratedPluginRequest struct {
 	Owner string `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// The name of the plugin, i.e. "connect-go".
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	// Semver-formatted plugin version.
+	// Optional: Semver-formatted plugin version.
+	// If not specified, the latest version will be retrieved.
 	Version string `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
 }
 

--- a/proto/buf/alpha/registry/v1alpha1/plugin_curation.proto
+++ b/proto/buf/alpha/registry/v1alpha1/plugin_curation.proto
@@ -212,7 +212,8 @@ message GetLatestCuratedPluginRequest {
   string owner = 1;
   // The name of the plugin, i.e. "connect-go".
   string name = 2;
-  // Semver-formatted plugin version.
+  // Optional: Semver-formatted plugin version.
+  // If not specified, the latest version will be retrieved.
   string version = 3;
 }
 


### PR DESCRIPTION
Update GetLatestCuratedPlugin to document that the version parameter is
optional.