### PR TITLE
Allow buf lint to start from a given git revision or patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gofrs/flock v0.8.1
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.13.0
 	github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 h1:DIPQnGy2Gv2FSA4B/hh8Q7xx3B7AIDk3DAMeHclH1vQ=
+github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6/go.mod h1:0AKcRCkMoKvUvlf89F6O7H2LYdhr1zBh736mBItOdRs=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/private/bufpkg/bufanalysis/input_issue.go
+++ b/private/bufpkg/bufanalysis/input_issue.go
@@ -1,0 +1,34 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufanalysis
+
+// Issue is a wrapper of `FileAnnotation` and implements `InputIssue` interface from `github.com/golangci/revgrep`.
+type Issue struct {
+	FileAnnotation
+}
+
+func NewIssue(annotation FileAnnotation) *Issue {
+	return &Issue{
+		FileAnnotation: annotation,
+	}
+}
+
+func (i *Issue) FilePath() string {
+	return i.FileInfo().ExternalPath()
+}
+
+func (i *Issue) Line() int {
+	return i.StartLine()
+}


### PR DESCRIPTION
## What's this PR about

Similar to what was released in [golangci-lint](https://github.com/golangci/golangci-lint/blob/master/CHANGELOG.md#september-2021), this PR allows buf linter to find new issues from a diff.

## Why is it needed

There are times when someone wants to add buf linter for an existing repo, with many existing issues. Some of such changes cannot even be fixed without a breaking change, and hereby has to stay as is. With this feature, people can add linter for an existing repo, which will work to detect new issues in the future.

## Reviewers

@jhump (Looks like you were the most active contributor recently. Not sure whether you will be the right reviewer and feel free to pass this PR to someone else)
