### PR TITLE
module reader: build from a manifest and blobs

### DIFF
--- a/private/bufpkg/bufapimodule/module_reader_test.go
+++ b/private/bufpkg/bufapimodule/module_reader_test.go
@@ -22,18 +22,95 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
-	v1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
+	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/manifest"
+	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/connect-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type mockDownloadService struct {
-	module   *v1alpha1.Module
-	manifest *v1alpha1.Blob
-	blobs    []*v1alpha1.Blob
-	err      error
+	module       *modulev1alpha1.Module
+	manifestBlob *modulev1alpha1.Blob
+	blobs        []*modulev1alpha1.Blob
+	err          error
+}
+
+type option interface {
+	apply(*mockDownloadService) error
+}
+
+type filemap map[string][]byte
+
+func (fm filemap) apply(m *mockDownloadService) error {
+	bucket, err := storagemem.NewReadBucket(fm)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	moduleManifest, blobSet, err := manifest.NewFromBucket(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	mBlob, err := moduleManifest.Blob()
+	if err != nil {
+		return err
+	}
+	m.manifestBlob, err = manifest.AsProtoBlob(ctx, mBlob)
+	if err != nil {
+		return err
+	}
+	blobs := blobSet.Blobs()
+	m.blobs = make([]*modulev1alpha1.Blob, 0, len(blobs))
+	for _, blob := range blobs {
+		protoBlob, err := manifest.AsProtoBlob(ctx, blob)
+		if err != nil {
+			return err
+		}
+		m.blobs = append(m.blobs, protoBlob)
+	}
+	return nil
+}
+
+func WithBlobsFromMap(files map[string][]byte) option {
+	return filemap(files)
+}
+
+type retErr struct{ err error }
+
+func (re retErr) apply(m *mockDownloadService) error {
+	m.err = re.err
+	return nil
+}
+
+func WithError(err error) option {
+	return retErr{err: err}
+}
+
+type retModule struct{ module *modulev1alpha1.Module }
+
+func (rm retModule) apply(m *mockDownloadService) error {
+	m.module = rm.module
+	return nil
+}
+
+func WithModule(module *modulev1alpha1.Module) option {
+	return retModule{module: module}
+}
+
+func NewMockDownloadService(
+	t *testing.T,
+	opts ...option,
+) *mockDownloadService {
+	m := &mockDownloadService{}
+	for _, opt := range opts {
+		if err := opt.apply(m); err != nil {
+			t.Error(err)
+		}
+	}
+	return m
 }
 
 func (m *mockDownloadService) factory(_ string) registryv1alpha1connect.DownloadServiceClient {
@@ -49,7 +126,7 @@ func (m *mockDownloadService) Download(
 	}
 	return connect.NewResponse(&registryv1alpha1.DownloadResponse{
 		Module:   m.module,
-		Manifest: m.manifest,
+		Manifest: m.manifestBlob,
 		Blobs:    m.blobs,
 	}), nil
 }
@@ -58,42 +135,67 @@ func TestDownload(t *testing.T) {
 	testDownload(
 		t,
 		"does-not-exist error",
-		&mockDownloadService{
-			err: connect.NewError(connect.CodeNotFound, nil),
-		},
+		NewMockDownloadService(
+			t,
+			WithError(connect.NewError(connect.CodeNotFound, nil)),
+		),
 		true,
 		"does not exist",
 	)
 	testDownload(
 		t,
 		"unexpected download service error",
-		&mockDownloadService{
-			err: errors.New("internal"),
-		},
+		NewMockDownloadService(
+			t,
+			WithError(errors.New("internal")),
+		),
 		true,
 		"internal",
 	)
 	testDownload(
 		t,
 		"success but response has all empty fields",
-		&mockDownloadService{},
+		NewMockDownloadService(t),
 		true,
-		"module is required",
+		"no module in response",
 	)
 	testDownload(
 		t,
 		"success",
-		&mockDownloadService{
-			module: &v1alpha1.Module{
-				Files: []*v1alpha1.ModuleFile{
+		NewMockDownloadService(
+			t,
+			WithModule(&modulev1alpha1.Module{
+				Files: []*modulev1alpha1.ModuleFile{
 					{
 						Path: "foo.proto",
 					},
 				},
-			},
-		},
+			}),
+		),
 		false,
 		"",
+	)
+	testDownload(
+		t,
+		"success with empty manifest module",
+		NewMockDownloadService(
+			t,
+			WithBlobsFromMap(map[string][]byte{}),
+		),
+		false,
+		"",
+	)
+	testDownload(
+		t,
+		"manifest module with invalid lock file",
+		NewMockDownloadService(
+			t,
+			WithBlobsFromMap(map[string][]byte{
+				"buf.lock": []byte("invalid lock file"),
+			}),
+		),
+		true,
+		"failed to decode lock file",
 	)
 }
 

--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -121,6 +121,26 @@ func AsProtoBlob(ctx context.Context, b Blob) (*modulev1alpha1.Blob, error) {
 	}, nil
 }
 
+// NewBlobFromProto returns A Blob from a proto module blob.
+func NewBlobFromProto(b *modulev1alpha1.Blob) (Blob, error) {
+	if b == nil {
+		return nil, fmt.Errorf("nil blob")
+	}
+	hashDigest, err := NewDigestFromBlobHash(b.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("digest from hash: %w", err)
+	}
+	memBlob, err := NewMemoryBlob(
+		*hashDigest,
+		b.Content,
+		MemoryBlobWithHashValidation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new memory blob: %w", err)
+	}
+	return memBlob, nil
+}
+
 // BlobSet represents a set of deduplicated blobs, by digests.
 type BlobSet struct {
 	digestToBlob map[string]Blob

--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -373,6 +373,25 @@ func testBlobEqual(
 	})
 }
 
+func TestProtoBlob(t *testing.T) {
+	t.Parallel()
+	content := []byte("hello world")
+	digester, err := manifest.NewDigester(manifest.DigestTypeShake256)
+	require.NoError(t, err)
+	digest, err := digester.Digest(bytes.NewReader(content))
+	require.NoError(t, err)
+	blob, err := manifest.NewMemoryBlob(*digest, content)
+	require.NoError(t, err)
+	ctx := context.Background()
+	protoBlob, err := manifest.AsProtoBlob(ctx, blob)
+	require.NoError(t, err)
+	rtBlob, err := manifest.NewBlobFromProto(protoBlob)
+	require.NoError(t, err)
+	equal, err := manifest.BlobEqual(ctx, blob, rtBlob)
+	require.NoError(t, err)
+	assert.True(t, equal)
+}
+
 func testBlobFromReader(t *testing.T, content []byte, digest []byte) {
 	t.Helper()
 	t.Parallel()

--- a/private/pkg/manifest/storage.go
+++ b/private/pkg/manifest/storage.go
@@ -15,10 +15,12 @@
 package manifest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 
+	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storageutil"
@@ -195,4 +197,45 @@ func (m *manifestBucket) Walk(ctx context.Context, prefix string, f func(storage
 		}
 	}
 	return nil
+}
+
+// NewBucketFromManifestBlobs builds a storage bucket from a manifest blob and
+// a set of other blobs, provided in protobuf form. This bucket is suitble for
+// building or exporting.
+func NewBucketFromManifestBlobs(
+	ctx context.Context,
+	manifestBlob *modulev1alpha1.Blob,
+	blobs []*modulev1alpha1.Blob,
+) (storage.ReadBucket, error) {
+	if _, err := NewBlobFromProto(manifestBlob); err != nil {
+		return nil, fmt.Errorf("invalid manifest: %w", err)
+	}
+	parsedManifest, err := NewFromReader(
+		bytes.NewReader(manifestBlob.Content),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest content: %w", err)
+	}
+	var memBlobs []Blob
+	for i, modBlob := range blobs {
+		memBlob, err := NewBlobFromProto(modBlob)
+		if err != nil {
+			return nil, fmt.Errorf("invalid blob at index %d: %w", i, err)
+		}
+		memBlobs = append(memBlobs, memBlob)
+	}
+	blobSet, err := NewBlobSet(ctx, memBlobs)
+	if err != nil {
+		return nil, fmt.Errorf("invalid blobs: %w", err)
+	}
+	manifestBucket, err := NewBucket(
+		*parsedManifest,
+		*blobSet,
+		BucketWithAllManifestBlobsValidation(),
+		BucketWithNoExtraBlobsValidation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new manifest bucket: %w", err)
+	}
+	return manifestBucket, nil
 }

--- a/private/pkg/manifest/storage.go
+++ b/private/pkg/manifest/storage.go
@@ -200,7 +200,7 @@ func (m *manifestBucket) Walk(ctx context.Context, prefix string, f func(storage
 }
 
 // NewBucketFromManifestBlobs builds a storage bucket from a manifest blob and
-// a set of other blobs, provided in protobuf form. This bucket is suitble for
+// a set of other blobs, provided in protobuf form. This bucket is suitable for
 // building or exporting.
 func NewBucketFromManifestBlobs(
 	ctx context.Context,


### PR DESCRIPTION
This updates bufapimodule.ModuleReader to build modules from manifest and blob content returned in DownloadService.Download's response. manifest.NewBucketFromManifestBlobs exposes this logic for other users.

This also adds manifest.NewBlobFromProto, which is the inverse mapper of manifest.AsProtoBlob.