### PR TITLE
lint: ignore unused field in module reader

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,3 +146,7 @@ issues:
         - staticcheck
       path: private/buf/cmd/buf/command/push/push_test.go
       text: "SA1019"
+    - linters:
+        - staticcheck
+      path: private/bufpkg/bufapimodule/module_reader.go
+      text: "SA1019"


### PR DESCRIPTION
This field must still be supported even if it's deprecated.