### PR TITLE
buffetch: correct bucket type doc

### DIFF
--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -222,7 +222,7 @@ type ReadBucketCloser internal.ReadBucketCloser
 // declaration to do so.
 type ReadWriteBucketCloser internal.ReadWriteBucketCloser
 
-// ReadBucketCloserWithTerminateFileProvider is a ReadWriteBucketCloser with a TerminateFileProvider.
+// ReadBucketCloserWithTerminateFileProvider is a ReadBucketCloser with a TerminateFileProvider.
 type ReadBucketCloserWithTerminateFileProvider internal.ReadBucketCloserWithTerminateFileProvider
 
 // ImageReader is an image reader.


### PR DESCRIPTION
`ReadBucketCloserWithTerminateFileProvider` is actually a `ReadBucketCloser` with `TerminateFileProvider`. It's not a writer.