### PR TITLE
Use connect.IsWireError for client error scenario

### DIFF
--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -190,19 +190,6 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 	})
 
 	t.Run("invalid_upstream", func(t *testing.T) {
-		// TODO: unskip this test. This is flaky because of two reasons:
-		//
-		// 1. When a connection is closed, the underlying HTTP client does not
-		// always knows it, since the http handler implementation in go has no way
-		// of changing the connection timeout. See:
-		// https://github.com/golang/go/issues/16100
-		//
-		// 2. The expected status code is `StatusBadGateway` since the issue
-		// happened client-side (a response never came back from the server). This
-		// is not deterministic in the business logic because we're based on the
-		// connect error code that's returned. See
-		// https://linear.app/bufbuild/issue/BSR-383/flaky-test-in-bufstudioagent-testgo
-		t.SkipNow()
 		listener, err := net.Listen("tcp", "127.0.0.1:")
 		require.NoError(t, err)
 		go func() {


### PR DESCRIPTION
Also unskips the test that was skipped due to this issue, which doesn't *seem* flaky now?