### PR TITLE
Call logger.Sync on exit

### DIFF
--- a/private/pkg/app/appflag/builder.go
+++ b/private/pkg/app/appflag/builder.go
@@ -113,6 +113,9 @@ func (b *builder) run(
 	if err != nil {
 		return err
 	}
+	defer func() {
+		retErr = multierr.Append(retErr, logger.Sync())
+	}()
 	verbosePrinter := appverbose.NewVerbosePrinter(appContainer.Stderr(), b.appName, b.verbose)
 	container, err := newContainer(appContainer, b.appName, logger, verbosePrinter)
 	if err != nil {


### PR DESCRIPTION
Fixes https://linear.app/bufbuild/issue/BSR-380/sync-zap-loggers-before-exit