### PR TITLE
add httpserver.Run function

### DIFF
--- a/private/pkg/transport/http/httpserver/httpserver.go
+++ b/private/pkg/transport/http/httpserver/httpserver.go
@@ -174,3 +174,51 @@ func RunnerWithSilentEndpoints(silentEndpoints ...string) RunnerOption {
 		}
 	}
 }
+
+// RunOption is an option for a new Run.
+type RunOption = RunnerOption
+
+// RunWithShutdownTimeout returns a new RunOption that uses the given shutdown timeout.
+//
+// The default is to use DefaultShutdownTimeout.
+// If shutdownTimeout is 0, no graceful shutdown will be performed.
+func RunWithShutdownTimeout(shutdownTimeout time.Duration) RunOption {
+	return func(runner *runner) {
+		runner.shutdownTimeout = shutdownTimeout
+	}
+}
+
+// RunWithReadHeaderTimeout returns a new RunOption that uses the given read header timeout.
+//
+// The default is to use DefaultReadHeaderTimeout.
+// If readHeaderTimeout is 0, no read header timeout will be used.
+func RunWithReadHeaderTimeout(readHeaderTimeout time.Duration) RunOption {
+	return func(runner *runner) {
+		runner.readHeaderTimeout = readHeaderTimeout
+	}
+}
+
+// RunWithTLSConfig returns a new RunOption that uses the given tls.Config.
+//
+// The default is to use no TLS.
+func RunWithTLSConfig(tlsConfig *tls.Config) RunOption {
+	return func(runner *runner) {
+		runner.tlsConfig = tlsConfig
+	}
+}
+
+// Run will start a HTTP server listening on the provided listener and
+// serving the provided handler. This call is blocking and the run
+// is cancelled when the input context is cancelled, the listener is
+// closed upon return.
+//
+// The Run can be configured further by passing a variety of options.
+func Run(
+	ctx context.Context,
+	logger *zap.Logger,
+	listener net.Listener,
+	handler http.Handler,
+	options ...RunOption,
+) (retErr error) {
+	return newRunner(logger, options...).serve(ctx, listener, handler)
+}

--- a/private/pkg/transport/http/httpserver/httpserver.go
+++ b/private/pkg/transport/http/httpserver/httpserver.go
@@ -212,7 +212,7 @@ func RunWithTLSConfig(tlsConfig *tls.Config) RunOption {
 // is cancelled when the input context is cancelled, the listener is
 // closed upon return.
 //
-// The Run can be configured further by passing a variety of options.
+// The Run function can be configured further by passing a variety of options.
 func Run(
 	ctx context.Context,
 	logger *zap.Logger,

--- a/private/pkg/transport/http/httpserver/runner.go
+++ b/private/pkg/transport/http/httpserver/runner.go
@@ -96,7 +96,17 @@ func (s *runner) Run(
 			return err
 		}
 	}
+	return s.serve(ctx, listener, mux)
+}
 
+// serve is intended to only be called within the httpserver package by
+// the Run function. Once callers have migrated away from NewRunner().Run()
+// it would be ideal to move this logic into the Run function.
+func (s *runner) serve(
+	ctx context.Context,
+	listener net.Listener,
+	mux http.Handler,
+) error {
 	stdLogger, err := zap.NewStdLogAt(s.logger, zap.ErrorLevel)
 	if err != nil {
 		return err

--- a/private/pkg/transport/http/httpserver/runner.go
+++ b/private/pkg/transport/http/httpserver/runner.go
@@ -105,20 +105,20 @@ func (s *runner) Run(
 func (s *runner) serve(
 	ctx context.Context,
 	listener net.Listener,
-	mux http.Handler,
+	handler http.Handler,
 ) error {
 	stdLogger, err := zap.NewStdLogAt(s.logger, zap.ErrorLevel)
 	if err != nil {
 		return err
 	}
 	httpServer := &http.Server{
-		Handler:           mux,
+		Handler:           handler,
 		ReadHeaderTimeout: s.readHeaderTimeout,
 		ErrorLog:          stdLogger,
 		TLSConfig:         s.tlsConfig,
 	}
 	if s.tlsConfig == nil {
-		httpServer.Handler = h2c.NewHandler(mux, &http2.Server{
+		httpServer.Handler = h2c.NewHandler(handler, &http2.Server{
 			IdleTimeout: DefaultIdleTimeout,
 		})
 	}


### PR DESCRIPTION
The Run function only concerns itself with running a http server and does not attempt to perform any routing setup. The http.Handler that is passed is expected to be a chi.Mux or other complex router that will take care of routing for the server.

I've copied the RunnerOptions that matter for the server setup into RunOptions and split out server logic from the Run function into a `serve` function that can be called privately by the new Run function.