### PR TITLE
improvements in filtering image

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -110,13 +110,13 @@ func WithAllowFilterByImportedType() ImageFilterOption {
 // those descriptors and their transitive closure of required descriptors, with
 // each file only contains the minimal required types and imports.
 //
-// Although this returns a new bufimage.Image, it mutates the original image's
-// underlying file's `descriptorpb.FileDescriptorProto` and the old image should
+// Although this returns a new [bufimage.Image], it mutates the original image's
+// underlying file's [descriptorpb.FileDescriptorProto]. So the old image should
 // not continue to be used.
 //
 // A descriptor is said to require another descriptor if the dependent
 // descriptor is needed to accurately and completely describe that descriptor.
-// For the follwing types that includes:
+// For the following types that includes:
 //
 //	Messages
 //	 - messages & enums referenced in fields
@@ -177,6 +177,9 @@ func ImageFilteredByTypes(image bufimage.Image, types ...string) (bufimage.Image
 	return ImageFilteredByTypesWithOptions(image, types)
 }
 
+// ImageFilteredByTypesWithOptions returns a minimal image containing only the descriptors
+// required to define those types. See ImageFilteredByTypes for more details. This version
+// allows for customizing the behavior with options.
 func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts ...ImageFilterOption) (bufimage.Image, error) {
 	options := newImageFilterOptions()
 	for _, o := range opts {
@@ -201,46 +204,26 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 		startingDescriptors = append(startingDescriptors, startingDescriptor)
 	}
 	// Find all types to include in filtered image.
-	seen := make(map[string]struct{})
-	neededDescriptors := []descriptorAndDirects{}
+	closure := newTransitiveClosure()
 	for _, startingDescriptor := range startingDescriptors {
-		closure, err := descriptorTransitiveClosure(startingDescriptor, imageIndex, seen, options)
-		if err != nil {
+		if err := closure.addElement(startingDescriptor, "", imageIndex, options); err != nil {
 			return nil, err
 		}
-		neededDescriptors = append(neededDescriptors, closure...)
-	}
-	descriptorsByFile := make(map[string][]descriptorAndDirects)
-	for _, descriptor := range neededDescriptors {
-		typeInfo := imageIndex.ByDescriptor[descriptor.Descriptor]
-		descriptorsByFile[typeInfo.file] = append(descriptorsByFile[typeInfo.file], descriptor)
 	}
 	// Create a new image with only the required descriptors.
 	var includedFiles []bufimage.ImageFile
 	for _, imageFile := range image.Files() {
-		descriptors, ok := descriptorsByFile[imageFile.Path()]
+		_, ok := closure.files[imageFile.Path()]
 		if !ok {
 			continue
 		}
-
-		importsRequired := make(map[string]struct{})
-		typesToKeep := make(map[string]struct{})
-		for _, descriptor := range descriptors {
-			typeInfo := imageIndex.ByDescriptor[descriptor.Descriptor]
-			typesToKeep[typeInfo.fullName] = struct{}{}
-			for _, importedDescriptor := range descriptor.Directs {
-				importedInfo := imageIndex.ByDescriptor[importedDescriptor]
-				if importedInfo.file != typeInfo.file {
-					importsRequired[importedInfo.file] = struct{}{}
-				}
-			}
-		}
-
 		includedFiles = append(includedFiles, imageFile)
 		imageFileDescriptor := imageFile.Proto()
+
+		importsRequired := closure.imports[imageFile.Path()]
 		// While employing
 		// https://github.com/golang/go/wiki/SliceTricks#filter-in-place,
-		// also keep a record of which index moved where so we can fixup
+		// also keep a record of which index moved where, so we can fixup
 		// the file's WeakDependency field.
 		indexFromTo := make(map[int32]int32)
 		indexTo := 0
@@ -272,29 +255,24 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 		}
 		imageFileDescriptor.WeakDependency = imageFileDescriptor.WeakDependency[:i]
 
-		prefix := ""
-		if imageFileDescriptor.Package != nil {
-			prefix = imageFileDescriptor.GetPackage() + "."
-		}
-		trimMessages, err := trimMessageDescriptor(imageFileDescriptor.MessageType, prefix, typesToKeep)
+		trimMessages, err := trimMessageDescriptor(imageFileDescriptor.MessageType, closure.elements)
 		if err != nil {
 			return nil, err
 		}
 		imageFileDescriptor.MessageType = trimMessages
-		trimEnums, err := trimEnumDescriptor(imageFileDescriptor.EnumType, prefix, typesToKeep)
+		trimEnums, err := trimEnumDescriptor(imageFileDescriptor.EnumType, closure.elements)
 		if err != nil {
 			return nil, err
 		}
 		imageFileDescriptor.EnumType = trimEnums
-		trimExtensions, err := trimExtensionDescriptors(imageFileDescriptor.Extension, prefix, typesToKeep)
+		trimExtensions, err := trimExtensionDescriptors(imageFileDescriptor.Extension, closure.elements)
 		if err != nil {
 			return nil, err
 		}
 		imageFileDescriptor.Extension = trimExtensions
 		i = 0
 		for _, serviceDescriptor := range imageFileDescriptor.Service {
-			name := prefix + serviceDescriptor.GetName()
-			if _, ok := typesToKeep[name]; ok {
+			if _, ok := closure.elements[serviceDescriptor]; ok {
 				imageFileDescriptor.Service[i] = serviceDescriptor
 				i++
 			}
@@ -310,22 +288,21 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 
 // trimMessageDescriptor removes (nested) messages and nested enums from a slice
 // of message descriptors if their type names are not found in the toKeep map.
-func trimMessageDescriptor(in []*descriptorpb.DescriptorProto, prefix string, toKeep map[string]struct{}) ([]*descriptorpb.DescriptorProto, error) {
+func trimMessageDescriptor(in []*descriptorpb.DescriptorProto, toKeep map[namedDescriptor]struct{}) ([]*descriptorpb.DescriptorProto, error) {
 	i := 0
 	for _, messageDescriptor := range in {
-		name := prefix + messageDescriptor.GetName()
-		if _, ok := toKeep[name]; ok {
-			trimMessages, err := trimMessageDescriptor(messageDescriptor.NestedType, name+".", toKeep)
+		if _, ok := toKeep[messageDescriptor]; ok {
+			trimMessages, err := trimMessageDescriptor(messageDescriptor.NestedType, toKeep)
 			if err != nil {
 				return nil, err
 			}
 			messageDescriptor.NestedType = trimMessages
-			trimEnums, err := trimEnumDescriptor(messageDescriptor.EnumType, name+".", toKeep)
+			trimEnums, err := trimEnumDescriptor(messageDescriptor.EnumType, toKeep)
 			if err != nil {
 				return nil, err
 			}
 			messageDescriptor.EnumType = trimEnums
-			trimExtensions, err := trimExtensionDescriptors(messageDescriptor.Extension, name+".", toKeep)
+			trimExtensions, err := trimExtensionDescriptors(messageDescriptor.Extension, toKeep)
 			if err != nil {
 				return nil, err
 			}
@@ -339,11 +316,10 @@ func trimMessageDescriptor(in []*descriptorpb.DescriptorProto, prefix string, to
 
 // trimEnumDescriptor removes enums from a slice of enum descriptors if their
 // type names are not found in the toKeep map.
-func trimEnumDescriptor(in []*descriptorpb.EnumDescriptorProto, prefix string, toKeep map[string]struct{}) ([]*descriptorpb.EnumDescriptorProto, error) {
+func trimEnumDescriptor(in []*descriptorpb.EnumDescriptorProto, toKeep map[namedDescriptor]struct{}) ([]*descriptorpb.EnumDescriptorProto, error) {
 	i := 0
 	for _, enumDescriptor := range in {
-		name := prefix + enumDescriptor.GetName()
-		if _, ok := toKeep[name]; ok {
+		if _, ok := toKeep[enumDescriptor]; ok {
 			in[i] = enumDescriptor
 			i++
 		}
@@ -353,11 +329,10 @@ func trimEnumDescriptor(in []*descriptorpb.EnumDescriptorProto, prefix string, t
 
 // trimExtensionDescriptors removes fields from a slice of field descriptors if their
 // type names are not found in the toKeep map.
-func trimExtensionDescriptors(in []*descriptorpb.FieldDescriptorProto, prefix string, toKeep map[string]struct{}) ([]*descriptorpb.FieldDescriptorProto, error) {
+func trimExtensionDescriptors(in []*descriptorpb.FieldDescriptorProto, toKeep map[namedDescriptor]struct{}) ([]*descriptorpb.FieldDescriptorProto, error) {
 	i := 0
 	for _, fieldDescriptor := range in {
-		name := prefix + fieldDescriptor.GetName()
-		if _, ok := toKeep[name]; ok {
+		if _, ok := toKeep[fieldDescriptor]; ok {
 			in[i] = fieldDescriptor
 			i++
 		}
@@ -365,29 +340,62 @@ func trimExtensionDescriptors(in []*descriptorpb.FieldDescriptorProto, prefix st
 	return in[:i], nil
 }
 
-// descriptorAndDirects holds a protosource.NamedDescriptor and a list of all
-// named descriptors it directly references. A directly referenced dependency is
-// any type that if defined in a different file from the principal descriptor,
-// an import statement would be required for the proto to compile.
-type descriptorAndDirects struct {
-	Descriptor namedDescriptor
-	Directs    []namedDescriptor
+// transitiveClosure accumulates the elements, files, and needed imports for a
+// subset of an image. When an element is added to the closure, all of its
+// dependencies are recursively added.
+type transitiveClosure struct {
+	elements map[namedDescriptor]struct{}
+	files    map[string]struct{}
+	imports  map[string]map[string]struct{}
 }
 
-func descriptorTransitiveClosure(
-	descriptor namedDescriptor,
-	imageIndex *imageIndex,
-	seen map[string]struct{},
-	opts *imageFilterOptions,
-) ([]descriptorAndDirects, error) {
-	descriptorInfo := imageIndex.ByDescriptor[descriptor]
-	if _, ok := seen[descriptorInfo.fullName]; ok {
-		return nil, nil
+func newTransitiveClosure() *transitiveClosure {
+	return &transitiveClosure{
+		elements: map[namedDescriptor]struct{}{},
+		files:    map[string]struct{}{},
+		imports:  map[string]map[string]struct{}{},
 	}
-	seen[descriptorInfo.fullName] = struct{}{}
+}
 
-	var directDependencies []namedDescriptor
-	var transitiveDependencies []descriptorAndDirects
+func (t *transitiveClosure) addImport(fromPath, toPath string) {
+	if fromPath == toPath {
+		return // no need for a file to import itself
+	}
+	imps := t.imports[fromPath]
+	if imps == nil {
+		imps = map[string]struct{}{}
+		t.imports[fromPath] = imps
+	}
+	imps[toPath] = struct{}{}
+}
+
+func (t *transitiveClosure) addFile(file string, imageIndex *imageIndex, opts *imageFilterOptions) error {
+	if _, ok := t.files[file]; ok {
+		return nil // already added
+	}
+	t.files[file] = struct{}{}
+	return t.exploreCustomOptions(imageIndex.Files[file], file, imageIndex, opts)
+}
+
+func (t *transitiveClosure) addElement(
+	descriptor namedDescriptor,
+	referrerFile string,
+	imageIndex *imageIndex,
+	opts *imageFilterOptions,
+) error {
+	descriptorInfo := imageIndex.ByDescriptor[descriptor]
+	if err := t.addFile(descriptorInfo.file, imageIndex, opts); err != nil {
+		return err
+	}
+	if referrerFile != "" {
+		t.addImport(referrerFile, descriptorInfo.file)
+	}
+
+	if _, ok := t.elements[descriptor]; ok {
+		return nil // already added this element
+	}
+	t.elements[descriptor] = struct{}{}
+
 	switch typedDescriptor := descriptor.(type) {
 	case *descriptorpb.DescriptorProto:
 		for _, field := range typedDescriptor.GetField() {
@@ -398,14 +406,11 @@ func descriptorTransitiveClosure(
 				typeName := strings.TrimPrefix(field.GetTypeName(), ".")
 				typeDescriptor, ok := imageIndex.ByName[typeName]
 				if !ok {
-					return nil, fmt.Errorf("missing %q", typeName)
+					return fmt.Errorf("missing %q", typeName)
 				}
-				directDependencies = append(directDependencies, typeDescriptor)
-				recursiveDescriptors, err := descriptorTransitiveClosure(typeDescriptor, imageIndex, seen, opts)
-				if err != nil {
-					return nil, err
+				if err := t.addElement(typeDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+					return err
 				}
-				transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 			case descriptorpb.FieldDescriptorProto_TYPE_DOUBLE,
 				descriptorpb.FieldDescriptorProto_TYPE_FLOAT,
 				descriptorpb.FieldDescriptorProto_TYPE_INT64,
@@ -424,15 +429,12 @@ func descriptorTransitiveClosure(
 				// nothing to explore for the field type, but
 				// there might be custom field options
 			default:
-				return nil, fmt.Errorf("unknown field type %d", field.GetType())
+				return fmt.Errorf("unknown field type %d", field.GetType())
 			}
-			// fieldoptions
-			explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(field, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			// Field options
+			if err := t.exploreCustomOptions(field, descriptorInfo.file, imageIndex, opts); err != nil {
+				return err
 			}
-			directDependencies = append(directDependencies, explicitOptionDeps...)
-			transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 		}
 		// Extensions declared for this message.
 		// TODO: We currently exclude all extensions for descriptor options types (and instead
@@ -440,11 +442,9 @@ func descriptorTransitiveClosure(
 		//  type were a named type for filtering, we SHOULD include all of them.
 		if opts.includeKnownExtensions && !isOptionsTypeName(descriptorInfo.fullName) {
 			for _, extendsDescriptor := range imageIndex.NameToExtensions[descriptorInfo.fullName] {
-				recursiveDescriptors, err := descriptorTransitiveClosure(extendsDescriptor, imageIndex, seen, opts)
-				if err != nil {
-					return nil, err
+				if err := t.addElement(extendsDescriptor, "", imageIndex, opts); err != nil {
+					return err
 				}
-				transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 			}
 		}
 		// Messages in which this message is nested
@@ -453,141 +453,100 @@ func descriptorTransitiveClosure(
 			//  referenced by other parts of the schema. As a reference from a nested message, we
 			//  only care about it as a namespace (so all of its other elements, aside from needed
 			//  nested types, could be omitted).
-			directDependencies = append(directDependencies, descriptorInfo.parent)
-			recursiveDescriptors, err := descriptorTransitiveClosure(descriptorInfo.parent, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			if err := t.addElement(descriptorInfo.parent, "", imageIndex, opts); err != nil {
+				return err
 			}
-			transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 		}
 		// Options for all oneofs in this message
 		for _, oneOfDescriptor := range typedDescriptor.GetOneofDecl() {
-			explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(oneOfDescriptor, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			if err := t.exploreCustomOptions(oneOfDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+				return err
 			}
-			directDependencies = append(directDependencies, explicitOptionDeps...)
-			transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 		}
 		// Options for all extension ranges in this message
 		for _, extRange := range typedDescriptor.GetExtensionRange() {
-			explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(extRange, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			if err := t.exploreCustomOptions(extRange, descriptorInfo.file, imageIndex, opts); err != nil {
+				return err
 			}
-			directDependencies = append(directDependencies, explicitOptionDeps...)
-			transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 		}
-		// Options
-		explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(typedDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		// Message options
+		if err := t.exploreCustomOptions(typedDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		directDependencies = append(directDependencies, explicitOptionDeps...)
-		transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 	case *descriptorpb.EnumDescriptorProto:
 		// Parent messages
 		if _, ok := descriptorInfo.parent.(*descriptorpb.DescriptorProto); ok {
 			// TODO: ditto above: unless the parent message is used elsewhere, we don't need the
 			//  entire message; we only need it as a placeholder for namespacing.
-			directDependencies = append(directDependencies, descriptorInfo.parent)
-			recursiveDescriptors, err := descriptorTransitiveClosure(descriptorInfo.parent, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			if err := t.addElement(descriptorInfo.parent, "", imageIndex, opts); err != nil {
+				return err
 			}
-			transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 		}
 		for _, enumValue := range typedDescriptor.GetValue() {
-			explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(enumValue, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			if err := t.exploreCustomOptions(enumValue, descriptorInfo.file, imageIndex, opts); err != nil {
+				return err
 			}
-			directDependencies = append(directDependencies, explicitOptionDeps...)
-			transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 		}
-		// Options
-		explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(typedDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		// Enum options
+		if err := t.exploreCustomOptions(typedDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		directDependencies = append(directDependencies, explicitOptionDeps...)
-		transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 	case *descriptorpb.ServiceDescriptorProto:
 		for _, method := range typedDescriptor.GetMethod() {
-			directDependencies = append(directDependencies, method)
-			recursiveDescriptors, err := descriptorTransitiveClosure(method, imageIndex, seen, opts)
-			if err != nil {
-				return nil, err
+			if err := t.addElement(method, "", imageIndex, opts); err != nil {
+				return err
 			}
-			transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 		}
-		// Options
-		explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(typedDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		// Service options
+		if err := t.exploreCustomOptions(typedDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		directDependencies = append(directDependencies, explicitOptionDeps...)
-		transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 	case *descriptorpb.MethodDescriptorProto:
 		// in case method was directly named as a filter type, make sure we include parent service
 		// TODO: if the service is not also named as a filter type, we could prune the service down
 		//  to only the named methods and shrink the size of the filtered image further.
-		recursiveDescriptors, err := descriptorTransitiveClosure(descriptorInfo.parent, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		if err := t.addElement(descriptorInfo.parent, "", imageIndex, opts); err != nil {
+			return err
 		}
-		transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 
 		inputName := strings.TrimPrefix(typedDescriptor.GetInputType(), ".")
 		inputDescriptor, ok := imageIndex.ByName[inputName]
 		if !ok {
-			return nil, fmt.Errorf("missing %q", inputName)
+			return fmt.Errorf("missing %q", inputName)
 		}
-		recursiveDescriptorsIn, err := descriptorTransitiveClosure(inputDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		if err := t.addElement(inputDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		transitiveDependencies = append(transitiveDependencies, recursiveDescriptorsIn...)
-		directDependencies = append(directDependencies, inputDescriptor)
 
 		outputName := strings.TrimPrefix(typedDescriptor.GetOutputType(), ".")
 		outputDescriptor, ok := imageIndex.ByName[outputName]
 		if !ok {
-			return nil, fmt.Errorf("missing %q", outputName)
+			return fmt.Errorf("missing %q", outputName)
 		}
-		recursiveDescriptorsOut, err := descriptorTransitiveClosure(outputDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		if err := t.addElement(outputDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		transitiveDependencies = append(transitiveDependencies, recursiveDescriptorsOut...)
-		directDependencies = append(directDependencies, outputDescriptor)
 
-		// options
-		explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(typedDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		// Method options
+		if err := t.exploreCustomOptions(typedDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		directDependencies = append(directDependencies, explicitOptionDeps...)
-		transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 
 	case *descriptorpb.FieldDescriptorProto:
 		// Regular fields get handled by protosource.Message, only
 		// protosource.Fields's for extends definitions should reach
 		// here.
 		if typedDescriptor.GetExtendee() == "" {
-			return nil, fmt.Errorf("expected extendee for field %q to not be empty", descriptorInfo.fullName)
+			return fmt.Errorf("expected extendee for field %q to not be empty", descriptorInfo.fullName)
 		}
 		extendeeName := strings.TrimPrefix(typedDescriptor.GetExtendee(), ".")
 		extendeeDescriptor, ok := imageIndex.ByName[extendeeName]
 		if !ok {
-			return nil, fmt.Errorf("missing %q", extendeeName)
+			return fmt.Errorf("missing %q", extendeeName)
 		}
-		directDependencies = append(directDependencies, extendeeDescriptor)
-		recursiveDescriptors, err := descriptorTransitiveClosure(extendeeDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		if err := t.addElement(extendeeDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 
 		switch typedDescriptor.GetType() {
 		case descriptorpb.FieldDescriptorProto_TYPE_ENUM,
@@ -596,14 +555,12 @@ func descriptorTransitiveClosure(
 			typeName := strings.TrimPrefix(typedDescriptor.GetTypeName(), ".")
 			typeDescriptor, ok := imageIndex.ByName[typeName]
 			if !ok {
-				return nil, fmt.Errorf("missing %q", typeName)
+				return fmt.Errorf("missing %q", typeName)
 			}
-			directDependencies = append(directDependencies, typeDescriptor)
-			recursiveDescriptors, err := descriptorTransitiveClosure(typeDescriptor, imageIndex, seen, opts)
+			err := t.addElement(typeDescriptor, descriptorInfo.file, imageIndex, opts)
 			if err != nil {
-				return nil, err
+				return err
 			}
-			transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
 		case descriptorpb.FieldDescriptorProto_TYPE_DOUBLE,
 			descriptorpb.FieldDescriptorProto_TYPE_FLOAT,
 			descriptorpb.FieldDescriptorProto_TYPE_INT64,
@@ -621,44 +578,27 @@ func descriptorTransitiveClosure(
 			descriptorpb.FieldDescriptorProto_TYPE_SINT64:
 			// nothing to follow, custom options handled below.
 		default:
-			return nil, fmt.Errorf("unknown field type %d", typedDescriptor.GetType())
+			return fmt.Errorf("unknown field type %d", typedDescriptor.GetType())
 		}
-		explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(typedDescriptor, imageIndex, seen, opts)
-		if err != nil {
-			return nil, err
+		if err := t.exploreCustomOptions(typedDescriptor, descriptorInfo.file, imageIndex, opts); err != nil {
+			return err
 		}
-		directDependencies = append(directDependencies, explicitOptionDeps...)
-		transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
 	default:
-		return nil, fmt.Errorf("unexpected protosource type %T", typedDescriptor)
+		return fmt.Errorf("unexpected protosource type %T", typedDescriptor)
 	}
 
-	fileDescriptor := imageIndex.Files[descriptorInfo.file]
-	explicitOptionDeps, recursedOptionDeps, err := exploreCustomOptions(fileDescriptor, imageIndex, seen, opts)
-	if err != nil {
-		return nil, err
-	}
-	directDependencies = append(directDependencies, explicitOptionDeps...)
-	transitiveDependencies = append(transitiveDependencies, recursedOptionDeps...)
-
-	return append(
-		transitiveDependencies,
-		descriptorAndDirects{Descriptor: descriptor, Directs: directDependencies},
-	), nil
+	return nil
 }
 
-func exploreCustomOptions(
+func (t *transitiveClosure) exploreCustomOptions(
 	descriptor proto.Message,
+	referrerFile string,
 	imageIndex *imageIndex,
-	seen map[string]struct{},
 	opts *imageFilterOptions,
-) ([]namedDescriptor, []descriptorAndDirects, error) {
+) error {
 	if !opts.includeCustomOptions {
-		return nil, nil, nil
+		return nil
 	}
-
-	var directDependencies []namedDescriptor
-	var transitiveDependencies []descriptorAndDirects
 
 	var options protoreflect.Message
 	switch descriptor := descriptor.(type) {
@@ -681,7 +621,7 @@ func exploreCustomOptions(
 	case *descriptorpb.DescriptorProto_ExtensionRange:
 		options = descriptor.GetOptions().ProtoReflect()
 	default:
-		return nil, nil, fmt.Errorf("unexpected type for exploring options %T", descriptor)
+		return fmt.Errorf("unexpected type for exploring options %T", descriptor)
 	}
 
 	optionsName := string(options.Descriptor().FullName())
@@ -696,19 +636,10 @@ func exploreCustomOptions(
 			err = fmt.Errorf("cannot find ext no %d on %s", fd.Number(), optionsName)
 			return false
 		}
-		directDependencies = append(directDependencies, field)
-		recursiveDescriptors, recurseErr := descriptorTransitiveClosure(field, imageIndex, seen, opts)
-		if recurseErr != nil {
-			err = recurseErr
-			return false
-		}
-		transitiveDependencies = append(transitiveDependencies, recursiveDescriptors...)
-		return true
+		err = t.addElement(field, referrerFile, imageIndex, opts)
+		return err == nil
 	})
-	if err != nil {
-		return nil, nil, err
-	}
-	return directDependencies, transitiveDependencies, nil
+	return err
 }
 
 func freeMessageRangeStringsRec(

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -17,7 +17,9 @@ package bufimageutil
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"os"
 	"sort"
 	"testing"
 
@@ -32,8 +34,11 @@ import (
 	"github.com/jhump/protoreflect/desc/protoprint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/tools/txtar"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 const shouldUpdateExpectations = false
@@ -164,23 +169,37 @@ func TestTypesFromMainModule(t *testing.T) {
 	assert.ErrorIs(t, err, ErrImageFilterTypeNotFound)
 }
 
-func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedFile string, opts ...ImageFilterOption) {
-	ctx := context.Background()
+func getImage(ctx context.Context, logger *zap.Logger, testdataDir string) (storage.ReadWriteBucket, bufimage.Image, error) {
 	bucket, err := storageos.NewProvider().NewReadWriteBucket(testdataDir)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, nil, err
+	}
 	module, err := bufmodule.NewModuleForBucket(
 		ctx,
 		storage.MapReadBucket(bucket, storage.MatchPathExt(".proto")),
 	)
-	require.NoError(t, err)
-	builder := bufimagebuild.NewBuilder(zaptest.NewLogger(t))
+	if err != nil {
+		return nil, nil, err
+	}
+	builder := bufimagebuild.NewBuilder(logger)
 	image, analysis, err := builder.Build(
 		ctx,
 		bufmodule.NewModuleFileSet(module, nil),
 		bufimagebuild.WithExcludeSourceCodeInfo(),
 	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(analysis) > 0 {
+		return nil, nil, fmt.Errorf("%d errors in source when building", len(analysis))
+	}
+	return bucket, image, nil
+}
+
+func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedFile string, opts ...ImageFilterOption) {
+	ctx := context.Background()
+	bucket, image, err := getImage(ctx, zaptest.NewLogger(t), testdataDir)
 	require.NoError(t, err)
-	require.Empty(t, analysis)
 
 	filteredImage, err := ImageFilteredByTypesWithOptions(image, typenames, opts...)
 	require.NoError(t, err)
@@ -236,4 +255,76 @@ func imageIsDependencyOrdered(image bufimage.Image) bool {
 		seen[file.Path()] = struct{}{}
 	}
 	return true
+}
+
+var benchmarkCases = []*struct {
+	folder string
+	image  bufimage.Image
+	types  []string
+}{
+	{
+		folder: "testdata/extensions",
+		types:  []string{"pkg.Foo"},
+	},
+	{
+		folder: "testdata/importmods",
+		types:  []string{"ImportRegular", "ImportWeak", "ImportPublic", "NoImports"},
+	},
+	{
+		folder: "testdata/nesting",
+		types:  []string{"pkg.Foo", "pkg.Foo.NestedFoo.NestedNestedFoo", "pkg.Baz", "pkg.FooEnum"},
+	},
+	{
+		folder: "testdata/options",
+		types:  []string{"pkg.Foo", "pkg.FooEnum", "pkg.FooService", "pkg.FooService.Do"},
+	},
+}
+
+func TestMain(m *testing.M) {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to create logger: %v", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
+	for _, benchmarkCase := range benchmarkCases {
+		_, image, err := getImage(ctx, logger, benchmarkCase.folder)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "failed to create image for %q: %v", benchmarkCase.folder, err)
+			os.Exit(1)
+		}
+		benchmarkCase.image = image
+	}
+	returnCode := m.Run()
+	os.Exit(returnCode)
+}
+
+func BenchmarkFilterImage(b *testing.B) {
+	i := 0
+	for {
+		for _, benchmarkCase := range benchmarkCases {
+			for _, typeName := range benchmarkCase.types {
+				// filtering is destructive, so we have to make a copy
+				b.StopTimer()
+				imageFiles := make([]bufimage.ImageFile, len(benchmarkCase.image.Files()))
+				for j, file := range benchmarkCase.image.Files() {
+					clone, ok := proto.Clone(file.Proto()).(*descriptorpb.FileDescriptorProto)
+					require.True(b, ok)
+					var err error
+					imageFiles[j], err = bufimage.NewImageFile(clone, nil, "", "", false, false, nil)
+					require.NoError(b, err)
+				}
+				image, err := bufimage.NewImage(imageFiles)
+				require.NoError(b, err)
+				b.StartTimer()
+
+				_, err = ImageFilteredByTypes(image, typeName)
+				require.NoError(b, err)
+				i++
+				if i == b.N {
+					return
+				}
+			}
+		}
+	}
 }

--- a/private/bufpkg/bufimage/bufimageutil/image_index.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_index.go
@@ -16,110 +16,120 @@ package bufimageutil
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/pkg/protosource"
+	"github.com/bufbuild/protocompile/walk"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
-// imageIndex holds an index of fully qualified type names to various
-// protosource descriptors.
+// imageIndex holds an index that allows for easily navigating a descriptor
+// hierarchy and its relationships.
 type imageIndex struct {
-	// NameToDescriptor maps fully qualified type names to a NamedDescriptor
-	// and can be used to lookup Descriptors referenced by other
-	// descriptor's fields like `Extendee`, `Parent`, `InputType`, etc.
-	NameToDescriptor map[string]protosource.NamedDescriptor
+	// ByDescriptor maps descriptor proto pointers to information about the
+	// element. The info includes the actual descriptor proto, its parent
+	// element (if it has one), and the file in which it is defined.
+	ByDescriptor map[namedDescriptor]elementInfo
+	// ByName maps fully qualified type names to information about the named
+	// element.
+	ByName map[string]namedDescriptor
+	// Files maps fully qualified type names to the path of the file that
+	// declares the type.
+	Files map[string]*descriptorpb.FileDescriptorProto
 
 	// NameToExtensions maps fully qualified type names to all known
 	// extension definitions for a type name.
-	NameToExtensions map[string][]protosource.Field
+	NameToExtensions map[string][]*descriptorpb.FieldDescriptorProto
 
 	// NameToOptions maps `google.protobuf.*Options` type names to their
 	// known extensions by field tag.
-	NameToOptions map[string]map[int32]protosource.Field
+	NameToOptions map[string]map[int32]*descriptorpb.FieldDescriptorProto
+}
+
+type namedDescriptor interface {
+	proto.Message
+	GetName() string
+}
+
+var _ namedDescriptor = (*descriptorpb.FileDescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.DescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.FieldDescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.OneofDescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.EnumDescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.EnumValueDescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.ServiceDescriptorProto)(nil)
+var _ namedDescriptor = (*descriptorpb.MethodDescriptorProto)(nil)
+
+type elementInfo struct {
+	fullName, file string
+	parent         namedDescriptor
 }
 
 // newImageIndexForImage builds an imageIndex for a given image.
 func newImageIndexForImage(image bufimage.Image, opts *imageFilterOptions) (*imageIndex, error) {
 	index := &imageIndex{
-		NameToDescriptor: make(map[string]protosource.NamedDescriptor),
+		ByName:       make(map[string]namedDescriptor),
+		ByDescriptor: make(map[namedDescriptor]elementInfo),
+		Files:        make(map[string]*descriptorpb.FileDescriptorProto),
 	}
 	if opts.includeCustomOptions {
-		index.NameToOptions = make(map[string]map[int32]protosource.Field)
+		index.NameToOptions = make(map[string]map[int32]*descriptorpb.FieldDescriptorProto)
 	}
 	if opts.includeKnownExtensions {
-		index.NameToExtensions = make(map[string][]protosource.Field)
+		index.NameToExtensions = make(map[string][]*descriptorpb.FieldDescriptorProto)
 	}
 
 	for _, file := range image.Files() {
-		// TODO: protosource.File is a heavyweight representation, and NewFile is not a cheap
-		//  operation. We only really need to gather fully-qualified names for each element
-		//  and to have some minimal level of upward references (e.g. access a descriptor's
-		//  parent element), which could be done with a far more efficient representation.
-		protosourceFile, err := protosource.NewFile(newInputFile(file))
-		if err != nil {
-			return nil, err
-		}
-		if err := protosource.ForEachMessage(func(message protosource.Message) error {
-			if storedDescriptor, ok := index.NameToDescriptor[message.FullName()]; ok && storedDescriptor != message {
-				return fmt.Errorf("duplicate for %q: %#v != %#v", message.FullName(), storedDescriptor, message)
+		fileName := file.Path()
+		fileDescriptorProto := file.Proto()
+		index.Files[fileName] = fileDescriptorProto
+		err := walk.DescriptorProtos(fileDescriptorProto, func(name protoreflect.FullName, msg proto.Message) error {
+			if _, ok := index.ByName[string(name)]; ok {
+				return fmt.Errorf("duplicate for %q", name)
 			}
-			index.NameToDescriptor[message.FullName()] = message
-			if !opts.includeKnownExtensions && !opts.includeCustomOptions {
+			descriptor, ok := msg.(namedDescriptor)
+			if !ok {
+				return fmt.Errorf("unexpected descriptor type %T", msg)
+			}
+			var parent namedDescriptor
+			if pos := strings.LastIndexByte(string(name), '.'); pos != -1 {
+				parent = index.ByName[string(name[:pos])]
+				if parent == nil {
+					// parent name was a package name, not an element name
+					parent = fileDescriptorProto
+				}
+			}
+
+			index.ByName[string(name)] = descriptor
+			index.ByDescriptor[descriptor] = elementInfo{
+				fullName: string(name),
+				parent:   parent,
+				file:     fileName,
+			}
+
+			ext, ok := descriptor.(*descriptorpb.FieldDescriptorProto)
+			if !ok || ext.Extendee == nil {
+				// not an extension, so the rest does not apply
 				return nil
 			}
-			for _, field := range message.Extensions() {
-				index.NameToDescriptor[field.FullName()] = field
-				extendeeName := field.Extendee()
-				if opts.includeCustomOptions && isOptionsTypeName(extendeeName) {
-					if _, ok := index.NameToOptions[extendeeName]; !ok {
-						index.NameToOptions[extendeeName] = make(map[int32]protosource.Field)
-					}
-					index.NameToOptions[extendeeName][int32(field.Number())] = field
-				}
-				if opts.includeKnownExtensions {
-					index.NameToExtensions[extendeeName] = append(index.NameToExtensions[extendeeName], field)
-				}
-			}
-			return nil
-		}, protosourceFile); err != nil {
-			return nil, err
-		}
-		if err = protosource.ForEachEnum(func(enum protosource.Enum) error {
-			if storedDescriptor, ok := index.NameToDescriptor[enum.FullName()]; ok {
-				return fmt.Errorf("duplicate for %q: %#v != %#v", enum.FullName(), storedDescriptor, enum)
-			}
-			index.NameToDescriptor[enum.FullName()] = enum
-			return nil
-		}, protosourceFile); err != nil {
-			return nil, err
-		}
-		for _, service := range protosourceFile.Services() {
-			if storedDescriptor, ok := index.NameToDescriptor[service.FullName()]; ok {
-				return nil, fmt.Errorf("duplicate for %q: %#v != %#v", service.FullName(), storedDescriptor, service)
-			}
-			index.NameToDescriptor[service.FullName()] = service
-			for _, method := range service.Methods() {
-				if storedDescriptor, ok := index.NameToDescriptor[method.FullName()]; ok {
-					return nil, fmt.Errorf("duplicate for %q: %#v != %#v", method.FullName(), storedDescriptor, method)
-				}
-				index.NameToDescriptor[method.FullName()] = method
-			}
-		}
-		if !opts.includeKnownExtensions && !opts.includeCustomOptions {
-			continue
-		}
-		for _, field := range protosourceFile.Extensions() {
-			index.NameToDescriptor[field.FullName()] = field
-			extendeeName := field.Extendee()
+
+			extendeeName := strings.TrimPrefix(ext.GetExtendee(), ".")
 			if opts.includeCustomOptions && isOptionsTypeName(extendeeName) {
 				if _, ok := index.NameToOptions[extendeeName]; !ok {
-					index.NameToOptions[extendeeName] = make(map[int32]protosource.Field)
+					index.NameToOptions[extendeeName] = make(map[int32]*descriptorpb.FieldDescriptorProto)
 				}
-				index.NameToOptions[extendeeName][int32(field.Number())] = field
+				index.NameToOptions[extendeeName][ext.GetNumber()] = ext
 			}
 			if opts.includeKnownExtensions {
-				index.NameToExtensions[extendeeName] = append(index.NameToExtensions[extendeeName], field)
+				index.NameToExtensions[extendeeName] = append(index.NameToExtensions[extendeeName], ext)
 			}
+
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 	return index, nil
@@ -131,6 +141,7 @@ func isOptionsTypeName(typeName string) bool {
 		"google.protobuf.MessageOptions",
 		"google.protobuf.FieldOptions",
 		"google.protobuf.OneofOptions",
+		"google.protobuf.ExtensionRangeOptions",
 		"google.protobuf.EnumOptions",
 		"google.protobuf.EnumValueOptions",
 		"google.protobuf.ServiceOptions",

--- a/private/bufpkg/bufimage/bufimageutil/image_index.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_index.go
@@ -86,7 +86,7 @@ func newImageIndexForImage(image bufimage.Image, opts *imageFilterOptions) (*ima
 		fileDescriptorProto := file.Proto()
 		index.Files[fileName] = fileDescriptorProto
 		err := walk.DescriptorProtos(fileDescriptorProto, func(name protoreflect.FullName, msg proto.Message) error {
-			if _, ok := index.ByName[string(name)]; ok {
+			if existing := index.ByName[string(name)]; existing != nil {
 				return fmt.Errorf("duplicate for %q", name)
 			}
 			descriptor, ok := msg.(namedDescriptor)


### PR DESCRIPTION
This addresses a TODO about using the `protosource` model. The assumption in that TODO was that it was heavy-weight. 

So this PR first adds a benchmark (see first commit), to evaluate if the change actually improves performance.

The second commit is the change that addresses the TODO (which did have an impact on performance). It adds more information to the `imageIndex` so that the descriptor protos can be used, instead of having to first wrap the whole hierarchy in `protosource` types.

The third commit is another change that IMO makes the code easier to read, but also improves performance a little further by keeping accumulator variables in a new `transitiveClosure` struct, instead of each recursive call having to repeatedly concatenate slices. This is also a pre-factor for addressing other TODOs, which will require tracking new state, which is much easier to add with this new approach, instead of having to change the return values and then update the accumulation logic at many recursive call sites. It also removes some redundant tracking: we were tracking the visited elements in both the returned `descriptorAndDependents` type and in the `seen` map. Now it's just a map in the `transitiveClosure` struct, and imports are tracked differently.

Benchmark results at the start (i.e. for the current implementation on `main`):
```
BenchmarkFilterImage-10    	   15546	     76453 ns/op	   83676 B/op	    2222 allocs/op
```
After the first commit (to just use descriptor protos instead of `protosource`):
```
BenchmarkFilterImage-10    	   21099	     55813 ns/op	   55538 B/op	     306 allocs/op
```
And after introducing the `transitiveClosure` accumulator type:
```
BenchmarkFilterImage-10    	   28183	     45259 ns/op	   50090 B/op	     187 allocs/op
```

So in the end, it's 1.7x as fast, uses 60% as much memory, with less than 1/10th as many allocations.