### PR TITLE
[bsr-721] Generate a new blobs array per test

### DIFF
--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -137,6 +137,7 @@ func TestNewBlobValidDuplicates(t *testing.T) {
 }
 
 func TestNewBlobInvalidDuplicates(t *testing.T) {
+	t.Parallel()
 	blobs := newBlobsArray(t)
 	incorrectBlob, err := manifest.NewMemoryBlob(
 		*blobs[0].Digest(),

--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -115,10 +115,9 @@ func TestInvalidNewDigestFromBlobHash(t *testing.T) {
 
 func TestNewBlobSet(t *testing.T) {
 	t.Parallel()
-	blobs := newBlobsArray(t)
 	blobSet, err := manifest.NewBlobSet(
 		context.Background(),
-		blobs,
+		newBlobsArray(t),
 		manifest.BlobSetWithContentValidation(),
 	)
 	require.NoError(t, err)
@@ -128,10 +127,9 @@ func TestNewBlobSet(t *testing.T) {
 func TestNewBlobValidDuplicates(t *testing.T) {
 	t.Parallel()
 	blobs := newBlobsArray(t)
-	duplicatedBlobs := append(blobs, blobs[0])
 	blobSet, err := manifest.NewBlobSet(
 		context.Background(),
-		duplicatedBlobs,
+		append(blobs, blobs[0]), // send the first blob twice
 		manifest.BlobSetWithContentValidation(),
 	)
 	require.NoError(t, err)
@@ -141,14 +139,14 @@ func TestNewBlobValidDuplicates(t *testing.T) {
 func TestNewBlobInvalidDuplicates(t *testing.T) {
 	blobs := newBlobsArray(t)
 	incorrectBlob, err := manifest.NewMemoryBlob(
-		*blobs[0].Digest(), []byte("some different content"),
+		*blobs[0].Digest(),
+		[]byte("not blobs[0] content"),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, incorrectBlob)
-	duplicatedBlobs := append(blobs, incorrectBlob)
 	_, err = manifest.NewBlobSet(
 		context.Background(),
-		duplicatedBlobs,
+		append(blobs, incorrectBlob), // send first digest twice, with diff content
 		manifest.BlobSetWithContentValidation(),
 	)
 	require.Error(t, err)

--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -115,58 +115,43 @@ func TestInvalidNewDigestFromBlobHash(t *testing.T) {
 
 func TestNewBlobSet(t *testing.T) {
 	t.Parallel()
-	var blobs []manifest.Blob
-	for i := 0; i < 10; i++ {
-		content := fmt.Sprintf("some content %d", i)
-		digest := mustDigestShake256(t, []byte(content))
-		blob, err := manifest.NewMemoryBlob(
-			*digest, []byte(content),
-			manifest.MemoryBlobWithHashValidation(),
-		)
-		require.NoError(t, err)
-		blobs = append(blobs, blob)
-	}
+	blobs := newBlobsArray(t)
+	blobSet, err := manifest.NewBlobSet(
+		context.Background(),
+		blobs,
+		manifest.BlobSetWithContentValidation(),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, blobSet)
+}
 
-	t.Run("Valid", func(t *testing.T) {
-		t.Parallel()
-		blobSet, err := manifest.NewBlobSet(
-			context.Background(),
-			blobs,
-			manifest.BlobSetWithContentValidation(),
-		)
-		require.NoError(t, err)
-		assert.NotNil(t, blobSet)
-	})
+func TestNewBlobValidDuplicates(t *testing.T) {
+	t.Parallel()
+	blobs := newBlobsArray(t)
+	duplicatedBlobs := append(blobs, blobs[0])
+	blobSet, err := manifest.NewBlobSet(
+		context.Background(),
+		duplicatedBlobs,
+		manifest.BlobSetWithContentValidation(),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, blobSet)
+}
 
-	t.Run("BlobSetWithContentValidation", func(t *testing.T) {
-		t.Parallel()
-		t.Run("DuplicatedValidBlobs", func(t *testing.T) {
-			t.Parallel()
-			duplicatedBlobs := append(blobs, blobs[0])
-			blobSet, err := manifest.NewBlobSet(
-				context.Background(),
-				duplicatedBlobs,
-				manifest.BlobSetWithContentValidation(),
-			)
-			require.NoError(t, err)
-			assert.NotNil(t, blobSet)
-		})
-
-		t.Run("DuplicatedInvalidBlobs", func(t *testing.T) {
-			t.Parallel()
-			incorrectBlob, err := manifest.NewMemoryBlob(
-				*blobs[0].Digest(), []byte("some different content"),
-			)
-			require.NoError(t, err)
-			require.NotNil(t, incorrectBlob)
-			_, err = manifest.NewBlobSet(
-				context.Background(),
-				append(blobs, incorrectBlob),
-				manifest.BlobSetWithContentValidation(),
-			)
-			require.Error(t, err)
-		})
-	})
+func TestNewBlobInvalidDuplicates(t *testing.T) {
+	blobs := newBlobsArray(t)
+	incorrectBlob, err := manifest.NewMemoryBlob(
+		*blobs[0].Digest(), []byte("some different content"),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, incorrectBlob)
+	duplicatedBlobs := append(blobs, incorrectBlob)
+	_, err = manifest.NewBlobSet(
+		context.Background(),
+		duplicatedBlobs,
+		manifest.BlobSetWithContentValidation(),
+	)
+	require.Error(t, err)
 }
 
 func TestBlobFromReader(t *testing.T) {
@@ -197,4 +182,19 @@ func testBlobFromReader(t *testing.T, content []byte, digest []byte) {
 		Content: content,
 	}
 	assert.Equal(t, expect, blob)
+}
+
+func newBlobsArray(t *testing.T) []manifest.Blob {
+	var blobs []manifest.Blob
+	for i := 0; i < 10; i++ {
+		content := fmt.Sprintf("some content %d", i)
+		digest := mustDigestShake256(t, []byte(content))
+		blob, err := manifest.NewMemoryBlob(
+			*digest, []byte(content),
+			manifest.MemoryBlobWithHashValidation(),
+		)
+		require.NoError(t, err)
+		blobs = append(blobs, blob)
+	}
+	return blobs
 }


### PR DESCRIPTION
Fixes [this failure](https://github.com/bufbuild/buf/actions/runs/3440666825/jobs/5739385649#step:5:212). It is an `append` issue :facepalm: ... TIL that [sometimes `append` modifies the underlying array in the first param](https://pkg.go.dev/builtin#append), so `t.Parallel()` was messing the shared blobs state.

> The append built-in function appends elements to the end of a slice. **If it has sufficient capacity, the destination is resliced to accommodate the new elements.** If it does not, a new underlying array will be allocated. Append returns the updated slice.