### PR TITLE
allow empty config for remote registry

### DIFF
--- a/private/bufpkg/bufplugin/bufplugin.go
+++ b/private/bufpkg/bufplugin/bufplugin.go
@@ -135,18 +135,22 @@ func PluginRegistryToProtoRegistryConfig(pluginRegistry *bufpluginconfig.Registr
 	if pluginRegistry.Go != nil {
 		goConfig := &registryv1alpha1.GoConfig{}
 		goConfig.MinimumVersion = pluginRegistry.Go.MinVersion
-		goConfig.RuntimeLibraries = make([]*registryv1alpha1.GoConfig_RuntimeLibrary, 0, len(pluginRegistry.Go.Deps))
-		for _, dependency := range pluginRegistry.Go.Deps {
-			goConfig.RuntimeLibraries = append(goConfig.RuntimeLibraries, goRuntimeDependencyToProtoGoRuntimeLibrary(dependency))
+		if pluginRegistry.Go.Deps != nil {
+			goConfig.RuntimeLibraries = make([]*registryv1alpha1.GoConfig_RuntimeLibrary, 0, len(pluginRegistry.Go.Deps))
+			for _, dependency := range pluginRegistry.Go.Deps {
+				goConfig.RuntimeLibraries = append(goConfig.RuntimeLibraries, goRuntimeDependencyToProtoGoRuntimeLibrary(dependency))
+			}
 		}
 		registryConfig.RegistryConfig = &registryv1alpha1.RegistryConfig_GoConfig{GoConfig: goConfig}
 	} else if pluginRegistry.NPM != nil {
 		npmConfig := &registryv1alpha1.NPMConfig{
 			RewriteImportPathSuffix: pluginRegistry.NPM.RewriteImportPathSuffix,
 		}
-		npmConfig.RuntimeLibraries = make([]*registryv1alpha1.NPMConfig_RuntimeLibrary, 0, len(pluginRegistry.NPM.Deps))
-		for _, dependency := range pluginRegistry.NPM.Deps {
-			npmConfig.RuntimeLibraries = append(npmConfig.RuntimeLibraries, npmRuntimeDependencyToProtoNPMRuntimeLibrary(dependency))
+		if pluginRegistry.NPM.Deps != nil {
+			npmConfig.RuntimeLibraries = make([]*registryv1alpha1.NPMConfig_RuntimeLibrary, 0, len(pluginRegistry.NPM.Deps))
+			for _, dependency := range pluginRegistry.NPM.Deps {
+				npmConfig.RuntimeLibraries = append(npmConfig.RuntimeLibraries, npmRuntimeDependencyToProtoNPMRuntimeLibrary(dependency))
+			}
 		}
 		registryConfig.RegistryConfig = &registryv1alpha1.RegistryConfig_NpmConfig{NpmConfig: npmConfig}
 	}
@@ -164,18 +168,24 @@ func ProtoRegistryConfigToPluginRegistry(config *registryv1alpha1.RegistryConfig
 	if config.GetGoConfig() != nil {
 		goConfig := &bufpluginconfig.GoRegistryConfig{}
 		goConfig.MinVersion = config.GetGoConfig().GetMinimumVersion()
-		goConfig.Deps = make([]*bufpluginconfig.GoRegistryDependencyConfig, 0, len(config.GetGoConfig().GetRuntimeLibraries()))
-		for _, library := range config.GetGoConfig().GetRuntimeLibraries() {
-			goConfig.Deps = append(goConfig.Deps, protoGoRuntimeLibraryToGoRuntimeDependency(library))
+		runtimeLibraries := config.GetGoConfig().GetRuntimeLibraries()
+		if runtimeLibraries != nil {
+			goConfig.Deps = make([]*bufpluginconfig.GoRegistryDependencyConfig, 0, len(runtimeLibraries))
+			for _, library := range runtimeLibraries {
+				goConfig.Deps = append(goConfig.Deps, protoGoRuntimeLibraryToGoRuntimeDependency(library))
+			}
 		}
 		registryConfig.Go = goConfig
 	} else if config.GetNpmConfig() != nil {
 		npmConfig := &bufpluginconfig.NPMRegistryConfig{
 			RewriteImportPathSuffix: config.GetNpmConfig().GetRewriteImportPathSuffix(),
 		}
-		npmConfig.Deps = make([]*bufpluginconfig.NPMRegistryDependencyConfig, 0, len(config.GetNpmConfig().GetRuntimeLibraries()))
-		for _, library := range config.GetNpmConfig().GetRuntimeLibraries() {
-			npmConfig.Deps = append(npmConfig.Deps, protoNPMRuntimeLibraryToNPMRuntimeDependency(library))
+		runtimeLibraries := config.GetNpmConfig().GetRuntimeLibraries()
+		if runtimeLibraries != nil {
+			npmConfig.Deps = make([]*bufpluginconfig.NPMRegistryDependencyConfig, 0, len(runtimeLibraries))
+			for _, library := range runtimeLibraries {
+				npmConfig.Deps = append(npmConfig.Deps, protoNPMRuntimeLibraryToNPMRuntimeDependency(library))
+			}
 		}
 		registryConfig.NPM = npmConfig
 	}

--- a/private/bufpkg/bufplugin/bufplugin_test.go
+++ b/private/bufpkg/bufplugin/bufplugin_test.go
@@ -39,6 +39,9 @@ func TestPluginRegistryRoundTrip(t *testing.T) {
 	assertPluginRegistryRoundTrip(t, nil)
 	assertPluginRegistryRoundTrip(t, &bufpluginconfig.RegistryConfig{})
 	assertPluginRegistryRoundTrip(t, &bufpluginconfig.RegistryConfig{
+		Go: &bufpluginconfig.GoRegistryConfig{},
+	})
+	assertPluginRegistryRoundTrip(t, &bufpluginconfig.RegistryConfig{
 		Go: &bufpluginconfig.GoRegistryConfig{
 			MinVersion: "1.18",
 			Deps: []*bufpluginconfig.GoRegistryDependencyConfig{
@@ -48,6 +51,9 @@ func TestPluginRegistryRoundTrip(t *testing.T) {
 				},
 			},
 		},
+	})
+	assertPluginRegistryRoundTrip(t, &bufpluginconfig.RegistryConfig{
+		NPM: &bufpluginconfig.NPMRegistryConfig{},
 	})
 	assertPluginRegistryRoundTrip(t, &bufpluginconfig.RegistryConfig{
 		NPM: &bufpluginconfig.NPMRegistryConfig{

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -261,9 +261,9 @@ type ExternalDependency struct {
 // ExternalRegistryConfig is the external configuration for the registry
 // of a plugin.
 type ExternalRegistryConfig struct {
-	Go   ExternalGoRegistryConfig  `json:"go,omitempty" yaml:"go,omitempty"`
-	NPM  ExternalNPMRegistryConfig `json:"npm,omitempty" yaml:"npm,omitempty"`
-	Opts []string                  `json:"opts,omitempty" yaml:"opts,omitempty"`
+	Go   *ExternalGoRegistryConfig  `json:"go,omitempty" yaml:"go,omitempty"`
+	NPM  *ExternalNPMRegistryConfig `json:"npm,omitempty" yaml:"npm,omitempty"`
+	Opts []string                   `json:"opts,omitempty" yaml:"opts,omitempty"`
 }
 
 // ExternalGoRegistryConfig is the external registry configuration for a Go plugin.
@@ -276,11 +276,6 @@ type ExternalGoRegistryConfig struct {
 	} `json:"deps,omitempty" yaml:"deps,omitempty"`
 }
 
-// IsEmpty returns true if the configuration is empty.
-func (e ExternalGoRegistryConfig) IsEmpty() bool {
-	return e.MinVersion == "" && len(e.Deps) == 0
-}
-
 // ExternalNPMRegistryConfig is the external registry configuration for a JavaScript NPM plugin.
 type ExternalNPMRegistryConfig struct {
 	RewriteImportPathSuffix string `json:"rewrite_import_path_suffix,omitempty" yaml:"rewrite_import_path_suffix,omitempty"`
@@ -288,11 +283,6 @@ type ExternalNPMRegistryConfig struct {
 		Package string `json:"package,omitempty" yaml:"package,omitempty"`
 		Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	} `json:"deps,omitempty" yaml:"deps,omitempty"`
-}
-
-// IsEmpty returns true if the configuration is empty.
-func (e ExternalNPMRegistryConfig) IsEmpty() bool {
-	return len(e.Deps) == 0
 }
 
 type externalConfigVersion struct {

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -191,6 +191,15 @@ func TestParsePluginConfigEmptyVersionYAML(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParsePluginConfigGoNoDepsOrMinVersion(t *testing.T) {
+	t.Parallel()
+	cfg, err := ParseConfig(filepath.Join("testdata", "success", "go-empty-registry", "buf.plugin.yaml"))
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.Registry)
+	assert.NotNil(t, cfg.Registry.Go)
+	assert.Equal(t, &GoRegistryConfig{}, cfg.Registry.Go)
+}
+
 func TestPluginOptionsRoundTrip(t *testing.T) {
 	assertPluginOptionsRoundTrip(t, nil)
 	assertPluginOptionsRoundTrip(t, map[string]string{})

--- a/private/bufpkg/bufplugin/bufpluginconfig/config.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/config.go
@@ -109,8 +109,8 @@ func newConfig(externalConfig ExternalConfig, options []ConfigOption) (*Config, 
 
 func newRegistryConfig(externalRegistryConfig ExternalRegistryConfig) (*RegistryConfig, error) {
 	var (
-		isGoEmpty  = externalRegistryConfig.Go.IsEmpty()
-		isNPMEmpty = externalRegistryConfig.NPM.IsEmpty()
+		isGoEmpty  = externalRegistryConfig.Go == nil
+		isNPMEmpty = externalRegistryConfig.NPM == nil
 	)
 	var registryCount int
 	for _, isEmpty := range []bool{
@@ -153,7 +153,10 @@ func newRegistryConfig(externalRegistryConfig ExternalRegistryConfig) (*Registry
 	}, nil
 }
 
-func newNPMRegistryConfig(externalNPMRegistryConfig ExternalNPMRegistryConfig) (*NPMRegistryConfig, error) {
+func newNPMRegistryConfig(externalNPMRegistryConfig *ExternalNPMRegistryConfig) (*NPMRegistryConfig, error) {
+	if externalNPMRegistryConfig == nil {
+		return nil, nil
+	}
 	var dependencies []*NPMRegistryDependencyConfig
 	for _, dep := range externalNPMRegistryConfig.Deps {
 		if dep.Package == "" {
@@ -185,7 +188,10 @@ func newNPMRegistryConfig(externalNPMRegistryConfig ExternalNPMRegistryConfig) (
 	}, nil
 }
 
-func newGoRegistryConfig(externalGoRegistryConfig ExternalGoRegistryConfig) (*GoRegistryConfig, error) {
+func newGoRegistryConfig(externalGoRegistryConfig *ExternalGoRegistryConfig) (*GoRegistryConfig, error) {
+	if externalGoRegistryConfig == nil {
+		return nil, nil
+	}
 	if externalGoRegistryConfig.MinVersion != "" && !modfile.GoVersionRE.MatchString(externalGoRegistryConfig.MinVersion) {
 		return nil, fmt.Errorf("the go minimum version %q must be a valid semantic version in the form of <major>.<minor>", externalGoRegistryConfig.MinVersion)
 	}

--- a/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go-empty-registry/buf.plugin.yaml
+++ b/private/bufpkg/bufplugin/bufpluginconfig/testdata/success/go-empty-registry/buf.plugin.yaml
@@ -1,0 +1,8 @@
+version: v1
+name: buf.build/library/go
+plugin_version: v1.28.1
+default_opts:
+  - paths=source_relative
+output_languages: [go]
+registry:
+  go: {}


### PR DESCRIPTION
Update the handling of the buf.plugin.yaml to allow a plugin to opt-in
for use in the remote registry without requiring it to specify
dependencies, Go minimum version, or other fields.