### PR TITLE
add --override-remote flag to plugin push

### DIFF
--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20220517 checked 20220520
+# https://github.com/golangci/golangci-lint/releases 20220804 checked 20220808
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.46.2
+GOLANGCI_LINT_VERSION ?= v1.48.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -55,7 +55,7 @@ func NewCommand(
 		Use:   name + " <source>",
 		Short: "Push a plugin to a registry.",
 		Long:  bufcli.GetSourceDirLong(`the source to push`),
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
 				return run(ctx, container, flags)
@@ -143,7 +143,11 @@ func run(
 	if existingConfigFilePath == "" {
 		return fmt.Errorf("please define a %s configuration file in the target directory", bufpluginconfig.ExternalConfigFilePath)
 	}
-	pluginConfig, err := bufpluginconfig.GetConfigForBucket(ctx, sourceBucket)
+	var options []bufpluginconfig.ConfigOption
+	if len(flags.OverrideRemote) > 0 {
+		options = append(options, bufpluginconfig.WithOverrideRemote(flags.OverrideRemote))
+	}
+	pluginConfig, err := bufpluginconfig.GetConfigForBucket(ctx, sourceBucket, options...)
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -105,6 +105,19 @@ func TestParsePluginConfigGoYAML(t *testing.T) {
 	)
 }
 
+func TestParsePluginConfigGoYAMLOverrideRemote(t *testing.T) {
+	t.Parallel()
+	pluginConfig, err := ParseConfig(filepath.Join("testdata", "success", "go", "buf.plugin.yaml"), WithOverrideRemote("buf.mydomain.com"))
+	require.NoError(t, err)
+	pluginIdentity, err := bufpluginref.PluginIdentityForString("buf.mydomain.com/library/go-grpc")
+	require.NoError(t, err)
+	pluginDependency, err := bufpluginref.PluginReferenceForString("buf.mydomain.com/library/go:v1.28.0", 1)
+	require.NoError(t, err)
+	assert.Equal(t, pluginIdentity, pluginConfig.Name)
+	require.Len(t, pluginConfig.Dependencies, 1)
+	assert.Equal(t, pluginDependency, pluginConfig.Dependencies[0])
+}
+
 func TestParsePluginConfigNPMYAML(t *testing.T) {
 	t.Parallel()
 	pluginConfig, err := ParseConfig(filepath.Join("testdata", "success", "npm", "buf.plugin.yaml"))

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -34,8 +34,13 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// pluginsImagePrefix is used to prefix all image names with the correct path for pushing to the OCI registry.
-const pluginsImagePrefix = "plugins."
+const (
+	// DefaultTarget is the default target architecture for Docker images.
+	DefaultTarget = "linux/amd64"
+
+	// pluginsImagePrefix is used to prefix all image names with the correct path for pushing to the OCI registry.
+	pluginsImagePrefix = "plugins."
+)
 
 // Client is a small abstraction over a Docker API client, providing the basic APIs we need to build plugins.
 // It ensures that we pass the appropriate parameters to build images (i.e. platform 'linux/amd64').
@@ -138,7 +143,7 @@ func (d *dockerAPIClient) Build(ctx context.Context, dockerfile io.Reader, plugi
 
 		target := params.target
 		if len(target) == 0 {
-			target = "linux/amd64"
+			target = DefaultTarget
 		}
 		response, err := d.cli.ImageBuild(ctx, dockerContext, types.ImageBuildOptions{
 			Tags:     []string{imageName},

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -84,6 +84,7 @@ func testPlainPostHandler(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Foo", "foo-value")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
+		defer response.Body.Close()
 
 		assert.Equal(t, http.StatusOK, response.StatusCode)
 		assert.Equal(t, "https://example.buf.build", response.Header.Get("Access-Control-Allow-Origin"))
@@ -115,6 +116,7 @@ func testPlainPostHandler(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Foo", "foo-value")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
+		defer response.Body.Close()
 
 		assert.Equal(t, http.StatusOK, response.StatusCode)
 		assert.Equal(t, "https://example.buf.build", response.Header.Get("Access-Control-Allow-Origin"))
@@ -156,6 +158,7 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Content-Type", "text/plain")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
+		defer response.Body.Close()
 		assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 	})
 
@@ -173,6 +176,7 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Content-Type", "text/plain")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
+		defer response.Body.Close()
 		assert.Equal(t, http.StatusOK, response.StatusCode)
 		responseBytes, err := io.ReadAll(response.Body)
 		assert.NoError(t, err)
@@ -220,6 +224,7 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Content-Type", "text/plain")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
+		defer response.Body.Close()
 		assert.Equal(t, http.StatusBadGateway, response.StatusCode)
 	})
 }

--- a/private/pkg/transport/http/httpclient/httpclient_test.go
+++ b/private/pkg/transport/http/httpclient/httpclient_test.go
@@ -15,7 +15,7 @@
 package httpclient
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -44,8 +44,9 @@ func TestProxy(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, string(proxyResponse), string(respBody))
 }


### PR DESCRIPTION
Update the 'buf alpha plugin push' command to add an '--override-remote'
flag to allow building/publishing a plugin to another BSR instance
(without requiring changes to the 'buf.plugin.yaml' file).