### PR TITLE
Make silent runners faster

### DIFF
--- a/private/pkg/command/command.go
+++ b/private/pkg/command/command.go
@@ -70,7 +70,7 @@ func RunWithStdin(stdin io.Reader) RunOption {
 
 // RunWithStdout returns a new RunOption that sets the stdout.
 //
-// The default is io.Discard.
+// The default is the null device (os.DevNull).
 func RunWithStdout(stdout io.Writer) RunOption {
 	return func(runOptions *runOptions) {
 		runOptions.stdout = stdout
@@ -79,7 +79,7 @@ func RunWithStdout(stdout io.Writer) RunOption {
 
 // RunWithStderr returns a new RunOption that sets the stderr.
 //
-// The default is io.Discard.
+// The default is the null device (os.DevNull).
 func RunWithStderr(stderr io.Writer) RunOption {
 	return func(runOptions *runOptions) {
 		runOptions.stderr = stderr

--- a/private/pkg/command/runner.go
+++ b/private/pkg/command/runner.go
@@ -56,15 +56,11 @@ func (r *runner) Run(ctx context.Context, name string, options ...RunOption) err
 	if runOptions.stdin == nil {
 		runOptions.stdin = ioextended.DiscardReader
 	}
-	if runOptions.stdout == nil {
-		runOptions.stdout = io.Discard
-	}
-	if runOptions.stderr == nil {
-		runOptions.stderr = io.Discard
-	}
 	cmd := exec.CommandContext(ctx, name, runOptions.args...)
 	cmd.Env = envSlice(runOptions.env)
 	cmd.Stdin = runOptions.stdin
+	// If Stdout or Stderr are nil, os/exec connects the process output directly
+	// to the null device.
 	cmd.Stdout = runOptions.stdout
 	cmd.Stderr = runOptions.stderr
 	// The default behavior for dir is what we want already, i.e. the current


### PR DESCRIPTION
If we're using `private/pkg/command` to run a command silently, sending
stdout and stderr to `io.Discard` is needlessly expensive: it creates a
pipe and spawns a goroutine to copy from the pipe to the writer, which
then throws the data away. If we leave stdout and stderr as nil,
`os/exec` instead connects the process directly to `/dev/null`, which is
functionally identical and cheaper.

See [the os/exec.Command docs](https://pkg.go.dev/os/exec#Cmd:~:text=Otherwise%2C%20during%20the%20execution%20of%20the%20command%20a%20separate%20goroutine) for details.
