### PR TITLE
Fix CI breakage on Go 1.18.

### DIFF
--- a/private/pkg/app/appproto/appprotoexec/appprotoexec_go18.go
+++ b/private/pkg/app/appproto/appprotoexec/appprotoexec_go18.go
@@ -17,7 +17,6 @@
 package appprotoexec
 
 import (
-	"errors"
 	"os/exec"
 )
 


### PR DESCRIPTION
It never occured to me that running `make` would not catch this kind of mistake. Entirely on me.