### PR TITLE
Make existing file error not an invalid argument error

### DIFF
--- a/private/buf/cmd/buf/command/mod/modinit/modinit.go
+++ b/private/buf/cmd/buf/command/mod/modinit/modinit.go
@@ -114,7 +114,7 @@ func run(
 		return err
 	}
 	if existingConfigFilePath != "" {
-		return appcmd.NewInvalidArgumentErrorf("%s already exists, not overwriting", existingConfigFilePath)
+		return fmt.Errorf("%s already exists, not overwriting", existingConfigFilePath)
 	}
 	var writeConfigOptions []bufconfig.WriteConfigOption
 	if container.NumArgs() > 0 {


### PR DESCRIPTION
This being an `appcmd.NewInvalidArgumentError` prints the usage as well, which doesn't really make sense in this case.