### PR TITLE
Preserve single quotes with buf format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change default for `--timeout` flag of `buf beta studio-agent` to `0` (no timeout). Before it was
   `2m` (the default for all the other `buf` commands).
 - Add support for experimental code generation with the `plugin:` key in `buf.gen.yaml`.
+- Preserve single quotes with `buf format`.
 
 ## [v1.7.0] - 2022-06-27
 

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -1453,27 +1453,22 @@ func (f *formatter) writeStringValue(stringValueNode ast.StringValueNode) {
 
 // writeStringWithStyle writes a string value with surrounding single quotes or double quotes
 // based on the string value's content. The formatter prefers double quotes, but uses single
-// quotes if the content contains any (") or (\") literals and not any (') or (\') literals.
+// quotes if the content contains any (") literals and not any (') literals.
 //
 // For example,
 //
-//  1. f"o"'o' -> "f\"o\"'o'"      (") and (') are used - surround with (")
-//  2. f"oo" -> 'f"oo"'            (") is used - surround with (')
-//  3. f'oo' -> "f'oo'"            (') is used - surround with (")
-//  4. f\"o\"\'o\' -> "f\"o\"'o'"  (\") and (\') are used - surround with (")
-//  5. f\"o\"o -> 'f"o"o'          (\") is used - surround with (')
-//  6. f\'o\'o -> "f'o'o"          (\') is used - surround with (")
-//  7. foo -> "foo"                By default, use double quotes
+//  1. f"o"'o' -> "f\"o\"'o'"  (") and (') are used - surround with (")
+//  2. f"oo" -> 'f"oo"'        (") is used - surround with (')
+//  3. f'oo' -> "f'oo'"        (') is used - surround with (")
+//  4. foo -> "foo"            By default, use double quotes
 //
 func (f *formatter) writeStringWithStyle(value string) {
 	var (
-		singleQuote        = strings.ContainsRune(value, '\'')
-		doubleQuote        = strings.ContainsRune(value, '"')
-		escapedSingleQuote = strings.Contains(value, "\\'")
-		escapedDoubleQuote = strings.Contains(value, `\\"`)
+		singleQuote = strings.ContainsRune(value, '\'')
+		doubleQuote = strings.ContainsRune(value, '"')
 	)
 	var formattedString string
-	if (doubleQuote || escapedDoubleQuote) && (!singleQuote && !escapedSingleQuote) {
+	if doubleQuote && !singleQuote {
 		// Use a single quote if the content contains any (") or (\")
 		// literals, and not any (') or (\') literals.
 		formattedString = fmt.Sprintf("'%s'", value)

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -1443,12 +1443,44 @@ func (f *formatter) writeSpecialFloatLiteral(specialFloatLiteralNode *ast.Specia
 
 // writeStringLiteral writes a string literal value (e.g. "foo").
 func (f *formatter) writeStringLiteral(stringLiteralNode *ast.StringLiteralNode) {
-	f.WriteString(fmt.Sprintf("%q", stringLiteralNode.Val))
+	f.writeStringWithStyle(stringLiteralNode.Val)
 }
 
 // writeStringValue writes a string value (e.g. "foo").
 func (f *formatter) writeStringValue(stringValueNode ast.StringValueNode) {
-	f.WriteString(fmt.Sprintf("%q", stringValueNode.AsString()))
+	f.writeStringWithStyle(stringValueNode.AsString())
+}
+
+// writeStringWithStyle writes a string value with surrounding single quotes or double quotes
+// based on the string value's content. The formatter prefers double quotes, but uses single
+// quotes if the content contains any (") or (\") literals and not any (') or (\') literals.
+//
+// For example,
+//
+//  1. f"o"'o' -> "f\"o\"'o'"      (") and (') are used - surround with (")
+//  2. f"oo" -> 'f"oo"'            (") is used - surround with (')
+//  3. f'oo' -> "f'oo'"            (') is used - surround with (")
+//  4. f\"o\"\'o\' -> "f\"o\"'o'"  (\") and (\') are used - surround with (")
+//  5. f\"o\"o -> 'f"o"o'          (\") is used - surround with (')
+//  6. f\'o\'o -> "f'o'o"          (\') is used - surround with (")
+//  7. foo -> "foo"                By default, use double quotes
+//
+func (f *formatter) writeStringWithStyle(value string) {
+	var (
+		singleQuote        = strings.ContainsRune(value, '\'')
+		doubleQuote        = strings.ContainsRune(value, '"')
+		escapedSingleQuote = strings.Contains(value, "\\'")
+		escapedDoubleQuote = strings.Contains(value, `\\"`)
+	)
+	var formattedString string
+	if (doubleQuote || escapedDoubleQuote) && (!singleQuote && !escapedSingleQuote) {
+		// Use a single quote if the content contains any (") or (\")
+		// literals, and not any (') or (\') literals.
+		formattedString = fmt.Sprintf("'%s'", value)
+	} else {
+		formattedString = fmt.Sprintf("%q", value)
+	}
+	f.WriteString(formattedString)
 }
 
 // writeUintLiteral writes a uint literal (e.g. '42').

--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -48,6 +48,7 @@ func testFormatProto2(t *testing.T) {
 	testFormatNoDiff(t, "testdata/proto2/license/v1")
 	testFormatNoDiff(t, "testdata/proto2/message/v1")
 	testFormatNoDiff(t, "testdata/proto2/option/v1")
+	testFormatNoDiff(t, "testdata/proto2/quotes/v1")
 
 	// TODO: Temporarily skipping this test since it's
 	// due to a bug in protocompile.

--- a/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.golden.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+message Foo {
+  string something = 1;
+}
+
+extend google.protobuf.FieldOptions {
+  string name = 10001;
+  Foo foo = 10002;
+}
+
+message Foo {
+  string one = 1 [(name) = "f\"o\"'o'"];
+  string two = 2 [(name) = 'f"oo"'];
+  string three = 3 [(name) = "f'oo'"];
+  string four = 4 [(name) = "f\"o\"'o'"];
+  string five = 5 [(name) = 'f"o"o'];
+  string six = 6 [(name) = "f'o'o"];
+  string seven = 7 [(name) = "foo"];
+  string eight = 8 [(foo) = {
+    something: 'something:"foo"'
+  }];
+}

--- a/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.proto
+++ b/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+message Foo {
+  string something = 1;
+}
+
+extend google.protobuf.FieldOptions {
+  string name = 10001;
+  Foo foo = 10002;
+}
+
+message Foo {
+  string one = 1 [(name) = "f\"o\"'o'"];
+  string two = 2 [(name) = 'f"oo"'];
+  string three = 3 [(name) = "f'oo'"];
+  string four = 4 [(name) = "f\"o\"\'o\'"];
+  string five = 5 [(name) = "f\"o\"o"];
+  string six = 6 [(name) = 'f\'o\'o'];
+  string seven = 7 [(name) = "foo"];
+  string eight = 8 [(foo) = {
+    something: 'something:"foo"'
+  }];
+}


### PR DESCRIPTION
Fixes #1093

This adjusts the formatter logic to preserve single quotes for string literals that contain `(")` or `(\")` literals. In general, the formatter prefers double quotes, so if the string literal contains a mix of `(")` and `(')` literals, the string will be surrounded with `(")`.