### PR TITLE
Trigger adjacent jobs in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,7 @@ jobs:
       - id: output_version
         name: Output version to adjacent flows
         run: |
-          VERSION="${{github.ref_name}}".replace("v", "")
+          VERSION="${{github.ref_name:1}}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
   trigger-npm-publish:
     runs-on: ubuntu-latest
@@ -216,7 +216,7 @@ jobs:
               workflow_id: "npm-publish.yaml",
               ref: "main",
               inputs: {
-                version: ${{needs.post-release.outputs.version}}
+                version: "${{needs.post-release.outputs.version}}"
               }
             })
   trigger-homebrew-buf-release:
@@ -233,7 +233,7 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: ${{needs.post-release.outputs.version}}
+                version: "${{needs.post-release.outputs.version}}"
               }
             })
   trigger-vim-buf-release:
@@ -250,7 +250,7 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: ${{needs.post-release.outputs.version}}
+                version: "${{needs.post-release.outputs.version}}"
               }
             })
   trigger-docs-buf-build-release:
@@ -267,7 +267,7 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: ${{needs.post-release.outputs.version}}
+                version: "${{needs.post-release.outputs.version}}"
               }
             })
   trigger-buf-setup-action-release:
@@ -284,6 +284,6 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: ${{needs.post-release.outputs.version}}
+                version: "${{needs.post-release.outputs.version}}"
               }
             })

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,6 +195,10 @@ jobs:
           title: "Return to development"
           body: Release complete for ${{github.ref_name}}
           token: ${{ steps.generate_token.outputs.token }}
+  trigger-npm-publish:
+    runs-on: ubuntu-latest
+    needs: post-release
+    steps:
       - name: trigger npm publish
         uses: actions/github-script@v6
         with:
@@ -203,11 +207,15 @@ jobs:
               owner: context.owner,
               repo: "buf-npm-publish",
               workflow_id: "npm-publish.yaml",
-              ref: "main"
+              ref: "main",
               inputs: {
                 version: "${{github.ref_name}}".replace("v", "")
               }
             })
+  trigger-homebrew-buf-release:
+    runs-on: ubuntu-latest
+    needs: post-release
+    steps:
       - name: trigger homebrew-buf release
         uses: actions/github-script@v6
         with:
@@ -216,11 +224,15 @@ jobs:
               owner: context.owner,
               repo: "homebrew-buf",
               workflow_id: "release.yaml",
-              ref: "main"
+              ref: "main",
               inputs: {
                 version: "${{github.ref_name}}".replace("v", "")
               }
             })
+  trigger-vim-buf-release:
+    runs-on: ubuntu-latest
+    needs: post-release
+    steps:
       - name: trigger vim-buf release
         uses: actions/github-script@v6
         with:
@@ -229,11 +241,15 @@ jobs:
               owner: context.owner,
               repo: "vim-buf",
               workflow_id: "release.yaml",
-              ref: "main"
+              ref: "main",
               inputs: {
                 version: "${{github.ref_name}}".replace("v", "")
               }
             })
+  trigger-docs-buf-build-release:
+    runs-on: ubuntu-latest
+    needs: post-release
+    steps:
       - name: trigger docs.buf.build release
         uses: actions/github-script@v6
         with:
@@ -242,11 +258,15 @@ jobs:
               owner: context.owner,
               repo: "docs.buf.build",
               workflow_id: "release.yaml",
-              ref: "main"
+              ref: "main",
               inputs: {
                 version: "${{github.ref_name}}".replace("v", "")
               }
             })
+  trigger-buf-setup-action-release:
+    runs-on: ubuntu-latest
+    needs: post-release
+    steps:
       - name: trigger buf-setup-action release
         uses: actions/github-script@v6
         with:
@@ -255,7 +275,7 @@ jobs:
               owner: context.owner,
               repo: "buf-setup-action",
               workflow_id: "release.yaml",
-              ref: "main"
+              ref: "main",
               inputs: {
                 version: "${{github.ref_name}}".replace("v", "")
               }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,11 +197,14 @@ jobs:
           title: "Return to development"
           body: Release complete for ${{github.ref_name}}
           token: ${{ steps.generate_token.outputs.token }}
+      - name: Get Version
+        uses: actions/github-script@v6
+        with:
+          script:
+            core.exportVariable('VERSION', "${{github.ref_name}}".replace("v", ""));
       - id: output_version
         name: Output version to adjacent flows
-        run: |
-          VERSION="${{github.ref_name:1}}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${{env.VERSION}}" >> "$GITHUB_OUTPUT"
   trigger-npm-publish:
     runs-on: ubuntu-latest
     needs: post-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -161,6 +161,8 @@ jobs:
   post-release:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' }}
+    outputs:
+      version: ${{ steps.output_version.outputs.version }}
     steps:
       - name: Generate token
         id: generate_token
@@ -195,6 +197,11 @@ jobs:
           title: "Return to development"
           body: Release complete for ${{github.ref_name}}
           token: ${{ steps.generate_token.outputs.token }}
+      - id: output_version
+        name: Output version to adjacent flows
+        run: |
+          VERSION="${{github.ref_name}}".replace("v", "")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
   trigger-npm-publish:
     runs-on: ubuntu-latest
     needs: post-release
@@ -209,7 +216,7 @@ jobs:
               workflow_id: "npm-publish.yaml",
               ref: "main",
               inputs: {
-                version: "${{github.ref_name}}".replace("v", "")
+                version: ${{needs.post-release.outputs.version}}
               }
             })
   trigger-homebrew-buf-release:
@@ -226,7 +233,7 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: "${{github.ref_name}}".replace("v", "")
+                version: ${{needs.post-release.outputs.version}}
               }
             })
   trigger-vim-buf-release:
@@ -243,7 +250,7 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: "${{github.ref_name}}".replace("v", "")
+                version: ${{needs.post-release.outputs.version}}
               }
             })
   trigger-docs-buf-build-release:
@@ -260,7 +267,7 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: "${{github.ref_name}}".replace("v", "")
+                version: ${{needs.post-release.outputs.version}}
               }
             })
   trigger-buf-setup-action-release:
@@ -277,6 +284,6 @@ jobs:
               workflow_id: "release.yaml",
               ref: "main",
               inputs: {
-                version: "${{github.ref_name}}".replace("v", "")
+                version: ${{needs.post-release.outputs.version}}
               }
             })

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -201,10 +201,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script:
-            core.exportVariable('VERSION', "${{github.ref_name}}".replace("v", ""));
-      - id: output_version
-        name: Output version to adjacent flows
-        run: echo "version=${{env.VERSION}}" >> "$GITHUB_OUTPUT"
+            core.setOutput('version', "${{github.ref_name}}".replace("v", ""));
   trigger-npm-publish:
     runs-on: ubuntu-latest
     needs: post-release


### PR DESCRIPTION
We had chained a number of jobs meaning that if one failed, they all failed. This PR changes that behaviour by having the following steps depend on post-release and then run independently.
- trigger npm publish
- trigger homebrew-buf release
- trigger vim-buf release
- trigger docs.buf.build release
- trigger buf-setup-action release

i achieved this by posting the `VERSION` as an output of the `post-release` job like [this](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs)