### PR TITLE
[BSR-542] Allow injecting write callback to `storagemem`

### DIFF
--- a/private/pkg/storage/storagemem/bucket.go
+++ b/private/pkg/storage/storagemem/bucket.go
@@ -28,13 +28,13 @@ import (
 
 type bucket struct {
 	pathToImmutableObject map[string]*internal.ImmutableObject
-	writeObjectCallback   func(objectPath string)
+	writeObjectCallback   func(objectPath string, data []byte)
 	lock                  sync.RWMutex
 }
 
 func newBucket(
 	pathToImmutableObject map[string]*internal.ImmutableObject,
-	writeObjectCallback func(objectPath string),
+	writeObjectCallback func(objectPath string, data []byte),
 ) *bucket {
 	if pathToImmutableObject == nil {
 		pathToImmutableObject = make(map[string]*internal.ImmutableObject)

--- a/private/pkg/storage/storagemem/bucket.go
+++ b/private/pkg/storage/storagemem/bucket.go
@@ -28,15 +28,20 @@ import (
 
 type bucket struct {
 	pathToImmutableObject map[string]*internal.ImmutableObject
+	writeObjectCallback   func(objectPath string)
 	lock                  sync.RWMutex
 }
 
-func newBucket(pathToImmutableObject map[string]*internal.ImmutableObject) *bucket {
+func newBucket(
+	pathToImmutableObject map[string]*internal.ImmutableObject,
+	writeObjectCallback func(objectPath string),
+) *bucket {
 	if pathToImmutableObject == nil {
 		pathToImmutableObject = make(map[string]*internal.ImmutableObject)
 	}
 	return &bucket{
 		pathToImmutableObject: pathToImmutableObject,
+		writeObjectCallback:   writeObjectCallback,
 	}
 }
 
@@ -93,7 +98,7 @@ func (b *bucket) Put(ctx context.Context, path string) (storage.WriteObjectClose
 	if err != nil {
 		return nil, err
 	}
-	return newWriteObjectCloser(b, path), nil
+	return newWriteObjectCloser(b, path, b.writeObjectCallback), nil
 }
 
 func (b *bucket) Delete(ctx context.Context, path string) error {

--- a/private/pkg/storage/storagemem/storagemem.go
+++ b/private/pkg/storage/storagemem/storagemem.go
@@ -26,14 +26,14 @@ import (
 var errDuplicatePath = errors.New("duplicate path")
 
 type readWriteBucketOptions struct {
-	writeObjectCallback func(objectPath string)
+	writeObjectCallback func(objectPath string, data []byte)
 }
 
 type ReadWriteBucketOption func(*readWriteBucketOptions)
 
 // ReadWriteBucketWithWriteObjectCallback invokes the given function everytime
 // there is a write in a bucket object, reporting its path.
-func ReadWriteBucketWithWriteObjectCallback(writeObjectCallback func(objectPath string)) ReadWriteBucketOption {
+func ReadWriteBucketWithWriteObjectCallback(writeObjectCallback func(objectPath string, data []byte)) ReadWriteBucketOption {
 	return func(opts *readWriteBucketOptions) {
 		opts.writeObjectCallback = writeObjectCallback
 	}

--- a/private/pkg/storage/storagemem/storagemem.go
+++ b/private/pkg/storage/storagemem/storagemem.go
@@ -32,7 +32,7 @@ type readWriteBucketOptions struct {
 type ReadWriteBucketOption func(*readWriteBucketOptions)
 
 // ReadWriteBucketWithWriteObjectCallback invokes the given function everytime
-// there is a write in a bucket object, reporting its path.
+// there is a write in a bucket object, reporting its path and the written data.
 func ReadWriteBucketWithWriteObjectCallback(writeObjectCallback func(objectPath string, data []byte)) ReadWriteBucketOption {
 	return func(opts *readWriteBucketOptions) {
 		opts.writeObjectCallback = writeObjectCallback

--- a/private/pkg/storage/storagemem/write_object_callback_test.go
+++ b/private/pkg/storage/storagemem/write_object_callback_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagemem_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteCallbackIsInvoked(t *testing.T) {
+	t.Parallel()
+	var (
+		wg          sync.WaitGroup
+		invocations int
+	)
+	const filePathToWrite = "my/path/to/file.foo"
+	callbackFn := func(objectPath string) {
+		assert.Equal(t, filePathToWrite, objectPath)
+		invocations++
+		wg.Done()
+	}
+	rwb := storagemem.NewReadWriteBucket(
+		storagemem.ReadWriteBucketWithWriteObjectCallback(callbackFn),
+	)
+	woc, err := rwb.Put(context.Background(), filePathToWrite)
+	require.NoError(t, err)
+	const writesToPerform = 5
+	for i := 0; i < writesToPerform; i++ {
+		wg.Add(1)
+		_, err = woc.Write([]byte(fmt.Sprintf("some data to write: %d", i)))
+		require.NoError(t, err)
+	}
+	wg.Wait()
+	assert.Equal(t, writesToPerform, invocations)
+}
+
+func TestWriteWorksIfNoCallbackIsPassed(t *testing.T) {
+	t.Parallel()
+	const filePathToWrite = "my/path/to/file.foo"
+	rwb := storagemem.NewReadWriteBucket() // no callbackfn
+	woc, err := rwb.Put(context.Background(), filePathToWrite)
+	require.NoError(t, err)
+	_, err = woc.Write([]byte("some data to write"))
+	require.NoError(t, err)
+}

--- a/private/pkg/storage/storagemem/write_object_closer.go
+++ b/private/pkg/storage/storagemem/write_object_closer.go
@@ -28,13 +28,13 @@ type writeObjectCloser struct {
 	externalPath        string
 	buffer              *bytes.Buffer
 	closed              bool
-	writeObjectCallback func(objectPath string)
+	writeObjectCallback func(objectPath string, data []byte)
 }
 
 func newWriteObjectCloser(
 	bucket *bucket,
 	path string,
-	writeObjectCallback func(objectPath string),
+	writeObjectCallback func(objectPath string, data []byte),
 ) *writeObjectCloser {
 	return &writeObjectCloser{
 		bucket:              bucket,
@@ -50,7 +50,7 @@ func (w *writeObjectCloser) Write(p []byte) (int, error) {
 	}
 	defer func() {
 		if w.writeObjectCallback != nil {
-			w.writeObjectCallback(w.path)
+			w.writeObjectCallback(w.path, p)
 		}
 	}()
 	return w.buffer.Write(p)


### PR DESCRIPTION
Allow callback for write in `storagemem`, so it's more easily testable.