### PR TITLE
bufmodulebuild: include the bucket's config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Push lint and breaking configuration to the registry.
 
 ## [v1.8.0] - 2022-09-14
 


### PR DESCRIPTION
`bufmodulebuild.BuildForBucket` calls `bufmodule.NewModuleForBucket`
with a different bucket than the one passed to it. This mapped bucket
didn't include `buf.yaml`, hence the built `bufmodule.Module` didn't
have values for breaking or linting config.

`buf push` will now pass good lint and breaking config to the registry.