### PR TITLE
bufwasm: moves more initialization to compile time and fixes leak

### DIFF
--- a/private/bufpkg/bufpluginexec/wasm_handler.go
+++ b/private/bufpkg/bufpluginexec/wasm_handler.go
@@ -83,6 +83,8 @@ func (h *wasmHandler) Handle(
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
+	defer compiledPlugin.Close()
+
 	responseBuffer := bytes.NewBuffer(nil)
 	if err := h.wasmPluginExecutor.Run(
 		ctx,


### PR DESCRIPTION
Before, we forgot to close the cache allocated by the wasm plugin. What was more subtle was that a large amount of initialization was happening per `Run` when it was known at compile time. This sorts out those issues so that as much overhead as possible happens before running a plugin.

The result is pretty sweet, as we are in tens of microseconds per Run.
```bash
$ go test -run='^$' -bench '^Benchmark.*' ./private/bufpkg/bufwasm -count=6 > old.txt
$ go test -run='^$' -bench '^Benchmark.*' ./private/bufpkg/bufwasm -count=6 > new.txt
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/bufbuild/buf/private/bufpkg/bufwasm
             │   old.txt    │              new.txt               │
             │    sec/op    │   sec/op     vs base               │
PluginRun-12   358.48µ ± 2%   23.85µ ± 5%  -93.35% (p=0.002 n=6)
```