### PR TITLE
Add option for cache to preserve external paths

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ linters-settings:
       - '^exec\.Cmd$'
       - '^exec\.Command$'
       - '^exec\.CommandContext$'
+      # This should only be used by github.com/bufbuild/buf-language-server
+      - '^bufcli\.NewModuleReaderAndCreateCacheDirsWithExternalPaths'
       # os.Rename does not work across filesystem boundaries
       # See https://github.com/bufbuild/buf/issues/639
       - '^os\.Rename$'

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -512,7 +512,7 @@ func NewModuleReaderAndCreateCacheDirs(
 // required cache directories, and configures the cache to preserve external paths.
 //
 // WARNING - this should only be used by systems like the LSP - leaking external paths from the module
-// cache is otherwise dangerous and NOT recommended.
+// cache is otherwise dangerous and requires manager approval.
 func NewModuleReaderAndCreateCacheDirsWithExternalPaths(
 	container appflag.Container,
 	registryProvider registryv1alpha1apiclient.Provider,

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -502,6 +502,33 @@ func NewModuleReaderAndCreateCacheDirs(
 	container appflag.Container,
 	registryProvider registryv1alpha1apiclient.Provider,
 ) (bufmodule.ModuleReader, error) {
+	return newModuleReaderAndCreateCacheDirs(
+		container,
+		registryProvider,
+	)
+}
+
+// NewModuleReaderAndCreateCacheDirsWithExternalPaths returns a new ModuleReader while creating the
+// required cache directories, and configures the cache to preserve external paths.
+//
+// WARNING - this should only be used by systems like the LSP - leaking external paths from the module
+// cache is otherwise dangerous and NOT recommended.
+func NewModuleReaderAndCreateCacheDirsWithExternalPaths(
+	container appflag.Container,
+	registryProvider registryv1alpha1apiclient.Provider,
+) (bufmodule.ModuleReader, error) {
+	return newModuleReaderAndCreateCacheDirs(
+		container,
+		registryProvider,
+		bufmodulecache.ModuleReaderWithExternalPaths(),
+	)
+}
+
+func newModuleReaderAndCreateCacheDirs(
+	container appflag.Container,
+	registryProvider registryv1alpha1apiclient.Provider,
+	moduleReaderOptions ...bufmodulecache.ModuleReaderOption,
+) (bufmodule.ModuleReader, error) {
 	cacheModuleDataDirPath := normalpath.Join(container.CacheDirPath(), v1CacheModuleDataRelDirPath)
 	cacheModuleLockDirPath := normalpath.Join(container.CacheDirPath(), v1CacheModuleLockRelDirPath)
 	cacheModuleSumDirPath := normalpath.Join(container.CacheDirPath(), v1CacheModuleSumRelDirPath)
@@ -544,6 +571,7 @@ func NewModuleReaderAndCreateCacheDirs(
 		sumReadWriteBucket,
 		bufapimodule.NewModuleReader(registryProvider),
 		registryProvider,
+		moduleReaderOptions...,
 	)
 	return moduleReader, nil
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache.go
@@ -23,6 +23,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// ModuleReaderOption is an option for creating a ModuleReader.
+type ModuleReaderOption func(*moduleReaderOptions)
+
 // NewModuleReader returns a new ModuleReader that uses cache as a caching layer, and
 // delegate as the source of truth.
 func NewModuleReader(
@@ -33,6 +36,7 @@ func NewModuleReader(
 	sumReadWriteBucket storage.ReadWriteBucket,
 	delegate bufmodule.ModuleReader,
 	repositoryServiceProvider registryv1alpha1apiclient.RepositoryServiceProvider,
+	options ...ModuleReaderOption,
 ) bufmodule.ModuleReader {
 	return newModuleReader(
 		logger,
@@ -42,5 +46,18 @@ func NewModuleReader(
 		sumReadWriteBucket,
 		delegate,
 		repositoryServiceProvider,
+		options...,
 	)
+}
+
+// ModuleReaderWithExternalPaths is used to preserve the external paths
+// to the files resolved from the module cache.
+func ModuleReaderWithExternalPaths() ModuleReaderOption {
+	return func(moduleReaderOptions *moduleReaderOptions) {
+		moduleReaderOptions.allowCacheExternalPaths = true
+	}
+}
+
+type moduleReaderOptions struct {
+	allowCacheExternalPaths bool
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -63,7 +63,7 @@ func TestReaderBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	delegateDataReadWriteBucket, delegateSumReadWriteBucket, delegateFileLocker := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), delegateDataReadWriteBucket, delegateSumReadWriteBucket)
+	moduleCacher := newModuleCacher(zap.NewNop(), delegateDataReadWriteBucket, delegateSumReadWriteBucket, false)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,
@@ -207,7 +207,7 @@ func TestCacherBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	dataReadWriteBucket, sumReadWriteBucket, _ := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, false)
 	_, err = moduleCacher.GetModule(ctx, modulePin)
 	require.True(t, storage.IsNotExist(err))
 
@@ -248,7 +248,7 @@ func TestModuleReaderCacherWithDocumentation(t *testing.T) {
 	require.NoError(t, err)
 
 	dataReadWriteBucket, sumReadWriteBucket, _ := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, false)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,
@@ -283,7 +283,7 @@ func TestModuleReaderCacherWithConfiguration(t *testing.T) {
 	require.NoError(t, err)
 
 	dataReadWriteBucket, sumReadWriteBucket, _ := newTestDataSumBucketsAndLocker(t)
-	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket)
+	moduleCacher := newModuleCacher(zap.NewNop(), dataReadWriteBucket, sumReadWriteBucket, false)
 	err = moduleCacher.PutModule(
 		context.Background(),
 		modulePin,

--- a/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_cacher.go
@@ -26,20 +26,23 @@ import (
 )
 
 type moduleCacher struct {
-	logger              *zap.Logger
-	dataReadWriteBucket storage.ReadWriteBucket
-	sumReadWriteBucket  storage.ReadWriteBucket
+	logger                  *zap.Logger
+	dataReadWriteBucket     storage.ReadWriteBucket
+	sumReadWriteBucket      storage.ReadWriteBucket
+	allowCacheExternalPaths bool
 }
 
 func newModuleCacher(
 	logger *zap.Logger,
 	dataReadWriteBucket storage.ReadWriteBucket,
 	sumReadWriteBucket storage.ReadWriteBucket,
+	allowCacheExternalPaths bool,
 ) *moduleCacher {
 	return &moduleCacher{
-		logger:              logger,
-		dataReadWriteBucket: dataReadWriteBucket,
-		sumReadWriteBucket:  sumReadWriteBucket,
+		logger:                  logger,
+		dataReadWriteBucket:     dataReadWriteBucket,
+		sumReadWriteBucket:      sumReadWriteBucket,
+		allowCacheExternalPaths: allowCacheExternalPaths,
 	}
 }
 
@@ -48,13 +51,17 @@ func (m *moduleCacher) GetModule(
 	modulePin bufmoduleref.ModulePin,
 ) (bufmodule.Module, error) {
 	modulePath := newCacheKey(modulePin)
-	// We do not want the external path of the cache to be propagated to the user.
-	dataReadWriteBucket := storage.NoExternalPathReadBucket(
-		storage.MapReadWriteBucket(
-			m.dataReadWriteBucket,
-			storage.MapOnPrefix(modulePath),
-		),
+	// Explicitly assign the variable as a storage.ReadBucket so
+	// that we can easily transform it with storage.NoExternalPathReadBucket
+	// below.
+	var dataReadWriteBucket storage.ReadBucket = storage.MapReadWriteBucket(
+		m.dataReadWriteBucket,
+		storage.MapOnPrefix(modulePath),
 	)
+	if !m.allowCacheExternalPaths {
+		// In general, we do not want the external path of the cache to be propagated to the user.
+		dataReadWriteBucket = storage.NoExternalPathReadBucket(dataReadWriteBucket)
+	}
 	exists, err := storage.Exists(ctx, dataReadWriteBucket, buflock.ExternalConfigFilePath)
 	if err != nil {
 		return nil, err

--- a/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
@@ -50,7 +50,12 @@ func newModuleReader(
 	sumReadWriteBucket storage.ReadWriteBucket,
 	delegate bufmodule.ModuleReader,
 	repositoryServiceProvider registryv1alpha1apiclient.RepositoryServiceProvider,
+	options ...ModuleReaderOption,
 ) *moduleReader {
+	moduleReaderOptions := &moduleReaderOptions{}
+	for _, option := range options {
+		option(moduleReaderOptions)
+	}
 	return &moduleReader{
 		logger:         logger,
 		verbosePrinter: verbosePrinter,
@@ -59,6 +64,7 @@ func newModuleReader(
 			logger,
 			dataReadWriteBucket,
 			sumReadWriteBucket,
+			moduleReaderOptions.allowCacheExternalPaths,
 		),
 		delegate:                  delegate,
 		repositoryServiceProvider: repositoryServiceProvider,


### PR DESCRIPTION
This adds `bufcli.NewModuleReaderAndCreateCacheDirsWithExternalPaths` so that callers can preserve the external paths within the module cache. 

In general, this is _not_ something we want to do (hence the loud `WARNING` in the function comment), but it's required for some features (e.g. a language server that refers to files in the cache).