### PR TITLE
README.md: `buf` is now in Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The [`buf`][buf] CLI is a tool for working with [Protocol Buffers][protobuf].
 You can install `buf` using [Homebrew][brew] (macOS or Linux):
 
 ```sh
-brew install bufbuild/buf/buf
+brew install buf
 ```
 
 This installs:


### PR DESCRIPTION
```
> brew info buf
==> buf: stable 1.10.0 (bottled), HEAD
New way of working with Protocol Buffers
https://github.com/bufbuild/buf
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/buf.rb
License: Apache-2.0
==> Dependencies
Build: go ✘
==> Options
--HEAD
	Install HEAD version
```