### PR TITLE
Use protoencoding for marshalling and unmarshalling

### DIFF
--- a/private/bufpkg/bufstudioagent/buffer_codec.go
+++ b/private/bufpkg/bufstudioagent/buffer_codec.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	connect "github.com/bufbuild/connect-go"
 	"google.golang.org/protobuf/proto"
 )
@@ -44,7 +45,7 @@ func (b *bufferCodec) Marshal(src any) ([]byte, error) {
 		// may also be used to unmarshal the errors in the
 		// grpc-status-details-bin trailer. The type used is not
 		// exported so we match against the general proto.Message.
-		return proto.Marshal(typedSrc)
+		return protoencoding.NewWireMarshaler().Marshal(typedSrc)
 	default:
 		return nil, fmt.Errorf("marshal unexpected type %T", src)
 	}
@@ -61,7 +62,7 @@ func (b *bufferCodec) Unmarshal(src []byte, dst any) error {
 		// may also be used to unmarshal the errors in the
 		// grpc-status-details-bin trailer. The type used is not
 		// exported so we match against the general proto.Message.
-		return proto.Unmarshal(src, destination)
+		return protoencoding.NewWireUnmarshaler(nil).Unmarshal(src, destination)
 	default:
 		return fmt.Errorf("unmarshal unexpected type %T", dst)
 	}

--- a/private/bufpkg/bufstudioagent/bufstudioagent_test.go
+++ b/private/bufpkg/bufstudioagent/bufstudioagent_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	studiov1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/studio/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/connect-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -254,7 +255,7 @@ func newTestConnectServer(t *testing.T, tls bool) *httptest.Server {
 }
 
 func protoMarshalBase64(t *testing.T, message proto.Message) []byte {
-	protoBytes, err := proto.Marshal(message)
+	protoBytes, err := protoencoding.NewWireMarshaler().Marshal(message)
 	require.NoError(t, err)
 	base64Bytes := make([]byte, base64.StdEncoding.EncodedLen(len(protoBytes)))
 	base64.StdEncoding.Encode(base64Bytes, protoBytes)
@@ -266,7 +267,7 @@ func protoUnmarshalBase64(t *testing.T, base64Bytes []byte, message proto.Messag
 	actualLen, err := base64.StdEncoding.Decode(protoBytes, base64Bytes)
 	require.NoError(t, err)
 	protoBytes = protoBytes[:actualLen]
-	require.NoError(t, proto.Unmarshal(protoBytes, message))
+	require.NoError(t, protoencoding.NewWireUnmarshaler(nil).Unmarshal(protoBytes, message))
 }
 
 func addProtoHeadersToGoHeader(fromHeaders []*studiov1alpha1.Headers, toHeaders http.Header) {

--- a/private/bufpkg/bufstudioagent/plain_post_handler.go
+++ b/private/bufpkg/bufstudioagent/plain_post_handler.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 
 	studiov1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/studio/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/connect-go"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
@@ -118,7 +119,7 @@ func (i *plainPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	envelopeRequest := &studiov1alpha1.InvokeRequest{}
-	if err := proto.Unmarshal(bodyBytes, envelopeRequest); err != nil {
+	if err := protoencoding.NewWireUnmarshaler(nil).Unmarshal(bodyBytes, envelopeRequest); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -238,7 +239,7 @@ func connectClientOptionsFromContentType(contentType string) ([]connect.ClientOp
 }
 
 func (i *plainPostHandler) writeProtoMessage(w http.ResponseWriter, message proto.Message) {
-	responseProtoBytes, err := proto.Marshal(message)
+	responseProtoBytes, err := protoencoding.NewWireMarshaler().Marshal(message)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
See https://github.com/bufbuild/buf/pull/1703 for the background here - this, plus #1703, will make it so that all of our marshalling/unmarshalling of Protobuf payloads goes through one common/consistent/vetted location.