### PR TITLE
ensure plugin options slice is sorted

### DIFF
--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
@@ -217,6 +218,7 @@ func PluginOptionsToOptionsSlice(pluginOptions map[string]string) []string {
 			options = append(options, key)
 		}
 	}
+	sort.Strings(options)
 	return options
 }
 

--- a/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
+++ b/private/bufpkg/bufplugin/bufpluginconfig/bufpluginconfig_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
@@ -211,7 +212,11 @@ func TestPluginOptionsRoundTrip(t *testing.T) {
 }
 
 func assertPluginOptionsRoundTrip(t testing.TB, options map[string]string) {
-	assert.Equal(t, options, OptionsSliceToPluginOptions(PluginOptionsToOptionsSlice(options)))
+	optionsSlice := PluginOptionsToOptionsSlice(options)
+	assert.True(t, sort.SliceIsSorted(optionsSlice, func(i, j int) bool {
+		return optionsSlice[i] < optionsSlice[j]
+	}))
+	assert.Equal(t, options, OptionsSliceToPluginOptions(optionsSlice))
 }
 
 func TestGetConfigForDataInvalidDependency(t *testing.T) {


### PR DESCRIPTION
In order to ensure consistent comparison of plugins, ensure that we
always sort a slice of options after conversion from a map.