### PR TITLE
Allow for buf beta convert to be used without input

### DIFF
--- a/private/buf/cmd/buf/command/beta/convert/convert.go
+++ b/private/buf/cmd/buf/command/beta/convert/convert.go
@@ -119,7 +119,7 @@ func run(
 	if err := bufcli.ValidateErrorFormatFlag(flags.ErrorFormat, errorFormatFlagName); err != nil {
 		return err
 	}
-	input, err := bufcli.GetInputValue(container, flags.InputHashtag, ".")
+	input, err := bufcli.GetInputValue(container, flags.InputHashtag, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
v simple change

- Remove default input from "." in convert as it doesn't need to be run in a buf module