### PR TITLE
Remove buf beta convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Remove the `buf beta convert` to `buf convert`. Any uses of `buf beta convert` will need to change to `buf convert` 
 
 ## [v1.12.0] - 2023-01-12
 - Add `buf curl` command to invoke RPCs via [Connect](https://connect-build),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Remove the `buf beta convert` to `buf convert`. Any uses of `buf beta convert` will need to change to `buf convert` 
+- Remove `buf beta convert` in favor of the now-stable `buf convert`.
 
 ## [v1.12.0] - 2023-01-12
 - Add `buf curl` command to invoke RPCs via [Connect](https://connect-build),

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -144,7 +144,6 @@ func NewRootCommand(name string) *appcmd.Command {
 				Use:   "beta",
 				Short: "Beta commands. Unstable and likely to change.",
 				SubCommands: []*appcmd.Command{
-					convert.NewCommand("convert", builder),
 					migratev1beta1.NewCommand("migrate-v1beta1", builder),
 					studioagent.NewCommand("studio-agent", noTimeoutBuilder),
 					{


### PR DESCRIPTION
Removes `buf beta convert` alias to `buf convert` 

```diff
Beta commands. Unstable and likely to change.

Usage:
  buf beta [flags]
  buf beta [command]

Available Commands:
-  convert         Convert a message from binary to JSON or vice versa
  migrate-v1beta1 Migrate any v1beta1 configuration files in the directory to the latest version.
  registry        Manage assets on the Buf Schema Registry.
  studio-agent    Run an HTTP(S) server as the Studio agent.
```