### PR TITLE
Do not start spans from the CLI

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -604,7 +604,6 @@ func newConnectClientConfigWithOptions(container appflag.Container, opts ...conn
 		return nil, err
 	}
 	client := httpclient.NewClient(
-		httpclient.WithObservability(),
 		httpclient.WithTLSConfig(config.TLS),
 	)
 	options := []connectclient.ConfigOption{


### PR DESCRIPTION
We should not be starting traces/spans from the CLI. This should be instrumented starting from the edge of our system.