### PR TITLE
update to go 1.18.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.4
+          go-version: 1.18.5
       - name: cache
         if: success()
         uses: actions/cache@v3
@@ -44,7 +44,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.4
+          go-version: 1.18.5
       - name: cache
         if: success()
         uses: actions/cache@v3

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -17,7 +17,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v3 # this contains a fix for Windows file extraction
         with:
-          go-version: 1.18.4
+          go-version: 1.18.5
       - name: cache
         if: success()
         uses: actions/cache@v3

--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.18.4-alpine3.16 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.18.5-alpine3.16 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.workspace
+++ b/Dockerfile.workspace
@@ -1,4 +1,4 @@
-FROM golang:1.18.4-alpine3.16
+FROM golang:1.18.5-alpine3.16
 
 ARG PROJECT
 ARG GO_MODULE

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -123,7 +123,7 @@ bufgeneratesteps:: \
 
 .PHONY: bufrelease
 bufrelease: $(MINISIGN)
-	DOCKER_IMAGE=golang:1.18.4-buster bash make/buf/scripts/release.bash
+	DOCKER_IMAGE=golang:1.18.5-buster bash make/buf/scripts/release.bash
 
 # We have to manually set the Homebrew version on the Homebrew badge as there
 # is no badge on shields.io for Homebrew packages outside of homebrew-core


### PR DESCRIPTION
Update to the latest security/bugfix release of Go 1.18.