### PR TITLE
Error if js is attempted to be used as a builtin plugin for protoc v21 and above

### DIFF
--- a/private/pkg/app/appproto/appprotoexec/version.go
+++ b/private/pkg/app/appproto/appprotoexec/version.go
@@ -135,6 +135,7 @@ func getKotlinSupportedAsBuiltin(version *pluginpb.Version) bool {
 	return true
 }
 
+// Is js supported as a builtin plugin?
 func getJSSupportedAsBuiltin(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {
 		return true

--- a/private/pkg/app/appproto/appprotoexec/version.go
+++ b/private/pkg/app/appproto/appprotoexec/version.go
@@ -95,7 +95,7 @@ func versionString(version *pluginpb.Version) string {
 }
 
 // Should I set the --experimental_allow_proto3_optional flag?
-func getExperimentalAllowProto3Optional(version *pluginpb.Version) bool {
+func getSetExperimentalAllowProto3OptionalFlag(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {
 		return false
 	}
@@ -106,7 +106,7 @@ func getExperimentalAllowProto3Optional(version *pluginpb.Version) bool {
 }
 
 // Should I notify that I am OK with the proto3 optional feature?
-func getFeatureProto3Optional(version *pluginpb.Version) bool {
+func getFeatureProto3OptionalSupported(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {
 		return true
 	}
@@ -120,7 +120,8 @@ func getFeatureProto3Optional(version *pluginpb.Version) bool {
 	return true
 }
 
-func getKotlinSupported(version *pluginpb.Version) bool {
+// Is kotlin supported as a builtin plugin?
+func getKotlinSupportedAsBuiltin(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {
 		return true
 	}
@@ -132,4 +133,21 @@ func getKotlinSupported(version *pluginpb.Version) bool {
 	}
 	// version.GetMajor() > 3
 	return true
+}
+
+func getJSSupportedAsBuiltin(version *pluginpb.Version) bool {
+	if version.GetSuffix() == "buf" {
+		return true
+	}
+	if version.GetMajor() < 3 {
+		return false
+	}
+	if version.GetMajor() == 3 {
+		// v21 and above of protoc still returns "3.MAJOR.Z" for version
+		return version.GetMinor() < 21
+	}
+	// version.GetMajor() > 3
+	// This will catch if they ever change protoc's returned version
+	// to the proper major version
+	return false
 }

--- a/private/pkg/app/appproto/appprotoexec/version_test.go
+++ b/private/pkg/app/appproto/appprotoexec/version_test.go
@@ -32,37 +32,49 @@ func TestVersionString(t *testing.T) {
 	assert.Equal(t, "21.1.1-rc-1", versionString(newVersion(21, 1, 1, "rc-1")))
 }
 
-func TestGetExperimentalAllowProto3Optional(t *testing.T) {
+func TestGetSetExperimentalAllowProto3OptionalFlag(t *testing.T) {
 	t.Parallel()
-	assert.False(t, getExperimentalAllowProto3Optional(newVersion(2, 12, 4, "")))
-	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 11, 1, "buf")))
-	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 11, 4, "")))
-	assert.True(t, getExperimentalAllowProto3Optional(newVersion(3, 12, 1, "")))
-	assert.True(t, getExperimentalAllowProto3Optional(newVersion(3, 14, 1, "")))
-	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 14, 1, "buf")))
-	assert.False(t, getExperimentalAllowProto3Optional(newVersion(3, 15, 0, "")))
-	assert.False(t, getExperimentalAllowProto3Optional(newVersion(21, 0, 0, "")))
+	assert.False(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(2, 12, 4, "")))
+	assert.False(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(3, 11, 1, "buf")))
+	assert.False(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(3, 11, 4, "")))
+	assert.True(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(3, 12, 1, "")))
+	assert.True(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(3, 14, 1, "")))
+	assert.False(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(3, 14, 1, "buf")))
+	assert.False(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(3, 15, 0, "")))
+	assert.False(t, getSetExperimentalAllowProto3OptionalFlag(newVersion(21, 0, 0, "")))
 }
 
-func TestGetFeatureProto3Optional(t *testing.T) {
+func TestGetFeatureProto3OptionalSupported(t *testing.T) {
 	t.Parallel()
-	assert.False(t, getFeatureProto3Optional(newVersion(2, 12, 4, "")))
-	assert.False(t, getFeatureProto3Optional(newVersion(3, 11, 4, "")))
-	assert.True(t, getFeatureProto3Optional(newVersion(3, 11, 1, "buf")))
-	assert.True(t, getFeatureProto3Optional(newVersion(3, 12, 1, "")))
-	assert.True(t, getFeatureProto3Optional(newVersion(3, 14, 1, "")))
-	assert.True(t, getFeatureProto3Optional(newVersion(3, 15, 0, "")))
-	assert.True(t, getFeatureProto3Optional(newVersion(21, 0, 0, "")))
+	assert.False(t, getFeatureProto3OptionalSupported(newVersion(2, 12, 4, "")))
+	assert.False(t, getFeatureProto3OptionalSupported(newVersion(3, 11, 4, "")))
+	assert.True(t, getFeatureProto3OptionalSupported(newVersion(3, 11, 1, "buf")))
+	assert.True(t, getFeatureProto3OptionalSupported(newVersion(3, 12, 1, "")))
+	assert.True(t, getFeatureProto3OptionalSupported(newVersion(3, 14, 1, "")))
+	assert.True(t, getFeatureProto3OptionalSupported(newVersion(3, 15, 0, "")))
+	assert.True(t, getFeatureProto3OptionalSupported(newVersion(21, 0, 0, "")))
 }
 
-func TestGetKotlinSupported(t *testing.T) {
+func TestGetKotlinSupportedAsBuiltin(t *testing.T) {
 	t.Parallel()
-	assert.True(t, getKotlinSupported(newVersion(3, 11, 1, "buf")))
-	assert.True(t, getKotlinSupported(newVersion(3, 17, 4, "")))
-	assert.True(t, getKotlinSupported(newVersion(21, 1, 0, "")))
-	assert.True(t, getKotlinSupported(newVersion(21, 1, 0, "buf")))
-	assert.False(t, getKotlinSupported(newVersion(3, 12, 1, "")))
-	assert.False(t, getKotlinSupported(newVersion(3, 14, 1, "")))
+	assert.True(t, getKotlinSupportedAsBuiltin(newVersion(3, 11, 1, "buf")))
+	assert.True(t, getKotlinSupportedAsBuiltin(newVersion(3, 17, 4, "")))
+	assert.True(t, getKotlinSupportedAsBuiltin(newVersion(21, 1, 0, "")))
+	assert.True(t, getKotlinSupportedAsBuiltin(newVersion(21, 1, 0, "buf")))
+	assert.False(t, getKotlinSupportedAsBuiltin(newVersion(3, 12, 1, "")))
+	assert.False(t, getKotlinSupportedAsBuiltin(newVersion(3, 14, 1, "")))
+}
+
+func TestGetJSSupportedAsBuiltin(t *testing.T) {
+	t.Parallel()
+	assert.False(t, getJSSupportedAsBuiltin(newVersion(2, 11, 1, "")))
+	assert.True(t, getJSSupportedAsBuiltin(newVersion(3, 11, 1, "buf")))
+	assert.True(t, getJSSupportedAsBuiltin(newVersion(3, 17, 4, "")))
+	assert.True(t, getJSSupportedAsBuiltin(newVersion(3, 20, 1, "")))
+	assert.False(t, getJSSupportedAsBuiltin(newVersion(3, 21, 1, "")))
+	assert.False(t, getJSSupportedAsBuiltin(newVersion(3, 22, 1, "")))
+	assert.False(t, getJSSupportedAsBuiltin(newVersion(21, 1, 0, "")))
+	assert.True(t, getJSSupportedAsBuiltin(newVersion(21, 1, 0, "buf")))
 }
 
 func TestParseVersionForCLIVersion(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/1806.

This also adjusts some of the function names to be clearer as to what they do.

Manually QA'ed.