### PR TITLE
Add bufmodulestat package

### DIFF
--- a/private/bufpkg/bufmodule/bufmodulestat/bufmodulestat.go
+++ b/private/bufpkg/bufmodule/bufmodulestat/bufmodulestat.go
@@ -1,0 +1,31 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufmodulestat
+
+import (
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/pkg/protostat"
+)
+
+// NewFileWalker returns a new FileWalker for the given Module.
+//
+// This walks all target files from TargetFileInfos.
+//
+// We use TargetFileInfos instead of SourceFileInfos as this means
+// that if someone sets up a filter at a higher level, this will respect it.
+// In most cases, TargetFileInfos is the same as SourceFileInfos.
+func NewFileWalker(module bufmodule.Module) protostat.FileWalker {
+	return newFileWalker(module)
+}

--- a/private/bufpkg/bufmodule/bufmodulestat/file_walker.go
+++ b/private/bufpkg/bufmodule/bufmodulestat/file_walker.go
@@ -1,0 +1,53 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufmodulestat
+
+import (
+	"context"
+	"io"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"go.uber.org/multierr"
+)
+
+type fileWalker struct {
+	module bufmodule.Module
+}
+
+func newFileWalker(module bufmodule.Module) *fileWalker {
+	return &fileWalker{
+		module: module,
+	}
+}
+
+func (f *fileWalker) Walk(ctx context.Context, fu func(io.Reader) error) error {
+	fileInfos, err := f.module.TargetFileInfos(ctx)
+	if err != nil {
+		return err
+	}
+	for _, fileInfo := range fileInfos {
+		moduleFile, err := f.module.GetModuleFile(ctx, fileInfo.Path())
+		if err != nil {
+			return err
+		}
+		if err := fu(moduleFile); err != nil {
+			return multierr.Append(err, moduleFile.Close())
+		}
+		if err := moduleFile.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/private/bufpkg/bufmodule/bufmodulestat/usage.gen.go
+++ b/private/bufpkg/bufmodule/bufmodulestat/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package bufmodulestat
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This is for `protostat` on a `bufmodule.Module` basis. I will likely use this in `buf alpha stats`, and @mfridman wanted it too.