### PR TITLE
Replace buf generate --include-types with buf generate --type

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -104,7 +104,7 @@ bufgenerateclean:: bufgeneratecleango
 .PHONY: bufgenerateprotogo
 bufgenerateprotogo:
 	$(BUF_BIN) generate proto --template data/template/buf.go.gen.yaml
-	$(BUF_BIN) generate buf.build/grpc/grpc --include-types grpc.reflection.v1.ServerReflection --template data/template/buf.go.gen.yaml
+	$(BUF_BIN) generate buf.build/grpc/grpc --type grpc.reflection.v1.ServerReflection --template data/template/buf.go.gen.yaml
 
 .PHONY: bufgenerateprotogoclient
 bufgenerateprotogoclient:


### PR DESCRIPTION
When updating `CHANGELOG.md`, I noticed that we have `buf build --type` and `buf generate --include-types`, both of which filter based on type. There are two issues:

- We don't pluralize string slice flags - a single value is valid, and a single value is what you specify on the command line, ie `--types foo` doesn't make sense, but `--type foo` does. This would mean renaming from `--include-types` to `--include-type`.
- `--include-.*` is a boolean flag everywhere else in `buf`, and we should be consistent across commands where possible, so this means renaming from `--include-type` to `--type`.

This deprecates `--include-types` and continues to handle it properly per our compatibility guarantee, but hides the flag, and prints a deprecation warning if it is used.

This also moves the names of the flags to `consts`, similar to the rest of the codebase.