### PR TITLE
fix local generation using plugin key

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -251,7 +251,7 @@ func (g *generator) execLocalPlugin(
 	response, err := appprotoexecGenerator.Generate(
 		ctx,
 		container,
-		pluginConfig.Name,
+		pluginConfig.PluginName(),
 		bufimage.ImagesToCodeGeneratorRequests(
 			pluginImages,
 			pluginConfig.Opt,


### PR DESCRIPTION
Update the local generation to look up the plugin name from the PluginName() accessor (which looks at the Plugin, Name, and Remote in order). This fixes local generation when using the new config key.