### PR TITLE
Add PR title linter

### DIFF
--- a/.github/workflows/pr-title-linter.yaml
+++ b/.github/workflows/pr-title-linter.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.0
         with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           title-regex: "^[A-Z].*[^.]$"
           on-failed-regex-fail-action: true
           on-failed-regex-create-review: false

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -21,7 +21,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           title-regex: "^[A-Z].*[^.]$"
           on-failed-regex-fail-action: true
-          on-failed-regex-create-review: true
-          on-failed-regex-request-changes: true
+          on-failed-regex-create-review: false
+          on-failed-regex-request-changes: false
           on-failed-regex-comment: "PRs must start with a capital letter and not end with a period."
           on-succeeded-regex-dismiss-review-comment: "Thanks for helping keep our PR titles consistent!"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,25 @@
+name: PR Title Linter
+# Prevent writing to the repository using the CI token.
+# Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
+permissions: read-all
+on:
+  pull_request:
+    # By default, a workflow only runs when a pull_request's activity type is opened,
+    # synchronize, or reopened. We explicity override here so that PR titles are
+    # re-linted when the PR text content is edited.
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+jobs:
+  pr-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: morrisoncole/pr-lint-action@v1.7.0
+        with:
+          title-regex: "^[A-Z].*[^.]$"
+          on-failed-regex-fail-action: true
+          on-failed-regex-create-review: false
+          on-failed-regex-request-changes: false
+          on-failed-regex-comment: "PRs must start with a capital letter and not end with a period."

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,4 +1,4 @@
-name: PR Title Linter
+name: pr-title
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
@@ -13,7 +13,7 @@ on:
       - reopened
       - synchronize
 jobs:
-  pr-lint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.0
@@ -21,6 +21,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           title-regex: "^[A-Z].*[^.]$"
           on-failed-regex-fail-action: true
-          on-failed-regex-create-review: false
-          on-failed-regex-request-changes: false
+          on-failed-regex-create-review: true
+          on-failed-regex-request-changes: true
           on-failed-regex-comment: "PRs must start with a capital letter and not end with a period."
+          on-succeeded-regex-dismiss-review-comment: "Thanks for helping keep our PR titles consistent!"


### PR DESCRIPTION
We have had inconsistent PR titles across our various repositories - some start with capital letters, some don't, some end in periods, some don't. No one way is the right way, but from day one I did PR titles with capital letters and no periods at the end, and one way is better than no way, so @akshayjshah had the idea that we should just enforce this as part of linting with this action. Trying this on bufbuild/buf, and it it works, we'll add to our other repositories as well.