### PR TITLE
fix ModuleReferenceForString with port in remote

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleref/module_reference_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_reference_test.go
@@ -67,6 +67,30 @@ func TestModuleReferenceForString(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedModuleReference, moduleReference)
 	require.False(t, IsCommitModuleReference(moduleReference))
+
+	expectedModuleReference, err = NewModuleReference("localhost:8080", "barr", "baz", "some/draft")
+	require.NoError(t, err)
+	require.Equal(t, "localhost:8080/barr/baz:some/draft", expectedModuleReference.String())
+	moduleReference, err = ModuleReferenceForString("localhost:8080/barr/baz:some/draft")
+	require.NoError(t, err)
+	require.Equal(t, expectedModuleReference, moduleReference)
+	require.False(t, IsCommitModuleReference(moduleReference))
+
+	expectedModuleReference, err = NewModuleReference("localhost:8080", "barr", "baz", "ref")
+	require.NoError(t, err)
+	require.Equal(t, "localhost:8080/barr/baz:ref", expectedModuleReference.String())
+	moduleReference, err = ModuleReferenceForString("localhost:8080/barr/baz:ref")
+	require.NoError(t, err)
+	require.Equal(t, expectedModuleReference, moduleReference)
+	require.False(t, IsCommitModuleReference(moduleReference))
+
+	expectedModuleReference, err = NewModuleReference("localhost:8080", "barr", "baz", "main")
+	require.NoError(t, err)
+	require.Equal(t, "localhost:8080/barr/baz", expectedModuleReference.String())
+	moduleReference, err = ModuleReferenceForString("localhost:8080/barr/baz")
+	require.NoError(t, err)
+	require.Equal(t, expectedModuleReference, moduleReference)
+	require.False(t, IsCommitModuleReference(moduleReference))
 }
 
 func TestModuleReferenceForStringError(t *testing.T) {


### PR DESCRIPTION
this fix the issue of `ModuleReferenceForString` handling a remote with port (e.g. `localhost:8080`)