### PR TITLE
Use latest protocompile in `buf format`, fix things up in the formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 - Push lint and breaking configuration to the registry.
+- Fixed issues in formatter related to whitespace around inline comments.
+- Updated formatter to use a compact, single-line representation for array
+  and message literals in option values that are sufficiently simple (single
+  scalar element or field).
 
 ## [v1.8.0] - 2022-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 ## [Unreleased]
 
 - Push lint and breaking configuration to the registry.
-- Fixed issues in formatter related to whitespace around inline comments.
-- Updated formatter to use a compact, single-line representation for array
-  and message literals in option values that are sufficiently simple (single
-  scalar element or field).
+- Formatter better edits/preserves whitespace around inline comments.
+- Formatter correctly indents multi-line block (C-style) comments.
+- Formatter now indents trailing comments at the end of an indented block body
+  (including contents of message and array literals and elements in compact options)
+  the same as the rest of the body (instead of out one level, like the closing
+  punctuation).
+- Formatter uses a compact, single-line representation for array and message literals
+  in option values that are sufficiently simple (single scalar element or field).
 
 ## [v1.8.0] - 2022-09-14
 

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.18
 
 require (
 	github.com/bufbuild/connect-go v0.4.0
+	github.com/bufbuild/protocompile v0.0.0-20220921194504-8e564fc19a59
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/gofrs/flock v0.8.1
 	github.com/gofrs/uuid v4.3.0+incompatible
 	github.com/google/go-cmp v0.5.9
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a
-	github.com/jhump/protocompile v0.0.0-20220916183013-0209c974984d
 	github.com/jhump/protoreflect v1.12.1-0.20220721211354-060cc04fc18b
 	github.com/klauspost/compress v1.15.10
 	github.com/klauspost/pgzip v1.2.5
@@ -32,7 +32,7 @@ require (
 	golang.org/x/sync v0.0.0-20220907140024-f12130a52804
 	golang.org/x/term v0.0.0-20220919170432-7a66f970e087
 	golang.org/x/tools v0.1.12
-	google.golang.org/protobuf v1.28.1
+	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bufbuild/connect-go v0.4.0
-	github.com/bufbuild/protocompile v0.0.0-20220921194504-8e564fc19a59
+	github.com/bufbuild/protocompile v0.0.0-20220927163942-e0e013a8d791
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/gofrs/flock v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bufbuild/connect-go v0.4.0 h1:fIMyUYG8mXSTH+nnlOx9KmRUf3mBF0R2uKK+BQBoOHE=
 github.com/bufbuild/connect-go v0.4.0/go.mod h1:ZEtBnQ7J/m7bvWOW+H8T/+hKQCzPVfhhhICuvtcnjlI=
+github.com/bufbuild/protocompile v0.0.0-20220921194504-8e564fc19a59 h1:OBG6ctAgp+Bo6JZyE/b6HjB6N3yavnKuFU9WtvDf1b4=
+github.com/bufbuild/protocompile v0.0.0-20220921194504-8e564fc19a59/go.mod h1:h7ARqP8PTzxVJlbAA4SiH8RmL+ynlUMKMWj6UKmNo2U=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -92,8 +94,6 @@ github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a/go.mod h1:Zi/ZFkEqFH
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
-github.com/jhump/protocompile v0.0.0-20220916183013-0209c974984d h1:c3jOebfd4rr/NjF3yFnD9n6QWJg6Ol2qBgnIaniGdVs=
-github.com/jhump/protocompile v0.0.0-20220916183013-0209c974984d/go.mod h1:qr2b5kx4HbFS7/g4uYO5qv9ei8303JMsC7ESbYiqr2Q=
 github.com/jhump/protoreflect v1.11.0/go.mod h1:U7aMIjN0NWq9swDP7xDdoMfRHb35uiuTd3Z9nFXJf5E=
 github.com/jhump/protoreflect v1.12.1-0.20220721211354-060cc04fc18b h1:izTof8BKh/nE1wrKOrloNA5q4odOarjf+Xpe+4qow98=
 github.com/jhump/protoreflect v1.12.1-0.20220721211354-060cc04fc18b/go.mod h1:JytZfP5d0r8pVNLZvai7U/MCuTWITgrI4tTg7puQFKI=
@@ -211,7 +211,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220907140024-f12130a52804 h1:0SH2R3f1b1VmIMG7BXbEZCBUu2dKmHschSmjqGUrW8A=
 golang.org/x/sync v0.0.0-20220907140024-f12130a52804/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -279,9 +278,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.27.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8 h1:KR8+MyP7/qOlV+8Af01LtjL04bu7on42eVsxT4EyBQk=
+google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bufbuild/connect-go v0.4.0 h1:fIMyUYG8mXSTH+nnlOx9KmRUf3mBF0R2uKK+BQBoOHE=
 github.com/bufbuild/connect-go v0.4.0/go.mod h1:ZEtBnQ7J/m7bvWOW+H8T/+hKQCzPVfhhhICuvtcnjlI=
-github.com/bufbuild/protocompile v0.0.0-20220921194504-8e564fc19a59 h1:OBG6ctAgp+Bo6JZyE/b6HjB6N3yavnKuFU9WtvDf1b4=
-github.com/bufbuild/protocompile v0.0.0-20220921194504-8e564fc19a59/go.mod h1:h7ARqP8PTzxVJlbAA4SiH8RmL+ynlUMKMWj6UKmNo2U=
+github.com/bufbuild/protocompile v0.0.0-20220927163942-e0e013a8d791 h1:S7nr+nK0ybHEN/tbKaPB9fOA1XM3Wj+2EbiOCnBhDsU=
+github.com/bufbuild/protocompile v0.0.0-20220927163942-e0e013a8d791/go.mod h1:ix/MMMdsT3fzxfw91dvbfzKW3fRRnuPCP47kpAm5m/4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/private/buf/bufformat/bufformat.go
+++ b/private/buf/bufformat/bufformat.go
@@ -21,8 +21,8 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/buf/private/pkg/thread"
-	"github.com/jhump/protocompile/parser"
-	"github.com/jhump/protocompile/reporter"
+	"github.com/bufbuild/protocompile/parser"
+	"github.com/bufbuild/protocompile/reporter"
 	"go.uber.org/multierr"
 )
 

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -210,7 +210,6 @@ func (f *formatter) writeFileHeader() {
 		packageNode *ast.PackageNode
 		importNodes []*ast.ImportNode
 		optionNodes []*ast.OptionNode
-		typeNodes   []ast.FileElement
 	)
 	for _, fileElement := range f.fileNode.Decls {
 		switch node := fileElement.(type) {
@@ -220,10 +219,8 @@ func (f *formatter) writeFileHeader() {
 			importNodes = append(importNodes, node)
 		case *ast.OptionNode:
 			optionNodes = append(optionNodes, node)
-		case *ast.EmptyDeclNode:
-			continue
 		default:
-			typeNodes = append(typeNodes, node)
+			continue
 		}
 	}
 	if f.fileNode.Syntax == nil && packageNode == nil && importNodes == nil && optionNodes == nil {
@@ -1874,11 +1871,6 @@ func (f *formatter) writeBodyEndInline(node ast.Node, leadingInline bool) {
 	}
 }
 
-func (f *formatter) writeBodyStartInline(node ast.Node) {
-	f.writeStart(node)
-	//f.writeBodyEndInline(node, false)
-}
-
 // writeLineEnd writes the node so that it ends a line.
 //
 // This is useful for writing individual nodes like ';' and other
@@ -2027,38 +2019,6 @@ func (f *formatter) writeTrailingEndComments(comments ast.Comments) {
 		f.WriteString(strings.TrimSpace(comment.RawText()))
 	}
 	f.P()
-}
-
-// startsWithNewline returns true if the formatter needs to insert a newline
-// before the node is printed. We need to use this in special circumstances,
-// namely the file header types, when we always want to include a newline
-// between the syntax, package, and import/option blocks.
-func (f *formatter) startsWithNewline(info ast.NodeInfo) bool {
-	nodeNewlineCount := newlineCount(info.LeadingWhitespace())
-	if info.LeadingComments().Len() > 0 {
-		// If leading comments are defined, the whitespace we care about
-		// is attached to the first comment.
-		nodeNewlineCount = newlineCount(info.LeadingComments().Index(0).LeadingWhitespace())
-	}
-	return nodeNewlineCount > 1
-}
-
-// previousTrailingCommentsWroteNewline returns true if the previous node's
-// trailing comments wrote a newline. We need to use this whenever we otherwise
-// need to add a newline (e.g. at the end of a composite type's body, and
-// for EOF comments).
-func (f *formatter) previousTrailingCommentsWroteNewline() bool {
-	return f.previousHasTrailingComments() && f.lastWritten == '\n'
-}
-
-// previousHasTrailingComments returns true if the previous node included
-// trailing comments
-func (f *formatter) previousHasTrailingComments() bool {
-	if f.previousNode == nil {
-		return false
-	}
-	previousTrailingComments := f.fileNode.NodeInfo(f.previousNode).TrailingComments()
-	return previousTrailingComments.Len() > 0
 }
 
 func (f *formatter) leadingCommentsContainBlankLine(n ast.Node) bool {

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -117,8 +117,10 @@ func (f *formatter) WriteString(elem string) {
 	if f.pendingSpace {
 		f.pendingSpace = false
 		first, _ := utf8.DecodeRuneInString(elem)
-		// only write space if next character is not a newline
-		if first != '\n' {
+		// We don't want dangling spaces before a newline or
+		// before a semicolon. So only print the space if the
+		// next character to write is neither of those.
+		if first != '\n' && first != ';' {
 			if _, err := f.writer.Write([]byte{' '}); err != nil {
 				f.err = multierr.Append(f.err, err)
 				return

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -117,10 +117,10 @@ func (f *formatter) WriteString(elem string) {
 	if f.pendingSpace {
 		f.pendingSpace = false
 		first, _ := utf8.DecodeRuneInString(elem)
-		// We don't want dangling spaces before a newline or
-		// before a semicolon. So only print the space if the
-		// next character to write is neither of those.
-		if first != '\n' && first != ';' {
+		// We don't want dangling spaces before a newline, a
+		// comma, or a semicolon. So only print the space if the
+		// next character to write is not any of those.
+		if first != '\n' && first != ';' && first != ',' {
 			if _, err := f.writer.Write([]byte{' '}); err != nil {
 				f.err = multierr.Append(f.err, err)
 				return

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -590,16 +590,6 @@ func (f *formatter) maybeWriteCompactMessageLiteral(
 	return true
 }
 
-func compactOptionHasMessageOrArray(compactOptionsNode *ast.CompactOptionsNode) bool {
-	for _, elem := range compactOptionsNode.Options {
-		switch elem.Val.(type) {
-		case *ast.ArrayLiteralNode, *ast.MessageLiteralNode:
-			return true
-		}
-	}
-	return false
-}
-
 func messageLiteralHasNestedMessageOrArray(messageLiteralNode *ast.MessageLiteralNode) bool {
 	for _, elem := range messageLiteralNode.Elements {
 		switch elem.Val.(type) {
@@ -1111,8 +1101,7 @@ func (f *formatter) writeCompactOptions(compactOptionsNode *ast.CompactOptionsNo
 		f.inCompactOptions = false
 	}()
 	if len(compactOptionsNode.Options) == 1 &&
-		!f.hasInteriorComments(compactOptionsNode) &&
-		!compactOptionHasMessageOrArray(compactOptionsNode) {
+		!f.hasInteriorComments(compactOptionsNode) {
 		// If there's only a single compact scalar option without comments, we can write it
 		// in-line. For example:
 		//

--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -17,7 +17,6 @@ package bufformat
 import (
 	"context"
 	"io"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -49,11 +48,7 @@ func testFormatProto2(t *testing.T) {
 	testFormatNoDiff(t, "testdata/proto2/message/v1")
 	testFormatNoDiff(t, "testdata/proto2/option/v1")
 	testFormatNoDiff(t, "testdata/proto2/quotes/v1")
-
-	// TODO: Temporarily skipping this test since it's
-	// due to a bug in protocompile.
-	//
-	// testFormatNoDiff(t, "testdata/proto2/utf8/v1")
+	testFormatNoDiff(t, "testdata/proto2/utf8/v1")
 }
 
 func testFormatProto3(t *testing.T) {
@@ -67,48 +62,45 @@ func testFormatProto3(t *testing.T) {
 }
 
 func testFormatNoDiff(t *testing.T, path string) {
-	ctx := context.Background()
-	runner := command.NewRunner()
-	moduleBucket, err := storageos.NewProvider().NewReadWriteBucket(path)
-	require.NoError(t, err)
-	module, err := bufmodule.NewModuleForBucket(ctx, moduleBucket)
-	require.NoError(t, err)
-	readBucket, err := Format(ctx, module)
-	require.NoError(t, err)
-	require.NoError(
-		t,
-		storage.WalkReadObjects(
-			ctx,
-			readBucket,
-			"",
-			func(formattedFile storage.ReadObject) error {
-				originalPath := formattedFile.Path()
-				if strings.HasPrefix(filepath.Base(originalPath), "option_name") {
-					// TODO: Temporarily skipping this test since it's
-					// due to a bug in protocompile.
-					//
-					// https://github.com/jhump/protocompile/pull/3
+	t.Run(path, func(t *testing.T) {
+		ctx := context.Background()
+		runner := command.NewRunner()
+		moduleBucket, err := storageos.NewProvider().NewReadWriteBucket(path)
+		require.NoError(t, err)
+		module, err := bufmodule.NewModuleForBucket(ctx, moduleBucket)
+		require.NoError(t, err)
+		readBucket, err := Format(ctx, module)
+		require.NoError(t, err)
+		require.NoError(
+			t,
+			storage.WalkReadObjects(
+				ctx,
+				readBucket,
+				"",
+				func(formattedFile storage.ReadObject) error {
+					originalPath := formattedFile.Path()
+					t.Run(originalPath, func(t *testing.T) {
+						if !strings.HasSuffix(originalPath, ".golden.proto") {
+							// If the fhe current file is not a golden file,
+							// we just need to make sure that the formatted
+							// result is equivalent to its original form.
+							//
+							// This ensures that formatting is idempotent.
+							originalPath = strings.Replace(originalPath, ".proto", ".golden.proto", 1)
+						}
+						formattedData, err := io.ReadAll(formattedFile)
+						require.NoError(t, err)
+						originalFile, err := moduleBucket.Get(ctx, originalPath)
+						require.NoError(t, err)
+						originalData, err := io.ReadAll(originalFile)
+						require.NoError(t, err)
+						fileDiff, err := diff.Diff(ctx, runner, formattedData, originalData, formattedFile.Path(), originalPath)
+						require.NoError(t, err)
+						require.Empty(t, string(fileDiff))
+					})
 					return nil
-				}
-				if !strings.HasSuffix(originalPath, ".golden.proto") {
-					// If the fhe current file is not a golden file,
-					// we just need to make sure that the formatted
-					// result is equivalent to its original form.
-					//
-					// This ensures that formatting is idempotent.
-					originalPath = strings.Replace(originalPath, ".proto", ".golden.proto", 1)
-				}
-				formattedData, err := io.ReadAll(formattedFile)
-				require.NoError(t, err)
-				originalFile, err := moduleBucket.Get(ctx, originalPath)
-				require.NoError(t, err)
-				originalData, err := io.ReadAll(originalFile)
-				require.NoError(t, err)
-				fileDiff, err := diff.Diff(ctx, runner, formattedData, originalData, formattedFile.Path(), originalPath)
-				require.NoError(t, err)
-				require.Empty(t, string(fileDiff))
-				return nil
-			},
-		),
-	)
+				},
+			),
+		)
+	})
 }

--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -78,23 +78,21 @@ func testFormatNoDiff(t *testing.T, path string) {
 				readBucket,
 				"",
 				func(formattedFile storage.ReadObject) error {
-					originalPath := formattedFile.Path()
-					t.Run(originalPath, func(t *testing.T) {
-						if !strings.HasSuffix(originalPath, ".golden.proto") {
-							// If the fhe current file is not a golden file,
-							// we just need to make sure that the formatted
-							// result is equivalent to its original form.
-							//
-							// This ensures that formatting is idempotent.
-							originalPath = strings.Replace(originalPath, ".proto", ".golden.proto", 1)
+					expectedPath := formattedFile.Path()
+					t.Run(expectedPath, func(t *testing.T) {
+						// The expecetd format result is the golden file. If
+						// this file IS a golden file, it is expected to not
+						// change.
+						if !strings.HasSuffix(expectedPath, ".golden.proto") {
+							expectedPath = strings.Replace(expectedPath, ".proto", ".golden.proto", 1)
 						}
 						formattedData, err := io.ReadAll(formattedFile)
 						require.NoError(t, err)
-						originalFile, err := moduleBucket.Get(ctx, originalPath)
+						expectedFile, err := moduleBucket.Get(ctx, expectedPath)
 						require.NoError(t, err)
-						originalData, err := io.ReadAll(originalFile)
+						expectedData, err := io.ReadAll(expectedFile)
 						require.NoError(t, err)
-						fileDiff, err := diff.Diff(ctx, runner, formattedData, originalData, formattedFile.Path(), originalPath)
+						fileDiff, err := diff.Diff(ctx, runner, expectedData, formattedData, expectedPath, formattedFile.Path()+" (formatted)")
 						require.NoError(t, err)
 						require.Empty(t, string(fileDiff))
 					})

--- a/private/buf/bufformat/testdata/customoptions/options.golden.proto
+++ b/private/buf/bufformat/testdata/customoptions/options.golden.proto
@@ -15,6 +15,7 @@ message Thing {
   repeated Thing repeated_thing = 7;
   repeated string repeated_baz = 8;
 }
+// this is a comment after Thing
 
 extend google.protobuf.MessageOptions {
   bool message_option = 80001;
@@ -70,10 +71,12 @@ extend google.protobuf.EnumValueOptions {
   Thing enum_value_thing_option = 80016;
 }
 
+// this is a comment before service options
 extend google.protobuf.ServiceOptions {
   bool service_option = 80012;
   Thing service_thing_option = 80014;
 }
+// this is a comment after service options
 
 extend google.protobuf.ExtensionRangeOptions {
   bool extension_range_option = 80012;

--- a/private/buf/bufformat/testdata/customoptions/options.proto
+++ b/private/buf/bufformat/testdata/customoptions/options.proto
@@ -15,6 +15,7 @@ message Thing {
   repeated Thing repeated_thing = 7;
   repeated string repeated_baz = 8;
 }
+// this is a comment after Thing
 
 extend google.protobuf.MessageOptions {
   bool message_option = 80001;
@@ -69,11 +70,12 @@ extend google.protobuf.EnumValueOptions {
   bool enum_value_option = 80015;
   Thing enum_value_thing_option = 80016;
 }
-
+// this is a comment before service options
 extend google.protobuf.ServiceOptions {
   bool service_option = 80012;
   Thing service_thing_option = 80014;
 }
+// this is a comment after service options
 
 extend google.protobuf.ExtensionRangeOptions {
   bool extension_range_option = 80012;

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum.golden.proto
@@ -5,12 +5,12 @@ enum Type {
   // Another trailing comment on Type.
   // A third trailing comment on Type.
 
-  TYPE_UNSPECIFIED/* Comment before '=' */ = /* Comment after '=' */0 [deprecated = true];
+  TYPE_UNSPECIFIED /* Comment before '=' */ = /* Comment after '=' */ 0 [deprecated = true];
 
   TYPE_ONE = 1; // In-line comment on TYPE_ONE.
 
   // TYPE_TWO leading comment.
-  TYPE_TWO = 2/* Before the ';' */;
+  TYPE_TWO = 2 /* Before the ';' */;
 
 // Leading comment on '}'.
 } // Trailing comment on '}'.

--- a/private/buf/bufformat/testdata/proto2/enum/v1/enum.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/enum/v1/enum.golden.proto
@@ -12,5 +12,5 @@ enum Type {
   // TYPE_TWO leading comment.
   TYPE_TWO = 2 /* Before the ';' */;
 
-// Leading comment on '}'.
+  // Leading comment on '}'.
 } // Trailing comment on '}'.

--- a/private/buf/bufformat/testdata/proto2/extend/v1/empty.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/extend/v1/empty.golden.proto
@@ -18,7 +18,6 @@ extend Foo {
 
   // Leading comment on '}'.
 } // Trailing comment on '}'.
-
 // Another trailing comment on '}'.
 
 // Comment on EOF.

--- a/private/buf/bufformat/testdata/proto2/extend/v1/empty.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/extend/v1/empty.golden.proto
@@ -16,7 +16,7 @@ extend Foo {
     optional int64 five = 5;
   } // Trailing comment on Additional.
 
-// Leading comment on '}'.
+  // Leading comment on '}'.
 } // Trailing comment on '}'.
 
 // Another trailing comment on '}'.

--- a/private/buf/bufformat/testdata/proto2/group/v1/empty.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/group/v1/empty.golden.proto
@@ -13,6 +13,6 @@ message Baz {
     // Trailing comment on '{'.
     // Another trailing comment on '{'.
 
-  // Leading comment on '}'.
+    // Leading comment on '}'.
   }
 }

--- a/private/buf/bufformat/testdata/proto2/header/v1/import.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/header/v1/import.golden.proto
@@ -1,4 +1,4 @@
 // This should be first.
 /* This should be second */
-import /* A well-known type */"google/protobuf/descriptor.proto"; // In-line on the descriptor.proto import.
-import /* Another well-known type */"google/protobuf/type.proto"; // In-line on the type.proto import.
+import /* A well-known type */ "google/protobuf/descriptor.proto"; // In-line on the descriptor.proto import.
+import /* Another well-known type */ "google/protobuf/type.proto"; // In-line on the type.proto import.

--- a/private/buf/bufformat/testdata/proto2/header/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/header/v1/option.golden.proto
@@ -1,3 +1,3 @@
 // The cc_enable_arenas option is defined below.
-option cc_enable_arenas = true/* Sometimes false */;
+option cc_enable_arenas = true /* Sometimes false */ ;
 option go_package = "github.com/foo/bar";

--- a/private/buf/bufformat/testdata/proto2/header/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/header/v1/option.golden.proto
@@ -1,3 +1,3 @@
 // The cc_enable_arenas option is defined below.
-option cc_enable_arenas = true /* Sometimes false */ ;
+option cc_enable_arenas = true /* Sometimes false */;
 option go_package = "github.com/foo/bar";

--- a/private/buf/bufformat/testdata/proto2/message/v1/message.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message.golden.proto
@@ -11,5 +11,5 @@ message Foo {
 
   repeated int64 values = 2;
 
-// Leading comment on '}'.
+  // Leading comment on '}'.
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_extensions.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_extensions.golden.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
 
 message Foo {
-  extensions 43 to /* Comment before 100 */100;
-  extensions /* Comment before 101 */101 to max/* Comment after max */;
-  extensions 1/* After 1 */, 2/* After bar */;
+  extensions 43 to /* Comment before 100 */ 100;
+  extensions /* Comment before 101 */ 101 to max /* Comment after max */;
+  extensions 1 /* After 1 */ , 2 /* After bar */ ;
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_extensions.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_extensions.golden.proto
@@ -3,5 +3,5 @@ syntax = "proto2";
 message Foo {
   extensions 43 to /* Comment before 100 */ 100;
   extensions /* Comment before 101 */ 101 to max /* Comment after max */;
-  extensions 1 /* After 1 */ , 2 /* After bar */ ;
+  extensions 1 /* After 1 */ , 2 /* After bar */;
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_extensions.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_extensions.golden.proto
@@ -3,5 +3,5 @@ syntax = "proto2";
 message Foo {
   extensions 43 to /* Comment before 100 */ 100;
   extensions /* Comment before 101 */ 101 to max /* Comment after max */;
-  extensions 1 /* After 1 */ , 2 /* After bar */;
+  extensions 1 /* After 1 */, 2 /* After bar */;
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_import.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_import.golden.proto
@@ -2,9 +2,7 @@ syntax = "proto2";
 
 import "custom.proto";
 
-message Thing {
-  // Trailing comment on '}'.
-
+message Thing { // Trailing comment on '}'.
   // Leading comment on thing field.
   custom.Thing thing = 1; // Trailing comment on thing field.
 

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_import.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_import.golden.proto
@@ -8,5 +8,5 @@ message Thing {
   // Leading comment on thing field.
   custom.Thing thing = 1; // Trailing comment on thing field.
 
-// Leading comment on '}',
+  // Leading comment on '}',
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
@@ -5,8 +5,8 @@ import "custom.proto";
 message Foo {
   // Leading comment on deprecated.
   option deprecated = false;
-  option/* Comment before the custom option name */ (custom.message_thing_option).foo = /* Comment on the bar value of the option */1;
-  option/* Comment before the custom option name */ (custom.message_thing_option)/* Comment between the name and the field */.bar = /* Comment on the foo value of the option */2;
+  option /* Comment before the custom option name */ (custom.message_thing_option).foo = /* Comment on the bar value of the option */ 1;
+  option /* Comment before the custom option name */ (custom.message_thing_option)/* Comment between the name and the field */.bar = /* Comment on the foo value of the option */ 2;
   option (custom.message_thing_option) = {
     // This should be a trailing comment block on the message literal.
     // It's spread across multiple lines.

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
@@ -48,18 +48,18 @@ message Foo {
         /*trail*/
       ]
       d [
-        <
-          foo: 99
-        >,
-        <
-          foo: 98
-        >,
+        <foo: 99>,
+        <foo: 98>,
         <
           /*lead*/
           foo: 97
           /*trail*/
         >
       ]
+      e []
+      f {}
+      g: [1]
     >
+    frobnitz: <foo: 1>
   };
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
@@ -22,7 +22,6 @@ message Foo {
   option (custom.message_thing_option) = {
     /*leading*/
     foo: 1
-
     /*trailing*/
   } /*leading*/; /*trailing*/
 
@@ -31,7 +30,6 @@ message Foo {
   repeated int64 values = 2 [
     /* leading comment */
     packed = false
-
     /* trailing comment */
   ];
 
@@ -47,7 +45,6 @@ message Foo {
         "foo",
         "bar",
         "baz"
-
         /*trail*/
       ]
       d [
@@ -56,7 +53,6 @@ message Foo {
         <
           /*lead*/
           foo: 97
-
           /*trail*/
         >
       ]

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
@@ -19,7 +19,47 @@ message Foo {
     truth: false
   };
 
+  option (custom.message_thing_option) = {
+    /*leading*/
+    foo: 1
+    /*trailing*/
+  } /*leading*/; /*trailing*/
+
   // This is attached to the optional label.
   optional string name = 1 [deprecated = true];
-  repeated int64 values = 2;
+  repeated int64 values = 2 [
+    /* leading comment */
+    packed = false
+    /* trailing comment */
+  ];
+
+  option (custom.message_thing_option) = {
+    foo: 1
+    bar: 2
+    baz: 3
+    buzz: <
+      a: "abc"
+      b: "xyz"
+      c: [
+        /*lead*/
+        "foo",
+        "bar",
+        "baz"
+        /*trail*/
+      ]
+      d [
+        <
+          foo: 99
+        >,
+        <
+          foo: 98
+        >,
+        <
+          /*lead*/
+          foo: 97
+          /*trail*/
+        >
+      ]
+    >
+  };
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.golden.proto
@@ -22,6 +22,7 @@ message Foo {
   option (custom.message_thing_option) = {
     /*leading*/
     foo: 1
+
     /*trailing*/
   } /*leading*/; /*trailing*/
 
@@ -30,6 +31,7 @@ message Foo {
   repeated int64 values = 2 [
     /* leading comment */
     packed = false
+
     /* trailing comment */
   ];
 
@@ -45,6 +47,7 @@ message Foo {
         "foo",
         "bar",
         "baz"
+
         /*trail*/
       ]
       d [
@@ -53,6 +56,7 @@ message Foo {
         <
           /*lead*/
           foo: 97
+
           /*trail*/
         >
       ]

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.proto
@@ -13,8 +13,25 @@ option (custom.message_thing_option) = {
 
  /* Leading comment on the 'foo' element */ foo:  1  /* Comment on bar */ bar:   2  /* Comment on truth */  truth:false    }  ;
 
+
+
+      option (custom.message_thing_option)=  { /*leading*/ foo: 1 /*trailing*/ } /*leading*/;/*trailing*/
+
        // This is attached to the optional label.
      optional string name = 1 [    deprecated   = true  ]; 
-   repeated int64 values = 2;  
+   repeated int64 values = 2 [  /* leading comment */ packed=false /* trailing comment */ ];
 
-  }
+
+option (custom.message_thing_option)= {
+  foo:1 bar:2 baz:3
+  buzz:<
+    a:"abc" b:"xyz"
+    c:[ /*lead*/"foo", "bar", "baz"/*trail*/]
+    d[
+      <foo: 99>,
+      <foo:98>,
+      </*lead*/foo:97/*trail*/>
+    ]
+  >
+};
+}

--- a/private/buf/bufformat/testdata/proto2/message/v1/message_options.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/message_options.proto
@@ -27,11 +27,16 @@ option (custom.message_thing_option)= {
   buzz:<
     a:"abc" b:"xyz"
     c:[ /*lead*/"foo", "bar", "baz"/*trail*/]
-    d[
-      <foo: 99>,
+    d[<
+        foo: 99
+      >,
       <foo:98>,
       </*lead*/foo:97/*trail*/>
     ]
+    e []
+    f { }
+       g: [1]
   >
+  frobnitz: <foo:1>
 };
 }

--- a/private/buf/bufformat/testdata/proto2/message/v1/multiple_nested.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/multiple_nested.golden.proto
@@ -3,14 +3,14 @@ syntax = "proto2";
 message Foo {
   option deprecated = false;
 
-  optional string name = 1/* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
+  optional string name = 1 /* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
 
   // Repeated values comment.
-  repeated int64 values = 2/* Before the semiolon */;
+  repeated int64 values = 2 /* Before the semiolon */ ;
 
-  message /* Bar is a nested message */Bar/* Before the '{' */ {
+  message /* Bar is a nested message */ Bar /* Before the '{' */ {
     /* This one is required */
-    required bool /* Between 'bool' and 'truth' */truth = 3;
+    required bool /* Between 'bool' and 'truth' */ truth = 3;
   }
   // Comment on the nested Baz message.
   message Baz {

--- a/private/buf/bufformat/testdata/proto2/message/v1/multiple_nested.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/multiple_nested.golden.proto
@@ -6,7 +6,7 @@ message Foo {
   optional string name = 1 /* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
 
   // Repeated values comment.
-  repeated int64 values = 2 /* Before the semiolon */ ;
+  repeated int64 values = 2 /* Before the semiolon */;
 
   message /* Bar is a nested message */ Bar /* Before the '{' */ {
     /* This one is required */

--- a/private/buf/bufformat/testdata/proto2/message/v1/nested.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/nested.golden.proto
@@ -6,7 +6,7 @@ message Foo {
   optional string name = 1 /* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
 
   // Repeated values comment.
-  repeated int64 values = 2 /* Before the semiolon */ ;
+  repeated int64 values = 2 /* Before the semiolon */;
 
   message /* Bar is a nested message */ Bar /* Before the '{' */ {
     /* This one is required */

--- a/private/buf/bufformat/testdata/proto2/message/v1/nested.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/message/v1/nested.golden.proto
@@ -3,13 +3,13 @@ syntax = "proto2";
 message Foo {
   option deprecated = false;
 
-  optional string name = 1/* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
+  optional string name = 1 /* Between the '1' and the '[' */ [deprecated = true]; // In-line comment on name.
 
   // Repeated values comment.
-  repeated int64 values = 2/* Before the semiolon */;
+  repeated int64 values = 2 /* Before the semiolon */ ;
 
-  message /* Bar is a nested message */Bar/* Before the '{' */ {
+  message /* Bar is a nested message */ Bar /* Before the '{' */ {
     /* This one is required */
-    required bool /* Between 'bool' and 'truth' */truth = 3;
+    required bool /* Between 'bool' and 'truth' */ truth = 3;
   }
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option.golden.proto
@@ -13,7 +13,7 @@ message Foo {
     // Leading comment on extension_range_option.
     (custom.extension_range_option) = true
 
-  // Leading comment on ']'.
+    // Leading comment on ']'.
   ];
 
   // Leading comment on deprecated.
@@ -61,7 +61,7 @@ message Foo {
     required string five = 7 [(custom.field_value_thing) = {
       // Trailing comment on '{'.
 
-    // Leading comment on '}'.
+      // Leading comment on '}'.
     }];
   }
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_array.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_array.golden.proto
@@ -16,10 +16,10 @@ message Foo {
         // Leading comment on '2'.
         2 // Trailing comment on '2'.
 
-      // Leading comment on ']'.
+        // Leading comment on ']'.
       ]
 
-    // Leading comment on '}'.
+      // Leading comment on '}'.
     }];
   }
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.golden.proto
@@ -40,10 +40,10 @@ option (list) = {
         45 // Trailing on '45'.
       ]
 
-    // Leading on '}'.
+      // Leading on '}'.
     }
 
-  // Leading comment on ']',
+    // Leading comment on ']',
   ]
 };
 

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.golden.proto
@@ -22,7 +22,7 @@ option (list) = {
     -42, // Trailing on '-42'.
 
     // Leading comment on '-43'.
-    -/* Between '-' and '43' */43 // Trailing on '43'.
+    - /* Between '-' and '43' */ 43 // Trailing on '43'.
   ],
 
   recursive: [

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_complex_array_literal.proto
@@ -46,9 +46,9 @@ option (list) = {
         45 // Trailing on '45'.
       ]
 
-    // Leading on '}'.
+      // Leading on '}'.
     }
 
-  // Leading comment on ']',
+    // Leading comment on ']',
   ]
 };

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_compound_name.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_compound_name.golden.proto
@@ -26,7 +26,7 @@ message Another {
   option (another).thing.(.foo.bar.Thing.Nested._NestedNested.one) = "one";
 
   // Leading on complex option name with in-line.
-  option (another).thing.( /* One */ . /* Two */ foo.bar.Thing.Nested._NestedNested.one) = "one"; // Trailing
+  option (another).thing.(/* One */ . /* Two */ foo.bar.Thing.Nested._NestedNested.one) = "one"; // Trailing
 
   optional Thing thing = 1;
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_compound_name.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_compound_name.golden.proto
@@ -4,7 +4,7 @@ package foo.bar;
 
 import "custom.proto";
 
-option (custom/* One */./* Two */file_thing_option)./* Three */foo = 0;
+option (custom /* One */ . /* Two */ file_thing_option). /* Three */ foo = 0;
 
 extend google.protobuf.MessageOptions {
   optional Another another = 20000;
@@ -26,7 +26,7 @@ message Another {
   option (another).thing.(.foo.bar.Thing.Nested._NestedNested.one) = "one";
 
   // Leading on complex option name with in-line.
-  option (another).thing.(/* One */./* Two */foo.bar.Thing.Nested._NestedNested.one) = "one"; // Trailing
+  option (another).thing.( /* One */ . /* Two */ foo.bar.Thing.Nested._NestedNested.one) = "one"; // Trailing
 
   optional Thing thing = 1;
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
@@ -9,7 +9,7 @@ message Simple {
   optional uint64 id = 2;
 }
 
-extend .google./* identifier broken up strangely should still be accepted */protobuf.ExtensionRangeOptions {
+extend .google. /* identifier broken up strangely should still be accepted */protobuf.ExtensionRangeOptions {
   optional string label = 20000;
 }
 
@@ -48,10 +48,10 @@ message Test {
         // Trailing comment on '{'.
 
         // Leading comment on 'foo'.
-        foo: "goo"/* Leading comment on ',' */, // Trailing comment on foo
+        foo: "goo" /* Leading comment on ',' */, // Trailing comment on foo
 
         // Leading comment on extension name.
-        [/* One */foo.bar.Test.Nested._NestedNested._garblez/* Two */]/* Three */: "boo" // Trailing comment on extension name.
+        [ /* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */ ] /* Three */ : "boo" // Trailing comment on extension name.
 
       // Leading comment on '}'.
       };

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
@@ -51,7 +51,7 @@ message Test {
         foo: "goo" /* Leading comment on ',' */, // Trailing comment on foo
 
         // Leading comment on extension name.
-        [ /* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */ ] /* Three */ : "boo" // Trailing comment on extension name.
+        [/* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */] /* Three */ : "boo" // Trailing comment on extension name.
 
       // Leading comment on '}'.
       };

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
@@ -53,7 +53,7 @@ message Test {
         // Leading comment on extension name.
         [/* One */ foo.bar.Test.Nested._NestedNested._garblez /* Two */] /* Three */ : "boo" // Trailing comment on extension name.
 
-      // Leading comment on '}'.
+        // Leading comment on '}'.
       };
       message NestedNestedNested {
         option (rept) = {

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
@@ -17,6 +17,6 @@ message Foo {
     // Leading comment on deprecated.
     deprecated /* After deprecated */ = true,
     // Leading comment on another.
-    ( /* One */ another /* Two */ ) = 2
+    (/* One */ another /* Two */) = 2
   ];
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_name.golden.proto
@@ -11,12 +11,12 @@ extend google.protobuf.FieldOptions {
 }
 
 message Foo {
-  option (/* One */something/* Two */) = 1;
+  option (/* One */ something /* Two */) = 1;
 
   string name = 1 [
     // Leading comment on deprecated.
-    deprecated/* After deprecated */ = true,
+    deprecated /* After deprecated */ = true,
     // Leading comment on another.
-    (/* One */another/* Two */) = 2
+    ( /* One */ another /* Two */ ) = 2
   ];
 }

--- a/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/quotes/v1/quotes.golden.proto
@@ -19,10 +19,6 @@ message Foo {
   string five = 5 [(name) = "f\"o\"o"];
   string six = 6 [(name) = 'f\'o\'o'];
   string seven = 7 [(name) = "foo"];
-  string eight = 8 [(foo) = {
-    something: 'something:"foo"'
-  }];
-  string nine = 9 [(foo) = {
-    something: "something:\"foo\"\nanother:\"bar\""
-  }];
+  string eight = 8 [(foo) = {something: 'something:"foo"'}];
+  string nine = 9 [(foo) = {something: "something:\"foo\"\nanother:\"bar\""}];
 }

--- a/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
@@ -49,9 +49,7 @@ message One {
   // subsequent message-option comment
   option (custom.message_option) = false; // message-option-inline comment
   // message-option comment 2
-  option (custom.message_thing_option) = {
-    foo: 5
-  }; // message-option-inline comment 2
+  option (custom.message_thing_option) = {foo: 5}; // message-option-inline comment 2
 
   // body comment 2
 
@@ -69,9 +67,7 @@ message One {
   int64 one_one = 1 [(custom.field_option) = true];
   Two one_two = 2 [
     (custom.field_option) = false,
-    (custom.field_thing_option) = {
-      foo: 6
-    }
+    (custom.field_thing_option) = {foo: 6}
   ]; // field-option-inline comment
 
   Three one_three = 3; /* field-inline c-style comment */
@@ -83,17 +79,13 @@ message One {
 
     // oneof-field comment
     option (custom.oneof_option) = true; // oneof-option-field-inline comment
-    option (custom.oneof_thing_option) = {
-      foo: 7
-    }; // oneof-option-field-inline comment 2
+    option (custom.oneof_thing_option) = {foo: 7}; // oneof-option-field-inline comment 2
     int64 foo1 = 8;
     string foo2 = 9;
     // oneof-field comment 2
     int64 woot3 = 10 [
       (custom.field_option) = false,
-      (custom.field_thing_option) = {
-        foo: 8
-      }
+      (custom.field_thing_option) = {foo: 8}
     ]; // oneof-option-field-inline comment 3
     // oneof-field comment 2
     custom.Thing custom_field = 11; // oneof-option-field-inline comment 4
@@ -152,7 +144,7 @@ message One {
     }
   ];
 
-// body comment one2
+  // body comment one2
 } // trailing comment one1
 
 message Two {
@@ -190,9 +182,7 @@ enum OtherEnum {
       bar: 2,
       recursive: {
         foo: 3,
-        recursive: {
-          bar: 2
-        }
+        recursive: {bar: 2}
       }
     }
   ]; // enum-option-inline comment
@@ -207,9 +197,7 @@ enum OtherEnum {
 // ExampleService is the example service.
 service ExampleService {
   option (custom.service_option) = true; // service-option-inline comment
-  option (custom.service_thing_option) = {
-    foo: 1
-  }; // service-option-inline comment 2
+  option (custom.service_thing_option) = {foo: 1}; // service-option-inline comment 2
   // rpc-leading comment
   rpc Example(One) returns (Two) {
     option (custom.method_option) = true;
@@ -218,9 +206,7 @@ service ExampleService {
       bar: 2,
       recursive: {
         foo: 3,
-        recursive: {
-          bar: 2
-        }
+        recursive: {bar: 2}
       }
     }; // service-option-inline comment 2
   } // rpc-inline comment

--- a/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/all/v1/all.golden.proto
@@ -61,7 +61,7 @@ message One {
   }
 
   /*
-  c-style comment
+     c-style comment
   */
 
   int64 one_one = 1 [(custom.field_option) = true];

--- a/private/buf/bufformat/testdata/proto3/header/v1/header.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/header.golden.proto
@@ -8,12 +8,12 @@
 //      All of them should retain their newlines.
 
 // This is another leading comment on the syntax.
-syntax/* This comment is attached to the '=' */ = "proto3"; // Trailing comment on syntax.
+syntax /* This comment is attached to the '=' */ = "proto3"; // Trailing comment on syntax.
 
 // Between syntax and package.
 
-package /* Leading on package name. */header.v1/* Leading on semicolon */; // Trailing in-line.
+package /* Leading on package name. */ header.v1 /* Leading on semicolon */; // Trailing in-line.
 
-import /* Leading on import path */"custom.proto";
+import /* Leading on import path */ "custom.proto";
 
-option /* Leading on option name */ (custom.file_thing_option).truth/* Between truth and value */ = true/* After 'true' */;
+option /* Leading on option name */ (custom.file_thing_option).truth /* Between truth and value */ = true /* After 'true' */;

--- a/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.golden.proto
@@ -41,7 +41,7 @@ message Foo {
       "Two"
       "Three"
     repeated_baz: [
-      // Firt element.
+      // First element.
       "this"
       // Second element.
       "is a"
@@ -62,7 +62,7 @@ message Foo {
         "Two"
         "Three"
       repeated_baz: [
-        // Firt element.
+        // First element.
         "this"
         // Second element.
         "is a"

--- a/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/compound_string.proto
@@ -43,7 +43,7 @@ message Foo {
         "Two"
         "Three"
       repeated_baz: [
-        // Firt element.
+        // First element.
         "this"
         // Second element.
         "is a"
@@ -64,7 +64,7 @@ message Foo {
           "Two"
           "Three"
         repeated_baz: [
-          // Firt element.
+          // First element.
           "this"
           // Second element.
           "is a"

--- a/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
@@ -4,20 +4,20 @@ import "custom.proto";
 
 message Foo {
   string name = 1 [
-    (custom.float_field_option) = /* Before */42.2/* After */, // Trailing
-    (custom.double_field_option) = /* Before */42.2424/* After */, // Trailing
-    (custom.int32_field_option) = /* Before */32/* After */, // Trailing
-    (custom.int64_field_option) = /* Before */64/* After */, // Trailing
-    (custom.uint32_field_option) = /* Before */3200/* After */, // Trailing
-    (custom.uint64_field_option) = /* Before */6400/* After */, // Trailing
-    (custom.sint32_field_option) = -/* The '-' can be detached. */32/* After 32 */, // Trailing
-    (custom.sint64_field_option) = -/* Again */64/* After 64 */, // Trailing
-    (custom.fixed32_field_option) = /* Before */3232/* After */, // Trailing
-    (custom.fixed64_field_option) = /* Before */6464/* After */, // Trailing
-    (custom.sfixed32_field_option) = -/* Again */3232/* After */, // Trailing
-    (custom.sfixed64_field_option) = -/* Finally */6464/* After */, // Trailing
-    (custom.bool_field_option) = /* Before */true/* After */, // Trailing
-    (custom.bytes_field_option) = /* Before */"bytes"/* After */, // Trailing
+    (custom.float_field_option) = /* Before */ 42.2 /* After */ , // Trailing
+    (custom.double_field_option) = /* Before */ 42.2424 /* After */ , // Trailing
+    (custom.int32_field_option) = /* Before */ 32 /* After */ , // Trailing
+    (custom.int64_field_option) = /* Before */ 64 /* After */, // Trailing
+    (custom.uint32_field_option) = /* Before */ 3200 /* After */, // Trailing
+    (custom.uint64_field_option) = /* Before */ 6400 /* After */ , // Trailing
+    (custom.sint32_field_option) = - /* The '-' can be detached. */ 32 /* After 32 */, // Trailing
+    (custom.sint64_field_option) = - /* Again */ 64 /* After 64 */, // Trailing
+    (custom.fixed32_field_option) = /* Before */ 3232 /* After */, // Trailing
+    (custom.fixed64_field_option) = /* Before */ 6464 /* After */, // Trailing
+    (custom.sfixed32_field_option) = - /* Again */ 3232 /* After */ , // Trailing
+    (custom.sfixed64_field_option) = - /* Finally */ 6464 /* After */, // Trailing
+    (custom.bool_field_option) = /* Before */ true /* After */ , // Trailing
+    (custom.bytes_field_option) = /* Before */ "bytes" /* After */ , // Trailing
     (custom.string_field_option) =
       /* One */
       "this"

--- a/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/literal_comments.golden.proto
@@ -4,20 +4,20 @@ import "custom.proto";
 
 message Foo {
   string name = 1 [
-    (custom.float_field_option) = /* Before */ 42.2 /* After */ , // Trailing
-    (custom.double_field_option) = /* Before */ 42.2424 /* After */ , // Trailing
-    (custom.int32_field_option) = /* Before */ 32 /* After */ , // Trailing
+    (custom.float_field_option) = /* Before */ 42.2 /* After */, // Trailing
+    (custom.double_field_option) = /* Before */ 42.2424 /* After */, // Trailing
+    (custom.int32_field_option) = /* Before */ 32 /* After */, // Trailing
     (custom.int64_field_option) = /* Before */ 64 /* After */, // Trailing
     (custom.uint32_field_option) = /* Before */ 3200 /* After */, // Trailing
-    (custom.uint64_field_option) = /* Before */ 6400 /* After */ , // Trailing
+    (custom.uint64_field_option) = /* Before */ 6400 /* After */, // Trailing
     (custom.sint32_field_option) = - /* The '-' can be detached. */ 32 /* After 32 */, // Trailing
     (custom.sint64_field_option) = - /* Again */ 64 /* After 64 */, // Trailing
     (custom.fixed32_field_option) = /* Before */ 3232 /* After */, // Trailing
     (custom.fixed64_field_option) = /* Before */ 6464 /* After */, // Trailing
-    (custom.sfixed32_field_option) = - /* Again */ 3232 /* After */ , // Trailing
+    (custom.sfixed32_field_option) = - /* Again */ 3232 /* After */, // Trailing
     (custom.sfixed64_field_option) = - /* Finally */ 6464 /* After */, // Trailing
-    (custom.bool_field_option) = /* Before */ true /* After */ , // Trailing
-    (custom.bytes_field_option) = /* Before */ "bytes" /* After */ , // Trailing
+    (custom.bool_field_option) = /* Before */ true /* After */, // Trailing
+    (custom.bytes_field_option) = /* Before */ "bytes" /* After */, // Trailing
     (custom.string_field_option) =
       /* One */
       "this"

--- a/private/buf/bufformat/testdata/proto3/literal/v1/special_literal.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/literal/v1/special_literal.golden.proto
@@ -3,10 +3,10 @@ syntax = "proto3";
 import "custom.proto";
 
 message Foo {
-  string key = 1 [(custom.float_field_option) = /* Before */nan/* Trailing */];
+  string key = 1 [(custom.float_field_option) = /* Before */ nan /* Trailing */];
   string value = 2 [
-    (custom.float_field_option) = /* Before */inf/* After */, // Trailing
+    (custom.float_field_option) = /* Before */ inf /* After */, // Trailing
     (custom.bool_field_option) = false
   ];
-  string another = 3 [(custom.float_field_option) =/* Before */ -/* Between */inf/* Trailing */];
+  string another = 3 [(custom.float_field_option) = /* Before */ - /* Between */ inf /* Trailing */];
 }

--- a/private/buf/bufformat/testdata/proto3/oneof/v1/multiple.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/oneof/v1/multiple.golden.proto
@@ -2,14 +2,14 @@ syntax = "proto3";
 
 message Foo {
   /* Leading comment on oneof */
-  oneof /* Comment between oneof and 'bar' */bar/* Comment before '{' */ {
+  oneof /* Comment between oneof and 'bar' */ bar /* Comment before '{' */ {
     // This is a trailing comment on the oneof's '{'.
     // This is another trailing comment.
 
     // This is a leading comment on name.
     string name = 1; // In-line comment on name.
 
-    float /* Comment after float */value = 2;
+    float /* Comment after float */ value = 2;
   } // Trailing comment on oneof's '}'.
 
   // Leading comment on baz.

--- a/private/buf/bufformat/testdata/proto3/oneof/v1/multiple.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/oneof/v1/multiple.golden.proto
@@ -19,5 +19,5 @@ message Foo {
     int64 four = 4;
   } // Trailing comment on oneof's '}'.
 
-// Another trailing comment before end of definition.
+  // Another trailing comment before end of definition.
 }

--- a/private/buf/bufformat/testdata/proto3/oneof/v1/multiple.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/oneof/v1/multiple.golden.proto
@@ -18,6 +18,5 @@ message Foo {
 
     int64 four = 4;
   } // Trailing comment on oneof's '}'.
-
   // Another trailing comment before end of definition.
 }

--- a/private/buf/bufformat/testdata/proto3/oneof/v1/simple.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/oneof/v1/simple.golden.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 message Foo {
   /* Leading comment on oneof */
-  oneof /* Comment between oneof and 'bar' */bar/* Comment before '{' */ {
+  oneof /* Comment between oneof and 'bar' */ bar /* Comment before '{' */ {
     // This is a trailing comment on the oneof's '{'.
     // This is another trailing comment.
 
     // This is a leading comment on name.
     string name = 1; // In-line comment on name.
-    float /* Comment after float */value = 2;
+    float /* Comment after float */ value = 2;
   } // Trailing comment on oneof's '}'.
 }

--- a/private/buf/bufformat/testdata/proto3/range/v1/range.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/range/v1/range.golden.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 message Foo {
   reserved /* 43 is the start */ 43 to /* max is the end */ max;
-  reserved "foo" /* Comment before the ',' */ , /* Comment before "bar" */ "bar";
+  reserved "foo" /* Comment before the ',' */, /* Comment before "bar" */ "bar";
 
   // Always reserve the forty-second field.
   reserved 42;

--- a/private/buf/bufformat/testdata/proto3/range/v1/range.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/range/v1/range.golden.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 message Foo {
-  reserved /* 43 is the start */43 to /* max is the end */max;
-  reserved "foo"/* Comment before the ',' */, /* Comment before "bar" */"bar";
+  reserved /* 43 is the start */ 43 to /* max is the end */ max;
+  reserved "foo" /* Comment before the ',' */ , /* Comment before "bar" */ "bar";
 
   // Always reserve the forty-second field.
   reserved 42;

--- a/private/buf/bufformat/testdata/proto3/service/v1/empty_rpc.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/service/v1/empty_rpc.golden.proto
@@ -13,5 +13,5 @@ service Foo {
     // Body comment.
   }
 
-// Leading comment on '}'.
+  // Leading comment on '}'.
 }

--- a/private/buf/bufformat/testdata/proto3/service/v1/service.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/service/v1/service.golden.proto
@@ -3,16 +3,12 @@ syntax = "proto3";
 message Message {}
 
 // Ping is an example service.
-service /* Before Ping comment */ Ping /* After Ping comment */ {
-  // Trailing comment on '{'
-
+service /* Before Ping comment */ Ping /* After Ping comment */ { // Trailing comment on '{'
   // This service is deprecated.
   option deprecated = true; // In-line comment on deprecated option.
 
   rpc /* Before Ping Method */ Ping(/* Before Request */Message/* After Request */) returns /* Before paren */ (Message);
-  rpc Echo(Message) returns (Message) {
-    // Trailing comment on '{'
-
+  rpc Echo(Message) returns (Message) { // Trailing comment on '{'
     option deprecated = true; // In-line on deprecated option.
 
     // This method has no side effects.

--- a/private/buf/bufformat/testdata/proto3/service/v1/service.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/service/v1/service.golden.proto
@@ -3,13 +3,13 @@ syntax = "proto3";
 message Message {}
 
 // Ping is an example service.
-service /* Before Ping comment */Ping/* After Ping comment */ {
+service /* Before Ping comment */ Ping /* After Ping comment */ {
   // Trailing comment on '{'
 
   // This service is deprecated.
   option deprecated = true; // In-line comment on deprecated option.
 
-  rpc /* Before Ping Method */Ping(/* Before Request */Message/* After Request */) returns/* Before paren */ (Message);
+  rpc /* Before Ping Method */ Ping(/* Before Request */Message/* After Request */) returns /* Before paren */ (Message);
   rpc Echo(Message) returns (Message) {
     // Trailing comment on '{'
 
@@ -20,5 +20,5 @@ service /* Before Ping comment */Ping/* After Ping comment */ {
   }
 
   // The Streamer method is bidirectional.
-  rpc Streamer(/* Client-side streaming */stream Message) returns (stream /* Server-side streaming */Message);
+  rpc Streamer( /* Client-side streaming */ stream Message) returns (stream /* Server-side streaming */ Message);
 }

--- a/private/buf/bufformat/testdata/proto3/service/v1/service.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/service/v1/service.golden.proto
@@ -20,5 +20,5 @@ service /* Before Ping comment */ Ping /* After Ping comment */ {
   }
 
   // The Streamer method is bidirectional.
-  rpc Streamer( /* Client-side streaming */ stream Message) returns (stream /* Server-side streaming */ Message);
+  rpc Streamer(/* Client-side streaming */ stream Message) returns (stream /* Server-side streaming */ Message);
 }


### PR DESCRIPTION
There were a few bugs in the formatter that were uncovered with the new version of `protocompile`, mostly around trailing vs. leading comments.

For example, there was previously a bug in protocompile (https://github.com/bufbuild/protocompile/pull/33) where certain elements (like extension names enclosed in parentheses in an option name, full options declaration enclosed in brackets) would not get leading comments. The comments that _should_ be interpreted as leading would usually instead be interpreted as a trailing comment on the previous token.

That means that there were some cases in the formatter where it was not correctly handling leading comments on certain elements (such as custom option names).

Also, this was treating leading/trailing comments for inline comments in between tokens as if the parser's classification of trailing vs. leading were authoritative. If it was a trailing comment in the AST, it would format it with _no whitespace_ after the token, before the comment. Similarly, for leading comments, it would format it with nothing after the comment, before the token. But this classification of trailing vs. leading is just heuristic (and mostly done to mirror this distinction in source code info in descriptors generated by `protoc`). So now, the formatter will preserve whitespace: if a comment had no whitespace between it and a token, that will be preserved. If it did have whitespace, it will be canonicalized to a single space.

Getting everything looking right involved a greater degree of changes to the formatter than I would have liked. 🤷 

The good news is that these changes should mostly be idempotent for users: they shouldn't see a lot of new diff churn from formatting with this new version. As you'll see in the new golden files, the only new differences are the whitespace around inline comments. And this change tries to _preserve_ existing whitespace there, so if a file was previously formatted with the old version and then re-formatted with the new, there shouldn't be a diff.