### PR TITLE
Make command short descriptions imperative and simplify

### DIFF
--- a/private/buf/cmd/buf/command/alpha/registry/token/tokenlist/tokenlist.go
+++ b/private/buf/cmd/buf/command/alpha/registry/token/tokenlist/tokenlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List my tokens",
+		Short: "List user tokens",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/migratev1beta1/migratev1beta1.go
+++ b/private/buf/cmd/buf/command/beta/migratev1beta1/migratev1beta1.go
@@ -33,9 +33,10 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <directory>",
-		Short: `Migrate any v1beta1 configuration files in the directory to the latest version`,
-		Long:  `Defaults to the current directory if not specified`,
-		Args:  cobra.MaximumNArgs(1),
+		Short: `Migrate v1beta1 configuration to the latest version`,
+		Long: `Migrate any v1beta1 configuration files in the directory to the latest version
+Defaults to the current directory if not specified`,
+		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
 				return run(ctx, container, flags)

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitget/commitget.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository[:ref]>",
-		Short: "Get details about a commit",
+		Short: "Get commit details",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository[:ref]>",
-		Short: "List commits",
+		Short: "List repository commits",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository:draft>",
-		Short: "Delete a draft of a BSR repository by name",
+		Short: "Delete a repository draft",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftlist/draftlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftlist/draftlist.go
@@ -43,7 +43,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "List drafts for the specified repository",
+		Short: "List repository drafts",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate/organizationcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate/organizationcreate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/organization>",
-		Short: "Create a new organization on the BSR",
+		Short: "Create a new BSR organization",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete/organizationdelete.go
@@ -40,7 +40,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/organization>",
-		Short: "Delete an organization by name on the BSR",
+		Short: "Delete a BSR organization",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/organization/organizationget/organizationget.go
+++ b/private/buf/cmd/buf/command/beta/registry/organization/organizationget/organizationget.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/organization>",
-		Short: "Get an organization on the BSR by name",
+		Short: "Get a BSR organization",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate/plugincreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugincreate/plugincreate.go
@@ -53,7 +53,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "Create a new Protobuf plugin",
+		Short: "Create a Protobuf plugin",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete/plugindelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete/plugindelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + internal.PluginsPathName + "/plugin>",
-		Short: "Delete a Protobuf plugin by name",
+		Short: "Delete a Protobuf plugin",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/plugindeprecate/plugindeprecate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "Deprecate a plugin by name",
+		Short: "Deprecate a Protobuf plugin",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist/pluginlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginlist/pluginlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List plugins on the specified remote",
+		Short: "List plugins on the specified BSR",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginundeprecate/pluginundeprecate.go
@@ -35,7 +35,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "Undeprecate a plugin by name",
+		Short: "Undeprecate a plugin",
 		Args:  cobra.ExactArgs(1),
 		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
 	}

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist/pluginversionlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginversion/pluginversionlist/pluginversionlist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.PluginsPathName + "/plugin>",
-		Short: "List versions for the specified plugin",
+		Short: "List plugin versions",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorycreate/repositorycreate.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Create a new repository on the BSR",
+		Short: "Create a BSR repository",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydelete/repositorydelete.go
@@ -40,7 +40,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Delete a BSR repository by name",
+		Short: "Delete a BSR repository",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositorydeprecate/repositorydeprecate.go
@@ -39,7 +39,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Deprecate a repository on the BSR",
+		Short: "Deprecate a BSR repository",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryget/repositoryget.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Get a BSR repository by name",
+		Short: "Get a BSR repository",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
+++ b/private/buf/cmd/buf/command/beta/registry/repository/repositoryupdate/repositoryupdate.go
@@ -39,7 +39,7 @@ func NewCommand(name string, builder appflag.Builder) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "Update a BSR repository settings",
+		Short: "Update BSR repository settings",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/tagcreate/tagcreate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository:commit> <tag>",
-		Short: "Create a tag for the specified commit",
+		Short: "Create a tag for a specified commit",
 		Args:  cobra.ExactArgs(2),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
+++ b/private/buf/cmd/buf/command/beta/registry/tag/taglist/taglist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/repository>",
-		Short: "List tags for the specified repository",
+		Short: "List repository tags",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatecreate/templatecreate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatecreate/templatecreate.go
@@ -54,7 +54,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Create a new Buf template",
+		Short: "Create a Buf template",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedelete/templatedelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedelete/templatedelete.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Delete a template by name",
+		Short: "Delete a template",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatedeprecate/templatedeprecate.go
@@ -41,7 +41,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Deprecate a template by name",
+		Short: "Deprecate a template",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templatelist/templatelist.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templatelist/templatelist.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <buf.build>",
-		Short: "List templates on the specified remote",
+		Short: "List templates on the specified BSR",
 		Args:  cobra.ExactArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/templateundeprecate.go
+++ b/private/buf/cmd/buf/command/beta/registry/template/templateundeprecate/templateundeprecate.go
@@ -35,7 +35,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <buf.build/owner/" + bufremoteplugin.TemplatesPathName + "/template>",
-		Short: "Undeprecate a template by name",
+		Short: "Undeprecate a template",
 		Args:  cobra.ExactArgs(1),
 		Run:   builder.NewRunFunc(run, bufcli.NewErrorInterceptor()),
 	}

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -53,9 +53,10 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input> --against <against-input>",
-		Short: "Verify that the input location has no breaking changes compared to the against location",
-		Long:  bufcli.GetInputLong(`the source, module, or image to check for breaking changes`),
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Verify no breaking changes have been made",
+		Long: `buf breaking makes sure that the <input> location has no breaking changes compared to the <against-input> location` +
+			bufcli.GetInputLong(`the source, module, or image to check for breaking changes`),
+		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {
 				return run(ctx, container, flags)

--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -51,7 +51,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Build all Protobuf files from the specified input and output a Buf image",
+		Short: "Build Protobuf files into a Buf image",
 		Long:  bufcli.GetInputLong(`the source or module to build or image to convert`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -55,7 +55,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <source>",
-		Short: "Export the files from the source location to an output location",
+		Short: "Export proto files from one location to another",
 		Long: bufcli.GetSourceOrModuleLong(`the source or module to export`) + `
 
 Examples:

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -64,7 +64,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Format all Protobuf files from the specified input and output the result",
+		Short: "Format Protobuf files",
 		Long: `
 By default, the input is the current directory and the formatted content is written to stdout.
 

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -54,7 +54,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Generate stubs for protoc plugins using a template",
+		Short: "Generate code with protoc plugins",
 		Long: `This command uses a template file of the shape:
 
     # buf.gen.yaml

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -48,7 +48,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Verify that the input location passes lint checks",
+		Short: "Run linting on Protobuf files",
 		Long:  bufcli.GetInputLong(`the source, module, or Image to lint`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -46,7 +46,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "List all Protobuf files for the input",
+		Short: "List Protobuf files",
 		Long:  bufcli.GetInputLong(`the source, module, or image to list from`),
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/mod/modclearcache/modclearcache.go
+++ b/private/buf/cmd/buf/command/mod/modclearcache/modclearcache.go
@@ -38,7 +38,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:     name,
 		Aliases: aliases,
-		Short:   "Clears the Buf module cache",
+		Short:   "Clear Buf module cache",
 		Args:    cobra.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modinit/modinit.go
+++ b/private/buf/cmd/buf/command/mod/modinit/modinit.go
@@ -44,7 +44,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name,
-		Short: fmt.Sprintf("Initializes and writes a new %s configuration file", bufconfig.ExternalConfigV1FilePath),
+		Short: fmt.Sprintf("Initialize and writes a new %s configuration file", bufconfig.ExternalConfigV1FilePath),
 		Args:  cobra.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -41,7 +41,7 @@ func NewCommand(
 ) *appcmd.Command {
 	return &appcmd.Command{
 		Use:   name + " <directory>",
-		Short: "Prunes unused dependencies from the " + buflock.ExternalConfigFilePath + " file",
+		Short: "Prune unused dependencies from the" + buflock.ExternalConfigFilePath + " file",
 		Long:  `The first argument is the directory of the local module to prune. Defaults to "." if no argument is specified`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(


### PR DESCRIPTION
Short descriptions should describe what the command does, but not pollute help text with specific flag or argument descriptions

For buf --help , for example
```
Available Commands:
  beta        Beta commands. Unstable and likely to change
  breaking    Verify that the input location has no breaking changes compared to the against location
  build       Build all Protobuf files from the specified input and output a Buf image
  completion  Generate auto-completion scripts for commonly used shells
  convert     Convert a message from binary to JSON or vice versa
  curl        Invoke an RPC endpoint, a la 'cURL'
  export      Export the files from the source location to an output location
  format      Format all Protobuf files from the specified input and output the result
  generate    Generate stubs for protoc plugins using a template
  help        Help about any command
  lint        Verify that the input location passes lint checks
  ls-files    List all Protobuf files for the input
  mod         Manage Buf modules
  push        Push a module to a registry
  registry    Manage assets on the Buf Schema Registry
```
breaking, build, export, format, lint, ls-files all specify specific things about input, which is not useful information for the user at this point

## New short descriptions

```
buf --help
The Buf CLI

A tool for working with Protocol Buffers and managing resources on the Buf Schema Registry (BSR)

Usage:
  buf [flags]
  buf [command]

Available Commands:
  beta        Beta commands. Unstable and likely to change
  breaking    Verify no breaking changes have been made
  build       Build Protobuf files into a Buf image
  completion  Generate auto-completion scripts for commonly used shells
  convert     Convert a message from binary to JSON or vice versa
  curl        Invoke an RPC endpoint, a la 'cURL'
  export      Export proto files from one location to another
  format      Format Protobuf files
  generate    Generate code with protoc plugins
  help        Help about any command
  lint        Run linting on Protobuf files
  ls-files    List Protobuf files
  mod         Manage Buf modules
  push        Push a module to a registry
  registry    Manage assets on the Buf Schema Registry
```

### Imperative Verb + Noun Phrase

Using this form is more concise, take for example 

> List commits of a repository

vs 

> List repository commits

The latter is chosen


