### PR TITLE
Fix export help text

### DIFF
--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -60,9 +60,9 @@ func NewCommand(
 
 Examples:
 
-    $ buf export <source> --output=<output-dir>
+Export proto files in <source> to an output directory.
 
-The output will be a directory with all of the .proto files in the <source>.
+    $ buf export <source> --output=<output-dir>
 
 Export current directory to another local directory. 
 

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -54,17 +54,15 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <input>",
-		Short: "Export the files from the input location to an output location.",
-		Long: bufcli.GetInputLong(`the source or module to export`) + `
+		Use:   name + " <source>",
+		Short: "Export the files from the source location to an output location.",
+		Long: bufcli.GetSourceOrModuleLong(`the source or module to export`) + `
 
 Examples:
 
-    $ buf export <input> --output=<output-dir>
+    $ buf export <source> --output=<output-dir>
 
-input can be of the format [dir,git,mod,protofile,tar,targz,zip].
-
-output will be a directory with all of the .proto files in the <input>.
+The output will be a directory with all of the .proto files in the <source>.
 
 Export current directory to another local directory. 
 


### PR DESCRIPTION
Currently `buf export` says that it accepts `bin` when it does not. 

`buf export` doesn't accept `bin` or `json` meaning that it accepts a `source` and not an `input`.

This is a diff of the help text:

```diff
- Export the files from the input location to an output location.
+ Export the files from the source location to an output location.

The first argument is the source or module to export.
- The first argument must be one of format [bin,dir,git,json,mod,protofile,tar,zip].
+ The first argument must be one of format [dir,git,mod,protofile,tar,zip].
If no argument is specified, defaults to ".".

Examples:

+ Export proto files in <source> to an output directory.

-     $ buf export <input> --output=<output-dir>
+     $ buf export <source> --output=<output-dir>

- input can be of the format [dir,git,mod,protofile,tar,targz,zip].

- output will be a directory with all of the .proto files in the <input>.

Export current directory to another local directory.

    $ buf export . --output=<output-dir>

Export the latest remote module to a local directory.

    $ buf export buf.build/<owner>/<repo> --output=<output-dir>

Export a specific version of a remote module to a local directory.

    $ buf export buf.build/<owner>/<repo>:<version> --output=<output-dir>

Export a git repo to a local directory.

    $ buf export https://<git-server>/<owner>/<repo>.git --output=<output-dir>

Usage:
-  buf export <input> [flags]
-  buf export <source> [flags]

Flags:
      --config string          The file or data to use for configuration.
      --disable-symlinks       Do not follow symlinks when reading sources or configuration from the local filesystem.
                               By default, symlinks are followed in this CLI, but never followed on the Buf Schema Registry.
      --exclude-imports        Exclude imports.
      --exclude-path strings   Exclude specific files or directories, for example "proto/a/a.proto" or "proto/a".
                               If specified multiple times, the union is taken.
  -h, --help                   help for export
  -o, --output string          The output directory for exported files.
      --path strings           Limit to specific files or directories, for example "proto/a/a.proto" or "proto/a".
                               If specified multiple times, the union is taken.

Global Flags:
      --debug               Turn on debug logging.
      --log-format string   The log format [text,color,json]. (default "color")
      --timeout duration    The duration until timing out. (default 2m0s)
  -v, --verbose             Turn on verbose mode.
```