### PR TITLE
More pkg/manifest documentation

### DIFF
--- a/private/pkg/manifest/digest.go
+++ b/private/pkg/manifest/digest.go
@@ -115,6 +115,7 @@ type shake256Digester struct {
 	hash sha3.ShakeHash
 }
 
+// NewDigester returns a digester of the requested type.
 func NewDigester(dtype DigestType) (Digester, error) {
 	if dtype != DigestTypeShake256 {
 		return nil, fmt.Errorf("not supported digest type %q", dtype)

--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-// Blob is a blob with a digest and a content.
+// Blob is an anonymous file associated with a digest.
 type Blob interface {
 	Digest() *Digest
 	Open(context.Context) (io.ReadCloser, error)
@@ -85,7 +85,7 @@ func (b *memoryBlob) Open(context.Context) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(b.content)), nil
 }
 
-// BlobSet represents a set of deduplicated blobs, by digests.
+// BlobSet represents a set of deduplicated blobs by their digests.
 type BlobSet struct {
 	digestToBlob map[string]Blob
 }

--- a/private/pkg/manifest/storage.go
+++ b/private/pkg/manifest/storage.go
@@ -42,8 +42,8 @@ func (o *manifestBucketObject) ExternalPath() string       { return o.path }
 func (o *manifestBucketObject) Read(p []byte) (int, error) { return o.file.Read(p) }
 func (o *manifestBucketObject) Close() error               { return o.file.Close() }
 
-// NewFromBucket creates a manifest and all its files' blobs from a storage
-// bucket, with all its digests in DigestTypeShake256.
+// NewFromBucket creates a manifest and blob set from the bucket's files. Blobs
+// in the blob set use the [DigestTypeShake256] digest.
 func NewFromBucket(
 	ctx context.Context,
 	bucket storage.ReadBucket,


### PR DESCRIPTION
The package overview has been expanded to cover interaction of most important types: Manifest, Digest, Blob, and BlobSet.

Some method docs have been rewritten for clarity.