### PR TITLE
Default origin for Studio Agent should contian URL scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Change default for `--origin` flag of `buf beta studio-agent` to `https://studio.buf.build`
 
 ## [v1.7.0] - 2022-06-27
 

--- a/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
+++ b/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
@@ -97,7 +97,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(
 		&f.Origin,
 		originFlagName,
-		"studio.buf.build",
+		"https://studio.buf.build",
 		"The allowed origin for CORS options.",
 	)
 	flagSet.StringSliceVar(


### PR DESCRIPTION
For CORS policies, the origin needs to be explicit, including the URL scheme.

Fixes #1310 