### PR TITLE
Remove the `buffetch.RefParserWithProtoFileRefAllowed` option.

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -815,7 +815,7 @@ func NewImageForSource(
 	externalDirOrFilePathsAllowNotExist bool,
 	excludeSourceCodeInfo bool,
 ) (bufimage.Image, error) {
-	ref, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, source)
+	ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, source)
 	if err != nil {
 		return nil, err
 	}

--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -169,19 +169,8 @@ type RefParser interface {
 // NewRefParser returns a new RefParser.
 //
 // This defaults to dir or module.
-func NewRefParser(logger *zap.Logger, options ...RefParserOption) RefParser {
-	return newRefParser(logger, options...)
-}
-
-// RefParserOption is an option for NewRefParser. Ref parser options are only accepted
-// for the default RefParser constructor.
-type RefParserOption func(*refParser)
-
-// RefParserWithProtoFileRefAllowed sets the option of allowing a proto file.
-func RefParserWithProtoFileRefAllowed() RefParserOption {
-	return func(r *refParser) {
-		r.allowProtoFileRef = true
-	}
+func NewRefParser(logger *zap.Logger) RefParser {
+	return newRefParser(logger)
 }
 
 // NewImageRefParser returns a new RefParser for images only.

--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -632,7 +632,6 @@ func WithModuleFormat(format string, options ...ModuleFormatOption) RefParserOpt
 }
 
 // WithProtoFileFormat attaches the given format as a single file format.
-// The ProtoFileRef format is only allowed if the option for the parser is given. Otherwise this is a no-op.
 //
 // It is up to the user to not incorrectly attach a format twice.
 func WithProtoFileFormat(format string, options ...ProtoFileFormatOption) RefParserOption {

--- a/private/buf/buffetch/ref_parser.go
+++ b/private/buf/buffetch/ref_parser.go
@@ -37,19 +37,14 @@ const (
 )
 
 type refParser struct {
-	allowProtoFileRef bool
-	logger            *zap.Logger
-	fetchRefParser    internal.RefParser
-	tracer            trace.Tracer
+	logger         *zap.Logger
+	fetchRefParser internal.RefParser
+	tracer         trace.Tracer
 }
 
-func newRefParser(logger *zap.Logger, options ...RefParserOption) *refParser {
-	refParser := &refParser{}
-	for _, option := range options {
-		option(refParser)
-	}
+func newRefParser(logger *zap.Logger) *refParser {
 	fetchRefParserOptions := []internal.RefParserOption{
-		internal.WithRawRefProcessor(newRawRefProcessor(refParser.allowProtoFileRef)),
+		internal.WithRawRefProcessor(newRawRefProcessor()),
 		internal.WithSingleFormat(formatBin),
 		internal.WithSingleFormat(formatJSON),
 		internal.WithSingleFormat(
@@ -82,17 +77,16 @@ func newRefParser(logger *zap.Logger, options ...RefParserOption) *refParser {
 		internal.WithGitFormat(formatGit),
 		internal.WithDirFormat(formatDir),
 		internal.WithModuleFormat(formatMod),
+		internal.WithProtoFileFormat(formatProtoFile),
 	}
-	if refParser.allowProtoFileRef {
-		fetchRefParserOptions = append(fetchRefParserOptions, internal.WithProtoFileFormat(formatProtoFile))
+	return &refParser{
+		logger: logger.Named(loggerName),
+		tracer: otel.GetTracerProvider().Tracer(tracerName),
+		fetchRefParser: internal.NewRefParser(
+			logger,
+			fetchRefParserOptions...,
+		),
 	}
-	refParser.logger = logger.Named(loggerName)
-	refParser.tracer = otel.GetTracerProvider().Tracer(tracerName)
-	refParser.fetchRefParser = internal.NewRefParser(
-		logger,
-		fetchRefParserOptions...,
-	)
-	return refParser
 }
 
 func newImageRefParser(logger *zap.Logger) *refParser {
@@ -364,7 +358,7 @@ func (a *refParser) checkDeprecated(parsedRef internal.ParsedRef) {
 	}
 }
 
-func newRawRefProcessor(allowProtoFileRef bool) func(*internal.RawRef) error {
+func newRawRefProcessor() func(*internal.RawRef) error {
 	return func(rawRef *internal.RawRef) error {
 		// if format option is not set and path is "-", default to bin
 		var format string
@@ -413,18 +407,14 @@ func newRawRefProcessor(allowProtoFileRef bool) func(*internal.RawRef) error {
 				// This only applies if the option accept `ProtoFileRef` is passed in, otherwise
 				// it falls through to the `default` case.
 			case ".proto":
-				if allowProtoFileRef {
-					fileInfo, err := os.Stat(rawRef.Path)
-					if err != nil && !os.IsNotExist(err) {
-						return fmt.Errorf("path provided is not a valid proto file: %s, %w", rawRef.Path, err)
-					}
-					if fileInfo != nil && fileInfo.IsDir() {
-						return fmt.Errorf("path provided is not a valid proto file: a directory named %s already exists", rawRef.Path)
-					}
-					format = formatProtoFile
-					break
+				fileInfo, err := os.Stat(rawRef.Path)
+				if err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("path provided is not a valid proto file: %s, %w", rawRef.Path, err)
 				}
-				fallthrough
+				if fileInfo != nil && fileInfo.IsDir() {
+					return fmt.Errorf("path provided is not a valid proto file: a directory named %s already exists", rawRef.Path)
+				}
+				format = formatProtoFile
 			default:
 				var err error
 				format, err = assumeModuleOrDir(rawRef.Path)

--- a/private/buf/cmd/buf/command/beta/price/price.go
+++ b/private/buf/cmd/buf/command/beta/price/price.go
@@ -108,7 +108,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	sourceOrModuleRef, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetSourceOrModuleRef(ctx, input)
+	sourceOrModuleRef, err := buffetch.NewRefParser(container.Logger()).GetSourceOrModuleRef(ctx, input)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -154,7 +154,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	ref, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, input)
+	ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, input)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func run(
 			return err
 		}
 	}
-	againstRef, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, flags.Against)
+	againstRef, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, flags.Against)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -660,7 +660,7 @@ func run(ctx context.Context, container appflag.Container, f *flags) (err error)
 		res, closeRes = bufcurl.NewServerReflectionResolver(ctx, transport, clientOptions, baseURL, reflectProtocol, reflectHeaders, container.VerbosePrinter())
 		defer closeRes()
 	} else {
-		ref, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, f.Schema)
+		ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, f.Schema)
 		if err != nil {
 			return err
 		}

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -138,7 +138,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	sourceOrModuleRef, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetSourceOrModuleRef(ctx, input)
+	sourceOrModuleRef, err := buffetch.NewRefParser(container.Logger()).GetSourceOrModuleRef(ctx, input)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -257,10 +257,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	refParser := buffetch.NewRefParser(
-		container.Logger(),
-		buffetch.RefParserWithProtoFileRefAllowed(),
-	)
+	refParser := buffetch.NewRefParser(container.Logger())
 	sourceOrModuleRef, err := refParser.GetSourceOrModuleRef(ctx, source)
 	if err != nil {
 		return err

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -299,7 +299,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	ref, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, input)
+	ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, input)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -109,7 +109,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	ref, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, input)
+	ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, input)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -114,7 +114,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	ref, err := buffetch.NewRefParser(container.Logger(), buffetch.RefParserWithProtoFileRefAllowed()).GetRef(ctx, input)
+	ref, err := buffetch.NewRefParser(container.Logger()).GetRef(ctx, input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This option is always passed into `buffetch.NewRefParser`, so I removed it.

There were no options left, so I also removed all options.