### PR TITLE
[BSR-998] Add digest back to (local) module pins

### DIFF
--- a/proto/buf/alpha/module/v1alpha1/module.proto
+++ b/proto/buf/alpha/module/v1alpha1/module.proto
@@ -87,13 +87,11 @@ message ModuleReference {
 
 // ModulePin is a module pin.
 message ModulePin {
-  reserved 6;
-  reserved "digest";
-
   string remote = 1;
   string owner = 2;
   string repository = 3;
   string branch = 4;
   string commit = 5;
+  string digest = 6;
   google.protobuf.Timestamp create_time = 7;
 }

--- a/proto/buf/alpha/registry/v1alpha1/module.proto
+++ b/proto/buf/alpha/registry/v1alpha1/module.proto
@@ -32,13 +32,11 @@ message LocalModuleReference {
 //
 // It does not include a remote.
 message LocalModulePin {
-  reserved 5;
-  reserved "digest";
-
   string owner = 1;
   string repository = 2;
   string branch = 3;
   string commit = 4;
+  string digest = 5;
   google.protobuf.Timestamp create_time = 7;
   string draft_name = 8;
 }


### PR DESCRIPTION
We need to populate the digest in modules in order to put that information in the `buf.lock` file.