### PR TITLE
Fix formatting of C-style block comments that use prefix symbols on each line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Unreleased]
 
-- Update built-in Well-Known Types to v22.0.
-
+- Update built-in Well-Known Types to Protobuf v22.0.
+- Fixes a bug in `buf format` where C-style block comments in which every
+  line includes a prefix (usually "*") would be incorrectly indented.
 
 ## [v1.14.0] - 2023-02-09
 
@@ -41,7 +42,6 @@
 - Introduce `ruby_package` option in managed mode, allowing `except` and `override`,
   in the same style as `objc_class_prefix`. Leaving `ruby_package` unspecified has
   the same effect as having mananged mode enabled in previous versions.
-
 
 ## [v1.11.0] - 2022-12-19
 - `buf generate` now batches remote plugin generation calls for improved performance.

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -2027,10 +2027,29 @@ func (f *formatter) writeComment(comment string) {
 		// find minimum indent, so we can make all other lines relative to that
 		minIndent := -1 // sentinel that means unset
 		// start at 1 because line at index zero starts with "/*", not whitespace
+		var prefix string
 		for i := 1; i < len(lines); i++ {
 			indent, ok := computeIndent(lines[i])
 			if ok && (minIndent == -1 || indent < minIndent) {
 				minIndent = indent
+			}
+			if i > 1 && len(prefix) == 0 {
+				// no shared prefix
+				continue
+			}
+			line := strings.TrimSpace(lines[i])
+			if line == "*/" {
+				continue
+			}
+			var linePrefix string
+			if len(line) > 0 && isCommentPrefix(line[0]) {
+				linePrefix = line[:1]
+			}
+			if i == 1 {
+				prefix = linePrefix
+			} else if linePrefix != prefix {
+				// they do not share prefix
+				prefix = ""
 			}
 		}
 		if minIndent < 0 {
@@ -2048,9 +2067,45 @@ func (f *formatter) writeComment(comment string) {
 				line = unindent(line, minIndent)
 				line = strings.TrimRightFunc(line, unicode.IsSpace)
 			}
+			// If we have a block comment with no prefix, we'll format
+			// like so:
+
+			/*
+			   This is a multi-line comment example.
+			   It has no comment prefix on each line.
+			*/
+
+			// But if there IS a prefix, "|" for example, we'll left-align
+			// the prefix symbol under the asterisk of the comment start
+			// like this:
+
+			/*
+			 | This comment has a prefix before each line.
+			 | Usually the prefix is asterisk, but it's a
+			 | pipe in this example.
+			*/
+
+			// Finally, if the comment prefix is an asterisk, we'll left-align
+			// the comment end so its asterisk also aligns, like so:
+
+			/*
+			 * This comment has a prefix before each line.
+			 * Usually the prefix is asterisk, which is the
+			 * case in this example.
+			 */
+
 			if i > 0 && line != "*/" {
-				line = "   " + line
+				if len(prefix) == 0 {
+					line = "   " + line
+				} else {
+					line = " " + line
+				}
 			}
+			if line == "*/" && prefix == "*" {
+				// align the comment end with the other astrisks
+				line = " " + line
+			}
+
 			if i != len(lines)-1 {
 				f.P(line)
 			} else {
@@ -2064,6 +2119,18 @@ func (f *formatter) writeComment(comment string) {
 		f.Indent(nil)
 		f.WriteString(strings.TrimSpace(comment))
 	}
+}
+
+func isCommentPrefix(ch byte) bool {
+	r := rune(ch)
+	// A multi-line comment prefix is *usually* an asterisk, like in the following
+	/*
+	 * Foo
+	 * Bar
+	 * Baz
+	 */
+	// But we'll allow other prefixes. But if it's a letter or number, it's not a prefix.
+	return !unicode.IsLetter(r) && !unicode.IsNumber(r)
 }
 
 func unindent(s string, unindent int) string {

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -2102,7 +2102,7 @@ func (f *formatter) writeComment(comment string) {
 				}
 			}
 			if line == "*/" && prefix == "*" {
-				// align the comment end with the other astrisks
+				// align the comment end with the other asterisks
 				line = " " + line
 			}
 

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -2059,7 +2059,7 @@ func (f *formatter) writeComment(comment string) {
 		}
 		for i, line := range lines {
 			trimmedLine := strings.TrimSpace(line)
-			if trimmedLine == "" || trimmedLine == "*/" {
+			if trimmedLine == "" || trimmedLine == "*/" || len(prefix) > 0 {
 				line = trimmedLine
 			} else {
 				// we only trim space from the right; for the left,

--- a/private/buf/bufformat/testdata/proto3/header/v1/header-block.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/header-block.golden.proto
@@ -1,0 +1,29 @@
+/*
+ * This is a top level leading comment attached to the syntax.
+ * It uses C-style block comments.
+ */
+
+//
+//  It can be separated across multiple lines like this.
+
+//
+//      All of them should retain their newlines.
+
+// This is another leading comment on the syntax.
+syntax /* This comment is attached to the '=' */ = "proto3"; // Trailing comment on syntax.
+
+// Between syntax and package.
+
+package /* Leading on package name. */ header.v1 /* Leading on semicolon */; // Trailing in-line.
+
+option /* Leading on option name */ (custom.file_thing_option).truth /* Between truth and value */ = true /* After 'true' */;
+
+import /* Leading on import path */ "custom.proto";
+
+message Foo {
+  /*
+   * This is a comment nested inside a block.
+   * It too uses C-style block comments.
+   */
+  string name = 1;
+}

--- a/private/buf/bufformat/testdata/proto3/header/v1/header-block.golden.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/header-block.golden.proto
@@ -16,10 +16,15 @@ syntax /* This comment is attached to the '=' */ = "proto3"; // Trailing comment
 
 package /* Leading on package name. */ header.v1 /* Leading on semicolon */; // Trailing in-line.
 
-option /* Leading on option name */ (custom.file_thing_option).truth /* Between truth and value */ = true /* After 'true' */;
-
 import /* Leading on import path */ "custom.proto";
 
+option /* Leading on option name */ (custom.file_thing_option).truth /* Between truth and value */ = true /* After 'true' */;
+
+/**
+ = Here's another block comment.
+ = But this one uses equal sign as the
+ = prefix for each line.
+*/
 message Foo {
   /*
    * This is a comment nested inside a block.

--- a/private/buf/bufformat/testdata/proto3/header/v1/header-block.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/header-block.proto
@@ -20,6 +20,11 @@ option /* Leading on option name */ (custom.file_thing_option).truth /* Between 
 
 import /* Leading on import path */        "custom.proto";
 
+ /**
+  = Here's another block comment.
+  = But this one uses equal sign as the
+  = prefix for each line.
+  */
 message Foo {
       /*
        * This is a comment nested inside a block.

--- a/private/buf/bufformat/testdata/proto3/header/v1/header-block.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/header-block.proto
@@ -1,7 +1,7 @@
   /*
-   * This is a top level leading comment attached to the syntax.
-   * It uses C-style block comments.
-   */
+    * This is a top level leading comment attached to the syntax.
+     * It uses C-style block comments.
+      */
 
 //
 //  It can be separated across multiple lines like this.
@@ -23,8 +23,8 @@ import /* Leading on import path */        "custom.proto";
  /**
   = Here's another block comment.
   = But this one uses equal sign as the
-  = prefix for each line.
-  */
+    = prefix for each line.
+ */
 message Foo {
       /*
        * This is a comment nested inside a block.

--- a/private/buf/bufformat/testdata/proto3/header/v1/header-block.proto
+++ b/private/buf/bufformat/testdata/proto3/header/v1/header-block.proto
@@ -1,0 +1,29 @@
+  /*
+   * This is a top level leading comment attached to the syntax.
+   * It uses C-style block comments.
+   */
+
+//
+//  It can be separated across multiple lines like this.
+
+//
+//      All of them should retain their newlines.
+
+// This is another leading comment on the syntax.
+syntax /* This comment is attached to the '=' */ = "proto3"; // Trailing comment on syntax.
+
+// Between syntax and package.
+
+package /* Leading on package name. */   header.v1   /* Leading on semicolon */;    // Trailing in-line.
+
+option /* Leading on option name */ (custom.file_thing_option).truth /* Between truth and value */ = true /* After 'true' */;
+
+import /* Leading on import path */        "custom.proto";
+
+message Foo {
+      /*
+       * This is a comment nested inside a block.
+       * It too uses C-style block comments.
+       */
+  string name = 1;
+}


### PR DESCRIPTION
Fixes #1839