### PR TITLE
Enforce import grouping

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,10 +44,11 @@ linters:
     - exportloopref
     - forbidigo
     - forcetypeassert
+    - gci
     - gochecknoinits
     - gofmt
     - goheader
-    - goimports
+    # - goimports
     - gomodguard
     - goprintffuncname
     - gosec


### PR DESCRIPTION
Switch from `goimports` to `gci`, which actually enforces the import
grouping style required by Buf's style guide.
