### PR TITLE
Update Github Actions outputs to new format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,9 +96,9 @@ jobs:
         id: tag
         run: |
           if echo "${GITHUB_REF}" | grep ^refs/heads/main$ >/dev/null; then
-            echo ::set-output name=tag::latest
+            echo "tag=latest" >> $GITHUB_OUTPUT
           elif echo "${GITHUB_REF}" | grep ^refs/tags/v >/dev/null; then
-            echo ::set-output name=tag::"$(echo "${GITHUB_REF}" | sed "s/refs\/tags\/v//")"
+            echo "tag=$(echo \"${GITHUB_REF}\" | sed \"s/refs\/tags\/v//\")" >> $GITHUB_OUTPUT
           fi
       - name: docker-build-push
         uses: docker/build-push-action@v3


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/