### PR TITLE
[bsr-383] Fix flaky studio agent test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - Change default for `--origin` flag of `buf beta studio-agent` to `https://studio.buf.build`
 - Change default for `--timeout` flag of `buf beta studio-agent` to `0` (no timeout). Before it was
   `2m` (the default for all the other `buf` commands).
-- Add `connect.CodeUnavailable` as an unhandled Connect error code for `buf beta studio-agent`,
-  which will trigger an `http.StatusBadGateway` response in case of a bad or unreachable upstream
-  server. Before the only unhandled Connect error code was `connect.CodeUnknown`.
 
 ## [v1.7.0] - 2022-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 - Change default for `--origin` flag of `buf beta studio-agent` to `https://studio.buf.build`
+- Change default for `--timeout` flag of `buf beta studio-agent` to `0` (no timeout). Before it was
+  `2m` (the default for all the other `buf` commands).
+- Add `connect.CodeUnavailable` as an unhandled Connect error code for `buf beta studio-agent`,
+  which will trigger an `http.StatusBadGateway` response in case of a bad or unreachable upstream
+  server. Before the only unhandled Connect error code was `connect.CodeUnknown`.
 
 ## [v1.7.0] - 2022-06-27
 

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -191,7 +192,9 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		listening := make(chan struct{}, 1)
 		go func(listening chan<- struct{}) {
 			listening <- struct{}{}
+			fmt.Println("signal sent")
 			conn, err := listener.Accept()
+			fmt.Println("connection arrived")
 			require.NoError(t, err)
 			require.NoError(t, conn.Close())
 		}(listening)
@@ -207,7 +210,9 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		request, err := http.NewRequest(http.MethodPost, agentServer.URL, bytes.NewReader(requestBytes))
 		require.NoError(t, err)
 		request.Header.Set("Content-Type", "text/plain")
+		fmt.Println("waiting before doing the request")
 		<-listening
+		fmt.Println("unblocked")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadGateway, response.StatusCode)

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
-	"time"
 
 	studiov1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/studio/v1alpha1"
 	"github.com/bufbuild/connect-go"
@@ -142,7 +141,6 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 			nil,
 		),
 	)
-	agentServer.Client().Timeout = time.Second
 	defer agentServer.Close()
 
 	t.Run("forbidden_header", func(t *testing.T) {

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -227,8 +227,10 @@ func newTestConnectServer(t *testing.T, tls bool) *httptest.Server {
 		},
 		connect.WithCodec(&bufferCodec{name: "proto"}),
 	))
+	// unknownPath returns the body as error message with code unknown, to test
+	// studio agent behavior on potential server closed connections.
 	mux.Handle(unknownPath, connect.NewUnaryHandler(
-		errorPath,
+		unknownPath,
 		func(ctx context.Context, r *connect.Request[bytes.Buffer]) (*connect.Response[bytes.Buffer], error) {
 			return nil, connect.NewError(connect.CodeUnknown, errors.New(r.Msg.String()))
 		},

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	studiov1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/studio/v1alpha1"
 	"github.com/bufbuild/connect-go"
@@ -142,6 +143,7 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 			nil,
 		),
 	)
+	agentServer.Client().Timeout = time.Second
 	defer agentServer.Close()
 
 	t.Run("forbidden_header", func(t *testing.T) {
@@ -197,6 +199,7 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 			fmt.Println("connection arrived")
 			require.NoError(t, err)
 			require.NoError(t, conn.Close())
+			fmt.Println("connection closed")
 		}(listening)
 		defer listener.Close()
 
@@ -212,8 +215,9 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Content-Type", "text/plain")
 		fmt.Println("waiting before doing the request")
 		<-listening
-		fmt.Println("unblocked")
+		fmt.Println("unblocked, starting request")
 		response, err := agentServer.Client().Do(request)
+		fmt.Println("request completed")
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadGateway, response.StatusCode)
 	})

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -169,7 +169,7 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO: should this context be cloned to remove attached values (but keep timeout)?``
 	response, err := client.CallUnary(r.Context(), request)
 	if err != nil {
-		// Connect marks any issues connecting with the Unavailable
+		// Any issue connecting is mapped by Connect to the Unavailable
 		// status code. We need to differentiate between server sent
 		// errors with the Unavailable code and client connection
 		// errors.
@@ -182,7 +182,8 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if connectErr := new(connect.Error); errors.As(err, &connectErr) {
-			if connectErr.Code() == connect.CodeUnknown {
+			switch connectErr.Code() {
+			case connect.CodeUnknown, connect.CodeUnavailable:
 				http.Error(w, err.Error(), http.StatusBadGateway)
 				return
 			}

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -183,6 +183,8 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if connectErr := new(connect.Error); errors.As(err, &connectErr) {
 			switch connectErr.Code() {
+			// The server is in some kind of bad and/or unreachable state, forward
+			// CodeUnavailable information as well.
 			case connect.CodeUnknown, connect.CodeUnavailable:
 				http.Error(w, err.Error(), http.StatusBadGateway)
 				return


### PR DESCRIPTION
Apparently, when doing [`conn.Close()`](https://github.com/bufbuild/buf/blob/bfa9bc47d59baf3d2487660044c7d92ffbc192f4/private/bufpkg/bufstudioagent/bufstudioagent_test.go#L194) in the test, to fake a server-closed connection, it's mapped sometimes as `connect.CodeUnavailable` instead of `connect.CodeUnknown`, that's what's causing the flakiness.

Dig into `connect-go`, and it's being returned [in the envelope](https://github.com/bufbuild/connect-go/blob/713199600fa7bc3a47957c910ddde9a85253036f/envelope.go#L178), by reading the error [from the request](https://github.com/bufbuild/connect-go/blob/713199600fa7bc3a47957c910ddde9a85253036f/duplex_http_call.go#L144).

The error that's being triggered is on the Connect's [`httpClient.Do`](https://github.com/bufbuild/connect-go/blob/713199600fa7bc3a47957c910ddde9a85253036f/duplex_http_call.go#L244) invocation, a `net/url.Error`:

```
error(*net/url.Error) *{Op: "Post", URL: "http://127.0.0.1:56188", Err: error(*errors.errorString) *{s: "io: read/write on closed pipe"}}
```

Which later is unwrapped into a regular error string `"io: read/write on closed pipe"`, and then wrapped again into a [`connect.CodeUnavailable`](https://github.com/bufbuild/connect-go/blob/713199600fa7bc3a47957c910ddde9a85253036f/duplex_http_call.go#L251).

That's the one that's being returned, but when doing `conn.Close()` the test is expecting a [`BadGateway`](https://github.com/bufbuild/buf/blob/bfa9bc47d59baf3d2487660044c7d92ffbc192f4/private/bufpkg/bufstudioagent/bufstudioagent_test.go#L210).

Not sure if this is expected, or what's the original intention of the test [`t.Run("invalid_upstream",`](https://github.com/bufbuild/buf/blob/bfa9bc47d59baf3d2487660044c7d92ffbc192f4/private/bufpkg/bufstudioagent/bufstudioagent_test.go#L188). Ticket [BSR-383](https://linear.app/bufbuild/issue/BSR-383/flaky-test-in-bufstudioagent-testgo)

tbh, not sure if the fix is here, or in Connect by returning a `CodeUnknown` instead of `CodeUnavailable` on the [catch-all non-Connect error](https://github.com/bufbuild/connect-go/blob/713199600fa7bc3a47957c910ddde9a85253036f/duplex_http_call.go#L251). Related [commit](https://github.com/bufbuild/connect-go/commit/1aba8655deeef4a3477e50a4526d4e30e7cf00b6).