### PR TITLE
When filtering image, include type references in Any messages in option values

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -116,6 +116,16 @@ func TestPackages(t *testing.T) {
 	runDiffTest(t, "testdata/packages", []string{"foo.bar.baz"}, "foo.bar.baz.txtar")
 }
 
+func TestAny(t *testing.T) {
+	t.Parallel()
+	runDiffTest(t, "testdata/any", []string{"ExtendedAnySyntax"}, "c1.txtar")
+	runDiffTest(t, "testdata/any", []string{"ExtendedAnySyntax_InField"}, "c2.txtar")
+	runDiffTest(t, "testdata/any", []string{"ExtendedAnySyntax_InList"}, "c3.txtar")
+	runDiffTest(t, "testdata/any", []string{"ExtendedAnySyntax_InMap"}, "c4.txtar")
+	runDiffTest(t, "testdata/any", []string{"NormalMessageSyntaxValidType"}, "d.txtar")
+	runDiffTest(t, "testdata/any", []string{"NormalMessageSyntaxInvalidType"}, "e.txtar")
+}
+
 func TestTransitivePublic(t *testing.T) {
 	ctx := context.Background()
 	bucket, err := storagemem.NewReadBucket(map[string][]byte{

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/a.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/a.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+  google.protobuf.Any extra = 10101;
+  AnyInField extra_in_field = 10102;
+  AnyInList extra_in_list = 10103;
+  AnyInMap extra_in_map = 10104;
+}
+
+message AnyInField {
+  google.protobuf.Any any = 1;
+}
+
+message AnyInList {
+  repeated google.protobuf.Any list_any = 1;
+}
+
+message AnyInMap {
+  map<string, AnyInField> map = 1;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/b.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/b.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package foo.bar.baz;
+
+message Foo {
+  string name = 1;
+  int32 id = 2;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c1.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c1.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "a.proto";
+import "b.proto";
+
+message ExtendedAnySyntax {
+  option (extra) = {
+    [type.googleapis.com/foo.bar.baz.Foo]: {
+      name: "Bob Loblaw"
+      id: 42
+    }
+  };
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c1.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c1.txtar
@@ -1,0 +1,69 @@
+-- a.proto --
+syntax = "proto3";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.MessageOptions {
+  google.protobuf.Any extra = 10101;
+}
+-- b.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Foo {
+  string name = 1;
+  int32 id = 2;
+}
+-- c1.proto --
+syntax = "proto3";
+import "a.proto";
+import "b.proto";
+message ExtendedAnySyntax {
+  option (extra) = {
+    type_url: "type.googleapis.com/foo.bar.baz.Foo"
+    value: "\n\nBob Loblaw\020*"
+  };
+}
+-- google/protobuf/any.proto --
+syntax = "proto3";
+package google.protobuf;
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_multiple_files = true;
+option java_outer_classname = "AnyProto";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c2.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c2.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+import "a.proto";
+import "b.proto";
+
+message ExtendedAnySyntax_InField {
+  option (extra_in_field) = {
+    any: {
+      [type.googleapis.com/foo.bar.baz.Foo]: {
+        name: "Bob Loblaw"
+        id: 42
+      }
+    }
+  };
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c2.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c2.txtar
@@ -1,0 +1,71 @@
+-- a.proto --
+syntax = "proto3";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+message AnyInField {
+  google.protobuf.Any any = 1;
+}
+extend google.protobuf.MessageOptions {
+  AnyInField extra_in_field = 10102;
+}
+-- b.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Foo {
+  string name = 1;
+  int32 id = 2;
+}
+-- c2.proto --
+syntax = "proto3";
+import "a.proto";
+import "b.proto";
+message ExtendedAnySyntax_InField {
+  option (extra_in_field) = {
+    any:<type_url:"type.googleapis.com/foo.bar.baz.Foo" value:"\n\nBob Loblaw\020*" >
+  };
+}
+-- google/protobuf/any.proto --
+syntax = "proto3";
+package google.protobuf;
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_multiple_files = true;
+option java_outer_classname = "AnyProto";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c3.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c3.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+import "a.proto";
+import "b.proto";
+
+message ExtendedAnySyntax_InList {
+  option (extra_in_list) = {
+    list_any: {
+      [type.googleapis.com/ExtendedAnySyntax_InList]: {}
+    }
+    list_any: {
+      [type.googleapis.com/foo.bar.baz.Foo]: {
+        name: "Bob Loblaw"
+        id: 42
+      }
+    }
+  };
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c3.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c3.txtar
@@ -1,0 +1,71 @@
+-- a.proto --
+syntax = "proto3";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+message AnyInList {
+  repeated google.protobuf.Any list_any = 1;
+}
+extend google.protobuf.MessageOptions {
+  AnyInList extra_in_list = 10103;
+}
+-- b.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Foo {
+  string name = 1;
+  int32 id = 2;
+}
+-- c3.proto --
+syntax = "proto3";
+import "a.proto";
+import "b.proto";
+message ExtendedAnySyntax_InList {
+  option (extra_in_list) = {
+    list_any:<type_url:"type.googleapis.com/ExtendedAnySyntax_InList" > list_any:<type_url:"type.googleapis.com/foo.bar.baz.Foo" value:"\n\nBob Loblaw\020*" >
+  };
+}
+-- google/protobuf/any.proto --
+syntax = "proto3";
+package google.protobuf;
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_multiple_files = true;
+option java_outer_classname = "AnyProto";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c4.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c4.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+import "a.proto";
+import "b.proto";
+
+message ExtendedAnySyntax_InMap {
+  option (extra_in_map) = {
+    map: [
+      {
+        key: "foo"
+        value: {
+          any: {
+            [type.googleapis.com/ExtendedAnySyntax_InMap]: {}
+          }
+        }
+      },
+      {
+        key: "bar"
+        value: {
+          any: {
+            [type.googleapis.com/foo.bar.baz.Foo]: {
+              name: "Bob Loblaw"
+              id: 42
+            }
+          }
+        }
+      }
+    ]
+  };
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/c4.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/c4.txtar
@@ -1,0 +1,74 @@
+-- a.proto --
+syntax = "proto3";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+message AnyInField {
+  google.protobuf.Any any = 1;
+}
+message AnyInMap {
+  map<string, AnyInField> map = 1;
+}
+extend google.protobuf.MessageOptions {
+  AnyInMap extra_in_map = 10104;
+}
+-- b.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Foo {
+  string name = 1;
+  int32 id = 2;
+}
+-- c4.proto --
+syntax = "proto3";
+import "a.proto";
+import "b.proto";
+message ExtendedAnySyntax_InMap {
+  option (extra_in_map) = {
+    map:<key:"bar" value:<any:<type_url:"type.googleapis.com/foo.bar.baz.Foo" value:"\n\nBob Loblaw\020*" >>> map:<key:"foo" value:<any:<type_url:"type.googleapis.com/ExtendedAnySyntax_InMap" >>>
+  };
+}
+-- google/protobuf/any.proto --
+syntax = "proto3";
+package google.protobuf;
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_multiple_files = true;
+option java_outer_classname = "AnyProto";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/d.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/d.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "a.proto";
+
+message NormalMessageSyntaxValidType {
+  option (extra) = {
+    type_url: "type.googleapis.com/foo.bar.baz.Foo"
+    value: "\x0a\x0a\x42\x6f\x62\x20\x4c\x6f\x62\x6c\x61\x77\x10\x2a"
+  };
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/d.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/d.txtar
@@ -1,0 +1,69 @@
+-- a.proto --
+syntax = "proto3";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.MessageOptions {
+  google.protobuf.Any extra = 10101;
+}
+-- b.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Foo {
+  string name = 1;
+  int32 id = 2;
+}
+-- d.proto --
+syntax = "proto3";
+import "a.proto";
+import "b.proto";
+message NormalMessageSyntaxValidType {
+  option (extra) = {
+    type_url: "type.googleapis.com/foo.bar.baz.Foo"
+    value: "\n\nBob Loblaw\020*"
+  };
+}
+-- google/protobuf/any.proto --
+syntax = "proto3";
+package google.protobuf;
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_multiple_files = true;
+option java_outer_classname = "AnyProto";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/e.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/e.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "a.proto";
+
+message NormalMessageSyntaxInvalidType {
+  option (extra) = {
+    type_url: "type.googleapis.com/blah.blah.Blah"
+    value: "\x01\x02\x03\x04"
+  };
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/any/e.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/any/e.txtar
@@ -1,0 +1,61 @@
+-- a.proto --
+syntax = "proto3";
+import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.MessageOptions {
+  google.protobuf.Any extra = 10101;
+}
+-- e.proto --
+syntax = "proto3";
+import "a.proto";
+message NormalMessageSyntaxInvalidType {
+  option (extra) = {
+    type_url: "type.googleapis.com/blah.blah.Blah"
+    value: "\001\002\003\004"
+  };
+}
+-- google/protobuf/any.proto --
+syntax = "proto3";
+package google.protobuf;
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_multiple_files = true;
+option java_outer_classname = "AnyProto";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}


### PR DESCRIPTION
This adds code to explore messages that appear in option values, recursing through any nested structure to find instances of `google.protobuf.Any`. If it finds an instance and it refers to a known message type, add that as an edge to the graph.

If you check out the new testdata file `d.proto` with message `NormalMessageSyntaxValidType`: it does _not_ import the referred message type and uses the normal syntax instead of the extended syntax. But when we filter the image, we end up synthesizing the import because we recognize the type.

The testdata file `e.proto` includes a reference to a bogus, non-existing type. In this case, everything still works, but there is no edge it can add to the graph. (Consumers of the Any will, of course, be unhappy...)

The Any messages in the test outputs are ugly because `protoprint` doesn't try to produce the extended any syntax.

Fixes TCN-1101