### PR TITLE
buf format: preserve interior indentation in multi-line comments

### DIFF
--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -2067,21 +2067,23 @@ func (f *formatter) writeComment(comment string) {
 }
 
 func unindent(s string, unindent int) string {
+	pos := 0
 	for i, r := range s {
-		if unindent == 0 {
+		if pos == unindent {
 			return s[i:]
 		}
-		if unindent < 0 {
+		if pos > unindent {
 			// removing tab-stop unindented too far, so we
 			// add back some spaces to compensate
-			return strings.Repeat(" ", -unindent) + s[i:]
+			return strings.Repeat(" ", pos-unindent) + s[i:]
 		}
 
 		switch r {
 		case ' ':
-			unindent--
+			pos++
 		case '\t':
-			unindent -= 4
+			// jump to next tab stop
+			pos += 8 - (pos % 8)
 		default:
 			return s[i:]
 		}
@@ -2100,7 +2102,8 @@ func computeIndent(s string) (int, bool) {
 		case ' ':
 			indent++
 		case '\t':
-			indent += 4
+			// jump to next tab stop
+			indent += 8 - (indent % 8)
 		default:
 			return indent, true
 		}

--- a/private/buf/bufformat/testdata/proto2/field/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/field/v1/option.golden.proto
@@ -6,6 +6,19 @@ message Foo {
     deprecated = true,
     lazy = true
   ];
+  /*
+     Heading 1:
+         Some content goes here.
+     					   More content indented with tabs.
+         Last bit.
+     Heading 2:
+         - bullet
+         - another bullet
+            1. nested bullet
+            2. nested bullet again
+         - last bullet
+        Last bit of content.
+  */
 
   // Leading comment on name_with_options.
   string name_with_options = 2 [
@@ -22,5 +35,8 @@ message Foo {
     (custom.sfixed32_field_option) = -11,
     (custom.sfixed64_field_option) = -12,
     (custom.bytes_field_option) = "fcf7c1b8749cf99d88e5f34271d636178fb5d130"
-  ];
+  ]; /* foo
+     bar
+      baz
+       buzz */
 }

--- a/private/buf/bufformat/testdata/proto2/field/v1/option.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/field/v1/option.golden.proto
@@ -9,7 +9,7 @@ message Foo {
   /*
      Heading 1:
          Some content goes here.
-     					   More content indented with tabs.
+         						   More content indented with tabs.
          Last bit.
      Heading 2:
          - bullet

--- a/private/buf/bufformat/testdata/proto2/field/v1/option.proto
+++ b/private/buf/bufformat/testdata/proto2/field/v1/option.proto
@@ -3,6 +3,19 @@ import "custom.proto";
 message Foo {
   // Leading comment on map field.
      map<  string,  int64  > pairs = 1 [ deprecated = true,        lazy = true    ] ;
+/*
+            Heading 1:
+                Some content goes here.
+								   More content indented with tabs.
+                Last bit.
+            Heading 2:
+                - bullet
+                - another bullet
+                   1. nested bullet
+                   2. nested bullet again
+                - last bullet
+               Last bit of content.
+           */
 
          // Leading comment on name_with_options.
    string name_with_options = 2 [
@@ -21,6 +34,9 @@ message Foo {
 (custom.bytes_field_option) = "fcf7c1b8749cf99d88e5f34271d636178fb5d130"
 
 
-   ]   ;
-    
+   ]   ; /* foo
+             bar
+              baz
+               buzz */
+
         }


### PR DESCRIPTION
The logic added in 1.9 was attempting to "fix" indentation for multi-line comments that were attached to an element that was moved. For example, if there's a trailing comment attached to a semicolon and the semicolon was moved as part of the re-format, the comment may need to be re-indented accordingly.

However, this re-indenting was too aggressive and turns out to be destructive for comments that have _intentional_ interior indentation.

The fix is to leave interior indentation alone by only re-indenting based on the _least_ indented line and leaving other lines in the comment indented relative to that. (Not sure if that sentence makes sense. Maybe reading the code will help clear it up?)

I'm not going to lie: I know the code in here (including some of the new code in this change) is hairy and feels brittle. Part of me really wants to just rewrite it all to be less complicated. But, alas, that's much easier said than done because the task at hand is complicated by its nature. (It would be simpler if this were less opinionated about line breaks and worked more like `gofmt`. But re-formatting line breaks -- sometimes joining multiple lines into one and sometimes breaking one line out across many -- and the associated possible movement of comments makes it kind of nasty.)

Fixes #1612 

Fixes TCN-778