### PR TITLE
Add protoc_path in buf.gen.yaml

### DIFF
--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -184,6 +184,8 @@ type PluginConfig struct {
 	Path []string
 	// Required
 	Strategy Strategy
+	// Required
+	ProtocPath string
 }
 
 // PluginName returns this PluginConfig's plugin name.
@@ -343,14 +345,15 @@ type ExternalConfigV1 struct {
 
 // ExternalPluginConfigV1 is an external plugin configuration.
 type ExternalPluginConfigV1 struct {
-	Plugin   string      `json:"plugin,omitempty" yaml:"plugin,omitempty"`
-	Revision int         `json:"revision,omitempty" yaml:"revision,omitempty"`
-	Name     string      `json:"name,omitempty" yaml:"name,omitempty"`
-	Remote   string      `json:"remote,omitempty" yaml:"remote,omitempty"`
-	Out      string      `json:"out,omitempty" yaml:"out,omitempty"`
-	Opt      interface{} `json:"opt,omitempty" yaml:"opt,omitempty"`
-	Path     interface{} `json:"path,omitempty" yaml:"path,omitempty"`
-	Strategy string      `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Plugin     string      `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Revision   int         `json:"revision,omitempty" yaml:"revision,omitempty"`
+	Name       string      `json:"name,omitempty" yaml:"name,omitempty"`
+	Remote     string      `json:"remote,omitempty" yaml:"remote,omitempty"`
+	Out        string      `json:"out,omitempty" yaml:"out,omitempty"`
+	Opt        interface{} `json:"opt,omitempty" yaml:"opt,omitempty"`
+	Path       interface{} `json:"path,omitempty" yaml:"path,omitempty"`
+	ProtocPath string      `json:"protoc_path,omitempty" yaml:"protoc_path,omitempty"`
+	Strategy   string      `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }
 
 // ExternalManagedConfigV1 is an external managed mode configuration.

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -184,7 +184,7 @@ type PluginConfig struct {
 	Path []string
 	// Required
 	Strategy Strategy
-	// Required
+	// Optional
 	ProtocPath string
 }
 

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -148,14 +148,15 @@ func newConfigV1(logger *zap.Logger, externalConfig ExternalConfigV1, id string)
 			return nil, err
 		}
 		pluginConfig := &PluginConfig{
-			Plugin:   plugin.Plugin,
-			Revision: plugin.Revision,
-			Name:     plugin.Name,
-			Remote:   plugin.Remote,
-			Out:      plugin.Out,
-			Opt:      opt,
-			Path:     path,
-			Strategy: strategy,
+			Plugin:     plugin.Plugin,
+			Revision:   plugin.Revision,
+			Name:       plugin.Name,
+			Remote:     plugin.Remote,
+			Out:        plugin.Out,
+			Opt:        opt,
+			Path:       path,
+			ProtocPath: plugin.ProtocPath,
+			Strategy:   strategy,
 		}
 		if pluginConfig.IsRemote() {
 			// Always use StrategyAll for remote plugins
@@ -237,6 +238,9 @@ func checkPathAndStrategyUnset(id string, plugin ExternalPluginConfigV1, pluginI
 	}
 	if plugin.Strategy != "" {
 		return fmt.Errorf("%s: remote plugin %s cannot specify a strategy", id, pluginIdentifier)
+	}
+	if plugin.ProtocPath != "" {
+		return fmt.Errorf("%s: remote plugin %s cannot specify a protoc path", id, pluginIdentifier)
 	}
 	return nil
 }

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -295,6 +295,12 @@ func (g *generator) execLocalPlugin(
 	if err != nil {
 		return nil, err
 	}
+	options := []appprotoexec.GenerateOption{
+		appprotoexec.GenerateWithPluginPath(pluginConfig.Path...),
+	}
+	if pluginConfig.ProtocPath != "" {
+		options = append(options, appprotoexec.GenerateWithProtocPath(pluginConfig.ProtocPath))
+	}
 	response, err := g.appprotoexecGenerator.Generate(
 		ctx,
 		container,
@@ -306,7 +312,7 @@ func (g *generator) execLocalPlugin(
 			includeImports,
 			includeWellKnownTypes,
 		),
-		appprotoexec.GenerateWithPluginPath(pluginConfig.Path...),
+		options...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("plugin %s: %v", pluginConfig.PluginName(), err)

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -295,12 +295,6 @@ func (g *generator) execLocalPlugin(
 	if err != nil {
 		return nil, err
 	}
-	options := []appprotoexec.GenerateOption{
-		appprotoexec.GenerateWithPluginPath(pluginConfig.Path...),
-	}
-	if pluginConfig.ProtocPath != "" {
-		options = append(options, appprotoexec.GenerateWithProtocPath(pluginConfig.ProtocPath))
-	}
 	response, err := g.appprotoexecGenerator.Generate(
 		ctx,
 		container,
@@ -312,7 +306,8 @@ func (g *generator) execLocalPlugin(
 			includeImports,
 			includeWellKnownTypes,
 		),
-		options...,
+		appprotoexec.GenerateWithPluginPath(pluginConfig.Path...),
+		appprotoexec.GenerateWithProtocPath(pluginConfig.ProtocPath),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("plugin %s: %v", pluginConfig.PluginName(), err)

--- a/private/pkg/app/appproto/appprotoexec/appprotoexec.go
+++ b/private/pkg/app/appproto/appprotoexec/appprotoexec.go
@@ -106,6 +106,14 @@ func GenerateWithPluginPath(pluginPath ...string) GenerateOption {
 	}
 }
 
+// GenerateWithProtocPath returns a new GenerateOption that uses the given protoc
+// path to the plugin.
+func GenerateWithProtocPath(protocPath string) GenerateOption {
+	return func(generateOptions *generateOptions) {
+		generateOptions.protocPath = protocPath
+	}
+}
+
 // NewHandler returns a new Handler based on the plugin name and optional path.
 //
 // protocPath and pluginPath are optional.

--- a/private/pkg/app/appproto/appprotoexec/generator.go
+++ b/private/pkg/app/appproto/appprotoexec/generator.go
@@ -59,6 +59,7 @@ func (g *generator) Generate(
 		g.runner,
 		pluginName,
 		HandlerWithPluginPath(generateOptions.pluginPath...),
+		HandlerWithProtocPath(generateOptions.protocPath),
 	)
 	if err != nil {
 		return nil, err
@@ -75,6 +76,7 @@ func (g *generator) Generate(
 
 type generateOptions struct {
 	pluginPath []string
+	protocPath string
 }
 
 func newGenerateOptions() *generateOptions {


### PR DESCRIPTION
Fixes #1462.

Added field `protoc_path` in `buf.gen.yaml` to allow specifying `protoc` path for built-in plugins as mentioned [here](https://github.com/bufbuild/buf/issues/1462).