### PR TITLE
update repository service and repository tag service clients to use plain Connect clients

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -571,7 +571,7 @@ func newModuleReaderAndCreateCacheDirs(
 		dataReadWriteBucket,
 		sumReadWriteBucket,
 		bufapimodule.NewModuleReader(registryProvider),
-		registryProvider,
+		bufmodulecache.NewRepositoryServiceClientFactory(registryProvider.ToClientConfig()),
 		moduleReaderOptions...,
 	)
 	return moduleReader, nil

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -21,8 +21,11 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -96,14 +99,13 @@ func run(
 	if err != nil {
 		return err
 	}
-	service, err := apiProvider.NewRepositoryService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
-	repository, err := service.CreateRepositoryByFullName(
+	service := connectclient.Make(apiProvider.ToClientConfig(), moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	resp, err := service.CreateRepositoryByFullName(
 		ctx,
-		moduleIdentity.Owner()+"/"+moduleIdentity.Repository(),
-		visibility,
+		connect.NewRequest(&registryv1alpha1.CreateRepositoryByFullNameRequest{
+			FullName:   moduleIdentity.Owner() + "/" + moduleIdentity.Repository(),
+			Visibility: visibility,
+		}),
 	)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeAlreadyExists {
@@ -111,6 +113,7 @@ func run(
 		}
 		return err
 	}
+	repository := resp.Msg.Repository
 	return bufprint.NewRepositoryPrinter(
 		apiProvider,
 		moduleIdentity.Remote(),

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -99,7 +99,11 @@ func run(
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(apiProvider.ToClientConfig(), moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		apiProvider.ToClientConfig(),
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	resp, err := service.CreateRepositoryByFullName(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.CreateRepositoryByFullNameRequest{

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
@@ -20,8 +20,11 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -76,20 +79,22 @@ func run(
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
 	if err != nil {
 		return err
 	}
-	service, err := apiProvider.NewRepositoryService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
+	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
 	if !flags.Force {
 		if err := bufcli.PromptUserForDelete(container, "repository", moduleIdentity.Repository()); err != nil {
 			return err
 		}
 	}
-	if err := service.DeleteRepositoryByFullName(ctx, moduleIdentity.Owner()+"/"+moduleIdentity.Repository()); err != nil {
+	if _, err := service.DeleteRepositoryByFullName(
+		ctx,
+		connect.NewRequest(&registryv1alpha1.DeleteRepositoryByFullNameRequest{
+			FullName: moduleIdentity.Owner() + "/" + moduleIdentity.Repository(),
+		}),
+	); err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return bufcli.NewRepositoryNotFoundError(container.Arg(0))
 		}

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
@@ -83,7 +83,11 @@ func run(
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		clientConfig,
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	if !flags.Force {
 		if err := bufcli.PromptUserForDelete(container, "repository", moduleIdentity.Repository()); err != nil {
 			return err

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
@@ -78,7 +78,11 @@ func run(ctx context.Context, container appflag.Container, flags *flags) error {
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		clientConfig,
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	if _, err := service.DeprecateRepositoryByName(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.DeprecateRepositoryByNameRequest{

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
@@ -20,8 +20,11 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -71,19 +74,18 @@ func run(ctx context.Context, container appflag.Container, flags *flags) error {
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
 	if err != nil {
 		return err
 	}
-	service, err := apiProvider.NewRepositoryService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
-	if _, err = service.DeprecateRepositoryByName(
+	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	if _, err := service.DeprecateRepositoryByName(
 		ctx,
-		moduleIdentity.Owner(),
-		moduleIdentity.Repository(),
-		flags.Message,
+		connect.NewRequest(&registryv1alpha1.DeprecateRepositoryByNameRequest{
+			OwnerName:          moduleIdentity.Owner(),
+			RepositoryName:     moduleIdentity.Repository(),
+			DeprecationMessage: flags.Message,
+		}),
 	); err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return bufcli.NewRepositoryNotFoundError(container.Arg(0))

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
@@ -89,7 +89,11 @@ func run(
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(apiProvider.ToClientConfig(), moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		apiProvider.ToClientConfig(),
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	resp, err := service.GetRepositoryByFullName(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
@@ -21,8 +21,12 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
+	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -111,19 +115,19 @@ func run(
 	if err != nil {
 		return err
 	}
-	service, err := apiProvider.NewRepositoryService(ctx, remote)
-	if err != nil {
-		return err
-	}
-	repositories, nextPageToken, err := service.ListRepositories(
+	service := connectclient.Make(apiProvider.ToClientConfig(), remote, registryv1alpha1connect.NewRepositoryServiceClient)
+	resp, err := service.ListRepositories(
 		ctx,
-		flags.PageSize,
-		flags.PageToken,
-		flags.Reverse,
+		connect.NewRequest(&registryv1alpha1.ListRepositoriesRequest{
+			PageSize:  flags.PageSize,
+			PageToken: flags.PageToken,
+			Reverse:   flags.Reverse,
+		}),
 	)
 	if err != nil {
 		return err
 	}
+	repositories, nextPageToken := resp.Msg.Repositories, resp.Msg.NextPageToken
 	return bufprint.NewRepositoryPrinter(
 		apiProvider,
 		remote,

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
@@ -115,7 +115,11 @@ func run(
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(apiProvider.ToClientConfig(), remote, registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		apiProvider.ToClientConfig(),
+		remote,
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	resp, err := service.ListRepositories(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.ListRepositoriesRequest{

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
@@ -20,8 +20,11 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 )
@@ -42,18 +45,17 @@ func run(ctx context.Context, container appflag.Container) error {
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
 	if err != nil {
 		return err
 	}
-	service, err := apiProvider.NewRepositoryService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
-	if _, err = service.UndeprecateRepositoryByName(
+	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	if _, err := service.UndeprecateRepositoryByName(
 		ctx,
-		moduleIdentity.Owner(),
-		moduleIdentity.Repository(),
+		connect.NewRequest(&registryv1alpha1.UndeprecateRepositoryByNameRequest{
+			OwnerName:      moduleIdentity.Owner(),
+			RepositoryName: moduleIdentity.Repository(),
+		}),
 	); err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return bufcli.NewRepositoryNotFoundError(container.Arg(0))

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
@@ -49,7 +49,11 @@ func run(ctx context.Context, container appflag.Container) error {
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		clientConfig,
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	if _, err := service.UndeprecateRepositoryByName(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.UndeprecateRepositoryByNameRequest{

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
@@ -20,8 +20,11 @@ import (
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -75,22 +78,19 @@ func run(
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
 	if err != nil {
 		return err
 	}
-	service, err := apiProvider.NewRepositoryService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
-	if err = service.UpdateRepositorySettingsByName(
+	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	if _, err := service.UpdateRepositorySettingsByName(
 		ctx,
-		moduleIdentity.Owner(),
-		moduleIdentity.Repository(),
-		visibility,
-		// TODO: pass description and url
-		nil,
-		nil,
+		connect.NewRequest(&registryv1alpha1.UpdateRepositorySettingsByNameRequest{
+			OwnerName:      moduleIdentity.Owner(),
+			RepositoryName: moduleIdentity.Repository(),
+			Visibility:     visibility,
+			// TODO: pass description and url
+		}),
 	); err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return bufcli.NewRepositoryNotFoundError(container.Arg(0))

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
@@ -82,7 +82,11 @@ func run(
 	if err != nil {
 		return err
 	}
-	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	service := connectclient.Make(
+		clientConfig,
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	if _, err := service.UpdateRepositorySettingsByName(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.UpdateRepositorySettingsByNameRequest{

--- a/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
@@ -21,8 +21,11 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -87,19 +90,17 @@ func run(
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
 
-	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
 	if err != nil {
 		return err
 	}
-	repositoryService, err := apiProvider.NewRepositoryService(ctx, moduleReference.Remote())
-	if err != nil {
-		return err
-	}
-	repositoryTagService, err := apiProvider.NewRepositoryTagService(ctx, moduleReference.Remote())
-	if err != nil {
-		return err
-	}
-	repository, _, err := repositoryService.GetRepositoryByFullName(ctx, moduleReference.Owner()+"/"+moduleReference.Repository())
+	repositoryService := connectclient.Make(clientConfig, moduleReference.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	repositoryTagService := connectclient.Make(clientConfig, moduleReference.Remote(), registryv1alpha1connect.NewRepositoryTagServiceClient)
+	resp, err := repositoryService.GetRepositoryByFullName(ctx,
+		connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
+			FullName: moduleReference.Owner() + "/" + moduleReference.Repository(),
+		}),
+	)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return bufcli.NewRepositoryNotFoundError(moduleReference.Remote() + "/" + moduleReference.Owner() + "/" + moduleReference.Repository())
@@ -108,11 +109,13 @@ func run(
 	}
 	tag := container.Arg(1)
 	commit := moduleReference.Reference()
-	repositoryTag, err := repositoryTagService.CreateRepositoryTag(
+	tagResp, err := repositoryTagService.CreateRepositoryTag(
 		ctx,
-		repository.Id,
-		tag,
-		commit,
+		connect.NewRequest(&registryv1alpha1.CreateRepositoryTagRequest{
+			RepositoryId: resp.Msg.Repository.Id,
+			Name:         tag,
+			CommitName:   commit,
+		}),
 	)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeAlreadyExists {
@@ -123,5 +126,5 @@ func run(
 		}
 		return err
 	}
-	return bufprint.NewRepositoryTagPrinter(container.Stdout()).PrintRepositoryTag(ctx, format, repositoryTag)
+	return bufprint.NewRepositoryTagPrinter(container.Stdout()).PrintRepositoryTag(ctx, format, tagResp.Msg.RepositoryTag)
 }

--- a/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
@@ -94,8 +94,16 @@ func run(
 	if err != nil {
 		return err
 	}
-	repositoryService := connectclient.Make(clientConfig, moduleReference.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
-	repositoryTagService := connectclient.Make(clientConfig, moduleReference.Remote(), registryv1alpha1connect.NewRepositoryTagServiceClient)
+	repositoryService := connectclient.Make(
+		clientConfig,
+		moduleReference.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
+	repositoryTagService := connectclient.Make(
+		clientConfig,
+		moduleReference.Remote(),
+		registryv1alpha1connect.NewRepositoryTagServiceClient,
+	)
 	resp, err := repositoryService.GetRepositoryByFullName(ctx,
 		connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
 			FullName: moduleReference.Owner() + "/" + moduleReference.Repository(),

--- a/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
@@ -115,7 +115,11 @@ func run(
 	if err != nil {
 		return err
 	}
-	repositoryService := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	repositoryService := connectclient.Make(
+		clientConfig,
+		moduleIdentity.Remote(),
+		registryv1alpha1connect.NewRepositoryServiceClient,
+	)
 	resp, err := repositoryService.GetRepositoryByFullName(ctx,
 		connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
 			FullName: moduleIdentity.Owner() + "/" + moduleIdentity.Repository(),

--- a/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
@@ -21,8 +21,11 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/connect-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -108,34 +111,34 @@ func run(
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
 
-	apiProvider, err := bufcli.NewRegistryProvider(ctx, container)
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
 	if err != nil {
 		return err
 	}
-	repositoryService, err := apiProvider.NewRepositoryService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
-	repository, _, err := repositoryService.GetRepositoryByFullName(ctx, moduleIdentity.Owner()+"/"+moduleIdentity.Repository())
+	repositoryService := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	resp, err := repositoryService.GetRepositoryByFullName(ctx,
+		connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
+			FullName: moduleIdentity.Owner() + "/" + moduleIdentity.Repository(),
+		}),
+	)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return bufcli.NewRepositoryNotFoundError(container.Arg(0))
 		}
 		return err
 	}
-	repositoryTagService, err := apiProvider.NewRepositoryTagService(ctx, moduleIdentity.Remote())
-	if err != nil {
-		return err
-	}
-	repositoryTags, nextPageToken, err := repositoryTagService.ListRepositoryTags(
+	repositoryTagService := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryTagServiceClient)
+	tagsResp, err := repositoryTagService.ListRepositoryTags(
 		ctx,
-		repository.Id,
-		flags.PageSize,
-		flags.PageToken,
-		flags.Reverse,
+		connect.NewRequest(&registryv1alpha1.ListRepositoryTagsRequest{
+			RepositoryId: resp.Msg.Repository.Id,
+			PageSize:     flags.PageSize,
+			PageToken:    flags.PageToken,
+			Reverse:      flags.Reverse,
+		}),
 	)
 	if err != nil {
 		return err
 	}
-	return bufprint.NewRepositoryTagPrinter(container.Stdout()).PrintRepositoryTags(ctx, format, nextPageToken, repositoryTags...)
+	return bufprint.NewRepositoryTagPrinter(container.Stdout()).PrintRepositoryTags(ctx, format, tagsResp.Msg.NextPageToken, tagsResp.Msg.RepositoryTags...)
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/verbose"
-	connect_go "github.com/bufbuild/connect-go"
+	"github.com/bufbuild/connect-go"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -383,9 +383,9 @@ type fakeRepositoryService struct {
 
 func (f *fakeRepositoryService) GetRepositoryByFullName(
 	_ context.Context,
-	_ *connect_go.Request[registryv1alpha1.GetRepositoryByFullNameRequest],
-) (*connect_go.Response[registryv1alpha1.GetRepositoryByFullNameResponse], error) {
-	return connect_go.NewResponse(&registryv1alpha1.GetRepositoryByFullNameResponse{
+	_ *connect.Request[registryv1alpha1.GetRepositoryByFullNameRequest],
+) (*connect.Response[registryv1alpha1.GetRepositoryByFullNameResponse], error) {
+	return connect.NewResponse(&registryv1alpha1.GetRepositoryByFullNameResponse{
 		Repository: f.repository,
 	}), nil
 }

--- a/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
@@ -21,21 +21,22 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/gen/proto/apiclient/buf/alpha/registry/v1alpha1/registryv1alpha1apiclient"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/filelock"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/verbose"
+	connect_go "github.com/bufbuild/connect-go"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
 type moduleReader struct {
-	logger                    *zap.Logger
-	verbosePrinter            verbose.Printer
-	fileLocker                filelock.Locker
-	cache                     *moduleCacher
-	delegate                  bufmodule.ModuleReader
-	repositoryServiceProvider registryv1alpha1apiclient.RepositoryServiceProvider
+	logger                  *zap.Logger
+	verbosePrinter          verbose.Printer
+	fileLocker              filelock.Locker
+	cache                   *moduleCacher
+	delegate                bufmodule.ModuleReader
+	repositoryClientFactory RepositoryServiceClientFactory
 
 	count     int
 	cacheHits int
@@ -49,7 +50,7 @@ func newModuleReader(
 	dataReadWriteBucket storage.ReadWriteBucket,
 	sumReadWriteBucket storage.ReadWriteBucket,
 	delegate bufmodule.ModuleReader,
-	repositoryServiceProvider registryv1alpha1apiclient.RepositoryServiceProvider,
+	repositoryClientFactory RepositoryServiceClientFactory,
 	options ...ModuleReaderOption,
 ) *moduleReader {
 	moduleReaderOptions := &moduleReaderOptions{}
@@ -66,8 +67,8 @@ func newModuleReader(
 			sumReadWriteBucket,
 			moduleReaderOptions.allowCacheExternalPaths,
 		),
-		delegate:                  delegate,
-		repositoryServiceProvider: repositoryServiceProvider,
+		delegate:                delegate,
+		repositoryClientFactory: repositoryClientFactory,
 	}
 }
 
@@ -145,18 +146,17 @@ func (m *moduleReader) GetModule(
 		return nil, err
 	}
 
-	repositoryService, err := m.repositoryServiceProvider.NewRepositoryService(ctx, modulePin.Remote())
-	if err != nil {
-		return nil, err
-	}
-	repository, _, err := repositoryService.GetRepositoryByFullName(
+	repositoryService := m.repositoryClientFactory(modulePin.Remote())
+	resp, err := repositoryService.GetRepositoryByFullName(
 		ctx,
-		fmt.Sprintf("%s/%s", modulePin.Owner(), modulePin.Repository()),
+		connect_go.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
+			FullName: fmt.Sprintf("%s/%s", modulePin.Owner(), modulePin.Repository()),
+		}),
 	)
 	if err != nil {
 		return nil, err
 	}
-
+	repository := resp.Msg.Repository
 	if repository.Deprecated {
 		warnMsg := fmt.Sprintf(`Repository "%s" is deprecated`, modulePin.IdentityString())
 		if repository.DeprecationMessage != "" {

--- a/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/module_reader.go
@@ -25,7 +25,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/filelock"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/verbose"
-	connect_go "github.com/bufbuild/connect-go"
+	"github.com/bufbuild/connect-go"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
@@ -149,7 +149,7 @@ func (m *moduleReader) GetModule(
 	repositoryService := m.repositoryClientFactory(modulePin.Remote())
 	resp, err := repositoryService.GetRepositoryByFullName(
 		ctx,
-		connect_go.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
+		connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
 			FullName: fmt.Sprintf("%s/%s", modulePin.Owner(), modulePin.Repository()),
 		}),
 	)


### PR DESCRIPTION
This change had a usage of the provider in a test (via a fake/mock). So I added a new type, bespoke to that usage, so that we can still provide a fake stub in the test.

Other than that, everything in here is pretty mechanical.

Fixes BSR-803