### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,8 +35,7 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
-    - contextcheck
-    - deadcode
+    # - contextcheck
     - decorder
     - depguard
     - dogsled
@@ -57,6 +56,7 @@ linters:
     - grouper
     - importas
     - ineffassign
+    - logrlint
     - makezero
     - misspell
     - nakedret
@@ -65,14 +65,13 @@ linters:
     - nosprintfhostport
     - predeclared
     - promlinter
+    - reassign
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
   disable-all: true

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -7,9 +7,9 @@ $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
 # Settable
-# https://github.com/golangci/golangci-lint/releases 20220804 checked 20220808
+# https://github.com/golangci/golangci-lint/releases 20220824 checked 20220920
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.48.0
+GOLANGCI_LINT_VERSION ?= v1.49.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):


### PR DESCRIPTION
See the release notes at https://github.com/golangci/golangci-lint/releases/tag/v1.49.0 for the changes in linters.

I did not add `interfacebloat`, a strongly opinionated linter that fails when there's more than 10 methods on an interface. `contextcheck` was re-enabled in this version of golangci-lint and we should fix the issues it brings up, temporarily disabled it for now.