### PR TITLE
Set default for curated plugin visibility

### DIFF
--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -477,13 +477,13 @@ func loadDockerImage(ctx context.Context, bucket storage.ReadBucket) (storage.Re
 	return image, nil
 }
 
-func visibilityFlagToVisibility(visibility string) (registryv1alpha1.CuratedPluginVisibility, error) {
+func visibilityFlagToVisibility(visibility string) registryv1alpha1.CuratedPluginVisibility {
 	switch visibility {
 	case publicVisibility:
-		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PUBLIC, nil
+		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PUBLIC
 	case privateVisibility:
-		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PRIVATE, nil
+		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PRIVATE
 	default:
-		return 0, fmt.Errorf("invalid visibility: %s, expected one of %s", visibility, stringutil.SliceToString(allVisibiltyStrings))
+		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_UNSPECIFIED
 	}
 }

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -477,13 +477,16 @@ func loadDockerImage(ctx context.Context, bucket storage.ReadBucket) (storage.Re
 	return image, nil
 }
 
-func visibilityFlagToVisibility(visibility string) registryv1alpha1.CuratedPluginVisibility {
+func visibilityFlagToVisibility(visibility string) (registryv1alpha1.CuratedPluginVisibility, error) {
 	switch visibility {
 	case publicVisibility:
-		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PUBLIC
+		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PUBLIC, nil
 	case privateVisibility:
-		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PRIVATE
+		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PRIVATE, nil
+	case "":
+		// TODO(mf): remove once we promote this command to beta and make visibility required.
+		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_UNSPECIFIED, nil
 	default:
-		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_UNSPECIFIED
+		return 0, fmt.Errorf("invalid visibility: %s, expected one of %s", visibility, stringutil.SliceToString(allVisibiltyStrings))
 	}
 }

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -135,7 +135,6 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"",
 		fmt.Sprintf(`The plugin's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
 	)
-	_ = cobra.MarkFlagRequired(flagSet, visibilityFlagName)
 }
 
 func run(

--- a/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/alpha/plugin/pluginpush/pluginpush.go
@@ -132,7 +132,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(
 		&f.Visibility,
 		visibilityFlagName,
-		"",
+		"public",
 		fmt.Sprintf(`The plugin's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
 	)
 }
@@ -483,9 +483,6 @@ func visibilityFlagToVisibility(visibility string) (registryv1alpha1.CuratedPlug
 		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PUBLIC, nil
 	case privateVisibility:
 		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PRIVATE, nil
-	case "":
-		// TODO(mf): remove once we promote this command to beta and make visibility required.
-		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_UNSPECIFIED, nil
 	default:
 		return 0, fmt.Errorf("invalid visibility: %s, expected one of %s", visibility, stringutil.SliceToString(allVisibiltyStrings))
 	}


### PR DESCRIPTION
Remove visibility as a required flag, will re-introduce this once this command is promoted to `beta` (from `alpha`) and the backend implementation is complete.