### PR TITLE
Expose rewrite_import_path_suffix to plugin file

### DIFF
--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -107,7 +107,9 @@ func PluginRegistryToProtoRegistryConfig(pluginRegistry *bufpluginconfig.Registr
 		}
 		registryConfig.RegistryConfig = &registryv1alpha1.RegistryConfig_GoConfig{GoConfig: goConfig}
 	} else if pluginRegistry.NPM != nil {
-		npmConfig := &registryv1alpha1.NPMConfig{}
+		npmConfig := &registryv1alpha1.NPMConfig{
+			RewriteImportPathSuffix: pluginRegistry.NPM.RewriteImportPathSuffix,
+		}
 		npmConfig.RuntimeLibraries = make([]*registryv1alpha1.NPMConfig_RuntimeLibrary, 0, len(pluginRegistry.NPM.Deps))
 		for _, dependency := range pluginRegistry.NPM.Deps {
 			npmConfig.RuntimeLibraries = append(npmConfig.RuntimeLibraries, npmRuntimeDependencyToProtoNPMRuntimeLibrary(dependency))
@@ -132,7 +134,9 @@ func ProtoRegistryConfigToPluginRegistry(config *registryv1alpha1.RegistryConfig
 		}
 		registryConfig.Go = goConfig
 	} else if config.GetNpmConfig() != nil {
-		npmConfig := &bufpluginconfig.NPMRegistryConfig{}
+		npmConfig := &bufpluginconfig.NPMRegistryConfig{
+			RewriteImportPathSuffix: config.GetNpmConfig().GetRewriteImportPathSuffix(),
+		}
 		npmConfig.Deps = make([]*bufpluginconfig.NPMRegistryDependencyConfig, 0, len(config.GetNpmConfig().GetRuntimeLibraries()))
 		for _, library := range config.GetNpmConfig().GetRuntimeLibraries() {
 			npmConfig.Deps = append(npmConfig.Deps, protoNPMRuntimeLibraryToNPMRuntimeDependency(library))

--- a/private/bufpkg/bufplugin/bufplugin_test.go
+++ b/private/bufpkg/bufplugin/bufplugin_test.go
@@ -51,6 +51,7 @@ func TestPluginRegistryRoundTrip(t *testing.T) {
 	})
 	assertPluginRegistryRoundTrip(t, &bufpluginconfig.RegistryConfig{
 		NPM: &bufpluginconfig.NPMRegistryConfig{
+			RewriteImportPathSuffix: "connectweb.js",
 			Deps: []*bufpluginconfig.NPMRegistryDependencyConfig{
 				{
 					Package: "@bufbuild/protobuf",

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -109,7 +109,8 @@ type GoRegistryDependencyConfig struct {
 
 // NPMRegistryConfig is the registry configuration for a JavaScript NPM plugin.
 type NPMRegistryConfig struct {
-	Deps []*NPMRegistryDependencyConfig
+	RewriteImportPathSuffix string
+	Deps                    []*NPMRegistryDependencyConfig
 }
 
 // NPMRegistryDependencyConfig is the npm registry dependency configuration.
@@ -226,7 +227,8 @@ func (e ExternalGoRegistryConfig) IsEmpty() bool {
 
 // ExternalNPMRegistryConfig is the external registry configuration for a JavaScript NPM plugin.
 type ExternalNPMRegistryConfig struct {
-	Deps []struct {
+	RewriteImportPathSuffix string `json:"rewrite_import_path_suffix,omitempty" yaml:"rewrite_import_path_suffix,omitempty"`
+	Deps                    []struct {
 		Package string `json:"package,omitempty" yaml:"package,omitempty"`
 		Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	} `json:"deps,omitempty" yaml:"deps,omitempty"`

--- a/private/bufpkg/bufplugin/bufpluginconfig/config.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/config.go
@@ -176,7 +176,8 @@ func newNPMRegistryConfig(externalNPMRegistryConfig ExternalNPMRegistryConfig) (
 		)
 	}
 	return &NPMRegistryConfig{
-		Deps: dependencies,
+		RewriteImportPathSuffix: externalNPMRegistryConfig.RewriteImportPathSuffix,
+		Deps:                    dependencies,
 	}, nil
 }
 


### PR DESCRIPTION
Expose new field, added in https://github.com/bufbuild/buf/pull/1342, to the buf plugin config file.

Example usage:

```yaml
[...]
registry:
  npm:
    rewrite_import_path_suffix: connectweb.js
    deps:
      # https://www.npmjs.com/package/@bufbuild/connect-web
      - package: "@bufbuild/connect-web"
        version: "0.1.0"
```