### PR TITLE
Add --stdin flag to 'buf format'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   `2m` (the default for all the other `buf` commands).
 - Add support for experimental code generation with the `plugin:` key in `buf.gen.yaml`.
 - Preserve single quotes with `buf format`.
+- Add `--stdin` flag to `buf format` to format the content read from stdin.
 
 ## [v1.7.0] - 2022-06-27
 

--- a/private/buf/bufformat/bufformat.go
+++ b/private/buf/bufformat/bufformat.go
@@ -15,6 +15,7 @@
 package bufformat
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
@@ -65,4 +66,17 @@ func Format(ctx context.Context, module bufmodule.Module) (_ storage.ReadBucket,
 		return nil, err
 	}
 	return readWriteBucket, nil
+}
+
+// FormatRaw formats the given raw bytes and returns the result.
+func FormatRaw(ctx context.Context, raw []byte) ([]byte, error) {
+	fileNode, err := parser.Parse("<proto>", bytes.NewReader(raw), reporter.NewHandler(nil))
+	if err != nil {
+		return nil, err
+	}
+	buffer := bytes.NewBuffer(nil)
+	if err := newFormatter(buffer, fileNode).Run(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
 }

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1987,6 +1987,95 @@ func TestFormatExitCode(t *testing.T) {
 	assert.NotEmpty(t, stdout.String())
 }
 
+func TestFormatStdin(t *testing.T) {
+	stdin := bytes.NewBuffer(
+		[]byte(`
+syntax = "proto3";
+
+
+package foo;
+`),
+	)
+	stdout := bytes.NewBuffer(nil)
+	testRun(
+		t,
+		0,
+		stdin,
+		stdout,
+		"format",
+		"--stdin",
+	)
+	assert.Equal(
+		t,
+		`syntax = "proto3";
+
+package foo;
+`,
+		stdout.String(),
+	)
+
+	stdin = bytes.NewBuffer(
+		[]byte(`
+syntax = "proto3";
+
+
+package foo;
+`),
+	)
+	stdout = bytes.NewBuffer(nil)
+	testRun(
+		t,
+		0,
+		stdin,
+		stdout,
+		"format",
+		"--stdin",
+		"--diff",
+	)
+	assert.NotEmpty(t, stdout.String())
+
+	stdin = bytes.NewBuffer(
+		[]byte(`
+syntax = "proto3";
+
+
+package foo;
+`),
+	)
+	stdout = bytes.NewBuffer(nil)
+	testRun(
+		t,
+		bufcli.ExitCodeFileAnnotation,
+		stdin,
+		stdout,
+		"format",
+		"--stdin",
+		"--exit-code",
+	)
+	assert.NotEmpty(t, stdout.String())
+
+	stdin = bytes.NewBuffer(
+		[]byte(`
+syntax = "proto3";
+
+
+package foo;
+`),
+	)
+	stdout = bytes.NewBuffer(nil)
+	testRun(
+		t,
+		bufcli.ExitCodeFileAnnotation,
+		stdin,
+		stdout,
+		"format",
+		"--stdin",
+		"--diff",
+		"--exit-code",
+	)
+	assert.NotEmpty(t, stdout.String())
+}
+
 // Tests if the image produced by the formatted result is
 // equivalent to the original result.
 func TestFormatEquivalence(t *testing.T) {
@@ -2042,6 +2131,28 @@ func TestFormatInvalidFlagCombination(t *testing.T) {
 		filepath.Join("testdata", "format", "diff"),
 		"-w",
 		"-o",
+		filepath.Join(tempDir, "formatted"),
+	)
+	testRunStdoutStderr(
+		t,
+		nil,
+		1,
+		"",
+		`Failure: --stdin cannot be used with --write`,
+		"format",
+		"--stdin",
+		"--write",
+		filepath.Join(tempDir, "formatted"),
+	)
+	testRunStdoutStderr(
+		t,
+		nil,
+		1,
+		"",
+		`Failure: --stdin cannot be used with --output`,
+		"format",
+		"--stdin",
+		"--output",
 		filepath.Join(tempDir, "formatted"),
 	)
 }


### PR DESCRIPTION
Fixes #1035

This adds a `--stdin` flag to `buf format` so that users can format the `.proto` content read from `stdin`, rather than requiring a file on disk. This makes it far easier to write developer tools that would otherwise need to create a temporary file containing the buffer's content (re: https://github.com/bufbuild/buf/issues/1334#issuecomment-1213539045).

Unsurprisingly, the `--output` and `--write` flags are not supported alongside `--stdin`. For anyone that needs to write the formatted content to disk, they can simply redirect the formatted result written to `stdout`.