### PR TITLE
TCN-858 explicitly define upload assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,17 +144,39 @@ jobs:
         run: |
           unset RELEASE_MINISIGN_PRIVATE_KEY
           unset RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD
-      - name: Set FILES variable from tag
-        run: |
-          echo "FILES=$(find ${{github.workspace}}/.build/release/buf/assets -type f)" >> $GITHUB_ENV
       - name: Release
         id: ghr
         uses: softprops/action-gh-release@v1
+        env:
+          PATH: ${{github.workspace}}/.build/release/buf/assets
         with:
           token: ${{ steps.generate_token.outputs.token }}
           generate_release_notes: true # change to the CHANGELOG somehow
           files: |
-            ${{env.FILES}}
+            ${{env.PATH}}/buf-Darwin-arm64
+            ${{env.PATH}}/buf-Darwin-arm64.tar.gz
+            ${{env.PATH}}/buf-Darwin-x86_64
+            ${{env.PATH}}/buf-Darwin-x86_64.tar.gz
+            ${{env.PATH}}/buf-Linux-aarch64
+            ${{env.PATH}}/buf-Linux-aarch64.tar.gz
+            ${{env.PATH}}/buf-Linux-x86_64
+            ${{env.PATH}}/buf-Linux-x86_64.tar.gz
+            ${{env.PATH}}/buf-Windows-arm64.exe
+            ${{env.PATH}}/buf-Windows-x86_64.exe
+            ${{env.PATH}}/protoc-gen-buf-breaking-Darwin-arm64
+            ${{env.PATH}}/protoc-gen-buf-breaking-Darwin-x86_64
+            ${{env.PATH}}/protoc-gen-buf-breaking-Linux-aarch64
+            ${{env.PATH}}/protoc-gen-buf-breaking-Linux-x86_64
+            ${{env.PATH}}/protoc-gen-buf-breaking-Windows-arm64.exe
+            ${{env.PATH}}/protoc-gen-buf-breaking-Windows-x86_64.exe
+            ${{env.PATH}}/protoc-gen-buf-lint-Darwin-arm64
+            ${{env.PATH}}/protoc-gen-buf-lint-Darwin-x86_64
+            ${{env.PATH}}/protoc-gen-buf-lint-Linux-aarch64
+            ${{env.PATH}}/protoc-gen-buf-lint-Linux-x86_64
+            ${{env.PATH}}/protoc-gen-buf-lint-Windows-arm64.exe
+            ${{env.PATH}}/protoc-gen-buf-lint-Windows-x86_64.exe
+            ${{env.PATH}}/sha256.txt
+            ${{env.PATH}}/sha256.txt.minisig
       - name: Slack Notification
         run: |
           jq --null-input '{ text: "BufCLI Release v${{env.VERSION}} is complete: ${{ steps.ghr.outputs.url }}" }' \


### PR DESCRIPTION
To determine the files to be uploaded, pipe the result of a find command into en env var, id only tested it on a single file in the past - when it has multiple files, it finds a new line character and terminates.

as such, release fails to upload assets. 

To move forward, im explicitly defining the upload assets so the release process can continue. Naturally a more elegant solution would be preferable but i think this still falls into the "win" category