### PR TITLE
Push a minimal set of blobs.

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -388,7 +388,7 @@ func NewWireImageConfigReader(
 		logger,
 		storageosProvider,
 		newFetchReader(logger, storageosProvider, runner, moduleResolver, moduleReader),
-		bufmodulebuild.NewModuleBucketBuilder(logger),
+		bufmodulebuild.NewModuleBucketBuilder(),
 		bufmodulebuild.NewModuleFileSetBuilder(logger, moduleReader),
 		bufimagebuild.NewBuilder(logger),
 	), nil
@@ -414,7 +414,7 @@ func NewWireModuleConfigReader(
 		logger,
 		storageosProvider,
 		newFetchReader(logger, storageosProvider, runner, moduleResolver, moduleReader),
-		bufmodulebuild.NewModuleBucketBuilder(logger),
+		bufmodulebuild.NewModuleBucketBuilder(),
 	), nil
 }
 
@@ -436,7 +436,7 @@ func NewWireModuleConfigReaderForModuleReader(
 		logger,
 		storageosProvider,
 		newFetchReader(logger, storageosProvider, runner, moduleResolver, moduleReader),
-		bufmodulebuild.NewModuleBucketBuilder(logger),
+		bufmodulebuild.NewModuleBucketBuilder(),
 	), nil
 }
 
@@ -460,7 +460,7 @@ func NewWireFileLister(
 		logger,
 		storageosProvider,
 		newFetchReader(logger, storageosProvider, runner, moduleResolver, moduleReader),
-		bufmodulebuild.NewModuleBucketBuilder(logger),
+		bufmodulebuild.NewModuleBucketBuilder(),
 		bufmodulebuild.NewModuleFileSetBuilder(logger, moduleReader),
 		bufimagebuild.NewBuilder(logger),
 	), nil
@@ -751,20 +751,6 @@ func BucketAndConfigForSource(
 	return sourceBucket, sourceConfig, nil
 }
 
-// ReadModule gets a module from a source bucket and its config.
-func ReadModule(
-	ctx context.Context,
-	logger *zap.Logger,
-	sourceBucket storage.ReadBucket,
-	sourceConfig *bufconfig.Config,
-) (bufmodule.Module, error) {
-	return bufmodulebuild.NewModuleBucketBuilder(logger).BuildForBucket(
-		ctx,
-		sourceBucket,
-		sourceConfig.Build,
-	)
-}
-
 // NewImageForSource resolves a single bufimage.Image from the user-provided source with the build options.
 func NewImageForSource(
 	ctx context.Context,
@@ -837,7 +823,7 @@ func WellKnownTypeImage(ctx context.Context, logger *zap.Logger, wellKnownType s
 	if err != nil {
 		return nil, err
 	}
-	module, err := bufmodulebuild.NewModuleBucketBuilder(logger).BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		ctx,
 		datawkt.ReadBucket,
 		sourceConfig.Build,

--- a/private/buf/bufcli/bufcli_test.go
+++ b/private/buf/bufcli/bufcli_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -82,27 +81,6 @@ func TestBucketAndConfigForSource(t *testing.T) {
 		ErrNoModuleName,
 		"",
 	)
-}
-
-func TestReadModule(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	logger := zap.NewNop()
-	sourceBucket, sourceConfig, err := bucketAndConfig(
-		ctx,
-		logger,
-		moduleFiles("remote/owner/repository"),
-		".",
-	)
-	require.NoError(t, err)
-	module, err := ReadModule(
-		ctx,
-		logger,
-		sourceBucket,
-		sourceConfig,
-	)
-	assert.NotNil(t, module)
-	assert.NoError(t, err)
 }
 
 func moduleFiles(name string) map[string][]byte {

--- a/private/buf/bufwire/file_lister.go
+++ b/private/buf/bufwire/file_lister.go
@@ -258,7 +258,7 @@ func (e *fileLister) sourceFileInfosForDirectory(
 	if err != nil {
 		return nil, err
 	}
-	module, err := e.moduleBucketBuilder.BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		ctx,
 		mappedReadBucket,
 		config.Build,

--- a/private/buf/bufwire/module_config_reader.go
+++ b/private/buf/bufwire/module_config_reader.go
@@ -657,7 +657,7 @@ func (m *moduleConfigReader) getModuleConfig(
 		}
 		buildOptions = append(buildOptions, bufmodulebuild.WithExcludePaths(bucketRelPaths))
 	}
-	module, err := m.moduleBucketBuilder.BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		ctx,
 		mappedReadBucket,
 		moduleConfig.Build,

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -143,7 +143,7 @@ func (w *workspaceBuilder) BuildWorkspace(
 		if err != nil {
 			return nil, err
 		}
-		module, err := w.moduleBucketBuilder.BuildForBucket(
+		module, err := bufmodulebuild.BuildForBucket(
 			ctx,
 			readBucketForDirectory,
 			moduleConfig.Build,

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
 	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
 	modulev1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
@@ -158,20 +159,19 @@ func run(
 		return err
 	}
 	moduleIdentity := sourceConfig.ModuleIdentity
-	module, err := bufcli.ReadModule(
+	builtModule, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
-		container.Logger(),
 		sourceBucket,
-		sourceConfig,
+		sourceConfig.Build,
 	)
 	if err != nil {
 		return err
 	}
-	protoModule, err := bufmodule.ModuleToProtoModule(ctx, module)
+	protoModule, err := bufmodule.ModuleToProtoModule(ctx, builtModule.Module)
 	if err != nil {
 		return err
 	}
-	manifest, blobs, err := manifestAndFilesBlobs(ctx, sourceBucket)
+	manifest, blobs, err := manifestAndFilesBlobs(ctx, builtModule.Bucket)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/push/push_test.go
+++ b/private/buf/cmd/buf/command/push/push_test.go
@@ -147,16 +147,16 @@ func TestPush(t *testing.T) {
 	)
 }
 
-func TestPushIsMinimal(t *testing.T) {
-	// Assert push only manifests the minimal amount of files needed to build
-	// the module.
+func TestPushIsSmallerBucket(t *testing.T) {
+	// Assert push only manifests with only the files needed to build the
+	// module as described by configuration and file extension.
 	t.Parallel()
 	server, mock := pushService(t)
 	t.Cleanup(func() {
 		server.Close()
 		mock.assertAllCallbacksCalled()
 	})
-	const owner = "minimal"
+	const owner = "smallerbucket"
 	mock.respond(
 		owner,
 		&registryv1alpha1.PushResponse{

--- a/private/buf/cmd/buf/command/push/push_test.go
+++ b/private/buf/cmd/buf/command/push/push_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/manifest"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	connect_go "github.com/bufbuild/connect-go"
 	"github.com/stretchr/testify/assert"
@@ -146,6 +147,46 @@ func TestPush(t *testing.T) {
 	)
 }
 
+func TestPushIsMinimal(t *testing.T) {
+	// Assert push only manifests the minimal amount of files needed to build
+	// the module.
+	t.Parallel()
+	server, mock := pushService(t)
+	t.Cleanup(func() {
+		server.Close()
+		mock.assertAllCallbacksCalled()
+	})
+	const owner = "minimal"
+	mock.respond(
+		owner,
+		&registryv1alpha1.PushResponse{
+			LocalModulePin: &registryv1alpha1.LocalModulePin{},
+		},
+	)
+	mock.callback(owner, func(req *registryv1alpha1.PushRequest) {
+		blob, err := manifest.NewBlobFromProto(req.Manifest)
+		require.NoError(t, err)
+		ctx := context.Background()
+		reader, err := blob.Open(ctx)
+		require.NoError(t, err)
+		defer reader.Close()
+		m, err := manifest.NewFromReader(reader)
+		require.NoError(t, err)
+		_, ok := m.DigestFor("baz.file")
+		assert.False(t, ok, "baz.file should not be pushed")
+	})
+	err := appRun(
+		t,
+		map[string][]byte{
+			"buf.yaml":  bufYAML(t, server.URL, owner, "repo"),
+			"foo.proto": nil,
+			"bar.proto": nil,
+			"baz.file":  nil,
+		},
+	)
+	require.NoError(t, err)
+}
+
 func TestBucketBlobs(t *testing.T) {
 	t.Parallel()
 	bucket, err := storagemem.NewReadBucket(
@@ -181,6 +222,36 @@ func pushService(t *testing.T) (*httptest.Server, *mockPushService) {
 	return httptest.NewServer(mux), mock
 }
 
+func appRun(
+	t *testing.T,
+	files map[string][]byte,
+) error {
+	const appName = "test"
+	return appcmd.Run(
+		context.Background(),
+		app.NewContainer(
+			ammendEnv(
+				internaltesting.NewEnvFunc(t),
+				func(env map[string]string) map[string]string {
+					env["BUF_TOKEN"] = "invalid"
+					buftransport.SetDisableAPISubdomain(env)
+					injectConfig(t, appName, env)
+					return env
+				},
+			)(appName),
+			tarball(files),
+			os.Stdout,
+			os.Stderr,
+			appName,        // push ran as appName, aka "test"
+			"-#format=tar", // using stdin as a tar
+		),
+		NewCommand(
+			appName,
+			appflag.NewBuilder(appName),
+		),
+	)
+}
+
 func testPush(
 	t *testing.T,
 	desc string,
@@ -199,33 +270,13 @@ func testPush(
 	})
 	t.Run(desc, func(t *testing.T) {
 		t.Parallel()
-		const appName = "test"
-		err := appcmd.Run(
-			context.Background(),
-			app.NewContainer(
-				ammendEnv(
-					internaltesting.NewEnvFunc(t),
-					func(env map[string]string) map[string]string {
-						env["BUF_TOKEN"] = "invalid"
-						buftransport.SetDisableAPISubdomain(env)
-						injectConfig(t, appName, env)
-						return env
-					},
-				)(appName),
-				tarball(map[string][]byte{
-					"buf.yaml":  bufYAML(t, URL, owner, "repo"),
-					"foo.proto": nil,
-					"bar.proto": nil,
-				}),
-				os.Stdout,
-				os.Stderr,
-				appName,        // push ran as appName, aka "test"
-				"-#format=tar", // using stdin as a tar
-			),
-			NewCommand(
-				appName,
-				appflag.NewBuilder(appName),
-			),
+		err := appRun(
+			t,
+			map[string][]byte{
+				"buf.yaml":  bufYAML(t, URL, owner, "repo"),
+				"foo.proto": nil,
+				"bar.proto": nil,
+			},
 		)
 		if errorMsg == "" {
 			assert.NoError(t, err)

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -737,7 +737,7 @@ func testBreaking(
 	previousConfig := testGetConfig(t, previousReadWriteBucket)
 	config := testGetConfig(t, readWriteBucket)
 
-	previousModule, err := bufmodulebuild.NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	previousModule, err := bufmodulebuild.BuildForBucket(
 		context.Background(),
 		previousReadWriteBucket,
 		previousConfig.Build,
@@ -760,7 +760,7 @@ func testBreaking(
 	require.Empty(t, previousFileAnnotations)
 	previousImage = bufimage.ImageWithoutImports(previousImage)
 
-	module, err := bufmodulebuild.NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config.Build,

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -925,7 +925,7 @@ func testLintConfigModifier(
 		configModifier(config)
 	}
 
-	module, err := bufmodulebuild.NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config.Build,

--- a/private/bufpkg/bufimage/bufimagebuild/bufimagebuildtesting/bufimagebuildtesting.go
+++ b/private/bufpkg/bufimage/bufimagebuild/bufimagebuildtesting/bufimagebuildtesting.go
@@ -115,7 +115,7 @@ func fuzzGetModuleFileSet(ctx context.Context, dirPath string) (bufmodule.Module
 	if err != nil {
 		return nil, err
 	}
-	module, err := bufmodulebuild.NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		ctx,
 		readWriteBucket,
 		config,

--- a/private/bufpkg/bufimage/bufimagebuild/builder_test.go
+++ b/private/bufpkg/bufimage/bufimagebuild/builder_test.go
@@ -356,7 +356,7 @@ func testGetModuleFileSet(t *testing.T, dirPath string) bufmodule.ModuleFileSet 
 	require.NoError(t, err)
 	config, err := bufmoduleconfig.NewConfigV1(bufmoduleconfig.ExternalConfigV1{})
 	require.NoError(t, err)
-	module, err := bufmodulebuild.NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := bufmodulebuild.BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,

--- a/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
@@ -18,9 +18,7 @@ import (
 	"context"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"go.uber.org/zap"
 )
@@ -53,22 +51,13 @@ func WithWorkspace(workspace bufmodule.Workspace) BuildModuleFileSetOption {
 }
 
 // ModuleBucketBuilder builds modules for buckets.
-type ModuleBucketBuilder interface {
-	// BuildForBucket builds a module for the given bucket.
-	//
-	// If paths is empty, all files are built.
-	// Paths should be relative to the bucket, not the roots.
-	BuildForBucket(
-		ctx context.Context,
-		readBucket storage.ReadBucket,
-		config *bufmoduleconfig.Config,
-		options ...BuildOption,
-	) (bufmodule.Module, error)
-}
+type ModuleBucketBuilder = *moduleBucketBuilder
 
 // NewModuleBucketBuilder returns a new BucketBuilder.
-func NewModuleBucketBuilder(logger *zap.Logger) ModuleBucketBuilder {
-	return newModuleBucketBuilder(logger)
+func NewModuleBucketBuilder(
+	options ...BuildOption,
+) ModuleBucketBuilder {
+	return newModuleBucketBuilder(options...)
 }
 
 // ModuleIncludeBuilder builds modules for includes.

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
@@ -78,7 +78,7 @@ func (b *moduleBucketBuilder) BuildForBucket(
 	ctx context.Context,
 	readBucket storage.ReadBucket,
 	config *bufmoduleconfig.Config,
-) (builtModule BuiltModule, err error) {
+) (*BuiltModule, error) {
 	// proxy plain files
 	externalPaths := []string{
 		buflock.ExternalConfigFilePath,
@@ -90,7 +90,7 @@ func (b *moduleBucketBuilder) BuildForBucket(
 	for _, path := range externalPaths {
 		bucket, err := getFileReadBucket(ctx, readBucket, path)
 		if err != nil {
-			return builtModule, err
+			return nil, err
 		}
 		if bucket != nil {
 			rootBuckets = append(rootBuckets, bucket)
@@ -140,7 +140,7 @@ func (b *moduleBucketBuilder) BuildForBucket(
 		),
 	)
 	if err != nil {
-		return builtModule, err
+		return nil, err
 	}
 	appliedModule, err := applyModulePaths(
 		module,
@@ -151,11 +151,12 @@ func (b *moduleBucketBuilder) BuildForBucket(
 		normalpath.Relative,
 	)
 	if err != nil {
-		return builtModule, err
+		return nil, err
 	}
-	builtModule.Module = appliedModule
-	builtModule.Bucket = bucket
-	return builtModule, nil
+	return &BuiltModule{
+		Module: appliedModule,
+		Bucket: bucket,
+	}, nil
 }
 
 // may return nil.

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
@@ -21,55 +21,64 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
-	"go.uber.org/zap"
 )
 
+// BuiltModule ties a bufmodule.Module with the configuration and a bucket
+// containing just the files required to build it.
+type BuiltModule struct {
+	Module bufmodule.Module
+	Bucket storage.ReadBucket
+}
+
 type moduleBucketBuilder struct {
-	logger *zap.Logger
+	opt buildOptions
 }
 
 func newModuleBucketBuilder(
-	logger *zap.Logger,
+	options ...BuildOption,
 ) *moduleBucketBuilder {
-	return &moduleBucketBuilder{
-		logger: logger,
+	opt := buildOptions{}
+	for _, option := range options {
+		option(&opt)
 	}
+	return &moduleBucketBuilder{opt: opt}
 }
 
-func (b *moduleBucketBuilder) BuildForBucket(
+// BuildForBucket is an alternative constructor of NewModuleBucketBuilder
+// followed by calling the BuildForBucket method.
+func BuildForBucket(
 	ctx context.Context,
 	readBucket storage.ReadBucket,
 	config *bufmoduleconfig.Config,
 	options ...BuildOption,
 ) (bufmodule.Module, error) {
-	buildOptions := &buildOptions{}
-	for _, option := range options {
-		option(buildOptions)
-	}
-	return b.buildForBucket(
+	builder := newModuleBucketBuilder(options...)
+	bm, err := builder.BuildForBucket(
 		ctx,
 		readBucket,
 		config,
-		buildOptions.moduleIdentity,
-		buildOptions.paths,
-		buildOptions.excludePaths,
-		buildOptions.pathsAllowNotExist,
 	)
+	if err != nil {
+		return nil, err
+	}
+	return bm.Module, nil
 }
 
-func (b *moduleBucketBuilder) buildForBucket(
+// BuildForBucket constructs a minimal bucket from the passed readBucket and
+// builds a module from it.
+//
+// config's value is used even if the bucket contains configuration (buf.yaml).
+// This means the module is built differently than described in storage, which
+// may cause building to fail or succeed when it shouldn't. For your own
+// sanity, you should pass a config value read from the provided bucket.
+func (b *moduleBucketBuilder) BuildForBucket(
 	ctx context.Context,
 	readBucket storage.ReadBucket,
 	config *bufmoduleconfig.Config,
-	moduleIdentity bufmoduleref.ModuleIdentity,
-	bucketRelPaths *[]string,
-	excludeRelPaths []string,
-	bucketRelPathsAllowNotExist bool,
-) (bufmodule.Module, error) {
+) (builtModule BuiltModule, err error) {
 	// proxy plain files
 	externalPaths := []string{
 		buflock.ExternalConfigFilePath,
@@ -81,7 +90,7 @@ func (b *moduleBucketBuilder) buildForBucket(
 	for _, path := range externalPaths {
 		bucket, err := getFileReadBucket(ctx, readBucket, path)
 		if err != nil {
-			return nil, err
+			return builtModule, err
 		}
 		if bucket != nil {
 			rootBuckets = append(rootBuckets, bucket)
@@ -122,22 +131,31 @@ func (b *moduleBucketBuilder) buildForBucket(
 			),
 		)
 	}
+	bucket := storage.MultiReadBucket(rootBuckets...)
 	module, err := bufmodule.NewModuleForBucket(
 		ctx,
-		storage.MultiReadBucket(rootBuckets...),
-		bufmodule.ModuleWithModuleIdentity(moduleIdentity /* This may be nil */),
+		bucket,
+		bufmodule.ModuleWithModuleIdentity(
+			b.opt.moduleIdentity, // This may be nil
+		),
 	)
 	if err != nil {
-		return nil, err
+		return builtModule, err
 	}
-	return applyModulePaths(
+	appliedModule, err := applyModulePaths(
 		module,
 		roots,
-		bucketRelPaths,
-		excludeRelPaths,
-		bucketRelPathsAllowNotExist,
+		b.opt.paths,
+		b.opt.excludePaths,
+		b.opt.pathsAllowNotExist,
 		normalpath.Relative,
 	)
+	if err != nil {
+		return builtModule, err
+	}
+	builtModule.Module = appliedModule
+	builtModule.Bucket = bucket
+	return builtModule, nil
 }
 
 // may return nil.

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestBucketGetFileInfos1(t *testing.T) {
@@ -352,7 +351,7 @@ lint:
 		bufmoduleconfig.ExternalConfigV1{},
 	)
 	require.NoError(t, err)
-	module, err := NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := BuildForBucket(
 		ctx,
 		bucket,
 		config,
@@ -405,7 +404,7 @@ func testBucketGetFileInfos(
 		storageos.ReadWriteBucketWithSymlinksIfSupported(),
 	)
 	require.NoError(t, err)
-	module, err := NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -428,7 +427,7 @@ func testBucketGetFileInfos(
 			require.NoError(t, err)
 			bucketRelPaths[i] = bucketRelPath
 		}
-		module, err := NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+		module, err := BuildForBucket(
 			context.Background(),
 			readWriteBucket,
 			config,
@@ -457,7 +456,7 @@ func testBucketGetAllFileInfosError(
 		storageos.ReadWriteBucketWithSymlinksIfSupported(),
 	)
 	require.NoError(t, err)
-	module, err := NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -491,7 +490,7 @@ func testBucketGetFileInfosForExternalPathsError(
 		require.NoError(t, err)
 		bucketRelPaths[i] = bucketRelPath
 	}
-	_, err = NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	_, err = BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -515,7 +514,7 @@ func testDocumentationBucket(
 		bufmoduleconfig.ExternalConfigV1{},
 	)
 	require.NoError(t, err)
-	module, err := NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -548,7 +547,7 @@ func testLicenseBucket(
 		bufmoduleconfig.ExternalConfigV1{},
 	)
 	require.NoError(t, err)
-	module, err := NewModuleBucketBuilder(zap.NewNop()).BuildForBucket(
+	module, err := BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,


### PR DESCRIPTION
This is an exercise in frustration to push only the set of blobs needed to build a module. The bug's cause was building a module did not expose the bucket used to build the module with, hence the manifest consumed the source bucket containing module-unrelated files.

bufmodulebuild tries to abstract away building but had, and still has, many rough edges. Some of note are:

 - Build configuration is in the bucket, but the build section of configuration is not read from the bucket.

 - Build configuration cannot be written to `buf.yaml`.

 - Incorrect build configuration in a bucket can make a bucket appear buildable when it is not.

 - Some build configuration is not in the build section nor in the bucket, instead being hard coded as options.

 - BuildForBucket would take options directly, even though it was a method. It's a plain function masquerading as a method, causing callers to believe they're injecting when really the tail call was constructing independent behavior.

I tried to remove passing configuration by value or to serialize configuration into a bucket if it must be passed as a value (e.g. in many tests). It turns out writing configuration from configuration structs is not possible; the build section is omitted. I suspect it's impossible to round-trip configuration to entities to configuration and back to identical entities.

Included in this commit is a compromise in exposing a minimal module bucket. It should produce correct buckets if configuration is passed that was read from the source bucket and no options are used to change the configuration's specified behavior. This is the case with `buf push` but not the case with some other commands, notably `buf lint` given it's `--config` option.

Changes include:

 - Remove bufcli.ReadModule wrapper on bufmodulebuild.  This wrapper didn't provide any value over directly invoking bufmodulebuild.

 - Remove logging support from bucket builder. Logging is not used, and should have been passed as a constructor option anyway.

 - Move BuildForBucket to be a function that construct a builder and calls a new BuildForBucket method.

 - Type alias ModuleBucketBuilder to avoid rewriting the world if the bucket builder needs a new method.

 - Expose the minified bucket by returning a struct with both a usable module and the bucket used to create it. This struct could include a usable configuration structure to inspect or write as a buf.yaml, but I'll leave that as an exercise for another unfortunate soul.

Fixes: TCN-796