### PR TITLE
Update 'buf mod update' to check digest changes

### DIFF
--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -16,7 +16,6 @@ package modupdate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -166,8 +165,7 @@ func run(
 	}
 
 	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, readWriteBucket, dependencyModulePins); err != nil {
-		var inconsistentDigestErr *bufmoduleref.DigestChangedError
-		if errors.As(err, &inconsistentDigestErr) {
+		if bufmoduleref.IsDigestChanged(err) {
 			return err
 		}
 		return bufcli.NewInternalError(err)

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -16,6 +16,7 @@ package modupdate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -165,6 +166,10 @@ func run(
 	}
 
 	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, readWriteBucket, dependencyModulePins); err != nil {
+		var inconsistentDigestErr bufmoduleref.InconsistentDigestError
+		if errors.As(err, &inconsistentDigestErr) {
+			return err
+		}
 		return bufcli.NewInternalError(err)
 	}
 	return nil

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -164,8 +164,7 @@ func run(
 		container.Logger().Warn(warnMsg)
 	}
 	// Before updating buf.lock file, verify that existing dependency digests didn't change for the same commit.
-	err = bufmoduleref.ValidateModulePinsConsistentDigests(ctx, readWriteBucket, dependencyModulePins)
-	if err != nil {
+	if err := bufmoduleref.ValidateModulePinsConsistentDigests(ctx, readWriteBucket, dependencyModulePins); err != nil {
 		if bufmoduleref.IsDigestChanged(err) {
 			return err
 		}

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -166,7 +166,7 @@ func run(
 	}
 
 	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, readWriteBucket, dependencyModulePins); err != nil {
-		var inconsistentDigestErr bufmoduleref.InconsistentDigestError
+		var inconsistentDigestErr *bufmoduleref.DigestChangedError
 		if errors.As(err, &inconsistentDigestErr) {
 			return err
 		}

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -446,28 +446,28 @@ func ModuleDigestB3(ctx context.Context, module Module) (string, error) {
 func ModuleToBucket(
 	ctx context.Context,
 	module Module,
-	readWriteBucket storage.ReadWriteBucket,
+	writeBucket storage.WriteBucket,
 ) error {
 	fileInfos, err := module.SourceFileInfos(ctx)
 	if err != nil {
 		return err
 	}
 	for _, fileInfo := range fileInfos {
-		if err := putModuleFileToBucket(ctx, module, fileInfo.Path(), readWriteBucket); err != nil {
+		if err := putModuleFileToBucket(ctx, module, fileInfo.Path(), writeBucket); err != nil {
 			return err
 		}
 	}
 	if docs := module.Documentation(); docs != "" {
-		if err := storage.PutPath(ctx, readWriteBucket, DocumentationFilePath, []byte(docs)); err != nil {
+		if err := storage.PutPath(ctx, writeBucket, DocumentationFilePath, []byte(docs)); err != nil {
 			return err
 		}
 	}
 	if license := module.License(); license != "" {
-		if err := storage.PutPath(ctx, readWriteBucket, LicenseFilePath, []byte(license)); err != nil {
+		if err := storage.PutPath(ctx, writeBucket, LicenseFilePath, []byte(license)); err != nil {
 			return err
 		}
 	}
-	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, readWriteBucket, module.DependencyModulePins()); err != nil {
+	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, writeBucket, module.DependencyModulePins()); err != nil {
 		return err
 	}
 	// This is the default version created by bufconfig getters. The versions should be the
@@ -496,7 +496,7 @@ func ModuleToBucket(
 		bufconfig.WriteConfigWithLintConfig(module.LintConfig()),
 		bufconfig.WriteConfigWithVersion(version),
 	}
-	return bufconfig.WriteConfig(ctx, readWriteBucket, writeConfigOptions...)
+	return bufconfig.WriteConfig(ctx, writeBucket, writeConfigOptions...)
 }
 
 // TargetModuleFilesToBucket writes the target files of the given Module to the WriteBucket.

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -446,28 +446,28 @@ func ModuleDigestB3(ctx context.Context, module Module) (string, error) {
 func ModuleToBucket(
 	ctx context.Context,
 	module Module,
-	writeBucket storage.WriteBucket,
+	readWriteBucket storage.ReadWriteBucket,
 ) error {
 	fileInfos, err := module.SourceFileInfos(ctx)
 	if err != nil {
 		return err
 	}
 	for _, fileInfo := range fileInfos {
-		if err := putModuleFileToBucket(ctx, module, fileInfo.Path(), writeBucket); err != nil {
+		if err := putModuleFileToBucket(ctx, module, fileInfo.Path(), readWriteBucket); err != nil {
 			return err
 		}
 	}
 	if docs := module.Documentation(); docs != "" {
-		if err := storage.PutPath(ctx, writeBucket, DocumentationFilePath, []byte(docs)); err != nil {
+		if err := storage.PutPath(ctx, readWriteBucket, DocumentationFilePath, []byte(docs)); err != nil {
 			return err
 		}
 	}
 	if license := module.License(); license != "" {
-		if err := storage.PutPath(ctx, writeBucket, LicenseFilePath, []byte(license)); err != nil {
+		if err := storage.PutPath(ctx, readWriteBucket, LicenseFilePath, []byte(license)); err != nil {
 			return err
 		}
 	}
-	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, writeBucket, module.DependencyModulePins()); err != nil {
+	if err := bufmoduleref.PutDependencyModulePinsToBucket(ctx, readWriteBucket, module.DependencyModulePins()); err != nil {
 		return err
 	}
 	// This is the default version created by bufconfig getters. The versions should be the
@@ -496,7 +496,7 @@ func ModuleToBucket(
 		bufconfig.WriteConfigWithLintConfig(module.LintConfig()),
 		bufconfig.WriteConfigWithVersion(version),
 	}
-	return bufconfig.WriteConfig(ctx, writeBucket, writeConfigOptions...)
+	return bufconfig.WriteConfig(ctx, readWriteBucket, writeConfigOptions...)
 }
 
 // TargetModuleFilesToBucket writes the target files of the given Module to the WriteBucket.

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -400,8 +400,9 @@ func ValidateModulePinsConsistentDigests(
 		if currentDigest != "" && pin.Digest() != "" && currentDigest != pin.Digest() {
 			return &inconsistentDigestError{
 				wrapped: fmt.Errorf(
-					"module %s digest changed: expected=%q, found=%q",
+					"module %s commit %q digest changed unexpectedly: expected=%q, found=%q",
 					pin.IdentityString(),
+					pin.Commit(),
 					currentDigest,
 					pin.Digest(),
 				),

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -483,13 +483,10 @@ func DependencyModulePinsForBucket(
 // PutDependencyModulePinsToBucket writes the module dependencies to the write bucket in the form of a lock file.
 func PutDependencyModulePinsToBucket(
 	ctx context.Context,
-	readWriteBucket storage.ReadWriteBucket,
+	writeBucket storage.WriteBucket,
 	modulePins []ModulePin,
 ) error {
 	if err := ValidateModulePinsUniqueByIdentity(modulePins); err != nil {
-		return err
-	}
-	if err := ValidateModulePinsConsistentDigests(ctx, readWriteBucket, modulePins); err != nil {
 		return err
 	}
 	SortModulePins(modulePins)
@@ -508,7 +505,7 @@ func PutDependencyModulePinsToBucket(
 			},
 		)
 	}
-	return buflock.WriteConfig(ctx, readWriteBucket, lockFile)
+	return buflock.WriteConfig(ctx, writeBucket, lockFile)
 }
 
 // SortFileInfos sorts the FileInfos by Path.

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -376,7 +376,7 @@ func ValidateModulePinsUniqueByIdentity(modulePins []ModulePin) error {
 // the module pin returned from the BSR.
 func ValidateModulePinsConsistentDigests(
 	ctx context.Context,
-	bucket storage.ReadWriteBucket,
+	bucket storage.ReadBucket,
 	modulePins []ModulePin,
 ) error {
 	currentConfig, err := buflock.ReadConfig(ctx, bucket)
@@ -395,7 +395,7 @@ func ValidateModulePinsConsistentDigests(
 		currentIdentityAndCommitToDigest[key] = dep.Digest
 	}
 	for _, pin := range modulePins {
-		key := fmt.Sprintf("%s/%s/%s:%s", pin.Remote(), pin.Owner(), pin.Repository(), pin.Commit())
+		key := fmt.Sprintf("%s:%s", pin.IdentityString(), pin.Commit())
 		currentDigest := currentIdentityAndCommitToDigest[key]
 		if currentDigest != "" && pin.Digest() != "" && currentDigest != pin.Digest() {
 			return &inconsistentDigestError{

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref_test.go
@@ -126,6 +126,7 @@ func TestValidateModulePinsConsistentDigests(t *testing.T) {
 		createDigest(t, []byte("abc")),
 		modulePin.CreateTime(),
 	)
+	require.NoError(t, err)
 	err = ValidateModulePinsConsistentDigests(ctx, bucket, []ModulePin{modulePinChangedDigest})
 	var digestChangedErr *DigestChangedError
 	assert.ErrorAs(t, err, &digestChangedErr)
@@ -141,6 +142,7 @@ func TestValidateModulePinsConsistentDigests(t *testing.T) {
 		createDigest(t, []byte("abc")),
 		modulePin.CreateTime(),
 	)
+	require.NoError(t, err)
 	require.NoError(t, ValidateModulePinsConsistentDigests(ctx, bucket, []ModulePin{modulePinChangedCommitAndDigest}))
 }
 

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref_test.go
@@ -128,10 +128,7 @@ func TestValidateModulePinsConsistentDigests(t *testing.T) {
 	)
 	require.NoError(t, err)
 	err = ValidateModulePinsConsistentDigests(ctx, bucket, []ModulePin{modulePinChangedDigest})
-	var digestChangedErr *DigestChangedError
-	assert.ErrorAs(t, err, &digestChangedErr)
-	assert.Equal(t, modulePin.Digest(), digestChangedErr.CurrentDigest)
-	assert.Equal(t, modulePinChangedDigest.Digest(), digestChangedErr.UpdatedPin.Digest())
+	assert.True(t, IsDigestChanged(err))
 	// Change commit and digest - this is ok
 	modulePinChangedCommitAndDigest, err := NewModulePin(
 		modulePin.Remote(),


### PR DESCRIPTION
If 'buf mod update' runs and resolves to the same module identity and commit, it should error out if the digest doesn't match what is recorded in the buf.lock file. While unlikely, this may indicate that a module has changed since last resolved against the BSR.