### PR TITLE
Webpages multi page output

### DIFF
--- a/private/pkg/app/appcmd/webpages.go
+++ b/private/pkg/app/appcmd/webpages.go
@@ -177,21 +177,21 @@ func generateMarkdownPage(cmd *cobra.Command, w io.Writer, config webpagesConfig
 	p(cmd.Short)
 	p("\n\n")
 	if cmd.Runnable() {
-		p("### Usage {#usage} \n")
+		p("### Usage\n")
 		p("```terminal\n$ %s\n```\n\n", cmd.UseLine())
 	}
 	if len(cmd.Long) > 0 {
-		p("### Description {#description}\n\n")
+		p("### Description\n\n")
 		p("%s \n\n", escapeDescription(cmd.Long))
 	}
 	if len(cmd.Example) > 0 {
-		p("### Examples {#examples}\n\n")
+		p("### Examples\n\n")
 		p("```\n%s\n```\n\n", escapeDescription(cmd.Example))
 	}
 	commandFlags := cmd.NonInheritedFlags()
 	if commandFlags.HasAvailableFlags() {
 		p("### Flags {#flags}\n\n")
-		if err := printFlags(cmd, commandFlags, w); err != nil {
+		if err := printFlags(commandFlags, w); err != nil {
 			return err
 		}
 	}
@@ -203,7 +203,7 @@ func generateMarkdownPage(cmd *cobra.Command, w io.Writer, config webpagesConfig
 		}
 	}
 	if hasSubCommands(cmd) {
-		p("### Subcommands {#subcommands}\n\n")
+		p("### Subcommands\n\n")
 		children := cmd.Commands()
 		orderCommands(config.WeightCommands, children)
 		for _, child := range children {
@@ -219,7 +219,7 @@ func generateMarkdownPage(cmd *cobra.Command, w io.Writer, config webpagesConfig
 		p("\n")
 	}
 	if cmd.HasParent() {
-		p("### Parent Command {#%s-parent-command}\n\n", id)
+		p("### Parent Command\n\n", id)
 		parent := cmd.Parent()
 		parentName := parent.CommandPath()
 		if hasSubCommands(cmd) {

--- a/private/pkg/app/appcmd/webpages.go
+++ b/private/pkg/app/appcmd/webpages.go
@@ -104,8 +104,8 @@ func newWebpagesCommand(
 			}
 			return generateMarkdownTree(
 				command,
-				cfg.OutputDir,
 				cfg,
+				cfg.OutputDir,
 			)
 		},
 		BindFlags: flags.Bind,
@@ -113,7 +113,7 @@ func newWebpagesCommand(
 }
 
 // generateMarkdownTree generates markdown for a whole command tree.
-func generateMarkdownTree(cmd *cobra.Command, parentDirPath string, config webpagesConfig) error {
+func generateMarkdownTree(cmd *cobra.Command, config webpagesConfig, parentDirPath string) error {
 	if !cmd.IsAvailableCommand() {
 		return nil
 	}
@@ -132,14 +132,14 @@ func generateMarkdownTree(cmd *cobra.Command, parentDirPath string, config webpa
 		return err
 	}
 	defer f.Close()
-	if err := generateMarkdownPage(cmd, f, config); err != nil {
+	if err := generateMarkdownPage(cmd, config, f); err != nil {
 		return err
 	}
 	if cmd.HasSubCommands() {
 		commands := cmd.Commands()
 		orderCommands(config.WeightCommands, commands)
 		for _, command := range commands {
-			if err := generateMarkdownTree(command, dirPath, config); err != nil {
+			if err := generateMarkdownTree(command, config, dirPath); err != nil {
 				return err
 			}
 		}
@@ -148,7 +148,7 @@ func generateMarkdownTree(cmd *cobra.Command, parentDirPath string, config webpa
 }
 
 // generateMarkdownPage creates custom markdown output.
-func generateMarkdownPage(cmd *cobra.Command, w io.Writer, config webpagesConfig) error {
+func generateMarkdownPage(cmd *cobra.Command, config webpagesConfig, w io.Writer) error {
 	var err error
 	p := func(format string, a ...any) {
 		_, err = w.Write([]byte(fmt.Sprintf(format, a...)))

--- a/private/pkg/app/appcmd/webpages.go
+++ b/private/pkg/app/appcmd/webpages.go
@@ -325,7 +325,6 @@ func printFlags(f *pflag.FlagSet, w io.Writer) error {
 		if flag.Hidden {
 			return
 		}
-
 		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
 			p("#### -%s, --%s", flag.Shorthand, flag.Name)
 		} else {
@@ -362,23 +361,29 @@ func printFlags(f *pflag.FlagSet, w io.Writer) error {
 	return err
 }
 
+// websiteSidebarPosition calculates the position of the given command in the website sidebar.
 func websiteSidebarPosition(cmd *cobra.Command, weights map[string]int) int {
-	var i int
+	// Return 0 if the command has no parent
 	if !cmd.HasParent() {
 		return 0
 	}
 	siblings := cmd.Parent().Commands()
 	orderCommands(weights, siblings)
+	position := 0
 	for _, sibling := range siblings {
-		if !cmd.IsAvailableCommand() || cmd.IsAdditionalHelpTopicCommand() || cmd.Hidden {
-			continue
-		}
-		i++
-		if sibling.CommandPath() == cmd.CommandPath() {
-			return i
+		if isCommandVisible(sibling) {
+			position++
+			if sibling.CommandPath() == cmd.CommandPath() {
+				return position
+			}
 		}
 	}
 	return -1
+}
+
+// isCommandVisible checks if a command is visible (available, not an additional help topic, and not hidden).
+func isCommandVisible(cmd *cobra.Command) bool {
+	return cmd.IsAvailableCommand() && !cmd.IsAdditionalHelpTopicCommand() && !cmd.Hidden
 }
 
 func websiteSlug(cmd *cobra.Command) string {

--- a/private/pkg/app/appcmd/webpages.go
+++ b/private/pkg/app/appcmd/webpages.go
@@ -46,13 +46,6 @@ type webpagesFlags struct {
 }
 
 // webpagesConfig configures the doc generator, example config:
-// prefix: |
-// ---
-// title: Buf CLI
-// sidebar_position: 0
-// toc_max_heading_level: 2
-// slug: /reference/cli/buf
-// ---
 // exclude_commands:
 // - buf completion
 // - buf ls-files
@@ -61,7 +54,6 @@ type webpagesFlags struct {
 // slug_prefix: /reference/cli/
 // output_dir: output/docs
 type webpagesConfig struct {
-	Prefix string `yaml:"prefix,omitempty"`
 	// ExcludeCommands will filter out these command paths from generation.
 	ExcludeCommands []string `yaml:"exclude_commands,omitempty"`
 	// WeightCommands will weight the command paths and show higher weighted commands later on the sidebar.

--- a/private/pkg/app/appcmd/webpages.go
+++ b/private/pkg/app/appcmd/webpages.go
@@ -153,7 +153,6 @@ func generateMarkdownPage(cmd *cobra.Command, config webpagesConfig, w io.Writer
 	p := func(format string, a ...any) {
 		_, err = w.Write([]byte(fmt.Sprintf(format, a...)))
 	}
-	id := websitePageID(cmd)
 	p("---\n")
 	p("id: %s\n", websitePageID(cmd))
 	p("title: %s\n", cmd.CommandPath())
@@ -189,7 +188,7 @@ func generateMarkdownPage(cmd *cobra.Command, config webpagesConfig, w io.Writer
 	}
 	inheritedFlags := cmd.InheritedFlags()
 	if inheritedFlags.HasAvailableFlags() {
-		p("### Flags inherited from parent commands {#%s-persistent-flags}\n", id)
+		p("### Flags inherited from parent commands {#persistent-flags}\n")
 		if err := printFlags(inheritedFlags, w); err != nil {
 			return err
 		}
@@ -211,7 +210,7 @@ func generateMarkdownPage(cmd *cobra.Command, config webpagesConfig, w io.Writer
 		p("\n")
 	}
 	if cmd.HasParent() {
-		p("### Parent Command\n\n", id)
+		p("### Parent Command\n\n")
 		parent := cmd.Parent()
 		parentName := parent.CommandPath()
 		if hasSubCommands(cmd) {


### PR DESCRIPTION
Changes:
- Addition of SlugPrefix and OutputDir fields to the webpagesConfig struct to allow for better customization of the generated markdown output.
- Modification of the generateMarkdownTree function to create the required directories and files for each command and its subcommands, organizing the output in a more structured manner.
- Refactoring of the generateMarkdownPage function to make the generated markdown files follow a more standardized format, including slug, sidebar position, and sidebar label.
- Addition of the websiteSlug and sidebarLabel functions to handle the generation of the slug and sidebar label for each command.

<details>
 <summary>tree structure</summary>

```
.
└── buf
    ├── beta
    │   ├── _category.json
    │   ├── index.md
    │   ├── migrate-v1beta1.md
    │   ├── price.md
    │   ├── registry
    │   │   ├── commit
    │   │   │   ├── get.md
    │   │   │   ├── index.md
    │   │   │   └── list.md
    │   │   ├── draft
    │   │   │   ├── delete.md
    │   │   │   ├── index.md
    │   │   │   └── list.md
    │   │   ├── index.md
    │   │   ├── organization
    │   │   │   ├── create.md
    │   │   │   ├── delete.md
    │   │   │   ├── get.md
    │   │   │   └── index.md
    │   │   ├── plugin
    │   │   │   ├── create.md
    │   │   │   ├── delete.md
    │   │   │   ├── deprecate.md
    │   │   │   ├── index.md
    │   │   │   ├── list.md
    │   │   │   ├── undeprecate.md
    │   │   │   └── version
    │   │   │       ├── index.md
    │   │   │       └── list.md
    │   │   ├── repository
    │   │   │   ├── create.md
    │   │   │   ├── delete.md
    │   │   │   ├── deprecate.md
    │   │   │   ├── get.md
    │   │   │   ├── index.md
    │   │   │   ├── list.md
    │   │   │   ├── undeprecate.md
    │   │   │   └── update.md
    │   │   ├── tag
    │   │   │   ├── create.md
    │   │   │   ├── index.md
    │   │   │   └── list.md
    │   │   ├── template
    │   │   │   ├── create.md
    │   │   │   ├── delete.md
    │   │   │   ├── deprecate.md
    │   │   │   ├── index.md
    │   │   │   ├── list.md
    │   │   │   ├── undeprecate.md
    │   │   │   └── version
    │   │   │       ├── create.md
    │   │   │       ├── index.md
    │   │   │       └── list.md
    │   │   └── webhook
    │   │       ├── create.md
    │   │       ├── delete.md
    │   │       ├── index.md
    │   │       └── list.md
    │   └── studio-agent.md
    ├── breaking.md
    ├── build.md
    ├── convert.md
    ├── curl.md
    ├── export.md
    ├── format.md
    ├── generate.md
    ├── index.md
    ├── lint.md
    ├── mod
    │   ├── clear-cache.md
    │   ├── index.md
    │   ├── init.md
    │   ├── ls-breaking-rules.md
    │   ├── ls-lint-rules.md
    │   ├── open.md
    │   ├── prune.md
    │   └── update.md
    ├── push.md
    └── registry
        ├── index.md
        ├── login.md
        └── logout.md

15 directories, 69 files

```

</details>
