### PR TITLE
Move bufwork directory check outside newConfigV1

### DIFF
--- a/private/buf/bufwork/bufwork_test.go
+++ b/private/buf/bufwork/bufwork_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufwork_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bufbuild/buf/private/buf/bufwork"
+	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConfigForBucket(t *testing.T) {
+	config, err := bufwork.GetConfigForBucket(
+		context.Background(),
+		storagemem.NewReadWriteBucket(),
+		".",
+	)
+	require.NoError(t, err)
+	require.Empty(t, config.Directories)
+}

--- a/private/buf/bufwork/config.go
+++ b/private/buf/bufwork/config.go
@@ -23,12 +23,6 @@ import (
 )
 
 func newConfigV1(externalConfig ExternalConfigV1, workspaceID string) (*Config, error) {
-	if len(externalConfig.Directories) == 0 {
-		return nil, fmt.Errorf(
-			`%s has no directories set. Please add "directories: [...]"`,
-			workspaceID,
-		)
-	}
 	directorySet := make(map[string]struct{}, len(externalConfig.Directories))
 	for _, directory := range externalConfig.Directories {
 		normalizedDirectory, err := normalpath.NormalizeAndValidate(directory)

--- a/private/buf/bufwork/get.go
+++ b/private/buf/bufwork/get.go
@@ -120,7 +120,20 @@ func getConfigForDataInternal(
 	if err := unmarshalStrict(data, &externalConfigV1); err != nil {
 		return nil, err
 	}
+	if err := validateDirectories(externalConfigV1, workspaceID); err != nil {
+		return nil, err
+	}
 	return newConfigV1(externalConfigV1, workspaceID)
+}
+
+func validateDirectories(externalConfig ExternalConfigV1, workspaceID string) error {
+	if len(externalConfig.Directories) == 0 {
+		return fmt.Errorf(
+			`%s has no directories set. Please add "directories: [...]"`,
+			workspaceID,
+		)
+	}
+	return nil
 }
 
 func validateExternalConfigVersion(externalConfigVersion externalConfigVersion, id string) error {


### PR DESCRIPTION
This check fails every time you run `getConfigForBucket` and hit `case 0` in the switch (no work config files found) because the `ExternalConfigV1{}` has no directories configured. Update the only other use case of `newConfigV1` to move the validation outside that function.