### PR TITLE
add MapperWithMiddlewares helper

### DIFF
--- a/private/pkg/transport/http/httpserver/httpserver.go
+++ b/private/pkg/transport/http/httpserver/httpserver.go
@@ -65,6 +65,19 @@ func HTTPHandlerMapperWithPrefix(prefix string) HTTPHandlerMapperOption {
 	}
 }
 
+// MapperWithMiddlewares rewrites the Map function of the Mapper to call the provided middlewares
+// inside a chi Group before mapping
+func MapperWithMiddlewares(mapper Mapper, middlewares chi.Middlewares) Mapper {
+	return MapperFunc(func(parent chi.Router) error {
+		var err error
+		parent.Group(func(r chi.Router) {
+			r.Use(middlewares...)
+			err = mapper.Map(r)
+		})
+		return err
+	})
+}
+
 // Runner is a runner.
 type Runner interface {
 	// Run runs the router.


### PR DESCRIPTION
this helper allows adding middlewares to a Mapper inside of a Group,
which stops them interfering with other routers defined under parent