### PR TITLE
BSR-704/default except override for optimize_for

### DIFF
--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -400,13 +400,13 @@ func (e ExternalOptimizeForConfigV1) IsEmpty() bool {
 }
 
 // UnmarshalYAML satisfies the yaml.Unmarshaler interface. This is done to maintain backward compatibility
-// of accepting a plain string value for java_package_prefix.
+// of accepting a plain string value for optimize_for.
 func (e *ExternalOptimizeForConfigV1) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return e.unmarshalWith(unmarshal)
 }
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface. This is done to maintain backward compatibility
-// of accepting a plain string value for java_package_prefix.
+// of accepting a plain string value for optimize_for.
 func (e *ExternalOptimizeForConfigV1) UnmarshalJSON(data []byte) error {
 	unmarshal := func(v interface{}) error {
 		return json.Unmarshal(data, v)

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -218,7 +218,7 @@ type ManagedConfig struct {
 	JavaMultipleFiles     *bool
 	JavaStringCheckUtf8   *bool
 	JavaPackagePrefix     *JavaPackagePrefixConfig
-	OptimizeFor           *descriptorpb.FileOptions_OptimizeMode
+	OptimizeFor           *OptimizeForConfig
 	GoPackagePrefixConfig *GoPackagePrefixConfig
 	Override              map[string]map[string]string
 }
@@ -229,6 +229,13 @@ type JavaPackagePrefixConfig struct {
 	Except  []bufmoduleref.ModuleIdentity
 	// bufmoduleref.ModuleIdentity -> java_package prefix.
 	Override map[bufmoduleref.ModuleIdentity]string
+}
+
+type OptimizeForConfig struct {
+	Default descriptorpb.FileOptions_OptimizeMode
+	Except  []bufmoduleref.ModuleIdentity
+	// bufmoduleref.ModuleIdentity -> optimize_for.
+	Override map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode
 }
 
 // GoPackagePrefixConfig is the go_package prefix configuration.
@@ -307,7 +314,7 @@ type ExternalManagedConfigV1 struct {
 	JavaMultipleFiles   *bool                             `json:"java_multiple_files,omitempty" yaml:"java_multiple_files,omitempty"`
 	JavaStringCheckUtf8 *bool                             `json:"java_string_check_utf8,omitempty" yaml:"java_string_check_utf8,omitempty"`
 	JavaPackagePrefix   ExternalJavaPackagePrefixConfigV1 `json:"java_package_prefix,omitempty" yaml:"java_package_prefix,omitempty"`
-	OptimizeFor         string                            `json:"optimize_for,omitempty" yaml:"optimize_for,omitempty"`
+	OptimizeFor         ExternalOptimizeForConfigV1       `json:"optimize_for,omitempty" yaml:"optimize_for,omitempty"`
 	GoPackagePrefix     ExternalGoPackagePrefixConfigV1   `json:"go_package_prefix,omitempty" yaml:"go_package_prefix,omitempty"`
 	Override            map[string]map[string]string      `json:"override,omitempty" yaml:"override,omitempty"`
 }
@@ -318,7 +325,7 @@ func (e ExternalManagedConfigV1) IsEmpty() bool {
 		e.JavaMultipleFiles == nil &&
 		e.JavaStringCheckUtf8 == nil &&
 		e.JavaPackagePrefix.IsEmpty() &&
-		e.OptimizeFor == "" &&
+		e.OptimizeFor.IsEmpty() &&
 		e.GoPackagePrefix.IsEmpty() &&
 		len(e.Override) == 0
 }
@@ -363,6 +370,52 @@ func (e *ExternalJavaPackagePrefixConfigV1) unmarshalWith(unmarshal func(interfa
 
 	type rawExternalJavaPackagePrefixConfigV1 ExternalJavaPackagePrefixConfigV1
 	if err := unmarshal((*rawExternalJavaPackagePrefixConfigV1)(e)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExternalOptimizeForConfigV1 is the external optimize_for configuration.
+type ExternalOptimizeForConfigV1 struct {
+	Default  string            `json:"default,omitempty" yaml:"default,omitempty"`
+	Except   []string          `json:"except,omitempty" yaml:"except,omitempty"`
+	Override map[string]string `json:"override,omitempty" yaml:"override,omitempty"`
+}
+
+// IsEmpty returns true if the config is empty
+func (e ExternalOptimizeForConfigV1) IsEmpty() bool {
+	return e.Default == "" &&
+		len(e.Except) == 0 &&
+		len(e.Override) == 0
+}
+
+// UnmarshalYAML satisfies the yaml.Unmarshaler interface. This is done to maintain backward compatibility
+// of accepting a plain string value for java_package_prefix.
+func (e *ExternalOptimizeForConfigV1) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return e.unmarshalWith(unmarshal)
+}
+
+// UnmarshalJSON satisfies the json.Unmarshaler interface. This is done to maintain backward compatibility
+// of accepting a plain string value for java_package_prefix.
+func (e *ExternalOptimizeForConfigV1) UnmarshalJSON(data []byte) error {
+	unmarshal := func(v interface{}) error {
+		return json.Unmarshal(data, v)
+	}
+
+	return e.unmarshalWith(unmarshal)
+}
+
+// unmarshalWith is used to unmarshal into json/yaml. See https://abhinavg.net/posts/flexible-yaml for details.
+func (e *ExternalOptimizeForConfigV1) unmarshalWith(unmarshal func(interface{}) error) error {
+	var optimizeFor string
+	if err := unmarshal(&optimizeFor); err == nil {
+		e.Default = optimizeFor
+		return nil
+	}
+
+	type rawExternalOptimizeForConfigV1 ExternalOptimizeForConfigV1
+	if err := unmarshal((*rawExternalOptimizeForConfigV1)(e)); err != nil {
 		return err
 	}
 

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -219,7 +219,7 @@ type ManagedConfig struct {
 	JavaStringCheckUtf8   *bool
 	JavaPackagePrefix     *JavaPackagePrefixConfig
 	CsharpNameSpaceConfig *CsharpNameSpaceConfig
-	OptimizeFor           *OptimizeForConfig
+	OptimizeForConfig     *OptimizeForConfig
 	GoPackagePrefixConfig *GoPackagePrefixConfig
 	Override              map[string]map[string]string
 }

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -515,13 +515,6 @@ func enumMapToStringSlice(enums map[string]int32) []string {
 	return slice
 }
 
-// optimizeModePtr is a convenience function for initializing the
-// *descriptorpb.FileOptions_OptimizeMode type in-line. This is
-// also useful in unit tests.
-func optimizeModePtr(value descriptorpb.FileOptions_OptimizeMode) *descriptorpb.FileOptions_OptimizeMode {
-	return &value
-}
-
 type readConfigOptions struct {
 	override string
 }

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -284,7 +284,7 @@ func newManagedConfigV1(logger *zap.Logger, externalManagedConfig ExternalManage
 		JavaStringCheckUtf8:   externalManagedConfig.JavaStringCheckUtf8,
 		JavaPackagePrefix:     javaPackagePrefixConfig,
 		CsharpNameSpaceConfig: csharpNamespaceConfig,
-		OptimizeFor:           optimizeForConfig,
+		OptimizeForConfig:     optimizeForConfig,
 		GoPackagePrefixConfig: goPackagePrefixConfig,
 		Override:              override,
 	}, nil
@@ -543,7 +543,7 @@ func newManagedConfigV1Beta1(externalOptionsConfig ExternalOptionsConfigV1Beta1,
 	return &ManagedConfig{
 		CcEnableArenas:    externalOptionsConfig.CcEnableArenas,
 		JavaMultipleFiles: externalOptionsConfig.JavaMultipleFiles,
-		OptimizeFor:       optimizeForConfig,
+		OptimizeForConfig: optimizeForConfig,
 	}, nil
 }
 

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -334,10 +334,7 @@ func newOptimizeForConfigV1(externalOptimizeForConfigV1 ExternalOptimizeForConfi
 		return nil, nil
 	}
 	if externalOptimizeForConfigV1.Default == "" {
-		// or just print a warning instead?
 		return nil, errors.New("optimize_for setting requires a default value")
-		// Also, if since default + non-empty except / override is not allowed,
-		// internal config of this shouldn't have a pointer as default
 	}
 	value, ok := descriptorpb.FileOptions_OptimizeMode_value[externalOptimizeForConfigV1.Default]
 	if !ok {
@@ -362,7 +359,6 @@ func newOptimizeForConfigV1(externalOptimizeForConfigV1 ExternalOptimizeForConfi
 	}
 	override := make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode, len(externalOptimizeForConfigV1.Override))
 	for moduleName, optimizeFor := range externalOptimizeForConfigV1.Override {
-		// perhaps check whether the override value equals the default value provided?
 		moduleIdentity, err := bufmoduleref.ModuleIdentityForString(moduleName)
 		if err != nil {
 			return nil, fmt.Errorf("invalid optimize_for override key: %w", err)
@@ -370,7 +366,7 @@ func newOptimizeForConfigV1(externalOptimizeForConfigV1 ExternalOptimizeForConfi
 		value, ok := descriptorpb.FileOptions_OptimizeMode_value[optimizeFor]
 		if !ok {
 			return nil, fmt.Errorf(
-				"invalid optimize_for value; expected one of %v",
+				"invalid optimize_for override value; expected one of %v",
 				enumMapToStringSlice(descriptorpb.FileOptions_OptimizeMode_value),
 			)
 		}

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -493,7 +493,9 @@ func newManagedConfigV1Beta1(externalOptionsConfig ExternalOptionsConfigV1Beta1,
 			)
 		}
 		optimizeForConfig = &OptimizeForConfig{
-			Default: descriptorpb.FileOptions_OptimizeMode(value),
+			Default:  descriptorpb.FileOptions_OptimizeMode(value),
+			Except:   make([]bufmoduleref.ModuleIdentity, 0),
+			Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
 		}
 	}
 	return &ManagedConfig{

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -314,6 +314,48 @@ func TestReadConfigV1(t *testing.T) {
 			},
 		},
 	}
+	successConfig9 := &Config{
+		ManagedConfig: &ManagedConfig{
+			OptimizeForConfig: &OptimizeForConfig{
+				Default: descriptorpb.FileOptions_CODE_SIZE,
+				Except: []bufmoduleref.ModuleIdentity{
+					mustCreateModuleIdentity(
+						t,
+						"someremote.com",
+						"owner",
+						"repo",
+					),
+					mustCreateModuleIdentity(
+						t,
+						"someremote.com",
+						"owner",
+						"foo",
+					),
+				},
+				Override: map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode{
+					mustCreateModuleIdentity(
+						t,
+						"someremote.com",
+						"owner",
+						"bar",
+					): descriptorpb.FileOptions_SPEED,
+					mustCreateModuleIdentity(
+						t,
+						"someremote.com",
+						"owner",
+						"baz",
+					): descriptorpb.FileOptions_LITE_RUNTIME,
+				},
+			},
+		},
+		PluginConfigs: []*PluginConfig{
+			{
+				Remote:   "someremote.com/owner/plugins/myplugin",
+				Out:      "gen/go",
+				Strategy: StrategyAll,
+			},
+		},
+	}
 
 	ctx := context.Background()
 	nopLogger := zap.NewNop()
@@ -497,6 +539,32 @@ func TestReadConfigV1(t *testing.T) {
 	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(string(data)))
 	require.NoError(t, err)
 	assertConfigsWithEqualCsharpnamespace(t, successConfig8, config)
+
+	//
+	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(filepath.Join("testdata", "v1", "gen_success9.yaml")))
+	require.NoError(t, err)
+	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)
+	data, err = os.ReadFile(filepath.Join("testdata", "v1", "gen_success9.yaml"))
+	require.NoError(t, err)
+	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride((string(data))))
+	require.NoError(t, err)
+	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)
+	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(filepath.Join("testdata", "v1", "gen_success9.json")))
+	require.NoError(t, err)
+	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)
+	data, err = os.ReadFile(filepath.Join("testdata", "v1", "gen_success9.json"))
+	require.NoError(t, err)
+	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(string(data)))
+	require.NoError(t, err)
+	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)
+	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(filepath.Join("testdata", "v1", "gen_success9.yml")))
+	require.NoError(t, err)
+	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)
+	data, err = os.ReadFile(filepath.Join("testdata", "v1", "gen_success9.yml"))
+	require.NoError(t, err)
+	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(string(data)))
+	require.NoError(t, err)
+	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)
 
 	testReadConfigError(t, nopLogger, provider, readBucket, filepath.Join("testdata", "v1", "gen_error1.yaml"))
 	testReadConfigError(t, nopLogger, provider, readBucket, filepath.Join("testdata", "v1", "gen_error2.yaml"))

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -45,7 +45,7 @@ func TestReadConfigV1Beta1(t *testing.T) {
 			CcEnableArenas:      &truth,
 			JavaMultipleFiles:   &truth,
 			JavaStringCheckUtf8: nil,
-			OptimizeFor: &OptimizeForConfig{
+			OptimizeForConfig: &OptimizeForConfig{
 				Default:  descriptorpb.FileOptions_CODE_SIZE,
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
@@ -54,7 +54,7 @@ func TestReadConfigV1Beta1(t *testing.T) {
 	}
 	successConfig2 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: &OptimizeForConfig{
+			OptimizeForConfig: &OptimizeForConfig{
 				Default:  descriptorpb.FileOptions_SPEED,
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
@@ -72,7 +72,7 @@ func TestReadConfigV1Beta1(t *testing.T) {
 	}
 	successConfig3 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: &OptimizeForConfig{
+			OptimizeForConfig: &OptimizeForConfig{
 				Default:  descriptorpb.FileOptions_LITE_RUNTIME,
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
@@ -176,7 +176,7 @@ func TestReadConfigV1(t *testing.T) {
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]string),
 			},
-			OptimizeFor: &OptimizeForConfig{
+			OptimizeForConfig: &OptimizeForConfig{
 				Default:  descriptorpb.FileOptions_CODE_SIZE,
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
@@ -188,7 +188,7 @@ func TestReadConfigV1(t *testing.T) {
 	}
 	successConfig2 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: &OptimizeForConfig{
+			OptimizeForConfig: &OptimizeForConfig{
 				Default:  descriptorpb.FileOptions_SPEED,
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
@@ -206,7 +206,7 @@ func TestReadConfigV1(t *testing.T) {
 	}
 	successConfig3 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: &OptimizeForConfig{
+			OptimizeForConfig: &OptimizeForConfig{
 				Default:  descriptorpb.FileOptions_LITE_RUNTIME,
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
@@ -585,10 +585,23 @@ func assertConfigsWithEqualCsharpnamespace(t *testing.T, successConfig *Config, 
 	assertEqualModuleIdentityKeyedMaps(t, successCsharpConfig.Override, csharpConfig.Override)
 }
 
-func assertEqualModuleIdentityKeyedMaps(t *testing.T, m1 map[bufmoduleref.ModuleIdentity]string, m2 map[bufmoduleref.ModuleIdentity]string) {
+func assertConfigsWithEqualOptimizeFor(t *testing.T, successConfig *Config, config *Config) {
+	require.Equal(t, successConfig.PluginConfigs, config.PluginConfigs)
+	require.NotNil(t, successConfig.ManagedConfig)
+	require.NotNil(t, config.ManagedConfig)
+	successOptimizeForConfig := successConfig.ManagedConfig.OptimizeForConfig
+	require.NotNil(t, successOptimizeForConfig)
+	optimizeForConfig := config.ManagedConfig.OptimizeForConfig
+	require.NotNil(t, optimizeForConfig)
+	require.Equal(t, successOptimizeForConfig.Default, optimizeForConfig.Default)
+	require.Equal(t, successOptimizeForConfig.Except, optimizeForConfig.Except)
+	assertEqualModuleIdentityKeyedMaps(t, optimizeForConfig.Override, optimizeForConfig.Override)
+}
+
+func assertEqualModuleIdentityKeyedMaps[V any](t *testing.T, m1 map[bufmoduleref.ModuleIdentity]V, m2 map[bufmoduleref.ModuleIdentity]V) {
 	require.Equal(t, len(m1), len(m2))
-	keyedM1 := make(map[string]string, len(m1))
-	keyedM2 := make(map[string]string, len(m2))
+	keyedM1 := make(map[string]V, len(m1))
+	keyedM2 := make(map[string]V, len(m2))
 	for k, v := range m1 {
 		keyedM1[k.IdentityString()] = v
 	}

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -539,8 +539,6 @@ func TestReadConfigV1(t *testing.T) {
 	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(string(data)))
 	require.NoError(t, err)
 	assertConfigsWithEqualCsharpnamespace(t, successConfig8, config)
-
-	//
 	config, err = ReadConfig(ctx, nopLogger, provider, readBucket, ReadConfigWithOverride(filepath.Join("testdata", "v1", "gen_success9.yaml")))
 	require.NoError(t, err)
 	assertConfigsWithEqualOptimizeFor(t, successConfig9, config)

--- a/private/buf/bufgen/config_test.go
+++ b/private/buf/bufgen/config_test.go
@@ -45,12 +45,20 @@ func TestReadConfigV1Beta1(t *testing.T) {
 			CcEnableArenas:      &truth,
 			JavaMultipleFiles:   &truth,
 			JavaStringCheckUtf8: nil,
-			OptimizeFor:         optimizeModePtr(descriptorpb.FileOptions_CODE_SIZE),
+			OptimizeFor: &OptimizeForConfig{
+				Default:  descriptorpb.FileOptions_CODE_SIZE,
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
+			},
 		},
 	}
 	successConfig2 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: optimizeModePtr(descriptorpb.FileOptions_SPEED),
+			OptimizeFor: &OptimizeForConfig{
+				Default:  descriptorpb.FileOptions_SPEED,
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
+			},
 		},
 		PluginConfigs: []*PluginConfig{
 			{
@@ -64,7 +72,11 @@ func TestReadConfigV1Beta1(t *testing.T) {
 	}
 	successConfig3 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: optimizeModePtr(descriptorpb.FileOptions_LITE_RUNTIME),
+			OptimizeFor: &OptimizeForConfig{
+				Default:  descriptorpb.FileOptions_LITE_RUNTIME,
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
+			},
 		},
 		PluginConfigs: []*PluginConfig{
 			{
@@ -164,7 +176,11 @@ func TestReadConfigV1(t *testing.T) {
 				Except:   make([]bufmoduleref.ModuleIdentity, 0),
 				Override: make(map[bufmoduleref.ModuleIdentity]string),
 			},
-			OptimizeFor: optimizeModePtr(descriptorpb.FileOptions_CODE_SIZE),
+			OptimizeFor: &OptimizeForConfig{
+				Default:  descriptorpb.FileOptions_CODE_SIZE,
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
+			},
 			Override: map[string]map[string]string{
 				bufimagemodify.JavaPackageID: {"a.proto": "override"},
 			},
@@ -172,7 +188,11 @@ func TestReadConfigV1(t *testing.T) {
 	}
 	successConfig2 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: optimizeModePtr(descriptorpb.FileOptions_SPEED),
+			OptimizeFor: &OptimizeForConfig{
+				Default:  descriptorpb.FileOptions_SPEED,
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
+			},
 		},
 		PluginConfigs: []*PluginConfig{
 			{
@@ -186,7 +206,11 @@ func TestReadConfigV1(t *testing.T) {
 	}
 	successConfig3 := &Config{
 		ManagedConfig: &ManagedConfig{
-			OptimizeFor: optimizeModePtr(descriptorpb.FileOptions_LITE_RUNTIME),
+			OptimizeFor: &OptimizeForConfig{
+				Default:  descriptorpb.FileOptions_LITE_RUNTIME,
+				Except:   make([]bufmoduleref.ModuleIdentity, 0),
+				Override: make(map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode),
+			},
 		},
 		PluginConfigs: []*PluginConfig{
 			{

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -496,13 +496,13 @@ func newModifier(
 		managedConfig.Override[bufimagemodify.CsharpNamespaceID],
 	)
 	modifier = bufimagemodify.Merge(modifier, csharpNamespaceModifier)
-	if managedConfig.OptimizeFor != nil {
+	if managedConfig.OptimizeForConfig != nil {
 		optimizeFor, err := bufimagemodify.OptimizeFor(
 			logger,
 			sweeper,
-			managedConfig.OptimizeFor.Default,
+			managedConfig.OptimizeForConfig.Default,
 			managedConfig.JavaPackagePrefix.Except,
-			managedConfig.OptimizeFor.Override,
+			managedConfig.OptimizeForConfig.Override,
 			managedConfig.Override[bufimagemodify.OptimizeForID],
 		)
 		if err != nil {

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -484,7 +484,9 @@ func newModifier(
 		optimizeFor, err := bufimagemodify.OptimizeFor(
 			logger,
 			sweeper,
-			*managedConfig.OptimizeFor,
+			managedConfig.OptimizeFor.Default,
+			managedConfig.JavaPackagePrefix.Except,
+			managedConfig.OptimizeFor.Override,
 			managedConfig.Override[bufimagemodify.OptimizeForID],
 		)
 		if err != nil {

--- a/private/buf/bufgen/testdata/v1/gen_success9.json
+++ b/private/buf/bufgen/testdata/v1/gen_success9.json
@@ -1,0 +1,23 @@
+{
+    "version": "v1",
+    "managed": {
+      "enabled": true,
+      "optimize_for": {
+        "default": "CODE_SIZE",
+        "except": [
+            "someremote.com/owner/repo",
+            "someremote.com/owner/foo"
+        ],
+        "override": {
+            "someremote.com/owner/bar": "SPEED",
+            "someremote.com/owner/baz": "LITE_RUNTIME"
+        }
+      }
+    },
+    "plugins": [
+      {
+        "remote": "someremote.com/owner/plugins/myplugin",
+        "out": "gen/go"
+      }
+    ]
+}

--- a/private/buf/bufgen/testdata/v1/gen_success9.yaml
+++ b/private/buf/bufgen/testdata/v1/gen_success9.yaml
@@ -1,0 +1,14 @@
+version: v1
+managed:  
+  enabled: true
+  optimize_for:
+    default: CODE_SIZE
+    except:
+      - someremote.com/owner/repo
+      - someremote.com/owner/foo
+    override:
+      someremote.com/owner/bar: SPEED
+      someremote.com/owner/baz: LITE_RUNTIME
+plugins:
+  - remote: someremote.com/owner/plugins/myplugin
+    out: gen/go

--- a/private/buf/bufgen/testdata/v1/gen_success9.yml
+++ b/private/buf/bufgen/testdata/v1/gen_success9.yml
@@ -1,0 +1,14 @@
+version: v1
+managed:  
+  enabled: true
+  optimize_for:
+    default: CODE_SIZE
+    except:
+      - someremote.com/owner/repo
+      - someremote.com/owner/foo
+    override:
+      someremote.com/owner/bar: SPEED
+      someremote.com/owner/baz: LITE_RUNTIME
+plugins:
+  - remote: someremote.com/owner/plugins/myplugin
+    out: gen/go

--- a/private/buf/bufmigrate/v1beta1_migrator.go
+++ b/private/buf/bufmigrate/v1beta1_migrator.go
@@ -356,7 +356,7 @@ func (m *v1beta1Migrator) maybeMigrateGenTemplate(dirPath string) (bool, error) 
 			Enabled:           v1beta1GenTemplate.Managed,
 			CcEnableArenas:    v1beta1GenTemplate.Options.CcEnableArenas,
 			JavaMultipleFiles: v1beta1GenTemplate.Options.JavaMultipleFiles,
-			OptimizeFor:       v1beta1GenTemplate.Options.OptimizeFor,
+			OptimizeFor:       bufgen.ExternalOptimizeForConfigV1{Default: v1beta1GenTemplate.Options.OptimizeFor},
 		},
 	}
 	for _, plugin := range v1beta1GenTemplate.Plugins {

--- a/private/buf/cmd/buf/testdata/migrate-v1beta1/success/complex/output/buf.gen.yaml
+++ b/private/buf/cmd/buf/testdata/migrate-v1beta1/success/complex/output/buf.gen.yaml
@@ -7,4 +7,5 @@ plugins:
     opt: paths=source_relative
 managed:
   enabled: true
-  optimize_for: CODE_SIZE
+  optimize_for:
+    default: CODE_SIZE

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -194,14 +194,16 @@ func JavaStringCheckUtf8(
 func OptimizeFor(
 	logger *zap.Logger,
 	sweeper Sweeper,
-	value descriptorpb.FileOptions_OptimizeMode,
+	defaultOptimizeFor descriptorpb.FileOptions_OptimizeMode,
+	except []bufmoduleref.ModuleIdentity,
+	moduleOverrides map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode,
 	overrides map[string]string,
 ) (Modifier, error) {
 	validatedOverrides, err := stringOverridesToOptimizeModeOverrides(overrides)
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", OptimizeForID, err)
 	}
-	return optimizeFor(logger, sweeper, value, validatedOverrides), nil
+	return optimizeFor(logger, sweeper, defaultOptimizeFor, validatedOverrides), nil
 }
 
 // GoPackageImportPathForFile returns the go_package import path for the given

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -203,7 +203,7 @@ func OptimizeFor(
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", OptimizeForID, err)
 	}
-	return optimizeFor(logger, sweeper, defaultOptimizeFor, validatedOverrides), nil
+	return optimizeFor(logger, sweeper, defaultOptimizeFor, except, moduleOverrides, validatedOverrides), nil
 }
 
 // GoPackageImportPathForFile returns the go_package import path for the given

--- a/private/bufpkg/bufimage/bufimagemodify/optimize_for.go
+++ b/private/bufpkg/bufimage/bufimagemodify/optimize_for.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -32,20 +33,54 @@ var optimizeForPath = []int32{8, 9}
 func optimizeFor(
 	logger *zap.Logger,
 	sweeper Sweeper,
-	value descriptorpb.FileOptions_OptimizeMode,
+	defaultOptimizeFor descriptorpb.FileOptions_OptimizeMode,
+	except []bufmoduleref.ModuleIdentity,
+	moduleOverrides map[bufmoduleref.ModuleIdentity]descriptorpb.FileOptions_OptimizeMode,
 	overrides map[string]descriptorpb.FileOptions_OptimizeMode,
 ) Modifier {
+	// Convert the bufmoduleref.ModuleIdentity types into
+	// strings so that they're comparable.
+	exceptModuleIdentityStrings := make(map[string]struct{}, len(except))
+	for _, moduleIdentity := range except {
+		exceptModuleIdentityStrings[moduleIdentity.IdentityString()] = struct{}{}
+	}
+	overrideModuleIdentityStrings := make(
+		map[string]descriptorpb.FileOptions_OptimizeMode,
+		len(moduleOverrides),
+	)
+	for moduleIdentity, optimizeFor := range moduleOverrides {
+		overrideModuleIdentityStrings[moduleIdentity.IdentityString()] = optimizeFor
+	}
 	return ModifierFunc(
 		func(ctx context.Context, image bufimage.Image) error {
+			seenModuleIdentityStrings := make(map[string]struct{}, len(overrideModuleIdentityStrings))
 			seenOverrideFiles := make(map[string]struct{}, len(overrides))
 			for _, imageFile := range image.Files() {
-				modifierValue := value
+				modifierValue := defaultOptimizeFor
+				if moduleIdentity := imageFile.ModuleIdentity(); moduleIdentity != nil {
+					moduleIdentityString := moduleIdentity.IdentityString()
+					if optimizeForOverrdie, ok := overrideModuleIdentityStrings[moduleIdentityString]; ok {
+						modifierValue = optimizeForOverrdie
+						seenModuleIdentityStrings[moduleIdentityString] = struct{}{}
+					}
+				}
 				if overrideValue, ok := overrides[imageFile.Path()]; ok {
 					modifierValue = overrideValue
 					seenOverrideFiles[imageFile.Path()] = struct{}{}
 				}
-				if err := optimizeForForFile(ctx, sweeper, imageFile, modifierValue); err != nil {
+				if err := optimizeForForFile(
+					ctx,
+					sweeper,
+					imageFile,
+					modifierValue,
+					exceptModuleIdentityStrings,
+				); err != nil {
 					return err
+				}
+			}
+			for moduleIdentityString := range overrideModuleIdentityStrings {
+				if _, ok := seenModuleIdentityStrings[moduleIdentityString]; !ok {
+					logger.Sugar().Warnf("%s override for %q was unused", moduleIdentityString)
 				}
 			}
 			for overrideFile := range overrides {
@@ -63,6 +98,7 @@ func optimizeForForFile(
 	sweeper Sweeper,
 	imageFile bufimage.ImageFile,
 	value descriptorpb.FileOptions_OptimizeMode,
+	exceptModuleIdentityStrings map[string]struct{},
 ) error {
 	descriptor := imageFile.Proto()
 	options := descriptor.GetOptions()
@@ -77,6 +113,11 @@ func optimizeForForFile(
 		// The option is not set, but the value we want to set is the
 		// same as the default, don't do anything.
 		return nil
+	}
+	if moduleIdentity := imageFile.ModuleIdentity(); moduleIdentity != nil {
+		if _, ok := exceptModuleIdentityStrings[moduleIdentity.IdentityString()]; ok {
+			return nil
+		}
 	}
 	if options == nil {
 		descriptor.Options = &descriptorpb.FileOptions{}

--- a/private/bufpkg/bufimage/bufimagemodify/optimize_for_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/optimize_for_test.go
@@ -34,7 +34,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -59,7 +59,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -80,7 +80,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -109,7 +109,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -138,7 +138,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -164,7 +164,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -185,7 +185,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -214,7 +214,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, map[string]string{"a.proto": "SPEED"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_LITE_RUNTIME, nil, nil, map[string]string{"a.proto": "SPEED"})
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -243,7 +243,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil, nil, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -269,7 +269,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil, nil, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -291,7 +291,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, optimizeForPath)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, map[string]string{"a.proto": "LITE_RUNTIME"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil, nil, map[string]string{"a.proto": "LITE_RUNTIME"})
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -319,7 +319,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, map[string]string{"a.proto": "LITE_RUNTIME"})
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil, nil, map[string]string{"a.proto": "LITE_RUNTIME"})
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),
@@ -347,7 +347,7 @@ func TestOptimizeForWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil, nil, nil)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			optimizeForModifier,
@@ -370,7 +370,7 @@ func TestOptimizeForWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil)
+		optimizeForModifier, err := OptimizeFor(zap.NewNop(), sweeper, descriptorpb.FileOptions_SPEED, nil, nil, nil)
 		require.NoError(t, err)
 		err = optimizeForModifier.Modify(
 			context.Background(),


### PR DESCRIPTION
* Add default, except override to managed mode `optimize_for` option
* preserves backward compatibility with the current `optimize_for` option being string