### PR TITLE
Misc buf cli fixes

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -215,7 +215,7 @@ func BindPaths(
 		pathsAddr,
 		pathsFlagName,
 		nil,
-		`Limit to specific files or directories, for example "proto/a/a.proto" or "proto/a".
+		`Limit to specific files or directories, e.g. "proto/a/a.proto", "proto/a".
 If specified multiple times, the union is taken.`,
 	)
 }
@@ -246,7 +246,7 @@ func BindExcludePaths(
 		excludePathsAddr,
 		excludePathsFlagName,
 		nil,
-		`Exclude specific files or directories, for example "proto/a/a.proto" or "proto/a".
+		`Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a".
 If specified multiple times, the union is taken.`,
 	)
 }

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -215,8 +215,8 @@ func BindPaths(
 		pathsAddr,
 		pathsFlagName,
 		nil,
-		`Limit to specific files or directories, e.g. "proto/a/a.proto", "proto/a".
-If specified multiple times, the union is taken.`,
+		`Limit to specific files or directories, e.g. "proto/a/a.proto", "proto/a"
+If specified multiple times, the union is taken`,
 	)
 }
 
@@ -246,8 +246,8 @@ func BindExcludePaths(
 		excludePathsAddr,
 		excludePathsFlagName,
 		nil,
-		`Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a".
-If specified multiple times, the union is taken.`,
+		`Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a"
+If specified multiple times, the union is taken`,
 	)
 }
 
@@ -257,8 +257,8 @@ func BindDisableSymlinks(flagSet *pflag.FlagSet, addr *bool, flagName string) {
 		addr,
 		flagName,
 		false,
-		`Do not follow symlinks when reading sources or configuration from the local filesystem.
-By default, symlinks are followed in this CLI, but never followed on the Buf Schema Registry.`,
+		`Do not follow symlinks when reading sources or configuration from the local filesystem
+By default, symlinks are followed in this CLI, but never followed on the Buf Schema Registry`,
 	)
 }
 

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -179,9 +179,9 @@ func BindAsFileDescriptorSet(flagSet *pflag.FlagSet, addr *bool, flagName string
 		addr,
 		flagName,
 		false,
-		`Output as a google.protobuf.FileDescriptorSet instead of an image.
+		`Output as a google.protobuf.FileDescriptorSet instead of an image
 Note that images are wire compatible with FileDescriptorSets, but this flag strips
-the additional metadata added for Buf usage.`,
+the additional metadata added for Buf usage`,
 	)
 }
 
@@ -201,7 +201,7 @@ func BindExcludeSourceInfo(flagSet *pflag.FlagSet, addr *bool, flagName string) 
 		addr,
 		flagName,
 		false,
-		"Exclude source info.",
+		"Exclude source info",
 	)
 }
 

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -105,7 +105,7 @@ func NewRootCommand(name string) *appcmd.Command {
 	return &appcmd.Command{
 		Use:                 name,
 		Short:               "The Buf CLI",
-		Long:                "A tool for working with Protocol Buffers and managing resources on the Buf Schema Registry (BSR).",
+		Long:                "A tool for working with Protocol Buffers and managing resources on the Buf Schema Registry (BSR)",
 		Version:             bufcli.Version,
 		BindPersistentFlags: appcmd.BindMultiple(builder.BindRoot, globalFlags.BindRoot),
 		SubCommands: []*appcmd.Command{
@@ -248,7 +248,7 @@ func NewRootCommand(name string) *appcmd.Command {
 			},
 			{
 				Use:    "alpha",
-				Short:  "Alpha commands. Unstable and recommended only for experimentation. These may be deleted.",
+				Short:  "Alpha commands. Unstable and recommended only for experimentation. These may be deleted",
 				Hidden: true,
 				SubCommands: []*appcmd.Command{
 					protoc.NewCommand("protoc", builder),

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -121,7 +121,7 @@ func NewRootCommand(name string) *appcmd.Command {
 			curl.NewCommand("curl", builder),
 			{
 				Use:   "mod",
-				Short: "Manage Buf modules.",
+				Short: "Manage Buf modules",
 				SubCommands: []*appcmd.Command{
 					modinit.NewCommand("init", builder),
 					modprune.NewCommand("prune", builder),
@@ -134,7 +134,7 @@ func NewRootCommand(name string) *appcmd.Command {
 			},
 			{
 				Use:   "registry",
-				Short: "Manage assets on the Buf Schema Registry.",
+				Short: "Manage assets on the Buf Schema Registry",
 				SubCommands: []*appcmd.Command{
 					registrylogin.NewCommand("login", builder),
 					registrylogout.NewCommand("logout", builder),
@@ -142,17 +142,17 @@ func NewRootCommand(name string) *appcmd.Command {
 			},
 			{
 				Use:   "beta",
-				Short: "Beta commands. Unstable and likely to change.",
+				Short: "Beta commands. Unstable and likely to change",
 				SubCommands: []*appcmd.Command{
 					migratev1beta1.NewCommand("migrate-v1beta1", builder),
 					studioagent.NewCommand("studio-agent", noTimeoutBuilder),
 					{
 						Use:   "registry",
-						Short: "Manage assets on the Buf Schema Registry.",
+						Short: "Manage assets on the Buf Schema Registry",
 						SubCommands: []*appcmd.Command{
 							{
 								Use:   "organization",
-								Short: "Manage organizations.",
+								Short: "Manage organizations",
 								SubCommands: []*appcmd.Command{
 									organizationcreate.NewCommand("create", builder),
 									organizationget.NewCommand("get", builder),
@@ -161,7 +161,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "repository",
-								Short: "Manage repositories.",
+								Short: "Manage repositories",
 								SubCommands: []*appcmd.Command{
 									repositorycreate.NewCommand("create", builder),
 									repositoryget.NewCommand("get", builder),
@@ -174,7 +174,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "tag",
-								Short: "Manage a repository's tags.",
+								Short: "Manage a repository's tags",
 								SubCommands: []*appcmd.Command{
 									tagcreate.NewCommand("create", builder),
 									taglist.NewCommand("list", builder),
@@ -182,7 +182,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "commit",
-								Short: "Manage a repository's commits.",
+								Short: "Manage a repository's commits",
 								SubCommands: []*appcmd.Command{
 									commitget.NewCommand("get", builder),
 									commitlist.NewCommand("list", builder),
@@ -190,7 +190,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "draft",
-								Short: "Manage a repository's drafts.",
+								Short: "Manage a repository's drafts",
 								SubCommands: []*appcmd.Command{
 									draftdelete.NewCommand("delete", builder),
 									draftlist.NewCommand("list", builder),
@@ -198,7 +198,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "plugin",
-								Short: "Manage Protobuf plugins.",
+								Short: "Manage Protobuf plugins",
 								SubCommands: []*appcmd.Command{
 									plugincreate.NewCommand("create", builder),
 									pluginlist.NewCommand("list", builder),
@@ -207,7 +207,7 @@ func NewRootCommand(name string) *appcmd.Command {
 									pluginundeprecate.NewCommand("undeprecate", builder),
 									{
 										Use:   "version",
-										Short: "Manage Protobuf plugin versions.",
+										Short: "Manage Protobuf plugin versions",
 										SubCommands: []*appcmd.Command{
 											pluginversionlist.NewCommand("list", builder),
 										},
@@ -216,7 +216,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "template",
-								Short: "Manage Protobuf templates on the Buf Schema Registry.",
+								Short: "Manage Protobuf templates on the Buf Schema Registry",
 								SubCommands: []*appcmd.Command{
 									templatecreate.NewCommand("create", builder),
 									templatelist.NewCommand("list", builder),
@@ -225,7 +225,7 @@ func NewRootCommand(name string) *appcmd.Command {
 									templateundeprecate.NewCommand("undeprecate", builder),
 									{
 										Use:   "version",
-										Short: "Manage Protobuf template versions.",
+										Short: "Manage Protobuf template versions",
 										SubCommands: []*appcmd.Command{
 											templateversioncreate.NewCommand("create", builder),
 											templateversionlist.NewCommand("list", builder),
@@ -235,7 +235,7 @@ func NewRootCommand(name string) *appcmd.Command {
 							},
 							{
 								Use:   "webhook",
-								Short: "Manage webhooks for a repository on the Buf Schema Registry.",
+								Short: "Manage webhooks for a repository on the Buf Schema Registry",
 								SubCommands: []*appcmd.Command{
 									webhookcreate.NewCommand("create", builder),
 									webhookdelete.NewCommand("delete", builder),
@@ -254,11 +254,11 @@ func NewRootCommand(name string) *appcmd.Command {
 					protoc.NewCommand("protoc", builder),
 					{
 						Use:   "registry",
-						Short: "Manage assets on the Buf Schema Registry.",
+						Short: "Manage assets on the Buf Schema Registry",
 						SubCommands: []*appcmd.Command{
 							{
 								Use:   "token",
-								Short: "Manage user tokens.",
+								Short: "Manage user tokens",
 								SubCommands: []*appcmd.Command{
 									tokencreate.NewCommand("create", builder),
 									tokenget.NewCommand("get", builder),
@@ -270,7 +270,7 @@ func NewRootCommand(name string) *appcmd.Command {
 					},
 					{
 						Use:   "plugin",
-						Short: "Manage plugins on the Buf Schema Registry.",
+						Short: "Manage plugins on the Buf Schema Registry",
 						SubCommands: []*appcmd.Command{
 							pluginpush.NewCommand("push", builder),
 							curatedplugindelete.NewCommand("delete", builder),

--- a/private/buf/cmd/buf/command/alpha/plugin/plugindelete/plugindelete.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/plugindelete/plugindelete.go
@@ -39,7 +39,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/plugin[:version]>",
-		Short: "Delete a plugin from the registry.",
+		Short: "Delete a plugin from the registry",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -65,7 +65,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <source>",
-		Short: "Push a plugin to a registry.",
+		Short: "Push a plugin to a registry",
 		Long:  bufcli.GetSourceDirLong(`the source to push (directory containing buf.plugin.yaml or plugin release zip)`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -103,7 +103,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors printed to stderr. Must be one of %s.",
+			"The format for build errors printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -111,13 +111,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.OverrideRemote,
 		overrideRemoteFlagName,
 		"",
-		"Override the default remote found in buf.plugin.yaml name and dependencies.",
+		"Override the default remote found in buf.plugin.yaml name and dependencies",
 	)
 	flagSet.StringVar(
 		&f.Image,
 		imageFlagName,
 		"",
-		"Existing image to push.",
+		"Existing image to push",
 	)
 }
 

--- a/private/buf/cmd/buf/command/alpha/protoc/protoc.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/protoc.go
@@ -48,7 +48,7 @@ func NewCommand(
 	flagsBuilder := newFlagsBuilder()
 	return &appcmd.Command{
 		Use:   name + " <proto_file1> <proto_file2> ...",
-		Short: "High-performance protoc replacement.",
+		Short: "High-performance protoc replacement",
 		Long: `This command replaces protoc using Buf's internal compiler.
 
 The implementation is in progress. Although it outperforms mainline protoc,

--- a/private/buf/cmd/buf/command/alpha/registry/token/tokencreate/tokencreate.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokencreate/tokencreate.go
@@ -45,7 +45,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "Create a new token for a user.",
+		Short: "Create a new token for a user",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/alpha/registry/token/tokendelete/tokendelete.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokendelete/tokendelete.go
@@ -42,7 +42,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "Delete a token by ID.",
+		Short: "Delete a token by ID",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/alpha/registry/token/tokendelete/tokendelete.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokendelete/tokendelete.go
@@ -68,13 +68,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Force,
 		forceFlagName,
 		false,
-		"Force deletion without confirming. Use with caution.",
+		"Force deletion without confirming. Use with caution",
 	)
 	flagSet.StringVar(
 		&f.TokenID,
 		tokenIDFlagName,
 		"",
-		"The ID of the token to delete.",
+		"The ID of the token to delete",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, tokenIDFlagName)
 }

--- a/private/buf/cmd/buf/command/alpha/registry/token/tokenget/tokenget.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokenget/tokenget.go
@@ -76,7 +76,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.TokenID,
 		tokenIDFlagName,
 		"",
-		"The ID of the token to get.",
+		"The ID of the token to get",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, tokenIDFlagName)
 }

--- a/private/buf/cmd/buf/command/alpha/registry/token/tokenget/tokenget.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokenget/tokenget.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "Get a token by ID.",
+		Short: "Get a token by ID",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/alpha/registry/token/tokenlist/tokenlist.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokenlist/tokenlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List my tokens.",
+		Short: "List my tokens",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/migratev1beta1/migratev1beta1.go
+++ b/private/buf/cmd/buf/command/beta/migratev1beta1/migratev1beta1.go
@@ -33,8 +33,8 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <directory>",
-		Short: `Migrate any v1beta1 configuration files in the directory to the latest version.`,
-		Long:  `Defaults to the current directory if not specified.`,
+		Short: `Migrate any v1beta1 configuration files in the directory to the latest version`,
+		Long:  `Defaults to the current directory if not specified`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository:ref>",
-		Short: "Get details about a commit.",
+		Short: "Get details about a commit",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
@@ -40,7 +40,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repository:ref>",
+		Use:   name + " <buf.build/owner/repository[:ref]>",
 		Short: "Get details about a commit",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
@@ -40,7 +40,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repo:ref>",
+		Use:   name + " <buf.build/owner/repository:ref>",
 		Short: "Get details about a commit.",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository:[ref]>",
-		Short: "List commits.",
+		Short: "List commits",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
@@ -45,7 +45,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repo[:ref]>",
+		Use:   name + " <buf.build/owner/repository:[ref]>",
 		Short: "List commits.",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
@@ -45,7 +45,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repository:[ref]>",
+		Use:   name + " <buf.build/owner/repository[:ref]>",
 		Short: "List commits",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
@@ -73,17 +73,17 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.Uint32Var(&f.PageSize,
 		pageSizeFlagName,
 		10,
-		`The page size.`,
+		`The page size`,
 	)
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,
 		false,
-		`Reverse the results.`,
+		`Reverse the results`,
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
@@ -40,7 +40,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repo:draft>",
+		Use:   name + " <buf.build/owner/repository:draft>",
 		Short: "Delete a draft of a BSR repository by name.",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
@@ -66,7 +66,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Force,
 		forceFlagName,
 		false,
-		"Force deletion without confirming. Use with caution.",
+		"Force deletion without confirming. Use with caution",
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository:draft>",
-		Short: "Delete a draft of a BSR repository by name.",
+		Short: "Delete a draft of a BSR repository by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftlist/draftlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftlist/draftlist.go
@@ -70,17 +70,17 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.Uint32Var(&f.PageSize,
 		pageSizeFlagName,
 		10,
-		`The page size.`,
+		`The page size`,
 	)
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,
 		false,
-		`Reverse the results.`,
+		`Reverse the results`,
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftlist/draftlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftlist/draftlist.go
@@ -43,7 +43,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "List drafts for the specified repository.",
+		Short: "List drafts for the specified repository",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate/organizationcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate/organizationcreate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/organization>",
-		Short: "Create a new organization on the BSR.",
+		Short: "Create a new organization on the BSR",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
@@ -65,7 +65,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Force,
 		forceFlagName,
 		false,
-		"Force deletion without confirming. Use with caution.",
+		"Force deletion without confirming. Use with caution",
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
@@ -40,7 +40,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/organization>",
-		Short: "Delete an organization by name on the BSR.",
+		Short: "Delete an organization by name on the BSR",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationget/organizationget.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationget/organizationget.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/organization>",
-		Short: "Get an organization on the BSR by name.",
+		Short: "Get an organization on the BSR by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate/plugincreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate/plugincreate.go
@@ -53,7 +53,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "Create a new Protobuf plugin.",
+		Short: "Create a new Protobuf plugin",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate/plugincreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate/plugincreate.go
@@ -79,7 +79,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Visibility,
 		visibilityFlagName,
 		"",
-		fmt.Sprintf(`The plugin's visibility setting. Must be one of %s.`, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The plugin's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
 	)
 	_ = cobra.MarkFlagRequired(flagSet, visibilityFlagName)
 	flagSet.StringVar(

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete/plugindelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete/plugindelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + internal.PluginsPathName + "/plugin>",
-		Short: "Delete a Protobuf plugin by name.",
+		Short: "Delete a Protobuf plugin by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete/plugindelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete/plugindelete.go
@@ -66,7 +66,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Force,
 		forceFlagName,
 		false,
-		"Force deletion without confirming. Use with caution.",
+		"Force deletion without confirming. Use with caution",
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
@@ -66,7 +66,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Message,
 		messageFlagName,
 		"",
-		`The message to display with deprecation warnings.`,
+		`The message to display with deprecation warnings`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "Deprecate a plugin by name.",
+		Short: "Deprecate a plugin by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist/pluginlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist/pluginlist.go
@@ -73,17 +73,17 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.Uint32Var(&f.PageSize,
 		pageSizeFlagName,
 		10,
-		`The page size.`,
+		`The page size`,
 	)
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,
 		false,
-		`Reverse the results.`,
+		`Reverse the results`,
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist/pluginlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist/pluginlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List plugins on the specified remote.",
+		Short: "List plugins on the specified remote",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
@@ -35,7 +35,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "Undeprecate a plugin by name.",
+		Short: "Undeprecate a plugin by name",
 		Args:  cobra.ExactArgs(1),
 		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
 	}

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist/pluginversionlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist/pluginversionlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "List versions for the specified plugin.",
+		Short: "List versions for the specified plugin",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist/pluginversionlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist/pluginversionlist.go
@@ -73,17 +73,17 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.Uint32Var(&f.PageSize,
 		pageSizeFlagName,
 		10,
-		`The page size.`,
+		`The page size`,
 	)
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,
 		false,
-		`Reverse the results.`,
+		`Reverse the results`,
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -72,7 +72,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Format,
 		formatFlagName,
 		bufprint.FormatText.String(),
-		fmt.Sprintf(`The output format to use. Must be one of %s.`, bufprint.AllFormatsString),
+		fmt.Sprintf(`The output format to use. Must be one of %s`, bufprint.AllFormatsString),
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Create a new repository on the BSR.",
+		Short: "Create a new repository on the BSR",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
@@ -40,7 +40,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Delete a BSR repository by name.",
+		Short: "Delete a BSR repository by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
@@ -65,7 +65,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Force,
 		forceFlagName,
 		false,
-		"Force deletion without confirming. Use with caution.",
+		"Force deletion without confirming. Use with caution",
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
@@ -39,7 +39,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Deprecate a repository on the BSR.",
+		Short: "Deprecate a repository on the BSR",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
@@ -64,7 +64,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Message,
 		messageFlagName,
 		"",
-		`The message to display with deprecation warnings.`,
+		`The message to display with deprecation warnings`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Get a BSR repository by name.",
+		Short: "Get a BSR repository by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
@@ -78,12 +78,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,
 		false,
-		`Reverse the results.`,
+		`Reverse the results`,
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorylist/repositorylist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List BSR repositories.",
+		Short: "List BSR repositories",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryundeprecate/repositoryundeprecate.go
@@ -33,7 +33,7 @@ import (
 func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Undeprecate a BSR repository.",
+		Short: "Undeprecate a BSR repository",
 		Args:  cobra.ExactArgs(1),
 		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
 	}

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
@@ -39,7 +39,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Update a BSR repository settings.",
+		Short: "Update a BSR repository settings",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository:commit> <tag>",
-		Short: "Create a tag for the specified commit.",
+		Short: "Create a tag for the specified commit",
 		Args:  cobra.ExactArgs(2),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
@@ -66,7 +66,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Format,
 		formatFlagName,
 		bufprint.FormatText.String(),
-		fmt.Sprintf(`The output format to use. Must be one of %s.`, bufprint.AllFormatsString),
+		fmt.Sprintf(`The output format to use. Must be one of %s`, bufprint.AllFormatsString),
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "List tags for the specified repository.",
+		Short: "List tags for the specified repository",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
@@ -78,12 +78,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,
 		false,
-		`Reverse the results.`,
+		`Reverse the results`,
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/beta/registry/template/templatecreate/templatecreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatecreate/templatecreate.go
@@ -81,14 +81,14 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The template file or data to use for configuration. Must be in either YAML or JSON format.`,
+		`The template file or data to use for configuration. Must be in either YAML or JSON format`,
 	)
 	_ = cobra.MarkFlagRequired(flagSet, configFlagName)
 	flagSet.StringVar(
 		&f.Visibility,
 		visibilityFlagName,
 		"",
-		fmt.Sprintf(`The template's visibility setting. Must be one of %s.`, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The template's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
 	)
 	_ = cobra.MarkFlagRequired(flagSet, visibilityFlagName)
 	flagSet.StringVar(

--- a/private/buf/cmd/buf/command/beta/registry/template/templatecreate/templatecreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatecreate/templatecreate.go
@@ -54,7 +54,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Create a new Buf template.",
+		Short: "Create a new Buf template",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedelete/templatedelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedelete/templatedelete.go
@@ -66,7 +66,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Force,
 		forceFlagName,
 		false,
-		"Force deletion without confirming. Use with caution.",
+		"Force deletion without confirming. Use with caution",
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedelete/templatedelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedelete/templatedelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Delete a template by name.",
+		Short: "Delete a template by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Deprecate a template by name.",
+		Short: "Deprecate a template by name",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
@@ -66,7 +66,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Message,
 		messageFlagName,
 		"",
-		`The message to display with deprecation warnings.`,
+		`The message to display with deprecation warnings`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/beta/registry/template/templatelist/templatelist.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatelist/templatelist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List templates on the specified remote.",
+		Short: "List templates on the specified remote",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatelist/templatelist.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatelist/templatelist.go
@@ -78,7 +78,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,

--- a/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/templateundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/templateundeprecate.go
@@ -35,7 +35,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Undeprecate a template by name.",
+		Short: "Undeprecate a template by name",
 		Args:  cobra.ExactArgs(1),
 		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
 	}

--- a/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate/templateversioncreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate/templateversioncreate.go
@@ -45,7 +45,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Create a new template version.",
+		Short: "Create a new template version",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate/templateversioncreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversioncreate/templateversioncreate.go
@@ -72,7 +72,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		"The template file or data to use for configuration. Must be in either YAML or JSON format.",
+		"The template file or data to use for configuration. Must be in either YAML or JSON format",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, configFlagName)
 	flagSet.StringVar(

--- a/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist/templateversionlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist/templateversionlist.go
@@ -78,7 +78,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.PageToken,
 		pageTokenFlagName,
 		"",
-		`The page token. If more results are available, a "next_page" key is present in the --format=json output.`,
+		`The page token. If more results are available, a "next_page" key is present in the --format=json output`,
 	)
 	flagSet.BoolVar(&f.Reverse,
 		reverseFlagName,

--- a/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist/templateversionlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateversion/templateversionlist/templateversionlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "List versions for the specified template.",
+		Short: "List versions for the specified template",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -75,35 +75,35 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.WebhookEvent,
 		webhookEventFlagName,
 		"",
-		"The event type to create a webhook for. The proto enum string value is used for this input (e.g. 'WEBHOOK_EVENT_REPOSITORY_PUSH').",
+		"The event type to create a webhook for. The proto enum string value is used for this input (e.g. 'WEBHOOK_EVENT_REPOSITORY_PUSH')",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, webhookEventFlagName)
 	flagSet.StringVar(
 		&f.OwnerName,
 		ownerFlagName,
 		"",
-		`The owner name of the repository to create a webhook for.`,
+		`The owner name of the repository to create a webhook for`,
 	)
 	_ = cobra.MarkFlagRequired(flagSet, ownerFlagName)
 	flagSet.StringVar(
 		&f.RepositoryName,
 		repositoryFlagName,
 		"",
-		"The repository name to create a webhook for.",
+		"The repository name to create a webhook for",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, repositoryFlagName)
 	flagSet.StringVar(
 		&f.CallbackURL,
 		callbackURLFlagName,
 		"",
-		"The url for the webhook to callback to on a given event.",
+		"The url for the webhook to callback to on a given event",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, callbackURLFlagName)
 	flagSet.StringVar(
 		&f.Remote,
 		remoteFlagName,
 		"",
-		"The remote of the repository the created webhook will belong to.",
+		"The remote of the repository the created webhook will belong to",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "Create a repository webhook.",
+		Short: "Create a repository webhook",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -67,14 +67,14 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.WebhookID,
 		webhookIDFlagName,
 		"",
-		"The webhook ID to delete.",
+		"The webhook ID to delete",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, webhookIDFlagName)
 	flagSet.StringVar(
 		&f.Remote,
 		remoteFlagName,
 		"",
-		"The remote of the repository the webhook ID belongs to.",
+		"The remote of the repository the webhook ID belongs to",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete/webhookdelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "Delete a repository webhook.",
+		Short: "Delete a repository webhook",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -43,7 +43,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "List repository webhooks.",
+		Short: "List repository webhooks",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -70,7 +70,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.OwnerName,
 		ownerFlagName,
 		"",
-		`The owner name of the repository to list webhooks for.`,
+		`The owner name of the repository to list webhooks for`,
 	)
 	_ = cobra.MarkFlagRequired(flagSet, ownerFlagName)
 	flagSet.StringVar(
@@ -84,7 +84,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Remote,
 		remoteFlagName,
 		"",
-		"The remote of the owner and repository to list webhooks for.",
+		"The remote of the owner and repository to list webhooks for",
 	)
 	_ = cobra.MarkFlagRequired(flagSet, remoteFlagName)
 }

--- a/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
+++ b/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
@@ -52,7 +52,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "Run an HTTP(S) server as the Studio agent.",
+		Short: "Run an HTTP(S) server as the Studio agent",
 		Args:  cobra.ExactArgs(0),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
+++ b/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
@@ -86,61 +86,61 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.BindAddress,
 		bindFlagName,
 		"127.0.0.1",
-		"The address to be exposed to accept HTTP requests.",
+		"The address to be exposed to accept HTTP requests",
 	)
 	flagSet.StringVar(
 		&f.Port,
 		portFlagName,
 		"8080",
-		"The port to be exposed to accept HTTP requests.",
+		"The port to be exposed to accept HTTP requests",
 	)
 	flagSet.StringVar(
 		&f.Origin,
 		originFlagName,
 		"https://studio.buf.build",
-		"The allowed origin for CORS options.",
+		"The allowed origin for CORS options",
 	)
 	flagSet.StringSliceVar(
 		&f.DisallowedHeaders,
 		disallowedHeadersFlagName,
 		nil,
-		`The header names that are disallowed by this agent. When the agent receives an enveloped request with these headers set, it will return an error rather than forward the request to the target server. Multiple headers are appended if specified multiple times.`,
+		`The header names that are disallowed by this agent. When the agent receives an enveloped request with these headers set, it will return an error rather than forward the request to the target server. Multiple headers are appended if specified multiple times`,
 	)
 	flagSet.StringToStringVar(
 		&f.ForwardHeaders,
 		forwardHeadersFlagName,
 		nil,
-		`The headers to be forwarded via the agent to the target server. Must be an equals sign separated key-value pair (like --forward-header=fromHeader1=toHeader1). Multiple header pairs are appended if specified multiple times.`,
+		`The headers to be forwarded via the agent to the target server. Must be an equals sign separated key-value pair (like --forward-header=fromHeader1=toHeader1). Multiple header pairs are appended if specified multiple times`,
 	)
 	flagSet.StringVar(
 		&f.CACert,
 		caCertFlagName,
 		"",
-		"The CA cert to be used in the client and server TLS configuration.",
+		"The CA cert to be used in the client and server TLS configuration",
 	)
 	flagSet.StringVar(
 		&f.ClientCert,
 		clientCertFlagName,
 		"",
-		"The cert to be used in the client TLS configuration.",
+		"The cert to be used in the client TLS configuration",
 	)
 	flagSet.StringVar(
 		&f.ClientKey,
 		clientKeyFlagName,
 		"",
-		"The key to be used in the client TLS configuration.",
+		"The key to be used in the client TLS configuration",
 	)
 	flagSet.StringVar(
 		&f.ServerCert,
 		serverCertFlagName,
 		"",
-		"The cert to be used in the server TLS configuration.",
+		"The cert to be used in the server TLS configuration",
 	)
 	flagSet.StringVar(
 		&f.ServerKey,
 		serverKeyFlagName,
 		"",
-		"The key to be used in the server TLS configuration.",
+		"The key to be used in the server TLS configuration",
 	)
 }
 

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -94,7 +94,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors or check violations printed to stdout. Must be one of %s.",
+			"The format for build errors or check violations printed to stdout. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -111,7 +111,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		fmt.Sprintf(
 			`Only run breaking checks against the files in the input.
 When set, the against input contains only the files in the input.
-Overrides --%s.`,
+Overrides --%s`,
 			pathsFlagName,
 		),
 	)
@@ -119,14 +119,14 @@ Overrides --%s.`,
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration.`,
+		`The file or data to use for configuration`,
 	)
 	flagSet.StringVar(
 		&f.Against,
 		againstFlagName,
 		"",
 		fmt.Sprintf(
-			`Required. The source, module, or image to check against. Must be one of format %s.`,
+			`Required. The source, module, or image to check against. Must be one of format %s`,
 			buffetch.AllFormatsString,
 		),
 	)
@@ -134,7 +134,7 @@ Overrides --%s.`,
 		&f.AgainstConfig,
 		againstConfigFlagName,
 		"",
-		`The file or data to use to configure the against source, module, or image.`,
+		`The file or data to use to configure the against source, module, or image`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -109,8 +109,8 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		limitToInputFilesFlagName,
 		false,
 		fmt.Sprintf(
-			`Only run breaking checks against the files in the input.
-When set, the against input contains only the files in the input.
+			`Only run breaking checks against the files in the input
+When set, the against input contains only the files in the input
 Overrides --%s`,
 			pathsFlagName,
 		),

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -53,7 +53,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input> --against <against-input>",
-		Short: "Verify that the input location has no breaking changes compared to the against location.",
+		Short: "Verify that the input location has no breaking changes compared to the against location",
 		Long:  bufcli.GetInputLong(`the source, module, or image to check for breaking changes`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -51,7 +51,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Build all Protobuf files from the specified input and output a Buf image.",
+		Short: "Build all Protobuf files from the specified input and output a Buf image",
 		Long:  bufcli.GetInputLong(`the source or module to build or image to convert`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -96,7 +96,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors printed to stderr. Must be one of %s.",
+			"The format for build errors printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -106,7 +106,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		outputFlagShortName,
 		app.DevNullFilePath,
 		fmt.Sprintf(
-			`The output location for the built image. Must be one of format %s.`,
+			`The output location for the built image. Must be one of format %s`,
 			buffetch.ImageFormatsString,
 		),
 	)
@@ -114,13 +114,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use to use for configuration.`,
+		`The file or data to use to use for configuration`,
 	)
 	flagSet.StringSliceVar(
 		&f.Types,
 		"type",
 		nil,
-		"The types (message, enum, service) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types.",
+		"The types (message, enum, service) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types",
 	)
 }
 

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -50,37 +50,33 @@ func NewCommand(
 		Long: `
 Use an input proto to interpret a proto/json message and convert it to a different format.
 
-The simplest form is:
+Examples:
 
     $ buf convert <input> --type=<type> --from=<payload> --to=<output>
 
-<input> is the same input as any other buf command. 
-It can be a local .proto file, binary output of "buf build", bsr module or local buf module.
-e.g.
+The <input> can be a local .proto file, binary output of "buf build", bsr module or local buf module:
 
     $ buf convert example.proto --type=Foo.proto --from=payload.json --to=output.bin
 
-Other examples
-
-All of <input>, "--from" and "to" accept formatting options
+All of <input>, "--from" and "to" accept formatting options:
 
     $ buf convert example.proto#format=bin --type=buf.Foo --from=payload#format=json --to=out#format=json
 
-Both <input> and "--from" accept stdin redirecting
+Both <input> and "--from" accept stdin redirecting:
 
     $ buf convert <(buf build -o -)#format=bin --type=foo.Bar --from=<(echo "{\"one\":\"55\"}")#format=json
 
-Redirect from stdin to --from
+Redirect from stdin to --from:
 
     $ echo "{\"one\":\"55\"}" | buf convert buf.proto --type buf.Foo --from -#format=json
 
-Redirect from stdin to <input>
+Redirect from stdin to <input>:
 
     $ buf build -o - | buf convert -#format=bin --type buf.Foo --from=payload.json
 
-Use a module on the bsr
+Use a module on the bsr:
 
-buf convert buf.build/<org>/<repo> --type buf.Foo --from=payload.json
+    $ buf convert <buf.build/owner/repository> --type buf.Foo --from=payload.json
 `,
 		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -110,7 +110,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors printed to stderr. Must be one of %s.",
+			"The format for build errors printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -125,7 +125,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		fromFlagName,
 		"-",
 		fmt.Sprintf(
-			`The location of the payload to be converted. Supported formats are %s.`,
+			`The location of the payload to be converted. Supported formats are %s`,
 			bufconvert.MessageEncodingFormatsString,
 		),
 	)
@@ -134,7 +134,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		outputFlagName,
 		"-",
 		fmt.Sprintf(
-			`The output location of the conversion. Supported formats are %s.`,
+			`The output location of the conversion. Supported formats are %s`,
 			bufconvert.MessageEncodingFormatsString,
 		),
 	)

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -228,7 +228,7 @@ server reflection. The format of this argument is the same as for the <input> ar
 other buf sub-commands such as build and generate. It can indicate a directory, a file, a
 remote module in the Buf Schema Registry, or even standard in ("-") for feeding an image or
 file descriptor set to the command in a shell pipeline.
-Setting this flags implies --%s=false.`,
+Setting this flags implies --%s=false`,
 			reflectFlagName,
 		),
 	)
@@ -236,7 +236,7 @@ Setting this flags implies --%s=false.`,
 		&f.Reflect,
 		reflectFlagName,
 		true,
-		`If true, use server reflection to determine the schema.`,
+		`If true, use server reflection to determine the schema`,
 	)
 	flagSet.StringSliceVar(
 		&f.ReflectHeaders,
@@ -250,7 +250,7 @@ flags) should also be included with reflection requests. A special value of '@<p
 means to read headers from the file at <path>. If the path is "-" then headers are
 read from stdin. It is not allowed to indicate a file with the same path as used with
 the request data flag (--data or -d). Furthermore, it is not allowed to indicate stdin
-if the schema is expected to be provided via stdin as a file descriptor set or image.`,
+if the schema is expected to be provided via stdin as a file descriptor set or image`,
 	)
 	flagSet.StringVar(
 		&f.ReflectProtocol,
@@ -264,21 +264,21 @@ and "grpc-v1alpha" is used if it doesn't work. If newer reflection protocols are
 they may be preferred in the absence of this flag being explicitly set to a specific protocol.
 The valid values for this flag are "grpc-v1" and "grpc-v1alpha". These correspond to services
 named "grpc.reflection.v1.ServerReflection" and "grpc.reflection.v1alpha.ServerReflection"
-respectively.`,
+respectively`,
 	)
 
 	flagSet.StringVar(
 		&f.Protocol,
 		protocolFlagName,
 		connect.ProtocolConnect,
-		`The RPC protocol to use. This can be one of "grpc", "grpcweb", or "connect".`,
+		`The RPC protocol to use. This can be one of "grpc", "grpcweb", or "connect"`,
 	)
 	flagSet.StringVar(
 		&f.UnixSocket,
 		unixSocketFlagName,
 		"",
 		`The path to a unix socket that will be used instead of opening a TCP socket to the host
-and port indicated in the URL.`,
+and port indicated in the URL`,
 	)
 	flagSet.BoolVar(
 		&f.HTTP2PriorKnowledge,
@@ -287,7 +287,7 @@ and port indicated in the URL.`,
 		`This flag can be used with URLs that use the http scheme (as opposed to https) to indicate
 that HTTP/2 should be used. Without this, HTTP 1.1 will be used with URLs with an http
 scheme. For https scheme, HTTP/2 will be negotiate during the TLS handshake if the server
-supports it (otherwise HTTP 1.1 is used).`,
+supports it (otherwise HTTP 1.1 is used)`,
 	)
 
 	flagSet.BoolVar(
@@ -295,20 +295,20 @@ supports it (otherwise HTTP 1.1 is used).`,
 		noKeepAliveFlagName,
 		false,
 		`By default, connections are created using TCP keepalive. If this flag is present, they
-will be disabled.`,
+will be disabled`,
 	)
 	flagSet.Float64Var(
 		&f.KeepAliveTimeSeconds,
 		keepAliveFlagName,
 		60,
-		`The duration, in seconds, between TCP keepalive transmissions.`,
+		`The duration, in seconds, between TCP keepalive transmissions`,
 	)
 	flagSet.Float64Var(
 		&f.ConnectTimeoutSeconds,
 		connectTimeoutFlagName,
 		0,
 		`The time limit, in seconds, for a connection to be established with the server. There is
-no limit if this flag is not present.`,
+no limit if this flag is not present`,
 	)
 
 	flagSet.StringVar(
@@ -318,7 +318,7 @@ no limit if this flag is not present.`,
 		`Path to a PEM-encoded X509 private key file, for using client certificates with TLS. This
 option is only valid when the URL uses the https scheme. A --cert flag must also be
 present to provide tha certificate and public key that corresponds to the given
-private key.`,
+private key`,
 	)
 	flagSet.StringVarP(
 		&f.Cert,
@@ -327,7 +327,7 @@ private key.`,
 		"",
 		`Path to a PEM-encoded X509 certificate file, for using client certificates with TLS. This
 option is only valid when the URL uses the https scheme. A --key flag must also be
-present to provide tha private key that corresponds to the given certificate.`,
+present to provide tha private key that corresponds to the given certificate`,
 	)
 	flagSet.StringVar(
 		&f.CACert,
@@ -336,7 +336,7 @@ present to provide tha private key that corresponds to the given certificate.`,
 		`Path to a PEM-encoded X509 certificate pool file that contains the set of trusted
 certificate authorities/issuers. If omitted, the system's default set of trusted
 certificates are used to verify the server's certificate. This option is only valid
-when the URL uses the https scheme. It is not applicable if --insecure flag is used.`,
+when the URL uses the https scheme. It is not applicable if --insecure flag is used`,
 	)
 	flagSet.BoolVarP(
 		&f.Insecure,
@@ -345,7 +345,7 @@ when the URL uses the https scheme. It is not applicable if --insecure flag is u
 		false,
 		`If set, the TLS connection will be insecure and the server's certificate will NOT be
 verified. This is generally discouraged. This option is only valid when the URL uses
-the https scheme.`,
+the https scheme`,
 	)
 	flagSet.StringVar(
 		&f.ServerName,
@@ -353,7 +353,7 @@ the https scheme.`,
 		"",
 		`The server name to use in TLS handshakes (for SNI) if the URL scheme is https. If not
 specified, the default is the origin host in the URL or the value in a "Host" header if
-one is provided.`,
+one is provided`,
 	)
 
 	flagSet.StringVarP(
@@ -374,7 +374,7 @@ A special value of '@<path>' means to read headers from the file at <path>. If t
 is "-" then headers are read from stdin. If the same file is indicated as used with the
 request data flag (--data or -d), the file must contain all headers, then a blank line,
 and then the request body. It is not allowed to indicate stdin if the schema is expected
-to be provided via stdin as a file descriptor set or image.`,
+to be provided via stdin as a file descriptor set or image`,
 	)
 	flagSet.StringVarP(
 		&f.Data,
@@ -387,14 +387,14 @@ message. For unary RPCs, there should be exactly one JSON document. A special va
 request data is read from stdin. If the same file is indicated as used with the request
 headers flags (--header or -H), the file must contain all headers, then a blank line, and
 then the request body. It is not allowed to indicate stdin if the schema is expected to be
-provided via stdin as a file descriptor set or image.`,
+provided via stdin as a file descriptor set or image`,
 	)
 	flagSet.StringVarP(
 		&f.Output,
 		outputFlagName,
 		"o",
 		"",
-		`Path to output file to create with response data. If absent, response is printed to stdout.`,
+		`Path to output file to create with response data. If absent, response is printed to stdout`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -361,7 +361,7 @@ one is provided`,
 		userAgentFlagName,
 		"A",
 		"",
-		`The user agent string to send.`,
+		`The user agent string to send`,
 	)
 	flagSet.StringSliceVarP(
 		&f.Headers,

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -86,7 +86,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <url>",
-		Short: "Invoke an RPC endpoint, a la 'cURL'.",
+		Short: "Invoke an RPC endpoint, a la 'cURL'",
 		Long: `This command helps you invoke HTTP RPC endpoints on a server that uses gRPC or Connect.
 
 By default, server reflection is used, unless the --reflect flag is set to false. Without server

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -118,14 +118,14 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		outputFlagName,
 		outputFlagShortName,
 		"",
-		`The output directory for exported files.`,
+		`The output directory for exported files`,
 	)
 	_ = cobra.MarkFlagRequired(flagSet, outputFlagName)
 	flagSet.StringVar(
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration.`,
+		`The file or data to use for configuration`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -70,15 +70,15 @@ Export current directory to another local directory.
 
 Export the latest remote module to a local directory.
 
-    $ buf export buf.build/<owner>/<repo> --output=<output-dir>
+    $ buf export <buf.build/owner/repository> --output=<output-dir>
 
 Export a specific version of a remote module to a local directory.
 
-    $ buf export buf.build/<owner>/<repo>:<version> --output=<output-dir>
+    $ buf export <buf.build/owner/repository:ref> --output=<output-dir>
 
 Export a git repo to a local directory.
 
-    $ buf export https://<git-server>/<owner>/<repo>.git --output=<output-dir>
+    $ buf export https://github.com/owner/repository.git --output=<output-dir>
 `,
 		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -55,7 +55,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <source>",
-		Short: "Export the files from the source location to an output location.",
+		Short: "Export the files from the source location to an output location",
 		Long: bufcli.GetSourceOrModuleLong(`the source or module to export`) + `
 
 Examples:

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -74,11 +74,11 @@ Write the current directory's formatted content to stdout:
 
     $ buf format
 
-Most people will want to rewrite the files defined in the current directory in-place with "-w":
+Most people will want to rewrite the files defined in the current directory in-place with -w:
 
     $ buf format -w
 
-Display a diff between the original and formatted content with "-d".
+Display a diff between the original and formatted content with -d
 Write a diff instead of the formatted file:
     
     $ buf format simple/simple.proto -d
@@ -128,7 +128,7 @@ Write the formatted module reference to stdout:
     $ buf format buf.build/acme/petapis
     ...
 
-Write the result to a specified output file or directory with "-o" e.g.
+Write the result to a specified output file or directory with -o e.g.
 
 Write the formatted file to another file:
 
@@ -142,7 +142,7 @@ This also works with module references:
 
     $ buf format buf.build/acme/weather -o formatted
 
-Rewrite the file(s) in-place with "-w". e.g.
+Rewrite the file(s) in-place with -w. e.g.
 
 Rewrite a single file in-place:
 

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -66,23 +66,20 @@ func NewCommand(
 		Use:   name + " <input>",
 		Short: "Format all Protobuf files from the specified input and output the result.",
 		Long: `
-By default, the input is the current directory and the formatted content is written to stdout. For example,
+By default, the input is the current directory and the formatted content is written to stdout.
 
-Write the current directory's formatted content to stdout
+Examples:
+
+Write the current directory's formatted content to stdout:
 
     $ buf format
 
-Rewrite the file(s) in-place with -w. For example,
-
-Rewrite the files defined in the current directory in-place
+Most people will want to rewrite the files defined in the current directory in-place with "-w":
 
     $ buf format -w
 
-Most people will want to use 'buf format -w'.
-
-Display a diff between the original and formatted content with -d. For example,
-
-Write a diff instead of the formatted file
+Display a diff between the original and formatted content with "-d".
+Write a diff instead of the formatted file:
     
     $ buf format simple/simple.proto -d
     
@@ -101,15 +98,14 @@ Write a diff instead of the formatted file
     +  bytes value = 2;
      }
 
-You can also use the --exit-code flag to exit with a non-zero exit code if there is a diff:
+Use the --exit-code flag to exit with a non-zero exit code if there is a diff:
 
     $ buf format --exit-code
     $ buf format -w --exit-code
     $ buf format -d --exit-code
 
-Format a file, directory, or module reference by specifying an input. For example,
-
-Write the formatted file to stdout
+Format a file, directory, or module reference by specifying an input e.g.
+Write the formatted file to stdout:
     
     $ buf format simple/simple.proto
     
@@ -122,41 +118,41 @@ Write the formatted file to stdout
       bytes value = 2;
     }
 
-Write the formatted directory to stdout
+Write the formatted directory to stdout:
 
     $ buf format simple
     ...
 
-Write the formatted module reference to stdout
+Write the formatted module reference to stdout:
 
     $ buf format buf.build/acme/petapis
     ...
 
-Write the result to a specified output file or directory with -o. For example,
+Write the result to a specified output file or directory with "-o" e.g.
 
-Write the formatted file to another file
+Write the formatted file to another file:
 
     $ buf format simple/simple.proto -o simple/simple.formatted.proto
 
-Write the formatted directory to another directory, creating it if it doesn't exist
+Write the formatted directory to another directory, creating it if it doesn't exist:
 
     $ buf format proto -o formatted
 
-This also works with module references
+This also works with module references:
 
     $ buf format buf.build/acme/weather -o formatted
 
-Rewrite the file(s) in-place with -w. For example,
+Rewrite the file(s) in-place with "-w". e.g.
 
-Rewrite a single file in-place
+Rewrite a single file in-place:
 
     $ buf format simple.proto -w
 
-Rewrite an entire directory in-place
+Rewrite an entire directory in-place:
 
     $ buf format proto -w
 
-Write a diff and rewrite the file(s) in-place
+Write a diff and rewrite the file(s) in-place:
 
     $ buf format simple -d -w
 

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -200,27 +200,27 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		diffFlagName,
 		diffFlagShortName,
 		false,
-		"Display diffs instead of rewriting files.",
+		"Display diffs instead of rewriting files",
 	)
 	flagSet.BoolVar(
 		&f.ExitCode,
 		exitCodeFlagName,
 		false,
-		"Exit with a non-zero exit code if files were not already formatted.",
+		"Exit with a non-zero exit code if files were not already formatted",
 	)
 	flagSet.BoolVarP(
 		&f.Write,
 		writeFlagName,
 		writeFlagShortName,
 		false,
-		"Rewrite files in-place.",
+		"Rewrite files in-place",
 	)
 	flagSet.StringVar(
 		&f.ErrorFormat,
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors printed to stderr. Must be one of %s.",
+			"The format for build errors printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -230,7 +230,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		outputFlagShortName,
 		"-",
 		fmt.Sprintf(
-			`The output location for the formatted files. Must be one of format %s. If omitted, the result is written to stdout.`,
+			`The output location for the formatted files. Must be one of format %s. If omitted, the result is written to stdout`,
 			buffetch.SourceFormatsString,
 		),
 	)
@@ -238,7 +238,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration.`,
+		`The file or data to use for configuration`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -64,7 +64,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Format all Protobuf files from the specified input and output the result.",
+		Short: "Format all Protobuf files from the specified input and output the result",
 		Long: `
 By default, the input is the current directory and the formatted content is written to stdout.
 

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -54,7 +54,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Generate stubs for protoc plugins using a template.",
+		Short: "Generate stubs for protoc plugins using a template",
 		Long: `This command uses a template file of the shape:
 
     # buf.gen.yaml

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -132,42 +132,40 @@ for the set of plugins you want to invoke.
 The first argument is the source, module, or image to generate from.
 If no argument is specified, defaults to ".".
 
-Call with:
-
-uses buf.gen.yaml as template, current directory as input
+Use buf.gen.yaml as template, current directory as input:
 
     $ buf generate
 
-same as the defaults (template of "buf.gen.yaml", current directory as input)
+Same as the defaults (template of "buf.gen.yaml", current directory as input):
 
     $ buf generate --template buf.gen.yaml .
 
---template also takes YAML or JSON data as input, so it can be used without a file
+The --template flag also takes YAML or JSON data as input, so it can be used without a file:
 
     $ buf generate --template '{"version":"v1","plugins":[{"plugin":"go","out":"gen/go"}]}'
 
-download the repository and generate code stubs per the bar.yaml template
+Download the repository and generate code stubs per the bar.yaml template:
 
     $ buf generate --template bar.yaml https://github.com/foo/bar.git
 
-generate to the bar/ directory, prepending bar/ to the out directives in the template
+Generate to the bar/ directory, prepending bar/ to the out directives in the template:
 
     $ buf generate --template bar.yaml -o bar https://github.com/foo/bar.git
 
-The paths in the template and the -o flag will be interpreted as relative to your
+The paths in the template and the -o flag will be interpreted as relative to the
 current directory, so you can place your template files anywhere.
 
-If you only want to generate stubs for a subset of your input, you can do so via the --path flag:
+If you only want to generate stubs for a subset of your input, you can do so via the --path. e.g.
 
-Only generate for the files in the directories proto/foo and proto/bar
+Only generate for the files in the directories proto/foo and proto/bar:
 
     $ buf generate --path proto/foo --path proto/bar
 
-Only generate for the files proto/foo/foo.proto and proto/foo/bar.proto
+Only generate for the files proto/foo/foo.proto and proto/foo/bar.proto:
 
     $ buf generate --path proto/foo/foo.proto --path proto/foo/bar.proto
 
-Only generate for the files in the directory proto/foo on your GitHub repository
+Only generate for the files in the directory proto/foo on your git repository:
 
     $ buf generate --template buf.gen.yaml https://github.com/foo/bar.git --path proto/foo
 

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -219,14 +219,14 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.IncludeImports,
 		includeImportsFlagName,
 		false,
-		"Also generate all imports except for Well-Known Types.",
+		"Also generate all imports except for Well-Known Types",
 	)
 	flagSet.BoolVar(
 		&f.IncludeWKT,
 		includeWKTFlagName,
 		false,
 		fmt.Sprintf(
-			"Also generate Well-Known Types. Cannot be set without --%s.",
+			"Also generate Well-Known Types. Cannot be set without --%s",
 			includeImportsFlagName,
 		),
 	)
@@ -234,21 +234,21 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Template,
 		templateFlagName,
 		"",
-		`The generation template file or data to use. Must be in either YAML or JSON format.`,
+		`The generation template file or data to use. Must be in either YAML or JSON format`,
 	)
 	flagSet.StringVarP(
 		&f.BaseOutDirPath,
 		baseOutDirPathFlagName,
 		baseOutDirPathFlagShortName,
 		".",
-		`The base directory to generate to. This is prepended to the out directories in the generation template.`,
+		`The base directory to generate to. This is prepended to the out directories in the generation template`,
 	)
 	flagSet.StringVar(
 		&f.ErrorFormat,
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors, printed to stderr. Must be one of %s.",
+			"The format for build errors, printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -256,7 +256,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration.`,
+		`The file or data to use for configuration`,
 	)
 	flagSet.StringSliceVar(
 		&f.IncludeTypes,

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -48,7 +48,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Verify that the input location passes lint checks.",
+		Short: "Verify that the input location passes lint checks",
 		Long:  bufcli.GetInputLong(`the source, module, or Image to lint`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -85,7 +85,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors or check violations printed to stdout. Must be one of %s.",
+			"The format for build errors or check violations printed to stdout. Must be one of %s",
 			stringutil.SliceToString(buflint.AllFormatStrings),
 		),
 	)
@@ -93,7 +93,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration.`,
+		`The file or data to use for configuration`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "List all Protobuf files for the input.",
+		Short: "List all Protobuf files for the input",
 		Long:  bufcli.GetInputLong(`the source, module, or image to list from`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -80,20 +80,20 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.AsImportPaths,
 		asImportPathsFlagName,
 		false,
-		"Strip local directory paths and print filepaths as they are imported.",
+		"Strip local directory paths and print filepaths as they are imported",
 	)
 	flagSet.StringVar(
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration.`,
+		`The file or data to use for configuration`,
 	)
 	flagSet.StringVar(
 		&f.ErrorFormat,
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors printed to stderr. Must be one of %s.",
+			"The format for build errors printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)
@@ -101,7 +101,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.IncludeImports,
 		includeImportsFlagName,
 		false,
-		"Include imports.",
+		"Include imports",
 	)
 }
 

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -29,7 +29,7 @@ func BindLSRulesAll(flagSet *pflag.FlagSet, addr *bool, flagName string) {
 		addr,
 		flagName,
 		false,
-		"List all rules and not just those currently configured.",
+		"List all rules and not just those currently configured",
 	)
 }
 
@@ -40,7 +40,7 @@ func BindLSRulesConfig(flagSet *pflag.FlagSet, addr *string, flagName string, al
 		flagName,
 		"",
 		fmt.Sprintf(
-			`The file or data to use for configuration. Ignored if --%s or --%s is specified.`,
+			`The file or data to use for configuration. Ignored if --%s or --%s is specified`,
 			allFlagName,
 			versionFlagName,
 		),
@@ -54,7 +54,7 @@ func BindLSRulesFormat(flagSet *pflag.FlagSet, addr *string, flagName string) {
 		flagName,
 		"text",
 		fmt.Sprintf(
-			"The format to print rules as. Must be one of %s.",
+			"The format to print rules as. Must be one of %s",
 			stringutil.SliceToString(bufcheck.AllRuleFormatStrings),
 		),
 	)
@@ -67,7 +67,7 @@ func BindLSRulesVersion(flagSet *pflag.FlagSet, addr *string, flagName string, a
 		flagName,
 		"", // do not set a default as we need to know if this is unset
 		fmt.Sprintf(
-			"List all the rules for the given configuration version. Implies --%s. Must be one of %s.",
+			"List all the rules for the given configuration version. Implies --%s. Must be one of %s",
 			allFlagName,
 			stringutil.SliceToString(bufconfig.AllVersions),
 		),

--- a/private/buf/cmd/buf/command/mod/modclearcache/modclearcache.go
+++ b/private/buf/cmd/buf/command/mod/modclearcache/modclearcache.go
@@ -38,7 +38,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:     name,
 		Aliases: aliases,
-		Short:   "Clears the Buf module cache.",
+		Short:   "Clears the Buf module cache",
 		Args:    cobra.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modinit/modinit.go
+++ b/private/buf/cmd/buf/command/mod/modinit/modinit.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: fmt.Sprintf("Initializes and writes a new %s configuration file.", bufconfig.ExternalConfigV1FilePath),
+		Short: fmt.Sprintf("Initializes and writes a new %s configuration file", bufconfig.ExternalConfigV1FilePath),
 		Args:  cobra.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
@@ -74,20 +74,20 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.DocumentationComments,
 		documentationCommentsFlagName,
 		false,
-		"Write inline documentation in the form of comments in the resulting configuration file.",
+		"Write inline documentation in the form of comments in the resulting configuration file",
 	)
 	flagSet.StringVarP(
 		&f.OutDirPath,
 		outDirPathFlagName,
 		outDirPathFlagShortName,
 		".",
-		`The directory to write the configuration file to.`,
+		`The directory to write the configuration file to`,
 	)
 	flagSet.BoolVar(
 		&f.Uncomment,
 		uncommentFlagName,
 		false,
-		"Uncomment examples in the resulting configuration file.",
+		"Uncomment examples in the resulting configuration file",
 	)
 	_ = flagSet.MarkHidden(uncommentFlagName)
 }

--- a/private/buf/cmd/buf/command/mod/modlsbreakingrules/modlsbreakingrules.go
+++ b/private/buf/cmd/buf/command/mod/modlsbreakingrules/modlsbreakingrules.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "List breaking rules.",
+		Short: "List breaking rules",
 		Args:  cobra.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modlslintrules/modlslintrules.go
+++ b/private/buf/cmd/buf/command/mod/modlslintrules/modlslintrules.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: "List lint rules.",
+		Short: "List lint rules",
 		Args:  cobra.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modopen/modopen.go
+++ b/private/buf/cmd/buf/command/mod/modopen/modopen.go
@@ -34,7 +34,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <directory>",
-		Short: "Open the module's homepage in a web browser.",
+		Short: "Open the module's homepage in a web browser",
 		Long:  `The first argument is the directory of the local module to open. If no argument is specified, defaults to "."`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -42,7 +42,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <directory>",
 		Short: "Prunes unused dependencies from the " + buflock.ExternalConfigFilePath + " file",
-		Long:  `The first argument is the directory of the local module to prune. Defaults to "." if no argument is specified.`,
+		Long:  `The first argument is the directory of the local module to prune. Defaults to "." if no argument is specified`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -41,7 +41,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <directory>",
-		Short: "Prunes unused dependencies from the " + buflock.ExternalConfigFilePath + " file.",
+		Short: "Prunes unused dependencies from the " + buflock.ExternalConfigFilePath + " file",
 		Long:  `The first argument is the directory of the local module to prune. Defaults to "." if no argument is specified.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -54,7 +54,7 @@ func NewCommand(
 		Long: "Fetch the latest digests for the specified references in the config file, " +
 			"and write them and their transitive dependencies to the " +
 			buflock.ExternalConfigFilePath +
-			` file. The first argument is the directory of the local module to update. Defaults to "." if no argument is specified.`,
+			` file. The first argument is the directory of the local module to update. Defaults to "." if no argument is specified`,
 		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
@@ -79,7 +79,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Only,
 		onlyFlagName,
 		nil,
-		"The name of the dependency to update. When set, only this dependency is updated (along with any of its sub-dependencies). May be passed multiple times.",
+		"The name of the dependency to update. When set, only this dependency is updated (along with any of its sub-dependencies). May be passed multiple times",
 	)
 }
 

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -50,7 +50,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <directory>",
-		Short: "Update a module's dependencies by updating the " + buflock.ExternalConfigFilePath + " file.",
+		Short: "Update a module's dependencies by updating the " + buflock.ExternalConfigFilePath + " file",
 		Long: "Fetch the latest digests for the specified references in the config file, " +
 			"and write them and their transitive dependencies to the " +
 			buflock.ExternalConfigFilePath +

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -56,7 +56,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <source>",
-		Short: "Push a module to a registry.",
+		Short: "Push a module to a registry",
 		Long:  bufcli.GetSourceLong(`the source to push`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -93,7 +93,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		tagFlagShortName,
 		nil,
 		fmt.Sprintf(
-			"Create a tag for the pushed commit. Multiple tags are created if specified multiple times. Cannot be used together with --%s.",
+			"Create a tag for the pushed commit. Multiple tags are created if specified multiple times. Cannot be used together with --%s",
 			draftFlagName,
 		),
 	)
@@ -102,7 +102,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		draftFlagName,
 		"",
 		fmt.Sprintf(
-			"Make the pushed commit a draft with the specified name. Cannot be used together with --%s (-%s).",
+			"Make the pushed commit a draft with the specified name. Cannot be used together with --%s (-%s)",
 			tagFlagName,
 			tagFlagShortName,
 		),
@@ -112,7 +112,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		errorFormatFlagName,
 		"text",
 		fmt.Sprintf(
-			"The format for build errors printed to stderr. Must be one of %s.",
+			"The format for build errors printed to stderr. Must be one of %s",
 			stringutil.SliceToString(bufanalysis.AllFormatStrings),
 		),
 	)

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -75,13 +75,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Username,
 		usernameFlagName,
 		"",
-		"The username to use. This command prompts for a username by default.",
+		"The username to use. This command prompts for a username by default",
 	)
 	flagSet.BoolVar(
 		&f.TokenStdin,
 		tokenStdinFlagName,
 		false,
-		"Read the token from stdin. This command prompts for a token by default.",
+		"Read the token from stdin. This command prompts for a token by default",
 	)
 }
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -47,7 +47,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <domain>",
-		Short: `Log in to the Buf Schema Registry.`,
+		Short: `Log in to the Buf Schema Registry`,
 		Long: fmt.Sprintf(`This prompts for your BSR username and a BSR token and updates your %s file with these credentials.
 The <domain> argument will default to buf.build if not specified.`, netrc.Filename),
 		Args: cobra.MaximumNArgs(1),

--- a/private/buf/cmd/buf/command/registry/registrylogout/registrylogout.go
+++ b/private/buf/cmd/buf/command/registry/registrylogout/registrylogout.go
@@ -37,7 +37,7 @@ func NewCommand(
 		// Not documenting the first arg (remote) as this is just for testing for now.
 		// TODO: Update when we have self-hosted.
 		Use:   name,
-		Short: `Log out of the Buf Schema Registry.`,
+		Short: `Log out of the Buf Schema Registry`,
 		Long:  fmt.Sprintf(`This command removes any BSR credentials from your %s file`, netrc.Filename),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/registry/registrylogout/registrylogout.go
+++ b/private/buf/cmd/buf/command/registry/registrylogout/registrylogout.go
@@ -38,7 +38,7 @@ func NewCommand(
 		// TODO: Update when we have self-hosted.
 		Use:   name,
 		Short: `Log out of the Buf Schema Registry.`,
-		Long:  fmt.Sprintf(`This command removes any BSR credentials from your %s file.`, netrc.Filename),
+		Long:  fmt.Sprintf(`This command removes any BSR credentials from your %s file`, netrc.Filename),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
@@ -79,9 +79,9 @@ func run(
 	if err != nil {
 		return err
 	}
-	loggedOutMessage := fmt.Sprintf("All existing BSR credentials removed from %s.\n", netrcFilePath)
+	loggedOutMessage := fmt.Sprintf("All existing BSR credentials removed from %s\n", netrcFilePath)
 	if !modified1 && !modified2 {
-		loggedOutMessage = fmt.Sprintf("No BSR credentials found in %s; you are already logged out.\n", netrcFilePath)
+		loggedOutMessage = fmt.Sprintf("No BSR credentials found in %s; you are already logged out\n", netrcFilePath)
 	}
 	if _, err := container.Stdout().Write([]byte(loggedOutMessage)); err != nil {
 		return err

--- a/private/pkg/app/appcmd/appcmd.go
+++ b/private/pkg/app/appcmd/appcmd.go
@@ -320,7 +320,7 @@ func commandToCobra(
 			&doVersion,
 			"version",
 			false,
-			"Print the version.",
+			"Print the version",
 		)
 		cobraCommand.Run = func(cmd *cobra.Command, args []string) {
 			if doVersion {

--- a/private/pkg/app/appcmd/appcmd.go
+++ b/private/pkg/app/appcmd/appcmd.go
@@ -137,11 +137,11 @@ func run(
 			container,
 			&Command{
 				Use:   "completion",
-				Short: "Generate auto-completion scripts for commonly used shells.",
+				Short: "Generate auto-completion scripts for commonly used shells",
 				SubCommands: []*Command{
 					{
 						Use:   "bash",
-						Short: "Generate auto-completion scripts for bash.",
+						Short: "Generate auto-completion scripts for bash",
 						Args:  cobra.NoArgs,
 						Run: func(ctx context.Context, container app.Container) error {
 							return cobraCommand.GenBashCompletion(container.Stdout())
@@ -149,7 +149,7 @@ func run(
 					},
 					{
 						Use:   "fish",
-						Short: "Generate auto-completion scripts for fish.",
+						Short: "Generate auto-completion scripts for fish",
 						Args:  cobra.NoArgs,
 						Run: func(ctx context.Context, container app.Container) error {
 							return cobraCommand.GenFishCompletion(container.Stdout(), true)
@@ -157,7 +157,7 @@ func run(
 					},
 					{
 						Use:   "powershell",
-						Short: "Generate auto-completion scripts for powershell.",
+						Short: "Generate auto-completion scripts for powershell",
 						Args:  cobra.NoArgs,
 						Run: func(ctx context.Context, container app.Container) error {
 							return cobraCommand.GenPowerShellCompletion(container.Stdout())
@@ -165,7 +165,7 @@ func run(
 					},
 					{
 						Use:   "zsh",
-						Short: "Generate auto-completion scripts for zsh.",
+						Short: "Generate auto-completion scripts for zsh",
 						Args:  cobra.NoArgs,
 						Run: func(ctx context.Context, container app.Container) error {
 							return cobraCommand.GenZshCompletion(container.Stdout())

--- a/private/pkg/app/appflag/builder.go
+++ b/private/pkg/app/appflag/builder.go
@@ -63,26 +63,26 @@ func newBuilder(appName string, options ...BuilderOption) *builder {
 }
 
 func (b *builder) BindRoot(flagSet *pflag.FlagSet) {
-	flagSet.BoolVarP(&b.verbose, "verbose", "v", false, "Turn on verbose mode.")
-	flagSet.BoolVar(&b.debug, "debug", false, "Turn on debug logging.")
-	flagSet.StringVar(&b.logFormat, "log-format", "color", "The log format [text,color,json].")
+	flagSet.BoolVarP(&b.verbose, "verbose", "v", false, "Turn on verbose mode")
+	flagSet.BoolVar(&b.debug, "debug", false, "Turn on debug logging")
+	flagSet.StringVar(&b.logFormat, "log-format", "color", "The log format [text,color,json]")
 	if b.defaultTimeout > 0 {
-		flagSet.DurationVar(&b.timeout, "timeout", b.defaultTimeout, `The duration until timing out.`)
+		flagSet.DurationVar(&b.timeout, "timeout", b.defaultTimeout, `The duration until timing out`)
 	}
 
-	flagSet.BoolVar(&b.profile, "profile", false, "Run profiling.")
+	flagSet.BoolVar(&b.profile, "profile", false, "Run profiling")
 	_ = flagSet.MarkHidden("profile")
-	flagSet.StringVar(&b.profilePath, "profile-path", "", "The profile base directory path.")
+	flagSet.StringVar(&b.profilePath, "profile-path", "", "The profile base directory path")
 	_ = flagSet.MarkHidden("profile-path")
-	flagSet.IntVar(&b.profileLoops, "profile-loops", 1, "The number of loops to run.")
+	flagSet.IntVar(&b.profileLoops, "profile-loops", 1, "The number of loops to run")
 	_ = flagSet.MarkHidden("profile-loops")
-	flagSet.StringVar(&b.profileType, "profile-type", "cpu", "The profile type [cpu,mem,block,mutex].")
+	flagSet.StringVar(&b.profileType, "profile-type", "cpu", "The profile type [cpu,mem,block,mutex]")
 	_ = flagSet.MarkHidden("profile-type")
-	flagSet.BoolVar(&b.profileAllowError, "profile-allow-error", false, "Allow errors for profiled commands.")
+	flagSet.BoolVar(&b.profileAllowError, "profile-allow-error", false, "Allow errors for profiled commands")
 	_ = flagSet.MarkHidden("profile-allow-error")
 
 	// We do not officially support this flag, this is for testing, where we need warnings turned off.
-	flagSet.BoolVar(&b.noWarn, "no-warn", false, "Turn off warn logging.")
+	flagSet.BoolVar(&b.noWarn, "no-warn", false, "Turn off warn logging")
 	_ = flagSet.MarkHidden("no-warn")
 }
 


### PR DESCRIPTION
## Description
This PR cleans up a couple of things in cli help text:
- Removes full stops from flag and command descriptions
- Shortens sentences where suitable (for example `for example -> e.g.`)
- Standardizing on placeholders: `buf.build/owner/repo` -> `buf.build/owner/repository`
- Use colons to indicate examples `Do foo with bar:`, usually this might be done with markdown headers `#` but we don't want to use that in cli help text
- Remove second person pronouns `your` -> `the` in order to make text more formal, similar to blog writing guide

## Outstanding questions

With multi-line descriptions is it better to end with full stops, or not?

> "The name of the dependency to update. When set, only this dependency is updated (along with any of its sub-dependencies). May be passed multiple times."

## Rational

### Removes full stops from flag and command descriptions

In most CLIs full stops are not used to end sentences. Full stops make the text feel noisy and add another layer of mental effort to understand. 

Take for example the following from `buf push --help`

>  -t, --tag strings           Create a tag for the pushed commit. Multiple tags are created if specified multiple times. Cannot be used together with --draft.

The ending sentence `--draft.` is messy because it's referring to a flag, but is still ended with a full stop. Whilst a solution to this can be to finish the sentence with `--draft flag.` it is just simpler to be able to omit the full stop. `--draft`

Examples that don't use full stops:

*git*
```
$ git --help
usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           [--super-prefix=<path>] [--config-env=<name>=<envvar>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone     Clone a repository into a new directory
   init      Create an empty Git repository or reinitialize an existing one
```

*kubectl*

```
$ kubectl --help
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/

Basic Commands (Beginner):
  create          Create a resource from a file or from stdin
  expose          Take a replication controller, service, deployment or pod and expose it as a new Kubernetes service
  run             Run a particular image on the cluster
  set             Set specific features on objects
```

gh

```
gh --help
Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:        Authenticate gh and git with GitHub
  browse:      Open the repository in the browser
  codespace:   Connect to and manage codespaces
  gist:        Manage gists
  issue:       Manage issues
  pr:          Manage pull requests
  release:     Manage releases
  repo:        Manage repositories

ACTIONS COMMANDS
  run:         View details about workflow runs
  workflow:    View details about GitHub Actions workflows

ADDITIONAL COMMANDS
  alias:       Create command shortcuts
  api:         Make an authenticated GitHub API request
  completion:  Generate shell completion scripts
  config:      Manage configuration for gh
  extension:   Manage gh extensions
  gpg-key:     Manage GPG keys
  help:        Help about any command
  label:       Manage labels
  search:      Search for repositories, issues, and pull requests
  secret:      Manage GitHub secrets
  ssh-key:     Manage SSH keys
  status:      Print information about relevant issues, pull requests, and notifications across repositories

HELP TOPICS
  actions:     Learn about working with GitHub Actions
  environment: Environment variables that can be used with gh
  exit-codes:  Exit codes used by gh
  formatting:  Formatting options for JSON data exported from gh
  mintty:      Information about using gh with MinTTY
  reference:   A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version
```


## Comparison to current `buf --help` 
### Current `buf --help` (inconsistent usage of full stops)

```
The Buf CLI

A tool for working with Protocol Buffers and managing resources on the Buf Schema Registry (BSR).

Usage:
  buf [flags]
  buf [command]

Available Commands:
  beta        Beta commands. Unstable and likely to change.
  breaking    Verify that the input location has no breaking changes compared to the against location.
  build       Build all Protobuf files from the specified input and output a Buf image.
  completion  Generate auto-completion scripts for commonly used shells.
  convert     Convert a message from binary to JSON or vice versa
  curl        Invoke an RPC endpoint, a la 'cURL'.
  export      Export the files from the source location to an output location.
  format      Format all Protobuf files from the specified input and output the result.
  generate    Generate stubs for protoc plugins using a template.
  help        Help about any command
  lint        Verify that the input location passes lint checks.
  ls-files    List all Protobuf files for the input.
  mod         Manage Buf modules.
  push        Push a module to a registry.
  registry    Manage assets on the Buf Schema Registry.

Flags:
      --debug               Turn on debug logging.
  -h, --help                help for buf
      --log-format string   The log format [text,color,json]. (default "color")
      --timeout duration    The duration until timing out. (default 2m0s)
  -v, --verbose             Turn on verbose mode.
      --version             Print the version.
```

### `buf --help` Without full stops

```
buf --help
The Buf CLI

A tool for working with Protocol Buffers and managing resources on the Buf Schema Registry (BSR).

Usage:
  buf [flags]
  buf [command]

Available Commands:
  beta        Beta commands. Unstable and likely to change
  breaking    Verify that the input location has no breaking changes compared to the against location
  build       Build all Protobuf files from the specified input and output a Buf image
  completion  Generate auto-completion scripts for commonly used shells
  convert     Convert a message from binary to JSON or vice versa
  curl        Invoke an RPC endpoint, a la 'cURL'
  export      Export the files from the source location to an output location
  format      Format all Protobuf files from the specified input and output the result
  generate    Generate stubs for protoc plugins using a template
  help        Help about any command
  lint        Verify that the input location passes lint checks
  ls-files    List all Protobuf files for the input
  mod         Manage Buf modules
  push        Push a module to a registry
  registry    Manage assets on the Buf Schema Registry

Flags:
      --debug               Turn on debug logging.
  -h, --help                help for buf
      --log-format string   The log format [text,color,json]. (default "color")
      --timeout duration    The duration until timing out. (default 2m0s)
  -v, --verbose             Turn on verbose mode
      --version             Print the version
```

## Shortens sentences where suitable (for example `for example -> e.g.`)

This is simply cutting down on character count which can be useful for smaller terminals. This saves ~7 characters per line where `for example` shows up.

[good commit messages]: https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/SubmittingPatches?h=v2.36.1#n181