### PR TITLE
bufmodulebuild: unncessary assert on err

### DIFF
--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
@@ -435,7 +435,6 @@ func testDocumentationBucket(
 	require.NoError(t, err)
 	require.NotNil(t, module)
 	assert.NotEmpty(t, module.Documentation())
-	require.NoError(t, err)
 	fileInfos, err := module.TargetFileInfos(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(


### PR DESCRIPTION
`require.NoError(t, err)` was already asserted and `err` has not mutated.