### PR TITLE
manifest: make Blob.EqualContent a pkg func

### DIFF
--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -31,7 +31,6 @@ var (
 	digestTypeToHashKind = map[DigestType]modulev1alpha1.HashKind{
 		DigestTypeShake256: modulev1alpha1.HashKind_HASH_KIND_SHAKE256,
 	}
-	blockSize = 4098
 )
 
 // Blob is a blob with a digest and a content.
@@ -236,6 +235,7 @@ func NewMemoryBlobFromReaderWithDigester(content io.Reader, digester Digester) (
 // An error is returned if an unexpected I/O error occurred when opening,
 // reading, or closing either blob.
 func BlobEqual(ctx context.Context, a, b Blob) (_ bool, retErr error) {
+	const blockSize = 4098
 	if !a.Digest().Equal(*b.Digest()) {
 		// digests don't match
 		return false, nil

--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -31,13 +31,13 @@ var (
 	digestTypeToHashKind = map[DigestType]modulev1alpha1.HashKind{
 		DigestTypeShake256: modulev1alpha1.HashKind_HASH_KIND_SHAKE256,
 	}
+	blockSize = 4098
 )
 
 // Blob is a blob with a digest and a content.
 type Blob interface {
 	Digest() *Digest
 	Open(context.Context) (io.ReadCloser, error)
-	EqualContent(ctx context.Context, other Blob) (bool, error)
 }
 
 type memoryBlob struct {
@@ -94,22 +94,6 @@ func (b *memoryBlob) Digest() *Digest {
 
 func (b *memoryBlob) Open(context.Context) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(b.content)), nil
-}
-
-func (b *memoryBlob) EqualContent(ctx context.Context, other Blob) (_ bool, retErr error) {
-	otherContentRC, err := other.Open(ctx)
-	if err != nil {
-		return false, fmt.Errorf("open other blob: %w", err)
-	}
-	defer func() { retErr = multierr.Append(retErr, otherContentRC.Close()) }()
-	otherContent, err := io.ReadAll(otherContentRC)
-	if err != nil {
-		return false, fmt.Errorf("read other blob: %w", err)
-	}
-	if c := bytes.Compare(b.content, otherContent); c != 0 {
-		return false, nil
-	}
-	return true, nil
 }
 
 // AsProtoBlob returns the passed blob as a proto module blob.
@@ -173,7 +157,7 @@ func NewBlobSet(ctx context.Context, blobs []Blob, opts ...BlobSetOption) (*Blob
 		if config.validateContent {
 			existingBlob, alreadyPresent := digestToBlobs[digestStr]
 			if alreadyPresent {
-				equalContent, err := b.EqualContent(ctx, existingBlob)
+				equalContent, err := BlobEqual(ctx, b, existingBlob)
 				if err != nil {
 					return nil, fmt.Errorf("compare duplicated blobs with digest %q: %w", digestStr, err)
 				}
@@ -244,4 +228,72 @@ func NewMemoryBlobFromReaderWithDigester(content io.Reader, digester Digester) (
 		digest:  *digest,
 		content: contentInMemory.Bytes(),
 	}, nil
+}
+
+// BlobEqual returns true if blob a is the same as blob b. The digest is
+// checked for equality and the content bytes compared.
+//
+// An error is returned if an unexpected I/O error occurred when opening,
+// reading, or closing either blob.
+func BlobEqual(ctx context.Context, a, b Blob) (_ bool, retErr error) {
+	if !a.Digest().Equal(*b.Digest()) {
+		// digests don't match
+		return false, nil
+	}
+	aFile, err := a.Open(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { retErr = multierr.Append(retErr, aFile.Close()) }()
+	bFile, err := b.Open(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { retErr = multierr.Append(retErr, bFile.Close()) }()
+	// Read blockSize from a, then from b, and compare.
+	aBlock := make([]byte, blockSize)
+	bBlock := make([]byte, blockSize)
+	for {
+		aN, aErr := aFile.Read(aBlock)
+		bN, bErr := io.ReadAtLeast(bFile, bBlock[:aN], aN) // exactly aN bytes
+		// We're running unexpected error processing (not EOF) before comparing
+		// bytes because it doesn't matter if the returned bytes match if an
+		// error occurred before an expected EOF.
+		if bErr == io.ErrUnexpectedEOF {
+			// b is shorter; we can error early
+			return false, nil
+		}
+		if aErr != nil && aErr != io.EOF {
+			// unexpected read error
+			return false, aErr
+		}
+		if bErr != nil && bErr != io.EOF {
+			// unexpected read error
+			return false, bErr
+		}
+		if !bytes.Equal(aBlock[:aN], bBlock[:bN]) {
+			// Read content doesn't match. Don't forget to forward any errors
+			// returned.
+			return false, multierr.Append(nilEOF(aErr), nilEOF(bErr))
+		}
+		if aErr == io.EOF || bErr == io.EOF {
+			// EOF
+			break
+		}
+	}
+	_, aErr := io.ReadAtLeast(aFile, aBlock, 1)
+	_, bErr := io.ReadAtLeast(bFile, bBlock, 1)
+	if aErr != io.EOF || bErr != io.EOF {
+		// a or b is longer, or we late errored
+		return false, multierr.Append(nilEOF(aErr), nilEOF(bErr))
+	}
+	return true, nil
+}
+
+// nilEOF maps io.EOF to nil
+func nilEOF(err error) error {
+	if err == io.EOF {
+		return nil
+	}
+	return err
 }

--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -281,13 +281,14 @@ func BlobEqual(ctx context.Context, a, b Blob) (_ bool, retErr error) {
 			break
 		}
 	}
-	_, aErr := io.ReadAtLeast(aFile, aBlock, 1)
-	_, bErr := io.ReadAtLeast(bFile, bBlock, 1)
-	if aErr != io.EOF || bErr != io.EOF {
-		// a or b is longer, or we late errored
-		return false, multierr.Append(nilEOF(aErr), nilEOF(bErr))
+	aN, aErr := aFile.Read(aBlock[:1])
+	bN, bErr := bFile.Read(bBlock[:1])
+	if aN == 0 && bN == 0 && aErr == io.EOF && bErr == io.EOF {
+		// a and b are at EOF with no more data for us
+		return true, nil
 	}
-	return true, nil
+	// either a or b are longer
+	return false, multierr.Append(nilEOF(aErr), nilEOF(bErr))
 }
 
 // nilEOF maps io.EOF to nil


### PR DESCRIPTION
Checking for blob equality doesn't really depend on the blob's implementation. It's a check if the digest and content are identical, both of which are exposed in the Digest and Open methods.

BlobEqual implements exactly this. It's a little tricky to read and compare content from two streams. They can throw errors at any point. Each read can return a different sized block. Reads can return an error with data. I hope I covered these edge cases and made sure to test them (100% coverage)!