### PR TITLE
fix regression in plugin generation

### DIFF
--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginref"
+	"github.com/bufbuild/buf/private/bufpkg/bufremoteplugin"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
@@ -219,7 +220,13 @@ func (p *PluginConfig) GetRemoteHostname() string {
 	if reference, err := bufpluginref.PluginReferenceForString(p.Plugin, 0); err == nil {
 		return reference.Remote()
 	}
-	return p.Remote
+	if p.Remote == "" {
+		return ""
+	}
+	if remote, _, _, _, err := bufremoteplugin.ParsePluginVersionPath(p.Remote); err == nil {
+		return remote
+	}
+	return ""
 }
 
 // ManagedConfig is the managed mode configuration.

--- a/private/buf/bufgen/bufgen_test.go
+++ b/private/buf/bufgen/bufgen_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020-2022 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginConfig_GetRemoteHostname(t *testing.T) {
+	assertPluginConfigRemoteHostname := func(config *PluginConfig, expected string) {
+		t.Helper()
+		assert.Equal(t, config.GetRemoteHostname(), expected)
+	}
+	assertPluginConfigRemoteHostname(&PluginConfig{Plugin: "buf.build/protocolbuffers/go:v1.28.1"}, "buf.build")
+	assertPluginConfigRemoteHostname(&PluginConfig{Plugin: "buf.build/protocolbuffers/go"}, "buf.build")
+	assertPluginConfigRemoteHostname(&PluginConfig{Remote: "buf.build/protocolbuffers/plugins/go:v1.28.1-1"}, "buf.build")
+	assertPluginConfigRemoteHostname(&PluginConfig{Remote: "buf.build/protocolbuffers/plugins/go"}, "buf.build")
+}


### PR DESCRIPTION
The 'Remote' field contains the full plugin name (including path and version information). For the GetRemoteHostname() method, we should parse the hostname portion and return it.

This resolves 404 errors when generating with older plugins.