### PR TITLE
bufcli: add test, storagemem: NewReadWriteBucket2

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -681,13 +681,14 @@ func PromptUserForPassword(container app.Container, prompt string) (string, erro
 // Workspaces are disabled for this function.
 func ReadModuleWithWorkspacesDisabled(
 	ctx context.Context,
-	container appflag.Container,
+	logger *zap.Logger,
+	container app.EnvStdinContainer,
 	storageosProvider storageos.Provider,
 	runner command.Runner,
 	source string,
 ) (bufmodule.Module, bufmoduleref.ModuleIdentity, error) {
 	sourceRef, err := buffetch.NewSourceRefParser(
-		container.Logger(),
+		logger,
 	).GetSourceRef(
 		ctx,
 		source,
@@ -696,7 +697,7 @@ func ReadModuleWithWorkspacesDisabled(
 		return nil, nil, err
 	}
 	sourceBucket, err := newFetchSourceReader(
-		container.Logger(),
+		logger,
 		storageosProvider,
 		runner,
 	).GetSourceBucket(
@@ -727,7 +728,7 @@ func ReadModuleWithWorkspacesDisabled(
 	if moduleIdentity == nil {
 		return nil, nil, ErrNoModuleName
 	}
-	module, err := bufmodulebuild.NewModuleBucketBuilder(container.Logger()).BuildForBucket(
+	module, err := bufmodulebuild.NewModuleBucketBuilder(logger).BuildForBucket(
 		ctx,
 		sourceBucket,
 		sourceConfig.Build,

--- a/private/buf/bufcli/bufcli_test.go
+++ b/private/buf/bufcli/bufcli_test.go
@@ -122,13 +122,13 @@ func testReadModuleWithWorkspacesDisabled(
 			assert.NotNil(t, module)
 			assert.NotNil(t, identity)
 			assert.NoError(t, err)
-		} else {
-			if expectedErr != nil {
-				assert.ErrorIs(t, err, expectedErr)
-			}
-			if expectedErrContains != "" {
-				assert.ErrorContains(t, err, expectedErrContains)
-			}
+			return
+		}
+		if expectedErr != nil {
+			assert.ErrorIs(t, err, expectedErr)
+		}
+		if expectedErrContains != "" {
+			assert.ErrorContains(t, err, expectedErrContains)
 		}
 	})
 }

--- a/private/buf/bufcli/bufcli_test.go
+++ b/private/buf/bufcli/bufcli_test.go
@@ -36,7 +36,7 @@ func (m *mockBucketProvider) NewReadWriteBucket(
 	_ string,
 	_ ...storageos.ReadWriteBucketOption,
 ) (storage.ReadWriteBucket, error) {
-	return storagemem.NewReadWriteBucket2(storagemem.WithFiles(m.files))
+	return storagemem.NewReadWriteBucketWithOptions(storagemem.WithFiles(m.files))
 }
 
 func TestReadModuleWithWorkspacesDisabled(t *testing.T) {

--- a/private/buf/bufcli/bufcli_test.go
+++ b/private/buf/bufcli/bufcli_test.go
@@ -1,0 +1,134 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufcli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/bufbuild/buf/private/pkg/app"
+	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/bufbuild/buf/private/pkg/storage"
+	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
+	"github.com/bufbuild/buf/private/pkg/storage/storageos"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type mockBucketProvider struct {
+	files map[string][]byte
+}
+
+func (m *mockBucketProvider) NewReadWriteBucket(
+	_ string,
+	_ ...storageos.ReadWriteBucketOption,
+) (storage.ReadWriteBucket, error) {
+	return storagemem.NewReadWriteBucket2(storagemem.WithFiles(m.files))
+}
+
+func TestReadModuleWithWorkspacesDisabled(t *testing.T) {
+	testReadModuleWithWorkspacesDisabled(
+		t,
+		"minimal module",
+		moduleFiles("remote/owner/repository"),
+		".",
+		nil,
+		"",
+	)
+	testReadModuleWithWorkspacesDisabled(
+		t,
+		"bad name",
+		moduleFiles("foo"),
+		".",
+		nil,
+		"module identity",
+	)
+	testReadModuleWithWorkspacesDisabled(
+		t,
+		"bad path",
+		moduleFiles("remote/owner/repository"),
+		"astrangescheme://",
+		nil,
+		"invalid dir path",
+	)
+	testReadModuleWithWorkspacesDisabled(
+		t,
+		"no config file",
+		nil,
+		".",
+		ErrNoConfigFile,
+		"",
+	)
+	testReadModuleWithWorkspacesDisabled(
+		t,
+		"no module name",
+		moduleFiles(""),
+		".",
+		ErrNoModuleName,
+		"",
+	)
+}
+
+func moduleFiles(name string) map[string][]byte {
+	bufConfig := "version: v1\n"
+	if name != "" {
+		bufConfig += fmt.Sprintf("name: %s\n", name)
+	}
+	return map[string][]byte{
+		"buf.yaml": []byte(bufConfig),
+	}
+}
+
+func testReadModuleWithWorkspacesDisabled(
+	t *testing.T,
+	desc string,
+	files map[string][]byte,
+	source string,
+	expectedErr error,
+	expectedErrContains string,
+) {
+	t.Helper()
+	t.Run(desc, func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		logger := zap.NewNop()
+		container := app.NewContainer(nil, nil, nil, nil)
+		bucketProvider := &mockBucketProvider{
+			files: files,
+		}
+		runner := command.NewRunner()
+		module, identity, err := ReadModuleWithWorkspacesDisabled(
+			ctx,
+			logger,
+			container,
+			bucketProvider,
+			runner,
+			source,
+		)
+		if expectedErr == nil && expectedErrContains == "" {
+			assert.NotNil(t, module)
+			assert.NotNil(t, identity)
+			assert.NoError(t, err)
+		} else {
+			if expectedErr != nil {
+				assert.ErrorIs(t, err, expectedErr)
+			}
+			if expectedErrContains != "" {
+				assert.ErrorContains(t, err, expectedErrContains)
+			}
+		}
+	})
+}

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -141,6 +141,7 @@ func run(
 	// given the configuration it has without any enclosing workspace.
 	module, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
 		ctx,
+		container.Logger(),
 		container,
 		storageosProvider,
 		runner,

--- a/private/pkg/storage/storagemem/storagemem.go
+++ b/private/pkg/storage/storagemem/storagemem.go
@@ -29,7 +29,7 @@ type options struct {
 	pathToData map[string][]byte
 }
 
-// Option is provided by NewReadWriteBucket2 options.
+// Option is provided by NewReadWriteBucketWithOptions options.
 type Option interface {
 	apply(*options)
 }
@@ -46,13 +46,14 @@ func WithFiles(pathToData map[string][]byte) Option {
 }
 
 // NewReadWriteBucket returns a new in-memory ReadWriteBucket.
+// Deprecated: Use NewReadWriteBucketWithOptions without any options.
 func NewReadWriteBucket() storage.ReadWriteBucket {
 	return newBucket(nil)
 }
 
-// NewReadWriteBucket2 returns a new in-memory ReadWriteBucket. Errors are
-// returned with invalid options.
-func NewReadWriteBucket2(opts ...Option) (storage.ReadWriteBucket, error) {
+// NewReadWriteBucketWithOptions returns a new in-memory ReadWriteBucket.
+// Errors are returned with invalid options.
+func NewReadWriteBucketWithOptions(opts ...Option) (storage.ReadWriteBucket, error) {
 	opt := options{}
 	for _, o := range opts {
 		o.apply(&opt)
@@ -75,5 +76,5 @@ func NewReadWriteBucket2(opts ...Option) (storage.ReadWriteBucket, error) {
 
 // NewReadBucket returns a new ReadBucket.
 func NewReadBucket(pathToData map[string][]byte) (storage.ReadBucket, error) {
-	return NewReadWriteBucket2(WithFiles(pathToData))
+	return NewReadWriteBucketWithOptions(WithFiles(pathToData))
 }


### PR DESCRIPTION
Coverage for bufcli.ReadModuleWithWorkspacesDisabled
----------------------------------------------------

ReadModuleWithWorkspacesDisabled didn't have coverage and I intend to do some minor refactoring soon. Now's a great time to document its behavior.

ReadModuleWithWorkspacesDisabled took a `appflag.Container`, but that's a very large interface to create and inject. I didn't see any obvious test fixture to provide it., so instead of building that I reduced signature to its minimal interface: a logger and an app.EnvStdinContainer.

IMHO, it's pretty odd to depend on a large interface type from a different package. I'll leave that yak shave for another day.

storagemem.NewReadWriteBucketWithOptions
------------------------------

It wasn't possible to initialize an in-memory storage bucket like you could with NewReadBucket. This new constructor produces a read-write bucket with the functionally of the read-only bucket.

NewReadWriteBucketWithOptions consumes the code in NewReadBucket, making the later nothing more than a type cast.

This change is in support of testing ReadModuleWithWorkspacesDisabled.