### PR TITLE
allow Dockerfile.plugin or Dockerfile

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -251,7 +251,7 @@ func loadDockerfile(ctx context.Context, bucket storage.ReadBucket) (storage.Rea
 	for _, path := range []string{bufplugindocker.SourceFilePath, bufplugindocker.SourceFileAlternatePath} {
 		var dockerfile storage.ReadObjectCloser
 		if dockerfile, err = bucket.Get(ctx, path); err == nil {
-			return dockerfile, err
+			return dockerfile, nil
 		}
 	}
 	if storage.IsNotExist(err) {

--- a/private/bufpkg/bufplugin/bufplugindocker/bufplugindocker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/bufplugindocker.go
@@ -18,3 +18,6 @@ package bufplugindocker
 // SourceFilePath is the default source file path
 // for the DockerSource.
 const SourceFilePath = "Dockerfile.plugin"
+
+// SourceFileAlternatePath is the alternate path for the DockerSource.
+const SourceFileAlternatePath = "Dockerfile"


### PR DESCRIPTION
In order to make it more flexible for plugin authoring, first check for
a `Dockerfile.plugin` and if not found fall back to looking for a
`Dockerfile`.