### PR TITLE
ModuleReferenceForString support reference with slash

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -234,9 +234,9 @@ func NewProtoModuleReferencesForModuleReferences(moduleReferences ...ModuleRefer
 }
 
 // ModuleReferenceForString returns a new ModuleReference for the given string.
-// If a branch or commit is not provided, the "main" branch is used.
+// If a branch, commit, or draft is not provided, the "main" branch is used.
 //
-// This parses the path in the form remote/owner/repository{:branch,:commit}.
+// This parses the path in the form remote/owner/repository{:branch,:commit,:draft}.
 func ModuleReferenceForString(path string) (ModuleReference, error) {
 	remote, owner, repository, reference, err := parseModuleReferenceComponents(path)
 	if err != nil {

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -234,9 +234,9 @@ func NewProtoModuleReferencesForModuleReferences(moduleReferences ...ModuleRefer
 }
 
 // ModuleReferenceForString returns a new ModuleReference for the given string.
-// If a branch, commit, or draft is not provided, the "main" branch is used.
+// If a branch, commit, draft, or tag is not provided, the "main" branch is used.
 //
-// This parses the path in the form remote/owner/repository{:branch,:commit,:draft}.
+// This parses the path in the form remote/owner/repository{:branch,:commit,:draft,:tag}.
 func ModuleReferenceForString(path string) (ModuleReference, error) {
 	remote, owner, repository, reference, err := parseModuleReferenceComponents(path)
 	if err != nil {

--- a/private/bufpkg/bufmodule/bufmoduleref/module_reference_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_reference_test.go
@@ -59,6 +59,14 @@ func TestModuleReferenceForString(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedModuleReference, commitModuleReference)
 	require.True(t, IsCommitModuleReference(commitModuleReference))
+
+	expectedModuleReference, err = NewModuleReference("foo.com", "barr", "baz", "some/draft")
+	require.NoError(t, err)
+	require.Equal(t, "foo.com/barr/baz:some/draft", expectedModuleReference.String())
+	moduleReference, err = ModuleReferenceForString("foo.com/barr/baz:some/draft")
+	require.NoError(t, err)
+	require.Equal(t, expectedModuleReference, moduleReference)
+	require.False(t, IsCommitModuleReference(moduleReference))
 }
 
 func TestModuleReferenceForStringError(t *testing.T) {

--- a/private/bufpkg/bufmodule/bufmoduleref/util.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/util.go
@@ -20,7 +20,7 @@ import (
 )
 
 // parseModuleReferenceComponents parses and returns the remote, owner, repository,
-// and ref (branch, commit, or draft) from the given path.
+// and ref (branch, commit, draft, or tag) from the given path.
 func parseModuleReferenceComponents(path string) (remote string, owner string, repository string, ref string, err error) {
 	split := strings.Split(path, ":")
 	switch len(split) {

--- a/private/bufpkg/bufmodule/bufmoduleref/util.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/util.go
@@ -20,25 +20,25 @@ import (
 )
 
 // parseModuleReferenceComponents parses and returns the remote, owner, repository,
-// and ref (branch or commit) from the given path.
+// and ref (branch, commit, or draft) from the given path.
 func parseModuleReferenceComponents(path string) (remote string, owner string, repository string, ref string, err error) {
-	remote, owner, rest, err := parseModuleIdentityComponents(path)
-	if err != nil {
-		return "", "", "", "", newInvalidModuleReferenceStringError(path)
-	}
-	restSplit := strings.Split(rest, ":")
-	repository = strings.TrimSpace(restSplit[0])
-	if len(restSplit) == 1 {
-		return remote, owner, repository, "", nil
-	}
-	if len(restSplit) == 2 {
-		ref := strings.TrimSpace(restSplit[1])
+	split := strings.Split(path, ":")
+	switch len(split) {
+	case 1:
+		// path has no colon, no need to handle its ref
+	case 2:
+		ref = strings.TrimSpace(split[1])
 		if ref == "" {
 			return "", "", "", "", newInvalidModuleReferenceStringError(path)
 		}
-		return remote, owner, repository, ref, nil
+	default:
+		return "", "", "", "", newInvalidModuleReferenceStringError(path)
 	}
-	return "", "", "", "", newInvalidModuleReferenceStringError(path)
+	remote, owner, repository, err = parseModuleIdentityComponents(split[0])
+	if err != nil {
+		return "", "", "", "", newInvalidModuleReferenceStringError(path)
+	}
+	return remote, owner, repository, ref, nil
 }
 
 func parseModuleIdentityComponents(path string) (remote string, owner string, repository string, err error) {


### PR DESCRIPTION
this make the `ModuleReferenceForString` support reference with slash (e.g. `buf.build/bufbuild/buf:test/draft`), as both tag and draft should support it