### PR TITLE
Update actions workflows to latest Ubuntu

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -5,7 +5,7 @@ on:
       - 'proto/**'
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.15.1
@@ -15,7 +15,7 @@ jobs:
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}
   breaking:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.15.1
@@ -26,7 +26,7 @@ jobs:
           against: buf.build/bufbuild/buf
           buf_token: ${{ secrets.BUF_TOKEN }}
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ env:
   MAKEFLAGS: '-j 2'
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
           BUF_INPUT_HTTPS_USERNAME: ${{ github.actor }}
           BUF_INPUT_HTTPS_PASSWORD: ${{ github.token }}
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
       - name: make-test
         run: make test
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - lint
       - test

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: setup-go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.x'
       - name: initialize
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,7 +14,7 @@ on:
       - main
 jobs:
   codeql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/previous.yaml
+++ b/.github/workflows/previous.yaml
@@ -7,14 +7,14 @@ env:
   MAKEFLAGS: "-j 2"
 jobs:
   test-previous:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
       - name: setup-go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.x'
       - name: cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.20.x"
+          go-version: "1.20.x"
       - name: Install Buf
         run: make installbuf
       - name: Update Buf Version
@@ -134,7 +134,7 @@ jobs:
           echo "VERSION=${{github.ref_name}}" >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.20.x"
+          go-version: "1.20.x"
       - name: Create assets
         env:
           RELEASE_MINISIGN_PRIVATE_KEY: ${{secrets.RELEASE_MINISIGN_PRIVATE_KEY}}


### PR DESCRIPTION
Update to ubuntu-latest in all workflows (we're about 50/50 right now). Setup Go in the CodeQL workflow to attempt to fix a warning. Use consistent syntax for specifying versions in workflows.