### PR TITLE
push: error if response's pin is missing

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -16,6 +16,7 @@ package push
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
@@ -182,6 +183,9 @@ func run(
 			return nil
 		}
 		return err
+	}
+	if localModulePin == nil {
+		return errors.New("Missing local module pin in the registry's response.")
 	}
 	if _, err := container.Stdout().Write([]byte(localModulePin.Commit + "\n")); err != nil {
 		return err


### PR DESCRIPTION
It's possible to succeed but have a missing LocalModulePin in the response. Check for this and report an error.