### PR TITLE
Fix panic in image filtering

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -737,15 +737,17 @@ func (t *transitiveClosure) exploreOptionValueForAny(
 	opts *imageFilterOptions,
 ) error {
 	switch {
-	case fd.IsMap() && isMessageKind(fd.MapValue().Kind()):
-		var err error
-		val.Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
-			if err = t.exploreOptionScalarValueForAny(v.Message(), referrerFile, imageIndex, opts); err != nil {
-				return false
-			}
-			return true
-		})
-		return err
+	case fd.IsMap():
+		if isMessageKind(fd.MapValue().Kind()) {
+			var err error
+			val.Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
+				if err = t.exploreOptionScalarValueForAny(v.Message(), referrerFile, imageIndex, opts); err != nil {
+					return false
+				}
+				return true
+			})
+			return err
+		}
 	case isMessageKind(fd.Kind()):
 		if fd.IsList() {
 			listVal := val.List()


### PR DESCRIPTION
🤦 Caught this while on-call. It happened in production when the BSR was handling an `ImageService.GetImage` request. I think this means use of `-type` param with `buf build` and `buf generate` will crash if the schema contains maps whose values are not message types 😢. So we'll probably want to create a patch release of the Buf CLI, too.

Fixes BSR-1543

