### PR TITLE
Specify that the --config flag is for a buf.yaml file

### DIFF
--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -135,7 +135,7 @@ Overrides --%s`,
 		&f.AgainstConfig,
 		againstConfigFlagName,
 		"",
-		`The file or data to use to configure the against source, module, or image`,
+		`The buf.yaml file or data to use to configure the against source, module, or image`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -120,7 +120,7 @@ Overrides --%s`,
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 	flagSet.StringVar(
 		&f.Against,

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -125,7 +125,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -238,7 +238,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -261,7 +261,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 	flagSet.StringSliceVar(
 		&f.Types,

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -93,7 +93,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 }
 

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -86,7 +86,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use for configuration`,
+		`The buf.yaml configuration file or data to use`,
 	)
 	flagSet.StringVar(
 		&f.ErrorFormat,

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -40,7 +40,7 @@ func BindLSRulesConfig(flagSet *pflag.FlagSet, addr *string, flagName string, al
 		flagName,
 		"",
 		fmt.Sprintf(
-			`The file or data to use for configuration. Ignored if --%s or --%s is specified`,
+			`The buf.yaml file or data to use for configuration. Ignored if --%s or --%s is specified`,
 			allFlagName,
 			versionFlagName,
 		),


### PR DESCRIPTION
This was asked in the buf slack channel, especially around the `buf format` command as the term "config" is ambiguous to if it configures the behaviour of the command or the entire buf module. 

Also, I think it might actually be more appropriate to have this as an inherited flag, this would make it more clear what was being configured. This might not play nicely with commands that do not need a module input at all (buf curl for example).

```diff
$ buf format --help
Flags:
-      --config string          The buf.yaml file or data to use for configuration
  -d, --diff                   Display diffs instead of rewriting files
      --disable-symlinks       Do not follow symlinks when reading sources or configuration from the local filesystem
                               By default, symlinks are followed in this CLI, but never followed on the Buf Schema Registry
      --error-format string    The format for build errors printed to stderr. Must be one of [text,json,msvs,junit] (default "text")
      --exclude-path strings   Exclude specific files or directories, e.g. "proto/a/a.proto", "proto/a"
                               If specified multiple times, the union is taken
      --exit-code              Exit with a non-zero exit code if files were not already formatted
  -h, --help                   help for format
  -o, --output string          The output location for the formatted files. Must be one of format [dir,git,protofile,tar,zip]. If omitted, the result is written to stdout (default "-")
      --path strings           Limit to specific files or directories, e.g. "proto/a/a.proto", "proto/a"
                               If specified multiple times, the union is taken
  -w, --write                  Rewrite files in-place

Global Flags:
+      --config string          The buf.yaml file or data to use for configuration
      --debug               Turn on debug logging
      --log-format string   The log format [text,color,json] (default "color")
      --timeout duration    The duration until timing out (default 2m0s)
  -v, --verbose             Turn on verbose mode
``` 