### PR TITLE
Rename ErrAuth to AuthError

### DIFF
--- a/private/bufpkg/bufconnect/errors.go
+++ b/private/bufpkg/bufconnect/errors.go
@@ -16,20 +16,20 @@ package bufconnect
 
 import "errors"
 
-// ErrAuth wraps the error returned in the auth provider to add additional context.
-type ErrAuth struct {
+// AuthError wraps the error returned in the auth provider to add additional context.
+type AuthError struct {
 	cause error
 
 	tokenEnvKey string
 }
 
 // Unwrap returns the underlying error.
-func (e *ErrAuth) Unwrap() error {
+func (e *AuthError) Unwrap() error {
 	return e.cause
 }
 
 // Error implements the error interface and returns the error message.
-func (e *ErrAuth) Error() string {
+func (e *AuthError) Error() string {
 	if e.cause == nil {
 		return "unknown error"
 	}
@@ -37,13 +37,13 @@ func (e *ErrAuth) Error() string {
 }
 
 // TokenEnvKey returns the environment variable used, if any, for authentication.
-func (e *ErrAuth) TokenEnvKey() string {
+func (e *AuthError) TokenEnvKey() string {
 	return e.tokenEnvKey
 }
 
-// AsAuthError uses errors.As to unwrap any error and look for an *ErrAuth.
-func AsAuthError(err error) (*ErrAuth, bool) {
-	var authErr *ErrAuth
+// AsAuthError uses errors.As to unwrap any error and look for an *AuthError.
+func AsAuthError(err error) (*AuthError, bool) {
+	var authErr *AuthError
 	ok := errors.As(err, &authErr)
 	return authErr, ok
 }

--- a/private/bufpkg/bufconnect/errors_test.go
+++ b/private/bufpkg/bufconnect/errors_test.go
@@ -22,30 +22,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrAuthUnwrap(t *testing.T) {
+func TestAuthErrorUnwrap(t *testing.T) {
 	cause := errors.New("underlying cause")
-	err := &ErrAuth{cause: cause}
-
+	err := &AuthError{cause: cause}
 	assert.Equal(t, cause, err.Unwrap())
 }
 
-func TestErrAuthError(t *testing.T) {
+func TestAuthErrorError(t *testing.T) {
 	cause := errors.New("underlying cause")
-	err := &ErrAuth{cause: cause}
-
+	err := &AuthError{cause: cause}
 	assert.Equal(t, "underlying cause", err.Error())
 }
 
-func TestErrAuthTokenEnvKey(t *testing.T) {
+func TestAuthErrorTokenEnvKey(t *testing.T) {
 	cause := errors.New("underlying cause")
-	err := &ErrAuth{cause: cause, tokenEnvKey: "abcd"}
-
+	err := &AuthError{cause: cause, tokenEnvKey: "abcd"}
 	assert.Equal(t, "abcd", err.TokenEnvKey())
 }
 
 func TestAsAuthError(t *testing.T) {
 	cause := errors.New("underlying cause")
-	authErr := &ErrAuth{cause: cause}
+	authErr := &AuthError{cause: cause}
 	err := fmt.Errorf("wrapped error: %w", authErr)
 
 	unwrapped, ok := AsAuthError(err)

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -69,7 +69,7 @@ func NewAuthorizationInterceptorProvider(tokenProviders ...TokenProvider) func(s
 				}
 				response, err := next(ctx, req)
 				if err != nil && usingTokenEnvKey {
-					err = &ErrAuth{cause: err, tokenEnvKey: tokenEnvKey}
+					err = &AuthError{cause: err, tokenEnvKey: tokenEnvKey}
 				}
 				return response, err
 			})


### PR DESCRIPTION
Per Go Code Standards in Notion, custom error type names should be suffixed in `Error`