### PR TITLE
need different abstraction for bufapimodule package

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -376,7 +376,10 @@ func NewWireImageConfigReader(
 	clientConfig *connectclient.Config,
 ) (bufwire.ImageConfigReader, error) {
 	logger := container.Logger()
-	moduleResolver := bufapimodule.NewModuleResolver(logger, clientConfig)
+	moduleResolver := bufapimodule.NewModuleResolver(
+		logger,
+		bufapimodule.NewRepositoryCommitServiceClientFactory(clientConfig),
+	)
 	moduleReader, err := NewModuleReaderAndCreateCacheDirs(container, clientConfig)
 	if err != nil {
 		return nil, err
@@ -399,7 +402,10 @@ func NewWireModuleConfigReader(
 	clientConfig *connectclient.Config,
 ) (bufwire.ModuleConfigReader, error) {
 	logger := container.Logger()
-	moduleResolver := bufapimodule.NewModuleResolver(logger, clientConfig)
+	moduleResolver := bufapimodule.NewModuleResolver(
+		logger,
+		bufapimodule.NewRepositoryCommitServiceClientFactory(clientConfig),
+	)
 	moduleReader, err := NewModuleReaderAndCreateCacheDirs(container, clientConfig)
 	if err != nil {
 		return nil, err
@@ -422,7 +428,10 @@ func NewWireModuleConfigReaderForModuleReader(
 	moduleReader bufmodule.ModuleReader,
 ) (bufwire.ModuleConfigReader, error) {
 	logger := container.Logger()
-	moduleResolver := bufapimodule.NewModuleResolver(logger, clientConfig)
+	moduleResolver := bufapimodule.NewModuleResolver(
+		logger,
+		bufapimodule.NewRepositoryCommitServiceClientFactory(clientConfig),
+	)
 	return bufwire.NewModuleConfigReader(
 		logger,
 		storageosProvider,
@@ -439,7 +448,10 @@ func NewWireFileLister(
 	clientConfig *connectclient.Config,
 ) (bufwire.FileLister, error) {
 	logger := container.Logger()
-	moduleResolver := bufapimodule.NewModuleResolver(logger, clientConfig)
+	moduleResolver := bufapimodule.NewModuleResolver(
+		logger,
+		bufapimodule.NewRepositoryCommitServiceClientFactory(clientConfig),
+	)
 	moduleReader, err := NewModuleReaderAndCreateCacheDirs(container, clientConfig)
 	if err != nil {
 		return nil, err
@@ -569,7 +581,7 @@ func newModuleReaderAndCreateCacheDirs(
 		fileLocker,
 		dataReadWriteBucket,
 		sumReadWriteBucket,
-		bufapimodule.NewModuleReader(clientConfig),
+		bufapimodule.NewModuleReader(bufapimodule.NewDownloadServiceClientFactory(clientConfig)),
 		bufmodulecache.NewRepositoryServiceClientFactory(clientConfig),
 		moduleReaderOptions...,
 	)

--- a/private/bufpkg/bufapimodule/bufapimodule.go
+++ b/private/bufpkg/bufapimodule/bufapimodule.go
@@ -17,23 +17,39 @@ package bufapimodule
 
 import (
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"go.uber.org/zap"
 )
 
+type DownloadServiceClientFactory func(address string) registryv1alpha1connect.DownloadServiceClient
+type RepositoryCommitServiceClientFactory func(address string) registryv1alpha1connect.RepositoryCommitServiceClient
+
+func NewDownloadServiceClientFactory(clientConfig *connectclient.Config) DownloadServiceClientFactory {
+	return func(address string) registryv1alpha1connect.DownloadServiceClient {
+		return connectclient.Make(clientConfig, address, registryv1alpha1connect.NewDownloadServiceClient)
+	}
+}
+
+func NewRepositoryCommitServiceClientFactory(clientConfig *connectclient.Config) RepositoryCommitServiceClientFactory {
+	return func(address string) registryv1alpha1connect.RepositoryCommitServiceClient {
+		return connectclient.Make(clientConfig, address, registryv1alpha1connect.NewRepositoryCommitServiceClient)
+	}
+}
+
 // NewModuleReader returns a new ModuleReader backed by the download service.
 func NewModuleReader(
-	clientConfig *connectclient.Config,
+	downloadClientFactory DownloadServiceClientFactory,
 ) bufmodule.ModuleReader {
 	return newModuleReader(
-		clientConfig,
+		downloadClientFactory,
 	)
 }
 
 // NewModuleResolver returns a new ModuleResolver backed by the resolve service.
 func NewModuleResolver(
 	logger *zap.Logger,
-	clientConfig *connectclient.Config,
+	repositoryCommitClientFactory RepositoryCommitServiceClientFactory,
 ) bufmodule.ModuleResolver {
-	return newModuleResolver(logger, clientConfig)
+	return newModuleResolver(logger, repositoryCommitClientFactory)
 }

--- a/private/bufpkg/bufapimodule/module_reader.go
+++ b/private/bufpkg/bufapimodule/module_reader.go
@@ -19,27 +19,25 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
-	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/connect-go"
 )
 
 type moduleReader struct {
-	clientConfig *connectclient.Config
+	downloadClientFactory DownloadServiceClientFactory
 }
 
 func newModuleReader(
-	clientConfig *connectclient.Config,
+	downloadClientFactory DownloadServiceClientFactory,
 ) *moduleReader {
 	return &moduleReader{
-		clientConfig: clientConfig,
+		downloadClientFactory: downloadClientFactory,
 	}
 }
 
 func (m *moduleReader) GetModule(ctx context.Context, modulePin bufmoduleref.ModulePin) (bufmodule.Module, error) {
-	downloadService := connectclient.Make(m.clientConfig, modulePin.Remote(), registryv1alpha1connect.NewDownloadServiceClient)
+	downloadService := m.downloadClientFactory(modulePin.Remote())
 	resp, err := downloadService.Download(
 		ctx,
 		connect.NewRequest(&registryv1alpha1.DownloadRequest{

--- a/private/bufpkg/bufprotoplugin/cmd/protoc-gen-go-apiclientconnect/main.go
+++ b/private/bufpkg/bufprotoplugin/cmd/protoc-gen-go-apiclientconnect/main.go
@@ -246,6 +246,10 @@ func generateServiceFile(helper protogenutil.NamedHelper, plugin *protogen.Plugi
 		g.P(`client `, clientGoIdentString)
 		g.P(`}`)
 		g.P()
+		g.P(`func (s *`, structName, `Client) Unwrap() `, clientGoIdentString, ` {`)
+		g.P(`return s.client`)
+		g.P(`}`)
+		g.P()
 
 		for _, method := range service.Methods {
 			if err := protogenutil.ValidateMethodUnary(method); err != nil {

--- a/private/gen/proto/apiclientconnect/buf/alpha/audit/v1alpha1/auditv1alpha1apiclientconnect/service.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/audit/v1alpha1/auditv1alpha1apiclientconnect/service.pb.go
@@ -30,6 +30,10 @@ type auditServiceClient struct {
 	client auditv1alpha1connect.AuditServiceClient
 }
 
+func (s *auditServiceClient) Unwrap() auditv1alpha1connect.AuditServiceClient {
+	return s.client
+}
+
 // ListAuditedEvents lists audited events recorded in the BSR instance.
 func (s *auditServiceClient) ListAuditedEvents(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/admin.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/admin.pb.go
@@ -29,6 +29,10 @@ type adminServiceClient struct {
 	client registryv1alpha1connect.AdminServiceClient
 }
 
+func (s *adminServiceClient) Unwrap() registryv1alpha1connect.AdminServiceClient {
+	return s.client
+}
+
 // ForceDeleteUser forces to delete a user. Resources and organizations that are
 // solely owned by the user will also be deleted.
 func (s *adminServiceClient) ForceDeleteUser(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/authn.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/authn.pb.go
@@ -29,6 +29,10 @@ type authnServiceClient struct {
 	client registryv1alpha1connect.AuthnServiceClient
 }
 
+func (s *authnServiceClient) Unwrap() registryv1alpha1connect.AuthnServiceClient {
+	return s.client
+}
+
 // GetCurrentUser gets information associated with the current user.
 //
 // The user's ID is retrieved from the request's authentication header.

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/authz.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/authz.pb.go
@@ -29,6 +29,10 @@ type authzServiceClient struct {
 	client registryv1alpha1connect.AuthzServiceClient
 }
 
+func (s *authzServiceClient) Unwrap() registryv1alpha1connect.AuthzServiceClient {
+	return s.client
+}
+
 // UserCanCreateOrganizationRepository returns whether the user is authorized
 // to create repositories in an organization.
 func (s *authzServiceClient) UserCanCreateOrganizationRepository(ctx context.Context, organizationId string) (authorized bool, _ error) {

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/convert.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/convert.pb.go
@@ -30,6 +30,10 @@ type convertServiceClient struct {
 	client registryv1alpha1connect.ConvertServiceClient
 }
 
+func (s *convertServiceClient) Unwrap() registryv1alpha1connect.ConvertServiceClient {
+	return s.client
+}
+
 // Convert converts a serialized message according to
 // the provided type name using an image.
 func (s *convertServiceClient) Convert(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/display.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/display.pb.go
@@ -29,6 +29,10 @@ type displayServiceClient struct {
 	client registryv1alpha1connect.DisplayServiceClient
 }
 
+func (s *displayServiceClient) Unwrap() registryv1alpha1connect.DisplayServiceClient {
+	return s.client
+}
+
 // DisplayOrganizationElements returns which organization elements should be displayed to the user.
 func (s *displayServiceClient) DisplayOrganizationElements(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/doc.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/doc.pb.go
@@ -29,6 +29,10 @@ type docServiceClient struct {
 	client registryv1alpha1connect.DocServiceClient
 }
 
+func (s *docServiceClient) Unwrap() registryv1alpha1connect.DocServiceClient {
+	return s.client
+}
+
 // GetSourceDirectoryInfo retrieves the directory and file structure for the
 // given owner, repository and reference.
 //

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/download.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/download.pb.go
@@ -30,6 +30,10 @@ type downloadServiceClient struct {
 	client registryv1alpha1connect.DownloadServiceClient
 }
 
+func (s *downloadServiceClient) Unwrap() registryv1alpha1connect.DownloadServiceClient {
+	return s.client
+}
+
 // Download downloads.
 func (s *downloadServiceClient) Download(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/generate.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/generate.pb.go
@@ -31,6 +31,10 @@ type generateServiceClient struct {
 	client registryv1alpha1connect.GenerateServiceClient
 }
 
+func (s *generateServiceClient) Unwrap() registryv1alpha1connect.GenerateServiceClient {
+	return s.client
+}
+
 // GeneratePlugins generates an array of files given the provided
 // module reference and plugin version and option tuples. No attempt
 // is made at merging insertion points.

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/github.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/github.pb.go
@@ -29,6 +29,10 @@ type githubServiceClient struct {
 	client registryv1alpha1connect.GithubServiceClient
 }
 
+func (s *githubServiceClient) Unwrap() registryv1alpha1connect.GithubServiceClient {
+	return s.client
+}
+
 // GetGithubAppConfig returns a Github Application Configuration.
 func (s *githubServiceClient) GetGithubAppConfig(ctx context.Context) (appConfig *v1alpha1.GithubAppConfig, _ error) {
 	response, err := s.client.GetGithubAppConfig(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/image.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/image.pb.go
@@ -30,6 +30,10 @@ type imageServiceClient struct {
 	client registryv1alpha1connect.ImageServiceClient
 }
 
+func (s *imageServiceClient) Unwrap() registryv1alpha1connect.ImageServiceClient {
+	return s.client
+}
+
 // GetImage serves a compiled image for the local module. It automatically
 // downloads dependencies if necessary.
 func (s *imageServiceClient) GetImage(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/jsonschema.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/jsonschema.pb.go
@@ -29,6 +29,10 @@ type jSONSchemaServiceClient struct {
 	client registryv1alpha1connect.JSONSchemaServiceClient
 }
 
+func (s *jSONSchemaServiceClient) Unwrap() registryv1alpha1connect.JSONSchemaServiceClient {
+	return s.client
+}
+
 // GetJSONSchema allows users to get an (approximate) json schema for a
 // protobuf type.
 func (s *jSONSchemaServiceClient) GetJSONSchema(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/organization.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/organization.pb.go
@@ -29,6 +29,10 @@ type organizationServiceClient struct {
 	client registryv1alpha1connect.OrganizationServiceClient
 }
 
+func (s *organizationServiceClient) Unwrap() registryv1alpha1connect.OrganizationServiceClient {
+	return s.client
+}
+
 // GetOrganization gets a organization by ID.
 func (s *organizationServiceClient) GetOrganization(ctx context.Context, id string) (organization *v1alpha1.Organization, _ error) {
 	response, err := s.client.GetOrganization(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/owner.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/owner.pb.go
@@ -29,6 +29,10 @@ type ownerServiceClient struct {
 	client registryv1alpha1connect.OwnerServiceClient
 }
 
+func (s *ownerServiceClient) Unwrap() registryv1alpha1connect.OwnerServiceClient {
+	return s.client
+}
+
 // GetOwnerByName takes an owner name and returns the owner as
 // either a user or organization.
 func (s *ownerServiceClient) GetOwnerByName(ctx context.Context, name string) (owner *v1alpha1.Owner, _ error) {

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/plugin.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/plugin.pb.go
@@ -29,6 +29,10 @@ type pluginServiceClient struct {
 	client registryv1alpha1connect.PluginServiceClient
 }
 
+func (s *pluginServiceClient) Unwrap() registryv1alpha1connect.PluginServiceClient {
+	return s.client
+}
+
 // ListPlugins returns all the plugins available to the user. This includes
 // public plugins, those uploaded to organizations the user is part of,
 // and any plugins uploaded directly by the user.

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/plugin_curation.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/plugin_curation.pb.go
@@ -30,6 +30,10 @@ type pluginCurationServiceClient struct {
 	client registryv1alpha1connect.PluginCurationServiceClient
 }
 
+func (s *pluginCurationServiceClient) Unwrap() registryv1alpha1connect.PluginCurationServiceClient {
+	return s.client
+}
+
 // ListCuratedPlugins returns all the curated plugins available.
 func (s *pluginCurationServiceClient) ListCuratedPlugins(
 	ctx context.Context,
@@ -121,6 +125,10 @@ func (s *pluginCurationServiceClient) GetLatestCuratedPlugin(
 type codeGenerationServiceClient struct {
 	logger *zap.Logger
 	client registryv1alpha1connect.CodeGenerationServiceClient
+}
+
+func (s *codeGenerationServiceClient) Unwrap() registryv1alpha1connect.CodeGenerationServiceClient {
+	return s.client
 }
 
 // GenerateCode generates code using the specified remote plugins.

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/push.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/push.pb.go
@@ -30,6 +30,10 @@ type pushServiceClient struct {
 	client registryv1alpha1connect.PushServiceClient
 }
 
+func (s *pushServiceClient) Unwrap() registryv1alpha1connect.PushServiceClient {
+	return s.client
+}
+
 // Push pushes.
 func (s *pushServiceClient) Push(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/recommendation.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/recommendation.pb.go
@@ -29,6 +29,10 @@ type recommendationServiceClient struct {
 	client registryv1alpha1connect.RecommendationServiceClient
 }
 
+func (s *recommendationServiceClient) Unwrap() registryv1alpha1connect.RecommendationServiceClient {
+	return s.client
+}
+
 // RecommendedRepositories returns a list of recommended repositories.
 func (s *recommendationServiceClient) RecommendedRepositories(ctx context.Context) (repositories []*v1alpha1.RecommendedRepository, _ error) {
 	response, err := s.client.RecommendedRepositories(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/reference.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/reference.pb.go
@@ -29,6 +29,10 @@ type referenceServiceClient struct {
 	client registryv1alpha1connect.ReferenceServiceClient
 }
 
+func (s *referenceServiceClient) Unwrap() registryv1alpha1connect.ReferenceServiceClient {
+	return s.client
+}
+
 // GetReferenceByName takes a reference name and returns the
 // reference either as 'main', a tag, or commit.
 func (s *referenceServiceClient) GetReferenceByName(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/repository.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/repository.pb.go
@@ -29,6 +29,10 @@ type repositoryServiceClient struct {
 	client registryv1alpha1connect.RepositoryServiceClient
 }
 
+func (s *repositoryServiceClient) Unwrap() registryv1alpha1connect.RepositoryServiceClient {
+	return s.client
+}
+
 // GetRepository gets a repository by ID.
 func (s *repositoryServiceClient) GetRepository(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/repository_commit.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/repository_commit.pb.go
@@ -29,6 +29,10 @@ type repositoryCommitServiceClient struct {
 	client registryv1alpha1connect.RepositoryCommitServiceClient
 }
 
+func (s *repositoryCommitServiceClient) Unwrap() registryv1alpha1connect.RepositoryCommitServiceClient {
+	return s.client
+}
+
 // ListRepositoryCommitsByBranch lists the repository commits associated
 // with a repository branch on a repository, ordered by their create time.
 func (s *repositoryCommitServiceClient) ListRepositoryCommitsByBranch(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/repository_tag.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/repository_tag.pb.go
@@ -29,6 +29,10 @@ type repositoryTagServiceClient struct {
 	client registryv1alpha1connect.RepositoryTagServiceClient
 }
 
+func (s *repositoryTagServiceClient) Unwrap() registryv1alpha1connect.RepositoryTagServiceClient {
+	return s.client
+}
+
 // CreateRepositoryTag creates a new repository tag.
 func (s *repositoryTagServiceClient) CreateRepositoryTag(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/resolve.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/resolve.pb.go
@@ -30,6 +30,10 @@ type resolveServiceClient struct {
 	client registryv1alpha1connect.ResolveServiceClient
 }
 
+func (s *resolveServiceClient) Unwrap() registryv1alpha1connect.ResolveServiceClient {
+	return s.client
+}
+
 // GetModulePins finds all the latest digests and respective dependencies of
 // the provided module references and picks a set of distinct modules pins.
 //
@@ -59,6 +63,10 @@ func (s *resolveServiceClient) GetModulePins(
 type localResolveServiceClient struct {
 	logger *zap.Logger
 	client registryv1alpha1connect.LocalResolveServiceClient
+}
+
+func (s *localResolveServiceClient) Unwrap() registryv1alpha1connect.LocalResolveServiceClient {
+	return s.client
 }
 
 // GetLocalModulePins gets the latest pins for the specified local module references.

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/resource.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/resource.pb.go
@@ -29,6 +29,10 @@ type resourceServiceClient struct {
 	client registryv1alpha1connect.ResourceServiceClient
 }
 
+func (s *resourceServiceClient) Unwrap() registryv1alpha1connect.ResourceServiceClient {
+	return s.client
+}
+
 // GetResourceByName takes a resource name and returns the
 // resource either as a repository or a plugin.
 func (s *resourceServiceClient) GetResourceByName(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/search.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/search.pb.go
@@ -29,6 +29,10 @@ type searchServiceClient struct {
 	client registryv1alpha1connect.SearchServiceClient
 }
 
+func (s *searchServiceClient) Unwrap() registryv1alpha1connect.SearchServiceClient {
+	return s.client
+}
+
 // Search searches the BSR.
 func (s *searchServiceClient) Search(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/studio.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/studio.pb.go
@@ -29,6 +29,10 @@ type studioServiceClient struct {
 	client registryv1alpha1connect.StudioServiceClient
 }
 
+func (s *studioServiceClient) Unwrap() registryv1alpha1connect.StudioServiceClient {
+	return s.client
+}
+
 // ListStudioAgentPresets returns a list of agent presets in the server.
 func (s *studioServiceClient) ListStudioAgentPresets(ctx context.Context) (agents []*v1alpha1.StudioAgentPreset, _ error) {
 	response, err := s.client.ListStudioAgentPresets(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/studio_request.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/studio_request.pb.go
@@ -29,6 +29,10 @@ type studioRequestServiceClient struct {
 	client registryv1alpha1connect.StudioRequestServiceClient
 }
 
+func (s *studioRequestServiceClient) Unwrap() registryv1alpha1connect.StudioRequestServiceClient {
+	return s.client
+}
+
 // CreateStudioRequest registers a favorite Studio Requests to the caller's
 // BSR profile.
 func (s *studioRequestServiceClient) CreateStudioRequest(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/token.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/token.pb.go
@@ -30,6 +30,10 @@ type tokenServiceClient struct {
 	client registryv1alpha1connect.TokenServiceClient
 }
 
+func (s *tokenServiceClient) Unwrap() registryv1alpha1connect.TokenServiceClient {
+	return s.client
+}
+
 // CreateToken creates a new token suitable for machine-to-machine authentication.
 func (s *tokenServiceClient) CreateToken(
 	ctx context.Context,

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/user.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/user.pb.go
@@ -29,6 +29,10 @@ type userServiceClient struct {
 	client registryv1alpha1connect.UserServiceClient
 }
 
+func (s *userServiceClient) Unwrap() registryv1alpha1connect.UserServiceClient {
+	return s.client
+}
+
 // CreateUser creates a new user with the given username.
 func (s *userServiceClient) CreateUser(ctx context.Context, username string) (user *v1alpha1.User, _ error) {
 	response, err := s.client.CreateUser(

--- a/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/webhook.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/registry/v1alpha1/registryv1alpha1apiclientconnect/webhook.pb.go
@@ -29,6 +29,10 @@ type webhookServiceClient struct {
 	client registryv1alpha1connect.WebhookServiceClient
 }
 
+func (s *webhookServiceClient) Unwrap() registryv1alpha1connect.WebhookServiceClient {
+	return s.client
+}
+
 // Create a webhook, subscribes to a given repository event for a callback URL
 // invocation.
 func (s *webhookServiceClient) CreateWebhook(

--- a/private/gen/proto/apiclientconnect/buf/alpha/webhook/v1alpha1/webhookv1alpha1apiclientconnect/event.pb.go
+++ b/private/gen/proto/apiclientconnect/buf/alpha/webhook/v1alpha1/webhookv1alpha1apiclientconnect/event.pb.go
@@ -30,6 +30,10 @@ type eventServiceClient struct {
 	client webhookv1alpha1connect.EventServiceClient
 }
 
+func (s *eventServiceClient) Unwrap() webhookv1alpha1connect.EventServiceClient {
+	return s.client
+}
+
 // Event is the rpc which receives webhook events.
 func (s *eventServiceClient) Event(
 	ctx context.Context,


### PR DESCRIPTION
This package is used internally (in bufd) and needs a different abstraction in order to work over there. Also, we need a way, in those internal tests, to _unwrap_ an "api" stub, to access its underlying raw connect client stub. So this adds that as well.
