### PR TITLE
allow pushing an existing image with plugin push

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -47,6 +47,7 @@ const (
 	dryRunFlagName          = "dry-run"
 	pullFlagName            = "pull"
 	buildArgFlagName        = "build-arg"
+	imageFlagName           = "image"
 )
 
 // NewCommand returns a new Command.
@@ -80,6 +81,7 @@ type flags struct {
 	DryRun          bool
 	PullParent      bool
 	BuildArgs       []string
+	Image           string
 }
 
 func newFlags() *flags {
@@ -138,6 +140,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		buildArgFlagName,
 		nil,
 		"Build arguments.",
+	)
+	flagSet.StringVar(
+		&f.Image,
+		imageFlagName,
+		"",
+		"Existing image to push.",
 	)
 }
 
@@ -201,26 +209,36 @@ func run(
 		retErr = multierr.Append(retErr, client.Close())
 	}()
 
-	buildResponse, err := client.Build(
-		ctx,
-		dockerfile,
-		pluginConfig,
-		bufplugindocker.WithConfigDirPath(container.ConfigDirPath()),
-		bufplugindocker.WithTarget(flags.Target),
-		bufplugindocker.WithCacheFrom(flags.CacheFrom),
-		bufplugindocker.WithPullParent(flags.PullParent),
-		bufplugindocker.WithBuildArgs(flags.BuildArgs),
-	)
-	if err != nil {
-		return err
+	var createdImage string
+	if len(flags.Image) > 0 {
+		tagResponse, err := client.Tag(ctx, flags.Image, pluginConfig)
+		if err != nil {
+			return err
+		}
+		createdImage = tagResponse.Image
+	} else {
+		buildResponse, err := client.Build(
+			ctx,
+			dockerfile,
+			pluginConfig,
+			bufplugindocker.WithConfigDirPath(container.ConfigDirPath()),
+			bufplugindocker.WithTarget(flags.Target),
+			bufplugindocker.WithCacheFrom(flags.CacheFrom),
+			bufplugindocker.WithPullParent(flags.PullParent),
+			bufplugindocker.WithBuildArgs(flags.BuildArgs),
+		)
+		if err != nil {
+			return err
+		}
+		createdImage = buildResponse.Image
 	}
 
 	// We build a Docker image using a unique ID label each time.
 	// After we're done publishing the image, we delete it to not leave a lot of images left behind.
 	// buildkit maintains a separate build cache so removing the image doesn't appear to impact future rebuilds.
 	defer func() {
-		if _, err := client.Delete(ctx, buildResponse.Image); err != nil {
-			retErr = multierr.Append(retErr, fmt.Errorf("failed to delete image %q", buildResponse.Image))
+		if _, err := client.Delete(ctx, createdImage); err != nil {
+			retErr = multierr.Append(retErr, fmt.Errorf("failed to delete image %q", createdImage))
 		}
 	}()
 
@@ -239,7 +257,7 @@ func run(
 		authConfig.Username = machine.Login()
 		authConfig.Password = machine.Password()
 	}
-	pushResponse, err := client.Push(ctx, buildResponse.Image, authConfig)
+	pushResponse, err := client.Push(ctx, createdImage, authConfig)
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -53,6 +53,8 @@ type Client interface {
 	Push(ctx context.Context, image string, auth *RegistryAuthConfig) (*PushResponse, error)
 	// Delete removes the Docker image from local Docker Engine.
 	Delete(ctx context.Context, image string) (*DeleteResponse, error)
+	// Tag creates a Docker image tag from an existing image and plugin config.
+	Tag(ctx context.Context, image string, config *bufpluginconfig.Config) (*TagResponse, error)
 	// Close releases any resources used by the underlying Docker client.
 	Close() error
 }
@@ -111,6 +113,13 @@ type PushResponse struct {
 	// Digest specifies the Docker image digest in the format <hash_algorithm>:<hash>.
 	// The digest returned from Client.Push differs from the image id returned in Client.Build.
 	Digest string
+}
+
+// TagResponse returns details of a successful image tag call.
+type TagResponse struct {
+	// Image contains the Docker image name in the local Docker engine including the tag.
+	// It is created from the bufpluginconfig.Config's Name.IdentityString() and a unique id.
+	Image string
 }
 
 // DeleteResponse is a placeholder for data to be returned from a successful image delete call.
@@ -243,6 +252,18 @@ func (d *dockerAPIClient) Build(ctx context.Context, dockerfile io.Reader, plugi
 		Image:   imageName,
 		ImageID: imageInfo.ID,
 	}, nil
+}
+
+func (d *dockerAPIClient) Tag(ctx context.Context, image string, config *bufpluginconfig.Config) (*TagResponse, error) {
+	buildID := stringid.GenerateRandomID()
+	imageName := config.Name.IdentityString() + ":" + buildID
+	if !strings.HasPrefix(imageName, pluginsImagePrefix) {
+		imageName = pluginsImagePrefix + imageName
+	}
+	if err := d.cli.ImageTag(ctx, image, imageName); err != nil {
+		return nil, err
+	}
+	return &TagResponse{Image: imageName}, nil
 }
 
 func (d *dockerAPIClient) Push(ctx context.Context, image string, auth *RegistryAuthConfig) (response *PushResponse, retErr error) {


### PR DESCRIPTION
Currently, calling 'buf alpha plugin push' requires rebuilding a Docker
image from scratch (including replicating context, build args, caching
arguments, and authentication credentials). In some cases, we may wish
to simply re-use an image built with a previous 'docker build' command.

To support this behavior, add an '--image' argument which can refer to
an existing image in the Docker client to be tagged (with the
appropriate BSR tag) and pushed.