### PR TITLE
Remove auto value from reflect protocol and make unset the default

### DIFF
--- a/private/buf/bufcurl/reflection_resolver.go
+++ b/private/buf/bufcurl/reflection_resolver.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -33,13 +34,62 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
-type ReflectProtocol string
-
 const (
-	ReflectProtocolGRPCv1      = ReflectProtocol("grpc-v1")
-	ReflectProtocolGRPCv1alpha = ReflectProtocol("grpc-v1alpha")
-	ReflectProtocolAuto        = ReflectProtocol("auto")
+	// ReflectProtocolUnknown represents that the server reflection protocol
+	// is unknown. If given this value, the server reflection resolver will
+	// cycle through the known reflection protocols from newest to oldest,
+	// trying each one until a reflection protocol that works is found.
+	ReflectProtocolUnknown ReflectProtocol = iota + 1
+	// ReflectProtocolGRPCV1 represents the gRPC server reflection protocol
+	// defined by the service grpc.reflection.v1.ServerReflection.
+	ReflectProtocolGRPCV1
+	// ReflectProtocolGRPCV1 represents the gRPC server reflection protocol
+	// defined by the service grpc.reflection.v1alpha.ServerReflection.
+	ReflectProtocolGRPCV1Alpha
 )
+
+var (
+	// AllKnownReflectProtocolStrings are all string values for
+	// ReflectProtocol that represent known reflection protocols.
+	AllKnownReflectProtocolStrings = []string{
+		"grpc-v1",
+		"grpc-v1alpha",
+	}
+
+	reflectProtocolToString = map[ReflectProtocol]string{
+		ReflectProtocolUnknown:     "",
+		ReflectProtocolGRPCV1:      "grpc-v1",
+		ReflectProtocolGRPCV1Alpha: "grpc-v1alpha",
+	}
+	stringToReflectProtocol = map[string]ReflectProtocol{
+		"":             ReflectProtocolUnknown,
+		"grpc-v1":      ReflectProtocolGRPCV1,
+		"grpc-v1alpha": ReflectProtocolGRPCV1Alpha,
+	}
+)
+
+// ReflectProtocol is a reflection protocol.
+type ReflectProtocol int
+
+// String implements fmt.Stringer.
+func (r ReflectProtocol) String() string {
+	s, ok := reflectProtocolToString[r]
+	if !ok {
+		return strconv.Itoa(int(r))
+	}
+	return s
+}
+
+// ParseReflectProtocol parses the ReflectProtocol.
+//
+// The empty string is a parse error.
+func ParseReflectProtocol(s string) (ReflectProtocol, error) {
+	r, ok := stringToReflectProtocol[strings.ToLower(strings.TrimSpace(s))]
+	if ok {
+		return r, nil
+	}
+	return 0, fmt.Errorf("unknown ReflectProtocol: %q", s)
+}
 
 // NewServerReflectionResolver creates a new resolver using the given details to
 // create an RPC reflection client, to ask the server for descriptors.
@@ -48,16 +98,16 @@ func NewServerReflectionResolver(
 	httpClient connect.HTTPClient,
 	opts []connect.ClientOption,
 	baseURL string,
-	reflectVersion ReflectProtocol,
+	reflectProtocol ReflectProtocol,
 	headers http.Header,
 	printer verbose.Printer,
 ) (r Resolver, closeResolver func()) {
 	baseURL = strings.TrimSuffix(baseURL, "/")
 	var v1Client, v1alphaClient *reflectClient
-	if reflectVersion != ReflectProtocolGRPCv1 {
+	if reflectProtocol != ReflectProtocolGRPCV1 {
 		v1alphaClient = connect.NewClient[reflectionv1.ServerReflectionRequest, reflectionv1.ServerReflectionResponse](httpClient, baseURL+"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", opts...)
 	}
-	if reflectVersion != ReflectProtocolGRPCv1alpha {
+	if reflectProtocol != ReflectProtocolGRPCV1Alpha {
 		v1Client = connect.NewClient[reflectionv1.ServerReflectionRequest, reflectionv1.ServerReflectionResponse](httpClient, baseURL+"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo", opts...)
 	}
 	// if version is neither "v1" nor "v1alpha", then we have both clients and
@@ -74,7 +124,7 @@ func NewServerReflectionResolver(
 		ctx:              ctx,
 		v1Client:         v1Client,
 		v1alphaClient:    v1alphaClient,
-		useV1Alpha:       reflectVersion == ReflectProtocolGRPCv1alpha,
+		useV1Alpha:       reflectProtocol == ReflectProtocolGRPCV1Alpha,
 		headers:          headers,
 		printer:          printer,
 		downloadedProtos: map[string]*descriptorpb.FileDescriptorProto{},

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -261,7 +261,7 @@ may only be used when server reflection is used. By default, this command will t
 reflection protocols from newest to oldest. If this results in a "Not Implemented" error,
 then older protocols will be used. In practice, this means that "grpc-v1" is tried first,
 and "grpc-v1alpha" is used if it doesn't work. If newer reflection protocols are introduced,
-they may be preferred in the absense of this flag being explicitly set to a specific protocol.
+they may be preferred in the absence of this flag being explicitly set to a specific protocol.
 The valid values for this flag are "grpc-v1" and "grpc-v1alpha". These correspond to services
 named "grpc.reflection.v1.ServerReflection" and "grpc.reflection.v1alpha.ServerReflection"
 respectively.`,

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -253,7 +253,7 @@ the request data flag (--data or -d). Furthermore, it is not allowed to indicate
 if the schema is expected to be provided via stdin as a file descriptor set or image.`,
 	)
 	flagSet.StringVar(
-		(*string)(&f.ReflectProtocol),
+		&f.ReflectProtocol,
 		reflectProtocolFlagName,
 		"",
 		`The reflection protocol to use for downloading information from the server. This flag

--- a/private/pkg/stringutil/stringutil.go
+++ b/private/pkg/stringutil/stringutil.go
@@ -191,6 +191,34 @@ func SliceToHumanStringQuoted(s []string) string {
 	}
 }
 
+// SliceToHumanStringOr prints the slice as "e1, e2, or e3".
+func SliceToHumanStringOr(s []string) string {
+	switch len(s) {
+	case 0:
+		return ""
+	case 1:
+		return s[0]
+	case 2:
+		return s[0] + " or " + s[1]
+	default:
+		return strings.Join(s[:len(s)-1], ", ") + ", or " + s[len(s)-1]
+	}
+}
+
+// SliceToHumanStringOrQuoted prints the slice as `"e1", "e2", or "e3"`.
+func SliceToHumanStringOrQuoted(s []string) string {
+	switch len(s) {
+	case 0:
+		return ""
+	case 1:
+		return `"` + s[0] + `"`
+	case 2:
+		return `"` + s[0] + `" or "` + s[1] + `"`
+	default:
+		return `"` + strings.Join(s[:len(s)-1], `", "`) + `", or "` + s[len(s)-1] + `"`
+	}
+}
+
 // SnakeCaseOption is an option for snake_case conversions.
 type SnakeCaseOption func(*snakeCaseOptions)
 

--- a/private/pkg/stringutil/stringutil_test.go
+++ b/private/pkg/stringutil/stringutil_test.go
@@ -204,6 +204,24 @@ func TestSliceToHumanStringQuoted(t *testing.T) {
 	assert.Equal(t, `"a", "b", and "c"`, SliceToHumanStringQuoted([]string{"a", "b", "c"}))
 }
 
+func TestSliceToHumanStringOr(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, ``, SliceToHumanStringOr(nil))
+	assert.Equal(t, ``, SliceToHumanStringOr([]string{}))
+	assert.Equal(t, `a`, SliceToHumanStringOr([]string{"a"}))
+	assert.Equal(t, `a or b`, SliceToHumanStringOr([]string{"a", "b"}))
+	assert.Equal(t, `a, b, or c`, SliceToHumanStringOr([]string{"a", "b", "c"}))
+}
+
+func TestSliceToHumanStringOrQuoted(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, ``, SliceToHumanStringOrQuoted(nil))
+	assert.Equal(t, ``, SliceToHumanStringOrQuoted([]string{}))
+	assert.Equal(t, `"a"`, SliceToHumanStringOrQuoted([]string{"a"}))
+	assert.Equal(t, `"a" or "b"`, SliceToHumanStringOrQuoted([]string{"a", "b"}))
+	assert.Equal(t, `"a", "b", or "c"`, SliceToHumanStringOrQuoted([]string{"a", "b", "c"}))
+}
+
 func TestSliceToUniqueSortedSlice(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, []string{}, SliceToUniqueSortedSlice(nil))


### PR DESCRIPTION
This changes the definition of `buf curl --reflect-protocol` slightly to make it such that this flag no longer has an `auto` value. Instead, this flag is defined as "use a specific reflection protocol. if no protocol is set, we will choose". This means there is no special value needed to be understood by our users - the default value for `--reflect-protocol` is no value.

As part of this change, this changes the `ReflectProtocol` type to be an enum in line with the rest of the codebase and our code standards (although we should make it more clear in our code standards, its a little obscure to be fair). We prefer `int` enums over `strings` because they do not allow people to do things such as cast user-provided flag values to their type directly :-) enums should be just that, and parsing should be commonly validated in the package that provides them. `bufanalysis` is a good example of this style (that `bufcurl` is now largely updated to reflect).