### PR TITLE
Only assign plugin path if set in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fixes a bug in `buf generate` with `v1beta1` config files.
 
 ## [v1.15.0] - 2023-02-28
 

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -580,16 +580,16 @@ func newConfigV1Beta1(externalConfig ExternalConfigV1Beta1, id string) (*Config,
 		if err != nil {
 			return nil, err
 		}
-		pluginConfigs = append(
-			pluginConfigs,
-			&PluginConfig{
-				Name:     plugin.Name,
-				Out:      plugin.Out,
-				Opt:      opt,
-				Path:     []string{plugin.Path},
-				Strategy: strategy,
-			},
-		)
+		pluginConfig := &PluginConfig{
+			Name:     plugin.Name,
+			Out:      plugin.Out,
+			Opt:      opt,
+			Strategy: strategy,
+		}
+		if plugin.Path != "" {
+			pluginConfig.Path = []string{plugin.Path}
+		}
+		pluginConfigs = append(pluginConfigs, pluginConfig)
 	}
 	return &Config{
 		PluginConfigs: pluginConfigs,

--- a/private/buf/bufgen/testdata/v1beta1/gen_success4_nopath.yaml
+++ b/private/buf/bufgen/testdata/v1beta1/gen_success4_nopath.yaml
@@ -1,0 +1,8 @@
+version: v1beta1
+managed: true
+options:
+  optimize_for: LITE_RUNTIME
+plugins:
+  - name: go
+    out: gen/go
+    strategy: all


### PR DESCRIPTION
When migrating a v1beta1 external config to a plugin config, we should only set the new path slice if the path in the config is non-empty. Otherwise, we'll try to exec an empty command by initializing the slice to `{""}`.

Fixes #1850.