### PR TITLE
bufcli: support HTTP registries

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -624,6 +624,9 @@ func newRegistryProviderWithOptions(container appflag.Container, opts ...bufapic
 			if buftransport.IsAPISubdomainEnabled(container) {
 				address = buftransport.PrependAPISubdomain(address)
 			}
+			if config.TLS == nil {
+				return buftransport.PrependHTTP(address)
+			}
 			return buftransport.PrependHTTPS(address)
 		}),
 		bufapiclient.RegistryProviderWithInterceptors(

--- a/private/bufpkg/buftransport/buftransport.go
+++ b/private/bufpkg/buftransport/buftransport.go
@@ -24,6 +24,7 @@ const (
 	// APISubdomain is the subdomain used for calls to the BSR API
 	APISubdomain = "api"
 
+	schemeHTTP  = "http"
 	schemeHTTPS = "https"
 
 	// TODO: change to based on "use"
@@ -43,6 +44,11 @@ func SetDisableAPISubdomain(env map[string]string) {
 // PrependAPISubdomain prepends the API subdomain to the given address.
 func PrependAPISubdomain(address string) string {
 	return APISubdomain + "." + address
+}
+
+// PrependHTTP prepends an http scheme to the given address
+func PrependHTTP(address string) string {
+	return schemeHTTP + "://" + address
 }
 
 // PrependHTTPS prepends an https scheme to the given address


### PR DESCRIPTION
Plain HTTP is useful for testing but the registry provider always used HTTPS even when the TLS config was nil.