### PR TITLE
Enable version negotiation with Docker client

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -188,7 +188,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	client, err := bufplugindocker.NewClient(ctx, container.Logger(), bufcli.Version)
+	client, err := bufplugindocker.NewClient(container.Logger(), bufcli.Version)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -188,7 +188,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	client, err := bufplugindocker.NewClient(container.Logger(), bufcli.Version)
+	client, err := bufplugindocker.NewClient(ctx, container.Logger(), bufcli.Version)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -199,7 +199,7 @@ func run(
 	if flags.Image != "" {
 		inspectResponse, err := client.Inspect(ctx, flags.Image)
 		if err != nil {
-			return nil
+			return err
 		}
 		imageID = inspectResponse.ImageID
 	} else {

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -225,6 +225,10 @@ func NewClient(logger *zap.Logger, cliVersion string, options ...ClientOption) (
 		client.WithHTTPHeaders(map[string]string{
 			"User-Agent": BufUpstreamClientUserAgentPrefix + cliVersion,
 		}),
+		// NOTE: This setting is not safe when a client is called from multiple goroutines:
+		// - https://github.com/moby/moby/issues/43729#issuecomment-1174446640
+		//
+		// Our usage is for the CLI with a single goroutine so we're ok to enable for compatibility.
 		client.WithAPIVersionNegotiation(),
 	}
 	if len(opts.host) > 0 {

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufplugin/bufpluginconfig"
 	"github.com/docker/docker/api/types"
@@ -94,13 +95,18 @@ type InspectResponse struct {
 }
 
 type dockerAPIClient struct {
-	cli    *client.Client
-	logger *zap.Logger
+	cli        *client.Client
+	logger     *zap.Logger
+	lock       sync.RWMutex // protects negotiated
+	negotiated bool
 }
 
 var _ Client = (*dockerAPIClient)(nil)
 
 func (d *dockerAPIClient) Load(ctx context.Context, image io.Reader) (_ *LoadResponse, retErr error) {
+	if err := d.negotiateVersion(ctx); err != nil {
+		return nil, err
+	}
 	response, err := d.cli.ImageLoad(ctx, image, true)
 	if err != nil {
 		return nil, err
@@ -140,6 +146,9 @@ func (d *dockerAPIClient) Load(ctx context.Context, image io.Reader) (_ *LoadRes
 }
 
 func (d *dockerAPIClient) Tag(ctx context.Context, image string, config *bufpluginconfig.Config) (*TagResponse, error) {
+	if err := d.negotiateVersion(ctx); err != nil {
+		return nil, err
+	}
 	buildID := stringid.GenerateRandomID()
 	imageName := config.Name.IdentityString() + ":" + buildID
 	if !strings.HasPrefix(imageName, PluginsImagePrefix) {
@@ -152,6 +161,9 @@ func (d *dockerAPIClient) Tag(ctx context.Context, image string, config *bufplug
 }
 
 func (d *dockerAPIClient) Push(ctx context.Context, image string, auth *RegistryAuthConfig) (response *PushResponse, retErr error) {
+	if err := d.negotiateVersion(ctx); err != nil {
+		return nil, err
+	}
 	registryAuth, err := auth.ToHeader()
 	if err != nil {
 		return nil, err
@@ -192,6 +204,9 @@ func (d *dockerAPIClient) Push(ctx context.Context, image string, auth *Registry
 }
 
 func (d *dockerAPIClient) Delete(ctx context.Context, image string) (*DeleteResponse, error) {
+	if err := d.negotiateVersion(ctx); err != nil {
+		return nil, err
+	}
 	_, err := d.cli.ImageRemove(ctx, image, types.ImageRemoveOptions{})
 	if err != nil {
 		return nil, err
@@ -200,6 +215,9 @@ func (d *dockerAPIClient) Delete(ctx context.Context, image string) (*DeleteResp
 }
 
 func (d *dockerAPIClient) Inspect(ctx context.Context, image string) (*InspectResponse, error) {
+	if err := d.negotiateVersion(ctx); err != nil {
+		return nil, err
+	}
 	inspect, _, err := d.cli.ImageInspectWithRaw(ctx, image)
 	if err != nil {
 		return nil, err
@@ -211,8 +229,29 @@ func (d *dockerAPIClient) Close() error {
 	return d.cli.Close()
 }
 
+func (d *dockerAPIClient) negotiateVersion(ctx context.Context) error {
+	d.lock.RLock()
+	negotiated := d.negotiated
+	d.lock.RUnlock()
+	if negotiated {
+		return nil
+	}
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if d.negotiated {
+		return nil
+	}
+	ping, err := d.cli.Ping(ctx)
+	if err != nil {
+		return err
+	}
+	d.cli.NegotiateAPIVersionPing(ping)
+	d.negotiated = true
+	return nil
+}
+
 // NewClient creates a new Client to use to build Docker plugins.
-func NewClient(ctx context.Context, logger *zap.Logger, cliVersion string, options ...ClientOption) (Client, error) {
+func NewClient(logger *zap.Logger, cliVersion string, options ...ClientOption) (Client, error) {
 	if logger == nil {
 		return nil, errors.New("logger required")
 	}
@@ -236,12 +275,6 @@ func NewClient(ctx context.Context, logger *zap.Logger, cliVersion string, optio
 	if err != nil {
 		return nil, err
 	}
-	// Force version negotiation before returning client
-	ping, err := cli.Ping(ctx)
-	if err != nil {
-		return nil, err
-	}
-	cli.NegotiateAPIVersionPing(ping)
 	return &dockerAPIClient{
 		cli:    cli,
 		logger: logger,

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -225,6 +225,7 @@ func NewClient(logger *zap.Logger, cliVersion string, options ...ClientOption) (
 		client.WithHTTPHeaders(map[string]string{
 			"User-Agent": BufUpstreamClientUserAgentPrefix + cliVersion,
 		}),
+		client.WithAPIVersionNegotiation(),
 	}
 	if len(opts.host) > 0 {
 		dockerClientOpts = append(dockerClientOpts, client.WithHost(opts.host))

--- a/private/bufpkg/bufplugin/bufplugindocker/docker.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker.go
@@ -225,12 +225,6 @@ func NewClient(ctx context.Context, logger *zap.Logger, cliVersion string, optio
 		client.WithHTTPHeaders(map[string]string{
 			"User-Agent": BufUpstreamClientUserAgentPrefix + cliVersion,
 		}),
-		// NOTE: This setting is not safe when a client is called from multiple goroutines:
-		// - https://github.com/moby/moby/issues/43729#issuecomment-1174446640
-		//
-		// Our usage is for the CLI with a single goroutine, so we're ok to enable for compatibility.
-		// We also force version negotiation below to ensure the client is in a consistent state prior to use.
-		client.WithAPIVersionNegotiation(),
 	}
 	if len(opts.host) > 0 {
 		dockerClientOpts = append(dockerClientOpts, client.WithHost(opts.host))

--- a/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
@@ -115,7 +115,7 @@ func createClient(ctx context.Context, t testing.TB, options ...ClientOption) Cl
 	t.Helper()
 	logger, err := zap.NewDevelopment()
 	require.Nilf(t, err, "failed to create zap logger")
-	dockerClient, err := NewClient(ctx, logger, "buf-cli-1.11.0", options...)
+	dockerClient, err := NewClient(logger, "buf-cli-1.11.0", options...)
 	require.Nilf(t, err, "failed to create client")
 	t.Cleanup(func() {
 		if err := dockerClient.Close(); err != nil {

--- a/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
@@ -56,12 +56,7 @@ func TestPushSuccess(t *testing.T) {
 	t.Parallel()
 	server := newDockerServer(t, dockerVersion)
 	listenerAddr := server.httpServer.Listener.Addr().String()
-	dockerClient := createClient(
-		context.Background(),
-		t,
-		WithHost("tcp://"+listenerAddr),
-		WithVersion(dockerVersion),
-	)
+	dockerClient := createClient(t, WithHost("tcp://"+listenerAddr), WithVersion(dockerVersion))
 	image, err := buildDockerPlugin(t, "testdata/success/Dockerfile", listenerAddr+"/library/go")
 	require.Nilf(t, err, "failed to build docker plugin")
 	require.NotEmpty(t, image)
@@ -77,12 +72,7 @@ func TestPushError(t *testing.T) {
 	// Send back an error on ImagePush (still return 200 OK).
 	server.pushErr = errors.New("failed to push image")
 	listenerAddr := server.httpServer.Listener.Addr().String()
-	dockerClient := createClient(
-		context.Background(),
-		t,
-		WithHost("tcp://"+listenerAddr),
-		WithVersion(dockerVersion),
-	)
+	dockerClient := createClient(t, WithHost("tcp://"+listenerAddr), WithVersion(dockerVersion))
 	image, err := buildDockerPlugin(t, "testdata/success/Dockerfile", listenerAddr+"/library/go")
 	require.Nilf(t, err, "failed to build docker plugin")
 	require.NotEmpty(t, image)
@@ -111,7 +101,7 @@ func TestMain(m *testing.M) {
 	}
 }
 
-func createClient(ctx context.Context, t testing.TB, options ...ClientOption) Client {
+func createClient(t testing.TB, options ...ClientOption) Client {
 	t.Helper()
 	logger, err := zap.NewDevelopment()
 	require.Nilf(t, err, "failed to create zap logger")

--- a/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
+++ b/private/bufpkg/bufplugin/bufplugindocker/docker_test.go
@@ -91,7 +91,7 @@ func TestPushError(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	var dockerEnabled bool
-	if cli, err := client.NewClientWithOpts(client.FromEnv); err == nil {
+	if cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation()); err == nil {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		if _, err := cli.Ping(ctx); err == nil {


### PR DESCRIPTION
Update Docker client to negotiate the client version and also fix typo in error handling.