### PR TITLE
avoid panic in OptionExtensionDescriptor

### DIFF
--- a/private/pkg/protosource/option_extension_descriptor.go
+++ b/private/pkg/protosource/option_extension_descriptor.go
@@ -31,6 +31,9 @@ func newOptionExtensionDescriptor(message proto.Message) optionExtensionDescript
 }
 
 func (o *optionExtensionDescriptor) OptionExtension(extensionType protoreflect.ExtensionType) (interface{}, bool) {
+	if extensionType.TypeDescriptor().ContainingMessage().FullName() != o.message.ProtoReflect().Descriptor().FullName() {
+		return nil, false
+	}
 	if !proto.HasExtension(o.message, extensionType) {
 		return nil, false
 	}

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -121,10 +121,6 @@ type OptionExtensionDescriptor interface {
 	// OptionExtension returns the value for an options extension field.
 	//
 	// Returns false if the extension is not set.
-	// Panics if the ExtensionType does not extend the message.
-	//
-	// TODO: handle the panic by figuring out if ExtensionType extends the
-	// message before passing to HasExtension or GetExtension.
 	//
 	// See https://pkg.go.dev/google.golang.org/protobuf/proto#HasExtension
 	// See https://pkg.go.dev/google.golang.org/protobuf/proto#GetExtension


### PR DESCRIPTION
I was looking through this code, just to get acquainted with it so I am prepared to talk to @seankimdev about potential upcoming changes, when I noticed this. It was a pretty easy fix, so I figured I'd go ahead and make the change.

Sadly, there are no tests in this package. I didn't add the first test because the process to create a `protosource.Message` appears non-trivial due to several layers between the underlying descriptor and the `protosource` layer. So I simply verified that no existing tests were broken by it. But this new check is the same as [the one that causes the panic](https://github.com/protocolbuffers/protobuf-go/blob/b0a944684d78a6b7c1f2bb6864fa910385d5b97a/internal/impl/message_reflect.go#L449-L452).