### PR TITLE
add runner option to silence logging certain endpoints

### DIFF
--- a/private/pkg/transport/http/httpserver/httpserver.go
+++ b/private/pkg/transport/http/httpserver/httpserver.go
@@ -169,6 +169,8 @@ func RunnerWithHealth() RunnerOption {
 // The default is to not silence any endpoints.
 func RunnerWithSilentEndpoints(silentEndpoints ...string) RunnerOption {
 	return func(runner *runner) {
-		runner.silentEndpoints = append(runner.silentEndpoints, silentEndpoints...)
+		for _, endpoint := range silentEndpoints {
+			runner.silentEndpoints[endpoint] = struct{}{}
+		}
 	}
 }

--- a/private/pkg/transport/http/httpserver/httpserver.go
+++ b/private/pkg/transport/http/httpserver/httpserver.go
@@ -162,3 +162,13 @@ func RunnerWithHealth() RunnerOption {
 		runner.health = true
 	}
 }
+
+// RunnerWithSilentEndpoints returns a new RunnerOption that disables logging from the
+// provided endpoints.
+//
+// The default is to not silence any endpoints.
+func RunnerWithSilentEndpoints(silentEndpoints ...string) RunnerOption {
+	return func(runner *runner) {
+		runner.silentEndpoints = append(runner.silentEndpoints, silentEndpoints...)
+	}
+}

--- a/private/pkg/transport/http/httpserver/runner.go
+++ b/private/pkg/transport/http/httpserver/runner.go
@@ -46,6 +46,7 @@ func newRunner(logger *zap.Logger, options ...RunnerOption) *runner {
 		logger:            logger.Named("httpserver"),
 		shutdownTimeout:   DefaultShutdownTimeout,
 		readHeaderTimeout: DefaultReadHeaderTimeout,
+		silentEndpoints:   make(map[string]struct{}),
 	}
 	for _, option := range options {
 		option(runner)

--- a/private/pkg/transport/http/httpserver/runner.go
+++ b/private/pkg/transport/http/httpserver/runner.go
@@ -38,7 +38,7 @@ type runner struct {
 	health            bool
 	maxBodySize       int64
 	walkFunc          chi.WalkFunc
-	silentEndpoints   []string
+	silentEndpoints   map[string]struct{}
 }
 
 func newRunner(logger *zap.Logger, options ...RunnerOption) *runner {

--- a/private/pkg/transport/http/httpserver/runner.go
+++ b/private/pkg/transport/http/httpserver/runner.go
@@ -38,6 +38,7 @@ type runner struct {
 	health            bool
 	maxBodySize       int64
 	walkFunc          chi.WalkFunc
+	silentEndpoints   []string
 }
 
 func newRunner(logger *zap.Logger, options ...RunnerOption) *runner {
@@ -69,7 +70,7 @@ func (s *runner) Run(
 	mux := chi.NewMux()
 	mux.Use(middleware.Recoverer)
 	mux.Use(middleware.StripSlashes)
-	mux.Use(newZapMiddleware(s.logger))
+	mux.Use(newZapMiddleware(s.logger, s.silentEndpoints))
 	if s.maxBodySize > 0 {
 		mux.Use(func(next http.Handler) http.Handler {
 			return http.MaxBytesHandler(next, s.maxBodySize)

--- a/private/pkg/transport/http/httpserver/zap.go
+++ b/private/pkg/transport/http/httpserver/zap.go
@@ -27,7 +27,7 @@ func newZapMiddleware(logger *zap.Logger, silentEndpoints map[string]struct{}) f
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			logEntry := newLogEntry(logger, request)
 			wrapResponseWriter := middleware.NewWrapResponseWriter(newCheckedResponseWriter(logger, writer, request), request.ProtoMajor)
-			if _, ok := silentEndpoints[request.URL.Path]; ok {
+			if _, ok := silentEndpoints[request.URL.Path]; !ok {
 				defer logRequest(logEntry, wrapResponseWriter, time.Now())
 			}
 			next.ServeHTTP(wrapResponseWriter, middleware.WithLogEntry(request, logEntry))

--- a/private/pkg/transport/http/httpserver/zap.go
+++ b/private/pkg/transport/http/httpserver/zap.go
@@ -22,26 +22,17 @@ import (
 	"go.uber.org/zap"
 )
 
-func newZapMiddleware(logger *zap.Logger, silentEndpoints []string) func(http.Handler) http.Handler {
+func newZapMiddleware(logger *zap.Logger, silentEndpoints map[string]struct{}) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			logEntry := newLogEntry(logger, request)
 			wrapResponseWriter := middleware.NewWrapResponseWriter(newCheckedResponseWriter(logger, writer, request), request.ProtoMajor)
-			if !contains(silentEndpoints, request.URL.Path) {
+			if _, ok := silentEndpoints[request.URL.Path]; ok {
 				defer logRequest(logEntry, wrapResponseWriter, time.Now())
 			}
 			next.ServeHTTP(wrapResponseWriter, middleware.WithLogEntry(request, logEntry))
 		})
 	}
-}
-
-func contains(l []string, s string) bool {
-	for _, v := range l {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }
 
 func logRequest(


### PR DESCRIPTION
pass a list of endpoints to ignore by path, the goal of this is to
stop logging requests to /health and /metrics