### PR TITLE
allow specifying build arguments to plugin push

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -46,6 +46,7 @@ const (
 	cacheFromFlagName       = "cache-from"
 	dryRunFlagName          = "dry-run"
 	pullFlagName            = "pull"
+	buildArgFlagName        = "build-arg"
 )
 
 // NewCommand returns a new Command.
@@ -78,6 +79,7 @@ type flags struct {
 	CacheFrom       []string
 	DryRun          bool
 	PullParent      bool
+	BuildArgs       []string
 }
 
 func newFlags() *flags {
@@ -130,6 +132,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		pullFlagName,
 		false,
 		"Pull latest base images prior to build.",
+	)
+	flagSet.StringArrayVar(
+		&f.BuildArgs,
+		buildArgFlagName,
+		nil,
+		"Build arguments.",
 	)
 }
 
@@ -201,6 +209,7 @@ func run(
 		bufplugindocker.WithTarget(flags.Target),
 		bufplugindocker.WithCacheFrom(flags.CacheFrom),
 		bufplugindocker.WithPullParent(flags.PullParent),
+		bufplugindocker.WithBuildArgs(flags.BuildArgs),
 	)
 	if err != nil {
 		return err

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -168,13 +168,12 @@ func (d *dockerAPIClient) Build(ctx context.Context, dockerfile io.Reader, plugi
 		if len(target) == 0 {
 			target = DefaultTarget
 		}
-		buildArgs := map[string]*string{
-			"PLUGIN_VERSION": &pluginConfig.PluginVersion,
-		}
+		buildArgs := make(map[string]*string)
 		for _, arg := range params.buildArgs {
 			name, val, _ := strings.Cut(arg, "=")
 			buildArgs[name] = &val
 		}
+		buildArgs["PLUGIN_VERSION"] = &pluginConfig.PluginVersion
 		response, err := d.cli.ImageBuild(ctx, dockerContext, types.ImageBuildOptions{
 			Tags:     []string{imageName},
 			Platform: target,


### PR DESCRIPTION
Update plugin push command to allow for optional --build-arg arguments
to be passed to the build.