### PR TITLE
Managed mode php_metadata_namespace file option field should be 44

### DIFF
--- a/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace.go
@@ -29,7 +29,7 @@ const PhpMetadataNamespaceID = "PHP_METADATA_NAMESPACE"
 var (
 	// phpMetadataNamespacePath is the SourceCodeInfo path for the php_metadata_namespace option.
 	// Ref: https://github.com/protocolbuffers/protobuf/blob/61689226c0e3ec88287eaed66164614d9c4f2bf7/src/google/protobuf/descriptor.proto#L448
-	phpMetadataNamespacePath = []int32{8, 41}
+	phpMetadataNamespacePath = []int32{8, 44}
 )
 
 func phpMetadataNamespace(


### PR DESCRIPTION
The `php_metadata_namespace` file option should `44` based on `descriptor.proto`.