### PR TITLE
Pull out logic from git-ls-files-unstaged, refactor to use better logic, and add logic to license-header

### DIFF
--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -98,11 +98,12 @@ type Lister interface {
 	// ListFilesAndUnstagedFiles lists all files checked into git except those that
 	// were deleted, and also lists unstaged files.
 	//
-	// This does not list unstaged deleted files, and does not list unignored
-	// files that were not added. This ignores regular files.
+	// This does not list unstaged deleted files
+	// This does not list unignored files that were not added.
+	// This ignores regular files.
 	//
-	// This is used for situations like license headers where we want all the potential git files
-	// during development.
+	// This is used for situations like license headers where we want all the
+	// potential git files during development.
 	//
 	// The returned paths will be unnormalized.
 	//

--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -92,3 +92,46 @@ type ClonerOptions struct {
 	SSHKeyFileEnvKey         string
 	SSHKnownHostsFilesEnvKey string
 }
+
+// Lister lists files in git repositories.
+type Lister interface {
+	// ListFilesAndUnstagedFiles lists all files checked into git except those that
+	// were deleted, and also lists unstaged files.
+	//
+	// This does not list unstaged deleted files, and does not list unignored
+	// files that were not added. This ignores regular files.
+	//
+	// This is used for situations like license headers where we want all the potential git files
+	// during development.
+	//
+	// The returned paths will be unnormalized.
+	//
+	// This is the equivalent of doing:
+	//
+	//	comm -23 \
+	//		<(git ls-files --cached --modified --others --no-empty-directory --exclude-standard | sort -u | grep -v -e IGNORE_PATH1 -e IGNORE_PATH2) \
+	//		<(git ls-files --deleted | sort -u)
+	ListFilesAndUnstagedFiles(
+		ctx context.Context,
+		envContainer app.EnvStdioContainer,
+		options ListFilesAndUnstagedFilesOptions,
+	) ([]string, error)
+}
+
+// NewLister returns a new Lister.
+func NewLister(runner command.Runner) Lister {
+	return newLister(runner)
+}
+
+// ListFilesAndUnstagedFilesOptions are options for ListFilesAndUnstagedFiles.
+type ListFilesAndUnstagedFilesOptions struct {
+	// IgnorePaths are paths to ignore.
+	//
+	// A simple substring operation is done, this is not a regex.
+	// If this string appears as part of the path, the path will be ignored.
+	// These paths will be unnormalized as part of ListFilesAndUnstagedFiles.
+	//
+	// We could later make this regular expressions if we want to v1.0 any tools
+	// based on this, but keeping it simple for now.
+	IgnorePaths []string
+}

--- a/private/pkg/git/lister.go
+++ b/private/pkg/git/lister.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package git
 
 import (

--- a/private/pkg/git/lister.go
+++ b/private/pkg/git/lister.go
@@ -131,6 +131,10 @@ func fileMatches(file string, unnormalizedMatchPaths map[string]struct{}) bool {
 	return false
 }
 
+// filterNonRegularFiles returns all regular files.
+//
+// This does an os.Stat call, so the files must exist for this to work.
+// Given our usage here, this is true by the time this function is called.
 func filterNonRegularFiles(files []string) []string {
 	filteredFiles := make([]string, 0, len(files))
 	for _, file := range files {

--- a/private/pkg/git/lister.go
+++ b/private/pkg/git/lister.go
@@ -1,0 +1,115 @@
+package git
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bufbuild/buf/private/pkg/app"
+	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/bufbuild/buf/private/pkg/normalpath"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
+)
+
+type lister struct {
+	runner command.Runner
+}
+
+func newLister(runner command.Runner) *lister {
+	return &lister{
+		runner: runner,
+	}
+}
+
+func (l *lister) ListFilesAndUnstagedFiles(
+	ctx context.Context,
+	container app.EnvStdioContainer,
+	options ListFilesAndUnstagedFilesOptions,
+) ([]string, error) {
+	allFilesOutput, err := command.RunStdout(
+		ctx,
+		container,
+		l.runner,
+		"git",
+		"ls-files",
+		"--cached",
+		"--modified",
+		"--others",
+		"--exclude-standard",
+	)
+	if err != nil {
+		return nil, err
+	}
+	deletedFilesOutput, err := command.RunStdout(
+		ctx,
+		container,
+		l.runner,
+		"git",
+		"ls-files",
+		"--deleted",
+	)
+	if err != nil {
+		return nil, err
+	}
+	return stringutil.SliceToUniqueSortedSlice(
+		filterIgnorePaths(
+			stringSliceExcept(
+				// This may not work in all Windows scenarios as we only split on "\n" but
+				// this is no worse than we previously had.
+				stringutil.SplitTrimLinesNoEmpty(string(allFilesOutput)),
+				stringutil.SplitTrimLinesNoEmpty(string(deletedFilesOutput)),
+			),
+			options.IgnorePaths,
+		),
+	), nil
+}
+
+// stringSliceExcept returns all elements in source that are not in except.
+func stringSliceExcept(source []string, except []string) []string {
+	sourceMap := stringutil.SliceToMap(source)
+	exceptMap := stringutil.SliceToMap(except)
+	result := make([]string, 0, len(source))
+	for s := range sourceMap {
+		if _, ok := exceptMap[s]; !ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// filterIgnorePaths filters the files that contain any of the ignorePaths
+// as a substring.
+func filterIgnorePaths(files []string, ignorePaths []string) []string {
+	if len(ignorePaths) == 0 {
+		return files
+	}
+	unnormalizedIgnorePathMap := unnormalizedPathMap(ignorePaths)
+	filteredFiles := make([]string, 0, len(files))
+	for _, file := range files {
+		if !fileMatches(file, unnormalizedIgnorePathMap) {
+			filteredFiles = append(filteredFiles, file)
+		}
+	}
+	return filteredFiles
+}
+
+// unnormalizedPathMap returns a map of the paths, but unnormalised.
+//
+// We return a map to remove duplicates easily.
+func unnormalizedPathMap(paths []string) map[string]struct{} {
+	unnormalizedPaths := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		unnormalizedPaths[normalpath.Unnormalize(path)] = struct{}{}
+	}
+	return unnormalizedPaths
+}
+
+// fileMatches returns true if any of the unnormalizedMatchPaths are
+// a substring of the file.
+func fileMatches(file string, unnormalizedMatchPaths map[string]struct{}) bool {
+	for unnormalizedMatchPath := range unnormalizedMatchPaths {
+		if strings.Contains(file, unnormalizedMatchPath) {
+			return true
+		}
+	}
+	return false
+}

--- a/private/pkg/licenseheader/cmd/license-header/main.go
+++ b/private/pkg/licenseheader/cmd/license-header/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/diff"
+	"github.com/bufbuild/buf/private/pkg/git"
 	"github.com/bufbuild/buf/private/pkg/licenseheader"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -37,6 +38,8 @@ const (
 	yearRangeFlagName       = "year-range"
 	diffFlagName            = "diff"
 	exitCodeFlagName        = "exit-code"
+	ignoreFlagName          = "ignore"
+	ignoreFlagShortName     = "e"
 )
 
 func main() {
@@ -60,6 +63,7 @@ type flags struct {
 	YearRange       string
 	Diff            bool
 	ExitCode        bool
+	Ignore          []string
 }
 
 func newFlags() *flags {
@@ -98,6 +102,15 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		false,
 		fmt.Sprintf("Exit with a non-zero exit code if a diff is present. Only valid with %s.", diffFlagName),
 	)
+	flagSet.StringSliceVarP(
+		&f.Ignore,
+		ignoreFlagName,
+		ignoreFlagShortName,
+		nil,
+		`File paths to ignore.
+If a file has any of these values as a substring, it will be ignored. This is not a regex.
+Only works if there are no arguments and license-header does its own search for files.`,
+	)
 }
 
 func run(ctx context.Context, container app.Container, flags *flags) error {
@@ -117,8 +130,11 @@ func run(ctx context.Context, container app.Container, flags *flags) error {
 		}
 	}
 	runner := command.NewRunner()
-	for i := 0; i < container.NumArgs(); i++ {
-		filename := container.Arg(i)
+	filenames, err := getFilenames(ctx, container, runner, flags.Ignore)
+	if err != nil {
+		return err
+	}
+	for _, filename := range filenames {
 		data, err := os.ReadFile(filename)
 		if err != nil {
 			return err
@@ -166,6 +182,27 @@ func run(ctx context.Context, container app.Container, flags *flags) error {
 		}
 	}
 	return nil
+}
+
+func getFilenames(
+	ctx context.Context,
+	container app.Container,
+	runner command.Runner,
+	ignores []string,
+) ([]string, error) {
+	if container.NumArgs() > 0 {
+		if len(ignores) > 0 {
+			return nil, appcmd.NewInvalidArgumentErrorf("cannot use flag %q with any arguments", ignoreFlagName)
+		}
+		return app.Args(container), nil
+	}
+	return git.NewLister(runner).ListFilesAndUnstagedFiles(
+		ctx,
+		container,
+		git.ListFilesAndUnstagedFilesOptions{
+			IgnorePaths: ignores,
+		},
+	)
 }
 
 func newRequiredFlagError(flagName string) error {


### PR DESCRIPTION
This PR does a few things:

- This pulls out the logic from `git-ls-files-unstaged` into the `git` package, so it can be reused.
- This uses @akshayjshah's logic in our OSS Makefile instead of the pre-existing logic, as there was a rare bug in the existing logic.
- This makes it so that if you call `license-header` with no arguments, `license-header` will by default do the equivalent of `git-ls-files-unstaged | xargs license-header`.
- This adds a `--ignore` flag to license-header that can replicate what we used `grep -e` for.

The result is we can make it so that our tools can just call `license-header` as opposed to doing other complicated logic with `git-ls-files, comm, git-ls-files-unstaged`.

I've QA'ed this manually and extensively, no worse than what was there before.

A few notes:

- This should also work on Windows now, but not for sure. But again, no worse than before, and we don't do development with these commands on Windows at the moment.
- The code style in `git` does not follow our current gold standard, especially with options, but instead it attempts to maximize local consistency, i.e. it matches the style already in `git`.
- Once we migrate our existing usage of `license-header`, we can get rid of the >1 args logic, so that there is no confusion. The current behavior with `--ignore` is a little weird, as this flag does not work with >1 args (this is documented).
- We could later extend `--ignore` to take regexes, but there's no need for us to do so at the moment.