### PR TITLE
Add UpstreamClientUserAgent to dockerclient

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -188,7 +188,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	client, err := bufplugindocker.NewClient(container.Logger())
+	client, err := bufplugindocker.NewClient(container.Logger(), bufcli.Version)
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -44,7 +43,7 @@ const (
 	// the value to the final outgoing User-Agent value in the form: [docker client's UA] UpstreamClient(buf-cli-1.11.0)
 	//
 	// Example: User-Agent = [docker/20.10.21 go/go1.18.7 git-commit/3056208 kernel/5.15.49-linuxkit os/linux arch/arm64 UpstreamClient(buf-cli-1.11.0)]
-	BufUpstreamClientUserAgent = "buf-cli-" + bufcli.Version
+	BufUpstreamClientUserAgentPrefix = "buf-cli-"
 )
 
 // Client is a small abstraction over a Docker API client, providing the basic APIs we need to build plugins.
@@ -213,7 +212,7 @@ func (d *dockerAPIClient) Close() error {
 }
 
 // NewClient creates a new Client to use to build Docker plugins.
-func NewClient(logger *zap.Logger, options ...ClientOption) (Client, error) {
+func NewClient(logger *zap.Logger, cliVersion string, options ...ClientOption) (Client, error) {
 	if logger == nil {
 		return nil, errors.New("logger required")
 	}
@@ -224,7 +223,7 @@ func NewClient(logger *zap.Logger, options ...ClientOption) (Client, error) {
 	dockerClientOpts := []client.Opt{
 		client.FromEnv,
 		client.WithHTTPHeaders(map[string]string{
-			"User-Agent": BufUpstreamClientUserAgent,
+			"User-Agent": BufUpstreamClientUserAgentPrefix + cliVersion,
 		}),
 	}
 	if len(opts.host) > 0 {

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -35,6 +36,15 @@ import (
 const (
 	// PluginsImagePrefix is used to prefix all image names with the correct path for pushing to the OCI registry.
 	PluginsImagePrefix = "plugins."
+
+	// Setting this value on the buf docker client allows us to propagate a custom
+	// value to the OCI registry. This is a useful property that enables registries
+	// to differentiate between the buf cli vs other tools like docker cli.
+	// Note, this does not override the final User-Agent entirely, but instead adds
+	// the value to the final outgoing User-Agent value in the form: [docker client's UA] UpstreamClient(buf-cli-1.11.0)
+	//
+	// Example: User-Agent = [docker/20.10.21 go/go1.18.7 git-commit/3056208 kernel/5.15.49-linuxkit os/linux arch/arm64 UpstreamClient(buf-cli-1.11.0)]
+	BufUpstreamClientUserAgent = "buf-cli-" + bufcli.Version
 )
 
 // Client is a small abstraction over a Docker API client, providing the basic APIs we need to build plugins.
@@ -211,7 +221,12 @@ func NewClient(logger *zap.Logger, options ...ClientOption) (Client, error) {
 	for _, option := range options {
 		option(opts)
 	}
-	dockerClientOpts := []client.Opt{client.FromEnv}
+	dockerClientOpts := []client.Opt{
+		client.FromEnv,
+		client.WithHTTPHeaders(map[string]string{
+			"User-Agent": BufUpstreamClientUserAgent,
+		}),
+	}
 	if len(opts.host) > 0 {
 		dockerClientOpts = append(dockerClientOpts, client.WithHost(opts.host))
 	}

--- a/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
@@ -113,7 +113,7 @@ func createClient(t testing.TB, options ...ClientOption) Client {
 	t.Helper()
 	logger, err := zap.NewDevelopment()
 	require.Nilf(t, err, "failed to create zap logger")
-	dockerClient, err := NewClient(logger, options...)
+	dockerClient, err := NewClient(logger, "buf-cli-1.11.0", options...)
 	require.Nilf(t, err, "failed to create client")
 	t.Cleanup(func() {
 		if err := dockerClient.Close(); err != nil {


### PR DESCRIPTION
This sets an UpstreamClient User-Agent on our docker client which gets injected in the outgoing request.

https://github.com/moby/moby/blob/a4cbaa958d03b54da713162c8a23574430dacfa8/dockerversion/useragent.go#L70-L78

On the OCI registry side we can inspect the incoming request, which will look something like this:

```
docker/20.10.21 go/go1.18.7 git-commit/3056208 kernel/5.15.49-linuxkit os/linux arch/arm64 UpstreamClient(buf-cli-1.11.0-dev)
```

And parse out the `UpstreamClient` portion.