### PR TITLE
Fix git unit test by using fake git server rather than file://

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -136,3 +136,8 @@ issues:
     - linters:
         - containedctx
       path: private/bufpkg/bufmodule/bufmoduleprotocompile
+      # We should be able to use net/http/cgi in a unit test, in addition the CVE mentions only versions of go < 1.6.3 are affected.
+    - linters:
+        - gosec
+      path: private/pkg/git/git_test.go
+      text: "G504:"


### PR DESCRIPTION
More recent versions of git fix a CVE by disabling some usage of the `file://` transport, see https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253. We were using this transport in tests.

Instead, use https://git-scm.com/docs/git-http-backend to serve up this repository locally so we don't have to use the file protocol. This should be a more accurate tests, since we mostly expect submodules to come from servers.