### PR TITLE
Delete bufimage.NewMultiImage

### DIFF
--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -106,25 +106,6 @@ func NewImage(imageFiles []ImageFile) (Image, error) {
 	return newImage(imageFiles, false)
 }
 
-// NewMultiImage returns a new Image for the given Images.
-//
-// Reorders the ImageFiles to be in DAG order.
-// Duplicates cannot exist across the Images.
-func NewMultiImage(images ...Image) (Image, error) {
-	switch len(images) {
-	case 0:
-		return nil, nil
-	case 1:
-		return images[0], nil
-	default:
-		var imageFiles []ImageFile
-		for _, image := range images {
-			imageFiles = append(imageFiles, image.Files()...)
-		}
-		return newImage(imageFiles, true)
-	}
-}
-
 // MergeImages returns a new Image for the given Images. ImageFiles
 // treated as non-imports in at least one of the given Images will
 // be treated as non-imports in the returned Image. The first non-import


### PR DESCRIPTION
This is supposed to do the same thing as MergeImages and MergeImages is correct