### PR TITLE
Set -buildvcs=false for all builds of binaries

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -11,7 +11,7 @@ COPY private /workspace/private
 ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-  go build -ldflags "-s -w" -trimpath -o /go/bin/buf ./cmd/buf
+  go build -ldflags "-s -w" -trimpath -buildvcs=false -o /go/bin/buf ./cmd/buf
 
 FROM --platform=${TARGETPLATFORM} alpine:3.17.1
 

--- a/make/buf/scripts/brew.sh
+++ b/make/buf/scripts/brew.sh
@@ -20,7 +20,7 @@ mkdir -p "${OUT_DIR}/share/man/man1"
 
 for binary in buf protoc-gen-buf-breaking protoc-gen-buf-lint; do
   echo CGO_ENABLED=0 go build -ldflags \"-s -w\" -trimpath -o \"${OUT_DIR}/bin/${binary}\" \"./cmd/${binary}\"
-  CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o "${OUT_DIR}/bin/${binary}" "./cmd/${binary}"
+  CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -buildvcs=false -o "${OUT_DIR}/bin/${binary}" "./cmd/${binary}"
 done
 echo \"${OUT_DIR}/bin/buf\" completion bash \> \"${OUT_DIR}/etc/bash_completion.d/buf\"
 "${OUT_DIR}/bin/buf" completion bash > "${OUT_DIR}/etc/bash_completion.d/buf"

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -97,7 +97,7 @@ for os in Darwin Linux Windows; do
       protoc-gen-buf-breaking \
       protoc-gen-buf-lint; do
       CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
-        go build -a -ldflags "-s -w" -trimpath -o "${dir}/bin/${binary}${extension}" "${DIR}/cmd/${binary}"
+        go build -a -ldflags "-s -w" -trimpath -buildvcs=false -o "${dir}/bin/${binary}${extension}" "${DIR}/cmd/${binary}"
       cp "${dir}/bin/${binary}${extension}" "${binary}-${os}-${arch}${extension}"
     done
   done


### PR DESCRIPTION
We do not use `debug.BuildSettings` anywhere and this is causing issues with our release.