### PR TITLE
bufcli: BucketAndConfigForSource

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -139,13 +139,23 @@ func run(
 	runner := command.NewRunner()
 	// We are pushing to the BSR, this module has to be independently buildable
 	// given the configuration it has without any enclosing workspace.
-	module, moduleIdentity, err := bufcli.ReadModuleWithWorkspacesDisabled(
+	sourceBucket, sourceConfig, err := bufcli.BucketAndConfigForSource(
 		ctx,
 		container.Logger(),
 		container,
 		storageosProvider,
 		runner,
 		source,
+	)
+	if err != nil {
+		return err
+	}
+	moduleIdentity := sourceConfig.ModuleIdentity
+	module, err := bufcli.ReadModule(
+		ctx,
+		container.Logger(),
+		sourceBucket,
+		sourceConfig,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
BucketAndConfigForSource assumes ReadModuleWithWorkspacesDisabled's fetching and validating a module's content into a bucket.

Renames ReadModuleWithWorkspacesDisabled to ReadModule as workspaces are no longer involved. ReadModule becomes shorthand for constructing a builder and building a module.