### PR TITLE
Add support for metrics tags on httpclient

### DIFF
--- a/private/pkg/observability/observability.go
+++ b/private/pkg/observability/observability.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/ioextended"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 )
 
@@ -106,10 +107,13 @@ func StartWithTraceViewExportCloser(traceViewExportCloser TraceViewExportCloser)
 }
 
 // NewHTTPTransport returns a HTTP transport instrumented with OpenCensus traces and metrics.
-func NewHTTPTransport(base http.RoundTripper) http.RoundTripper {
-	return &ochttp.Transport{
-		NewClientTrace: ochttp.NewSpanAnnotatingClientTrace,
-		Base:           base,
+func NewHTTPTransport(base http.RoundTripper, tags ...tag.Mutator) http.RoundTripper {
+	return &wrappedRoundTripper{
+		Base: &ochttp.Transport{
+			NewClientTrace: ochttp.NewSpanAnnotatingClientTrace,
+			Base:           base,
+		},
+		Tags: tags,
 	}
 }
 

--- a/private/pkg/observability/wrapped_round_tripper.go
+++ b/private/pkg/observability/wrapped_round_tripper.go
@@ -1,0 +1,35 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"net/http"
+
+	"go.opencensus.io/tag"
+)
+
+type wrappedRoundTripper struct {
+	Base http.RoundTripper
+	Tags []tag.Mutator
+}
+
+func (w *wrappedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, err := tag.New(req.Context(), w.Tags...)
+	if err != nil {
+		return nil, err
+	}
+	wrappedRequest := req.WithContext(ctx)
+	return w.Base.RoundTrip(wrappedRequest)
+}

--- a/private/pkg/transport/http/httpclient/client.go
+++ b/private/pkg/transport/http/httpclient/client.go
@@ -20,15 +20,17 @@ import (
 	"net/http"
 
 	"github.com/bufbuild/buf/private/pkg/observability"
+	"go.opencensus.io/tag"
 	"golang.org/x/net/http2"
 )
 
 type clientOptions struct {
-	tlsConfig       *tls.Config
-	observability   bool
-	proxy           Proxy
-	interceptorFunc ClientInterceptorFunc
-	h2c             bool
+	tlsConfig         *tls.Config
+	observability     bool
+	observabilityTags []tag.Mutator
+	proxy             Proxy
+	interceptorFunc   ClientInterceptorFunc
+	h2c               bool
 }
 
 func newClient(options ...ClientOption) *http.Client {
@@ -57,7 +59,7 @@ func newClient(options ...ClientOption) *http.Client {
 		roundTripper = opts.interceptorFunc(roundTripper)
 	}
 	if opts.observability {
-		roundTripper = observability.NewHTTPTransport(roundTripper)
+		roundTripper = observability.NewHTTPTransport(roundTripper, opts.observabilityTags...)
 	}
 	return &http.Client{
 		Transport: roundTripper,

--- a/private/pkg/transport/http/httpclient/httpclient.go
+++ b/private/pkg/transport/http/httpclient/httpclient.go
@@ -18,6 +18,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
+
+	"go.opencensus.io/tag"
 )
 
 // NewClient returns a new Client.
@@ -44,9 +46,10 @@ func WithTLSConfig(tlsConfig *tls.Config) ClientOption {
 // OpenCensus tracing and metrics.
 //
 // The default is to use no observability.
-func WithObservability() ClientOption {
+func WithObservability(tags ...tag.Mutator) ClientOption {
 	return func(opts *clientOptions) {
 		opts.observability = true
+		opts.observabilityTags = tags
 	}
 }
 


### PR DESCRIPTION
In order to tag the HTTP clients we use in the BSR, we need to
add the ability to create custom tags and get the data from the
request context.
This has been tested on a local BSR cluster.