### PR TITLE
Add a `Base` Matcher

### DIFF
--- a/private/pkg/storage/matcher.go
+++ b/private/pkg/storage/matcher.go
@@ -33,6 +33,13 @@ func MatchPathExt(ext string) Matcher {
 	})
 }
 
+// MatchPathBase returns a Matcher for the base.
+func MatchPathBase(base string) Matcher {
+	return pathMatcherFunc(func(path string) bool {
+		return normalpath.Base(path) == base
+	})
+}
+
 // MatchPathEqual returns a Matcher for the path.
 func MatchPathEqual(equalPath string) Matcher {
 	return pathMatcherFunc(func(path string) bool {


### PR DESCRIPTION
Adds a new `storage.Matcher` that matches on the `Base` of a path.  