### PR TITLE
format: Handle special escaped characters

### DIFF
--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -1455,6 +1455,26 @@ func (f *formatter) writeStringValue(stringValueNode ast.StringValueNode) {
 // based on the string value's content. The formatter prefers double quotes, but uses single
 // quotes if the content contains any (") literals and not any (') literals.
 //
+// > If the string contains any of the special escaped characters, then double quotes will be used.
+//
+//  TODO: The change proposed here isn't actually valid. With this,
+//  the user's input would unconditionally use double quotes whenever
+//  it encounters one of the following literals. It'd be impossible
+//  for the a string literal to specify a literal \n (without it
+//  being interpreted as a newline).
+//
+//  We need access to the original string's surrounding quote style so
+//  that we can preserve it in the formatted output - if the user specified
+//  a string with single quotes ('') or double quotes (""), then the formatted
+//  result should always use the same style.
+//
+//  It doesn't look like this information is available from the protocompile
+//  AST today - we'll need to see what we can do to make this possible.
+//  Otherwise, it's impossible for the formatter to know how to user's
+//  string.
+//
+//  The original issue relates to https://github.com/bufbuild/buf/issues/1093
+//
 // For example,
 //
 //  1. f"o"'o' -> "f\"o\"'o'"  (") and (') are used - surround with (")
@@ -1463,13 +1483,27 @@ func (f *formatter) writeStringValue(stringValueNode ast.StringValueNode) {
 //  4. foo -> "foo"            By default, use double quotes
 func (f *formatter) writeStringWithStyle(value string) {
 	var (
-		singleQuote = strings.ContainsRune(value, '\'')
-		doubleQuote = strings.ContainsRune(value, '"')
+		singleQuote       = strings.ContainsRune(value, '\'')
+		doubleQuote       = strings.ContainsRune(value, '"')
+		escapedCharacters = []rune{
+			'\n',
+			'\r',
+			'\t',
+			'\v',
+			'\f',
+			'\\',
+		}
+		hexadecimalPrefix = strings.Contains(value, "\\x")
 	)
+	isEscaped := hexadecimalPrefix
+	for _, escapedCharacter := range escapedCharacters {
+		isEscaped = isEscaped || strings.ContainsRune(value, escapedCharacter)
+	}
 	var formattedString string
-	if doubleQuote && !singleQuote {
+	if doubleQuote && !singleQuote && !isEscaped {
 		// Use a single quote if the content contains any (") or (\")
-		// literals, and not any (') or (\') literals.
+		// literals, and not any (') literals or other escapable
+		// characters (e.g. '\n').
 		formattedString = fmt.Sprintf("'%s'", value)
 	} else {
 		formattedString = fmt.Sprintf("%q", value)

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
@@ -20,7 +20,7 @@ message Test {
   repeated Simple r = 4;
   map<string, int32> m = 5;
 
-  optional bytes b = 6 [default = "\x00\x01\x02\x03\x04\x05\x06\afubar!"];
+  optional bytes b = 6 [default = "\0\1\2\3\4\5\6\7fubar!"];
 
   extensions 100 to 200;
 

--- a/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.golden.proto
@@ -15,11 +15,14 @@ message Foo {
   string one = 1 [(name) = "f\"o\"'o'"];
   string two = 2 [(name) = 'f"oo"'];
   string three = 3 [(name) = "f'oo'"];
-  string four = 4 [(name) = "f\"o\"'o'"];
-  string five = 5 [(name) = 'f"o"o'];
-  string six = 6 [(name) = "f'o'o"];
+  string four = 4 [(name) = "f\"o\"\'o\'"];
+  string five = 5 [(name) = "f\"o\"o"];
+  string six = 6 [(name) = 'f\'o\'o'];
   string seven = 7 [(name) = "foo"];
   string eight = 8 [(foo) = {
     something: 'something:"foo"'
+  }];
+  string nine = 9 [(foo) = {
+    something: "something:\"foo\"\nanother:\"bar\""
   }];
 }

--- a/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.proto
+++ b/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.proto
@@ -22,4 +22,7 @@ message Foo {
   string eight = 8 [(foo) = {
     something: 'something:"foo"'
   }];
+  string nine = 9 [(foo) = {
+    something: "something:\"foo\"\nanother:\"bar\""
+  }];
 }


### PR DESCRIPTION
Fixes #1370

This adjusts the change made to fix https://github.com/bufbuild/buf/issues/1093 (which has not yet been released), so that we always preserve the raw string specified in the original source.

Note that we don't need a new `CHANGELOG.md` entry here because it was already introduced in #1332.