### PR TITLE
Untar check file size after mapping

### DIFF
--- a/private/pkg/storage/storagearchive/storagearchive.go
+++ b/private/pkg/storage/storagearchive/storagearchive.go
@@ -109,15 +109,15 @@ func Untar(
 		if tarHeader.Size < 0 {
 			return fmt.Errorf("invalid size for tar file %s: %d", tarHeader.Name, tarHeader.Size)
 		}
-		if tarHeader.Size > options.maxFileSize {
-			return fmt.Errorf("%w %s:%d", ErrFileSizeLimit, tarHeader.Name, tarHeader.Size)
-		}
 		path, ok, err := unmapArchivePath(tarHeader.Name, mapper, stripComponentCount)
 		if err != nil {
 			return err
 		}
 		if !ok || !tarHeader.FileInfo().Mode().IsRegular() {
 			continue
+		}
+		if tarHeader.Size > options.maxFileSize {
+			return fmt.Errorf("%w %s:%d", ErrFileSizeLimit, tarHeader.Name, tarHeader.Size)
 		}
 		if err := storage.CopyReader(ctx, writeBucket, tarReader, path); err != nil {
 			return err

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -1521,9 +1521,10 @@ func RunTestSuite(
 		writeBucket := newWriteBucket(t, defaultProvider)
 		const limit = 2048
 		files := map[string][]byte{
-			"within":  bytes.Repeat([]byte{0}, limit-1),
-			"at":      bytes.Repeat([]byte{0}, limit),
-			"exceeds": bytes.Repeat([]byte{0}, limit+1),
+			"within":     bytes.Repeat([]byte{0}, limit-1),
+			"at":         bytes.Repeat([]byte{0}, limit),
+			"exceeds":    bytes.Repeat([]byte{0}, limit+1),
+			"match-file": bytes.Repeat([]byte{0}, limit-1),
 		}
 		for path, data := range files {
 			err := storage.PutPath(context.Background(), writeBucket, path, data)
@@ -1543,6 +1544,15 @@ func RunTestSuite(
 		_, err = tarball.Seek(0, io.SeekStart)
 		require.NoError(t, err)
 		err = storagearchive.Untar(context.Background(), tarball, writeBucket, nil, 0, storagearchive.WithMaxFileSizeUntarOption(limit+1))
+		assert.NoError(t, err)
+		err = storagearchive.Untar(
+			context.Background(),
+			tarball,
+			writeBucket,
+			storage.MatchPathEqual("match-file"),
+			0,
+			storagearchive.WithMaxFileSizeUntarOption(limit),
+		)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
The ability to limit file size was added in #1408. But the mapper may exclude large files that will not be copied into the reader, so only check the file size after mapping occurs.