### PR TITLE
Include rule name in breaking change output

### DIFF
--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -405,11 +405,11 @@ func TestFailCheckBreaking1(t *testing.T) {
 		nil,
 		bufcli.ExitCodeFileAnnotation,
 		filepath.FromSlash(`
-		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:5:1:Previously present field "3" with name "three" on message "Two" was deleted.
-		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:10:1:Previously present field "3" with name "three" on message "Three" was deleted.
-		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:12:5:Previously present field "3" with name "three" on message "Five" was deleted.
-		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:22:3:Previously present field "3" with name "three" on message "Seven" was deleted.
-		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/2.proto:57:1:Previously present field "3" with name "three" on message "Nine" was deleted.
+		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:5:1: FIELD_NO_DELETE: Previously present field "3" with name "three" on message "Two" was deleted.
+		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:10:1: FIELD_NO_DELETE: Previously present field "3" with name "three" on message "Three" was deleted.
+		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:12:5: FIELD_NO_DELETE: Previously present field "3" with name "three" on message "Five" was deleted.
+		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/1.proto:22:3: FIELD_NO_DELETE: Previously present field "3" with name "three" on message "Seven" was deleted.
+		../../../bufpkg/bufcheck/bufbreaking/testdata/breaking_field_no_delete/2.proto:57:1: FIELD_NO_DELETE: Previously present field "3" with name "three" on message "Nine" was deleted.
 		`),
 		"", // stderr should be empty
 		"breaking",
@@ -426,7 +426,7 @@ func TestFailCheckBreaking2(t *testing.T) {
 		t,
 		nil,
 		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`testdata/protofileref/breaking/a/foo.proto:7:3:Field "2" on message "Foo" changed type from "int32" to "string".`),
+		filepath.FromSlash(`testdata/protofileref/breaking/a/foo.proto:7:3: FIELD_SAME_TYPE: Field "2" on message "Foo" changed type from "int32" to "string".`),
 		"breaking",
 		filepath.Join("testdata", "protofileref", "breaking", "a", "foo.proto"),
 		"--against",
@@ -441,8 +441,8 @@ func TestFailCheckBreaking3(t *testing.T) {
 		nil,
 		bufcli.ExitCodeFileAnnotation,
 		filepath.FromSlash(`
-		<input>:1:1:Previously present file "bar.proto" was deleted.
-		testdata/protofileref/breaking/a/foo.proto:7:3:Field "2" on message "Foo" changed type from "int32" to "string".
+		<input>:1:1: FILE_NO_DELETE: Previously present file "bar.proto" was deleted.
+		testdata/protofileref/breaking/a/foo.proto:7:3: FIELD_SAME_TYPE: Field "2" on message "Foo" changed type from "int32" to "string".
 		`),
 		"breaking",
 		filepath.Join("testdata", "protofileref", "breaking", "a", "foo.proto"),
@@ -458,8 +458,8 @@ func TestFailCheckBreaking4(t *testing.T) {
 		nil,
 		bufcli.ExitCodeFileAnnotation,
 		filepath.FromSlash(`
-		testdata/protofileref/breaking/a/bar.proto:5:1:Previously present field "2" with name "value" on message "Bar" was deleted.
-		testdata/protofileref/breaking/a/foo.proto:7:3:Field "2" on message "Foo" changed type from "int32" to "string".
+		testdata/protofileref/breaking/a/bar.proto:5:1: FIELD_NO_DELETE: Previously present field "2" with name "value" on message "Bar" was deleted.
+		testdata/protofileref/breaking/a/foo.proto:7:3: FIELD_SAME_TYPE: Field "2" on message "Foo" changed type from "int32" to "string".
 		`),
 		"breaking",
 		fmt.Sprintf("%s#include_package_files=true", filepath.Join("testdata", "protofileref", "breaking", "a", "foo.proto")),
@@ -475,8 +475,8 @@ func TestFailCheckBreaking5(t *testing.T) {
 		nil,
 		bufcli.ExitCodeFileAnnotation,
 		filepath.FromSlash(`
-    <input>:1:1:Previously present file "bar.proto" was deleted.
-		testdata/protofileref/breaking/a/foo.proto:7:3:Field "2" on message "Foo" changed type from "int32" to "string".
+    <input>:1:1: FILE_NO_DELETE: Previously present file "bar.proto" was deleted.
+		testdata/protofileref/breaking/a/foo.proto:7:3: FIELD_SAME_TYPE: Field "2" on message "Foo" changed type from "int32" to "string".
 		`),
 		"breaking",
 		filepath.Join("testdata", "protofileref", "breaking", "a", "foo.proto"),
@@ -1497,9 +1497,9 @@ func TestBreakingWithPaths(t *testing.T) {
 		t,
 		nil,
 		bufcli.ExitCodeFileAnnotation,
-		`a/v3/a.proto:6:3:Field "1" on message "Foo" changed type from "string" to "int32".
-a/v3/a.proto:7:3:Field "2" with name "Value" on message "Foo" changed option "json_name" from "value" to "Value".
-a/v3/a.proto:7:10:Field "2" on message "Foo" changed name from "value" to "Value".`,
+		`a/v3/a.proto:6:3: FIELD_SAME_TYPE: Field "1" on message "Foo" changed type from "string" to "int32".
+a/v3/a.proto:7:3: FIELD_SAME_JSON_NAME: Field "2" with name "Value" on message "Foo" changed option "json_name" from "value" to "Value".
+a/v3/a.proto:7:10: FIELD_SAME_NAME: Field "2" on message "Foo" changed name from "value" to "Value".`,
 		"",
 		"breaking",
 		filepath.Join(tempDir, "current.bin"),

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -261,6 +261,7 @@ func run(
 			container.Stdout(),
 			bufanalysis.DeduplicateAndSortFileAnnotations(allFileAnnotations),
 			flags.ErrorFormat,
+			bufanalysis.PrintWithRuleName(),
 		); err != nil {
 			return err
 		}

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -153,9 +153,9 @@ func TestWorkspaceDir(t *testing.T) {
 			t,
 			nil,
 			bufcli.ExitCodeFileAnnotation,
-			filepath.FromSlash(`testdata/workspace/success/breaking/other/proto/request.proto:5:1:Previously present field "1" with name "name" on message "Request" was deleted.
-		    testdata/workspace/success/breaking/proto/rpc.proto:8:5:Field "1" with name "request" on message "RPC" changed option "json_name" from "req" to "request".
-		    testdata/workspace/success/breaking/proto/rpc.proto:8:21:Field "1" on message "RPC" changed name from "req" to "request".`),
+			filepath.FromSlash(`testdata/workspace/success/breaking/other/proto/request.proto:5:1: FIELD_NO_DELETE: Previously present field "1" with name "name" on message "Request" was deleted.
+		    testdata/workspace/success/breaking/proto/rpc.proto:8:5: FIELD_SAME_JSON_NAME: Field "1" with name "request" on message "RPC" changed option "json_name" from "req" to "request".
+		    testdata/workspace/success/breaking/proto/rpc.proto:8:21: FIELD_SAME_NAME: Field "1" on message "RPC" changed name from "req" to "request".`),
 			"breaking",
 			filepath.Join("testdata", "workspace", "success", "breaking"),
 			"--against",

--- a/private/bufpkg/bufanalysis/bufanalysis.go
+++ b/private/bufpkg/bufanalysis/bufanalysis.go
@@ -108,7 +108,9 @@ type FileInfo interface {
 type FileAnnotation interface {
 	// Stringer returns the string representation of this annotation.
 	fmt.Stringer
-
+	// StringWithRuleName returns the string representation of this
+	// annotation with Rule Name.
+	StringWithRuleName() string
 	// FileInfo is the FileInfo for this annotation.
 	//
 	// This may be nil.
@@ -194,7 +196,7 @@ func DeduplicateAndSortFileAnnotations(fileAnnotations []FileAnnotation) []FileA
 }
 
 // PrintFileAnnotations prints the file annotations separated by newlines.
-func PrintFileAnnotations(writer io.Writer, fileAnnotations []FileAnnotation, formatString string) error {
+func PrintFileAnnotations(writer io.Writer, fileAnnotations []FileAnnotation, formatString string, options ...PrintOption) error {
 	format, err := ParseFormat(formatString)
 	if err != nil {
 		return err
@@ -202,13 +204,13 @@ func PrintFileAnnotations(writer io.Writer, fileAnnotations []FileAnnotation, fo
 
 	switch format {
 	case FormatText:
-		return printAsText(writer, fileAnnotations)
+		return printAsText(writer, fileAnnotations, options...)
 	case FormatJSON:
-		return printAsJSON(writer, fileAnnotations)
+		return printAsJSON(writer, fileAnnotations, options...)
 	case FormatMSVS:
-		return printAsMSVS(writer, fileAnnotations)
+		return printAsMSVS(writer, fileAnnotations, options...)
 	case FormatJUnit:
-		return printAsJUnit(writer, fileAnnotations)
+		return printAsJUnit(writer, fileAnnotations, options...)
 	default:
 		return fmt.Errorf("unknown FileAnnotation Format: %v", format)
 	}

--- a/private/bufpkg/bufanalysis/file_annotation.go
+++ b/private/bufpkg/bufanalysis/file_annotation.go
@@ -111,3 +111,43 @@ func (f *fileAnnotation) String() string {
 	_, _ = buffer.WriteString(message)
 	return buffer.String()
 }
+
+func (f *fileAnnotation) StringWithRuleName() string {
+	if f == nil {
+		return ""
+	}
+	path := "<input>"
+	line := f.startLine
+	column := f.startColumn
+	message := f.message
+	if f.fileInfo != nil {
+		path = f.fileInfo.ExternalPath()
+	}
+	if line == 0 {
+		line = 1
+	}
+	if column == 0 {
+		column = 1
+	}
+	if message == "" {
+		message = f.typeString
+		// should never happen but just in case
+		if message == "" {
+			message = "FAILURE"
+		}
+	}
+	buffer := bytes.NewBuffer(nil)
+	_, _ = buffer.WriteString(path)
+	_, _ = buffer.WriteRune(':')
+	_, _ = buffer.WriteString(strconv.Itoa(line))
+	_, _ = buffer.WriteRune(':')
+	_, _ = buffer.WriteString(strconv.Itoa(column))
+	_, _ = buffer.WriteRune(':')
+	if message != f.typeString {
+		_, _ = buffer.WriteRune(' ')
+		_, _ = buffer.WriteString(f.typeString)
+		_, _ = buffer.WriteString(": ")
+	}
+	_, _ = buffer.WriteString(message)
+	return buffer.String()
+}


### PR DESCRIPTION
Proposed by [this issue](https://github.com/bufbuild/buf/issues/1799), I added `PrintOption` type for `PrintFileAnnotations` in `bufanalysis.bufanalysis.go`. Now printing file annotations can include rule name or exclude rule name depending on situation. 