### PR TITLE
Fix/gh 982 line chars

### DIFF
--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1509,6 +1509,54 @@ a/v3/a.proto:7:10:Field "2" on message "Foo" changed name from "value" to "Value
 	)
 }
 
+func TestBreakingInt64ToMessage(t *testing.T) {
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`
+		testdata/messages/message/test.proto:3:3:Field "1" on message "Foooo" changed type from "int64" to "message".
+		`),
+		"breaking",
+		"--against",
+		filepath.Join(".", "testdata", "messages", "int64", "test.proto"),
+		filepath.Join(".", "testdata", "messages", "message", "test.proto"),
+	)
+}
+
+func TestBreakingInt32ToInt64(t *testing.T) {
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`
+		testdata/messages/int64/test.proto:3:3:Field "1" on message "Foooo" changed type from "int32" to "int64".
+		`),
+		"breaking",
+		"--against",
+		filepath.Join(".", "testdata", "messages", "int32", "test.proto"),
+		filepath.Join(".", "testdata", "messages", "int64", "test.proto"),
+	)
+}
+
+func TestBreakingMessageToMessage(t *testing.T) {
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`
+		testdata/messages/message2/test.proto:3:3:Field "1" on message "Foooo" changed type from "Foooo" to "Foooo2".
+		`),
+		"breaking",
+		"--against",
+		filepath.Join(".", "testdata", "messages", "message", "test.proto"),
+		filepath.Join(".", "testdata", "messages", "message2", "test.proto"),
+	)
+}
+
 func TestVersion(t *testing.T) {
 	t.Parallel()
 	testRunStdout(t, nil, 0, bufcli.Version, "--version")

--- a/private/buf/cmd/buf/testdata/messages/int32/buf.yaml
+++ b/private/buf/cmd/buf/testdata/messages/int32/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: bufbuild.test/workspace/message

--- a/private/buf/cmd/buf/testdata/messages/int32/test.proto
+++ b/private/buf/cmd/buf/testdata/messages/int32/test.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+message Foooo {
+  int32 foo = 1;
+}

--- a/private/buf/cmd/buf/testdata/messages/int64/buf.yaml
+++ b/private/buf/cmd/buf/testdata/messages/int64/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: bufbuild.test/workspace/message

--- a/private/buf/cmd/buf/testdata/messages/int64/test.proto
+++ b/private/buf/cmd/buf/testdata/messages/int64/test.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+message Foooo {
+  int64 foo = 1;
+}

--- a/private/buf/cmd/buf/testdata/messages/message/buf.yaml
+++ b/private/buf/cmd/buf/testdata/messages/message/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: bufbuild.test/workspace/message

--- a/private/buf/cmd/buf/testdata/messages/message/test.proto
+++ b/private/buf/cmd/buf/testdata/messages/message/test.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+message Foooo {
+  Foooo foo = 1;
+}

--- a/private/buf/cmd/buf/testdata/messages/message2/buf.yaml
+++ b/private/buf/cmd/buf/testdata/messages/message2/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: bufbuild.test/workspace/message

--- a/private/buf/cmd/buf/testdata/messages/message2/test.proto
+++ b/private/buf/cmd/buf/testdata/messages/message2/test.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+message Foooo {
+  Foooo2 foo = 1;
+}
+message Foooo2 {
+  int32 foo = 1;
+}

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
@@ -476,10 +476,21 @@ func addFieldChangedType(add addFunc, previousField protosource.Field, field pro
 	}
 	// otherwise prints as hex
 	previousNumberString := strconv.FormatInt(int64(previousField.Number()), 10)
+
+	var typeNameLocation protosource.Location
+
+	// TypeLocation does not work on message types for some reason.
+	switch field.Type() {
+	case protosource.FieldDescriptorProtoTypeMessage:
+		typeNameLocation = field.Location()
+	default:
+		typeNameLocation = field.TypeLocation()
+	}
+
 	add(
 		field,
 		nil,
-		field.TypeLocation(),
+		typeNameLocation,
 		`Field %q on message %q changed type from %q to %q.%s`,
 		previousNumberString,
 		field.Message().Name(),


### PR DESCRIPTION
So `message` types for filedescriptors field types and (all?) other types seem to use slightly different source code location paths

The issue in #982 was that the int32 path did not exist from the message type:

int32 path for message: 
```
path key [4 0 2 0 5]

Keys that existed within the filedescriptor sourcecodelocations:
[4 0 2 0]
[4 0 2 0 6]
[4 0 2 0 1]
[4 0 2 0 3]
[]
[12]
[4 0]
[4 0 1]
``` 

above the key `4 0 2 0 5` does not exist, unlike for an `int32` which does:


```
path key [4 0 2 0 5]

[4 0 2 0 1]
[4 0 2 0 3]
[]
[12]
[4 0]
[4 0 1]
[4 0 2 0]
[4 0 2 0 5]
```




Fixes #982 