### PR TITLE
Add buf generate pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,9 @@
+- id: buf-generate
+  name: buf generate
+  language: golang
+  entry: buf generate
+  types: [proto]
+  pass_filenames: false
 - id: buf-breaking
   name: buf breaking
   language: golang


### PR DESCRIPTION
This adds an option to run `buf generate` when `.proto` files change. Users may need to override the `entry` with additional flags and/or specify the hook more than once with variations, but it should work fine.