### PR TITLE
Add full stops to long descriptions

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -277,7 +277,7 @@ func GetInputLong(inputArgDescription string) string {
 	return fmt.Sprintf(
 		`The first argument is %s.
 The first argument must be one of format %s.
-If no argument is specified, defaults to ".".`,
+Defaults to "." if no argument is specified.`,
 		inputArgDescription,
 		buffetch.AllFormatsString,
 	)
@@ -288,7 +288,7 @@ func GetSourceLong(inputArgDescription string) string {
 	return fmt.Sprintf(
 		`The first argument is %s.
 The first argument must be one of format %s.
-If no argument is specified, defaults to ".".`,
+Defaults to "." if no argument is specified.`,
 		inputArgDescription,
 		buffetch.SourceFormatsString,
 	)
@@ -299,7 +299,7 @@ func GetSourceDirLong(inputArgDescription string) string {
 	return fmt.Sprintf(
 		`The first argument is %s.
 The first argument must be one of format %s.
-If no argument is specified, defaults to ".".`,
+Defaults to "." if no argument is specified.`,
 		inputArgDescription,
 		buffetch.SourceDirFormatsString,
 	)
@@ -310,7 +310,7 @@ func GetSourceOrModuleLong(inputArgDescription string) string {
 	return fmt.Sprintf(
 		`The first argument is %s.
 The first argument must be one of format %s.
-If no argument is specified, defaults to ".".`,
+Defaults to "." if no argument is specified.`,
 		inputArgDescription,
 		buffetch.SourceOrModuleFormatsString,
 	)

--- a/private/buf/cmd/buf/command/beta/migratev1beta1/migratev1beta1.go
+++ b/private/buf/cmd/buf/command/beta/migratev1beta1/migratev1beta1.go
@@ -34,8 +34,8 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <directory>",
 		Short: `Migrate v1beta1 configuration to the latest version`,
-		Long: `Migrate any v1beta1 configuration files in the directory to the latest version
-Defaults to the current directory if not specified`,
+		Long: `Migrate any v1beta1 configuration files in the directory to the latest version.
+Defaults to the current directory if not specified.`,
 		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -54,7 +54,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <input> --against <against-input>",
 		Short: "Verify no breaking changes have been made",
-		Long: `buf breaking makes sure that the <input> location has no breaking changes compared to the <against-input> location` +
+		Long: `buf breaking makes sure that the <input> location has no breaking changes compared to the <against-input> location. ` +
 			bufcli.GetInputLong(`the source, module, or image to check for breaking changes`),
 		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -132,7 +132,7 @@ By default, buf generate will look for a file of this shape named
 for the set of plugins you want to invoke.
 
 The first argument is the source, module, or image to generate from.
-If no argument is specified, defaults to ".".
+Defaults to "." if no argument is specified.
 
 Use buf.gen.yaml as template, current directory as input:
 

--- a/private/buf/cmd/buf/command/mod/modopen/modopen.go
+++ b/private/buf/cmd/buf/command/mod/modopen/modopen.go
@@ -35,7 +35,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <directory>",
 		Short: "Open the module's homepage in a web browser",
-		Long:  `The first argument is the directory of the local module to open. If no argument is specified, defaults to "."`,
+		Long:  `The first argument is the directory of the local module to open. Defaults to "." if no argument is specified.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -42,7 +42,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <directory>",
 		Short: "Prune unused dependencies from the" + buflock.ExternalConfigFilePath + " file",
-		Long:  `The first argument is the directory of the local module to prune. Defaults to "." if no argument is specified`,
+		Long:  `The first argument is the directory of the local module to prune. Defaults to "." if no argument is specified.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -54,7 +54,7 @@ func NewCommand(
 		Long: "Fetch the latest digests for the specified references in the config file, " +
 			"and write them and their transitive dependencies to the " +
 			buflock.ExternalConfigFilePath +
-			` file. The first argument is the directory of the local module to update. Defaults to "." if no argument is specified`,
+			` file. The first argument is the directory of the local module to update. Defaults to "." if no argument is specified.`,
 		Args: cobra.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appflag.Container) error {


### PR DESCRIPTION
Adds full stops in long descriptions. 

Changes the phrase 
> If no argument is specified, defaults to ".".

to 

> Defaults to "." if no argument is specified.

to Avoid the ugly looking period next to the quoted period `".".`