### PR TITLE
Release new version in adjacent repositories automatically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -208,3 +208,56 @@ jobs:
                 version: "${{github.ref_name}}".replace("v", "")
               }
             })
+      - name: trigger homebrew-buf release
+        uses: actions/github-script@v6
+        with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.owner,
+            repo: "homebrew-buf",
+            workflow_id: "release.yaml",
+            ref: "main"
+            inputs: {
+              version: "${{github.ref_name}}".replace("v", "")
+            }
+          })
+      - name: trigger vim-buf release
+        uses: actions/github-script@v6
+        with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.owner,
+            repo: "vim-buf",
+            workflow_id: "release.yaml",
+            ref: "main"
+            inputs: {
+              version: "${{github.ref_name}}".replace("v", "")
+            }
+          })
+      - name: trigger docs.buf.build release
+        uses: actions/github-script@v6
+        with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.owner,
+            repo: "docs.buf.build",
+            workflow_id: "release.yaml",
+            ref: "main"
+            inputs: {
+              version: "${{github.ref_name}}".replace("v", "")
+            }
+          })
+      - name: trigger buf-setup-action release
+        uses: actions/github-script@v6
+        with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.owner,
+            repo: "buf-setup-action",
+            workflow_id: "release.yaml",
+            ref: "main"
+            inputs: {
+              version: "${{github.ref_name}}".replace("v", "")
+            }
+          })
+


### PR DESCRIPTION
The end of the `bufbuild/buf` release, automatically release the new version in all adjacent repositories.
    1. [homebrew-buf](https://github.com/bufbuild/homebrew-buf/actions/workflows/release.yaml)
    2. [vim-buf](https://github.com/bufbuild/vim-buf/actions/workflows/release.yaml)
    3. [docs.buf.build](https://github.com/bufbuild/docs.buf.build/actions/workflows/release.yaml)
    4. [buf-setup-action](https://github.com/bufbuild/buf-setup-action/actions/workflows/release.yaml)