### PR TITLE
use plain Connect client stub for AuthnService

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -642,7 +642,7 @@ func newRegistryProviderWithOptions(container appflag.Container, opts ...bufapic
 // up the token in the container or in netrc based on the address of each individual client.
 // It is then set in the header of all outgoing requests from clients created using this config.
 func NewConnectClientConfig(container appflag.Container) (*connectclient.Config, error) {
-	// TODO: when the generated provider is ripped out, create this config directly
+	// TODO(BSR-798): when the generated provider is ripped out, create this config directly
 	//  instead of converting from the provider
 	prov, err := NewRegistryProvider(context.Background(), container)
 	if err != nil {

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufconnect"
 	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
-	"github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/connectclient"


### PR DESCRIPTION
Also adds some functions to `bufcli` that will eventually _replace_ the `NewRegistryProvider*` functions.

Updates usage of the `AuthnService` to use a plain Connect client stub.

Fixes BSR-802
