### PR TITLE
Manifest.Range: iterate entries (path, digest)

### DIFF
--- a/private/bufpkg/bufmodule/bufmodulecache/cas_module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/cas_module_cacher.go
@@ -68,7 +68,7 @@ func (c *casModuleCacher) GetModule(
 	}
 	var blobs []manifest.Blob
 	blobDigests := make(map[string]struct{})
-	if err := manifestFromCache.IteratePaths(func(path string, digest manifest.Digest) error {
+	if err := manifestFromCache.Range(func(path string, digest manifest.Digest) error {
 		if _, ok := blobDigests[digest.String()]; ok {
 			// We've already loaded this blob
 			return nil
@@ -118,7 +118,7 @@ func (c *casModuleCacher) PutModule(
 	moduleBasedir := normalpath.Join(modulePin.Remote(), modulePin.Owner(), modulePin.Repository())
 	// Write blobs
 	writtenDigests := make(map[string]struct{})
-	if err := moduleManifest.IteratePaths(func(path string, digest manifest.Digest) error {
+	if err := moduleManifest.Range(func(path string, digest manifest.Digest) error {
 		blobDigestStr := digest.String()
 		if _, ok := writtenDigests[blobDigestStr]; ok {
 			return nil

--- a/private/bufpkg/bufmodule/bufmodulecache/cas_module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/cas_module_cacher.go
@@ -68,20 +68,19 @@ func (c *casModuleCacher) GetModule(
 	}
 	var blobs []manifest.Blob
 	blobDigests := make(map[string]struct{})
-	for _, path := range manifestFromCache.Paths() {
-		digest, found := manifestFromCache.DigestFor(path)
-		if !found {
-			return nil, fmt.Errorf("digest not found for path: %s", path)
-		}
+	if err := manifestFromCache.IteratePaths(func(path string, digest manifest.Digest) error {
 		if _, ok := blobDigests[digest.String()]; ok {
 			// We've already loaded this blob
-			continue
+			return nil
 		}
-		blob, err := c.readBlob(ctx, moduleBasedir, digest)
+		blob, err := c.readBlob(ctx, moduleBasedir, &digest)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		blobs = append(blobs, blob)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	blobSet, err := manifest.NewBlobSet(ctx, blobs)
 	if err != nil {
@@ -119,14 +118,10 @@ func (c *casModuleCacher) PutModule(
 	moduleBasedir := normalpath.Join(modulePin.Remote(), modulePin.Owner(), modulePin.Repository())
 	// Write blobs
 	writtenDigests := make(map[string]struct{})
-	for _, path := range moduleManifest.Paths() {
-		blobDigest, found := moduleManifest.DigestFor(path)
-		if !found {
-			return fmt.Errorf("failed to find digest for path=%q", path)
-		}
-		blobDigestStr := blobDigest.String()
+	if err := moduleManifest.IteratePaths(func(path string, digest manifest.Digest) error {
+		blobDigestStr := digest.String()
 		if _, ok := writtenDigests[blobDigestStr]; ok {
-			continue
+			return nil
 		}
 		blob, found := module.BlobSet().BlobFor(blobDigestStr)
 		if !found {
@@ -136,6 +131,9 @@ func (c *casModuleCacher) PutModule(
 			return err
 		}
 		writtenDigests[blobDigestStr] = struct{}{}
+		return nil
+	}); err != nil {
+		return err
 	}
 	// Write manifest
 	if err := c.writeBlob(ctx, moduleBasedir, manifestBlob); err != nil {

--- a/private/pkg/manifest/manifest.go
+++ b/private/pkg/manifest/manifest.go
@@ -142,11 +142,14 @@ func (m *Manifest) Paths() []string {
 
 // IteratePaths invokes a function for all the paths in the manifest, passing
 // the path and its digest. The order in which the paths are iterated is not
-// guaranteed.
-func (m *Manifest) IteratePaths(f func(string, Digest)) {
+// guaranteed. This func will stop iterating if an error is returned.
+func (m *Manifest) IteratePaths(f func(path string, digest Digest) error) error {
 	for path, digest := range m.pathToDigest {
-		f(path, digest)
+		if err := f(path, digest); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // PathsFor returns one or more matching path for a given digest. The digest is

--- a/private/pkg/manifest/manifest.go
+++ b/private/pkg/manifest/manifest.go
@@ -131,7 +131,7 @@ func (m *Manifest) AddEntry(path string, digest Digest) error {
 }
 
 // Paths returns all paths in the manifest. If you want to iterate the paths and
-// their digests, consider using `IteratePaths` instead.
+// their digests, consider using `Range` instead.
 func (m *Manifest) Paths() []string {
 	paths := make([]string, 0, len(m.pathToDigest))
 	for path := range m.pathToDigest {

--- a/private/pkg/manifest/manifest.go
+++ b/private/pkg/manifest/manifest.go
@@ -130,13 +130,23 @@ func (m *Manifest) AddEntry(path string, digest Digest) error {
 	return nil
 }
 
-// Paths returns all paths in the manifest.
+// Paths returns all paths in the manifest. If you want to iterate the paths and
+// their digests, consider using `IteratePaths` instead.
 func (m *Manifest) Paths() []string {
 	paths := make([]string, 0, len(m.pathToDigest))
 	for path := range m.pathToDigest {
 		paths = append(paths, path)
 	}
 	return paths
+}
+
+// IteratePaths invokes a function for all the paths in the manifest, passing
+// the path and its digest. The order in which the paths are iterated is not
+// guaranteed.
+func (m *Manifest) IteratePaths(f func(string, Digest)) {
+	for path, digest := range m.pathToDigest {
+		f(path, digest)
+	}
 }
 
 // PathsFor returns one or more matching path for a given digest. The digest is

--- a/private/pkg/manifest/manifest.go
+++ b/private/pkg/manifest/manifest.go
@@ -140,10 +140,10 @@ func (m *Manifest) Paths() []string {
 	return paths
 }
 
-// IteratePaths invokes a function for all the paths in the manifest, passing
-// the path and its digest. The order in which the paths are iterated is not
-// guaranteed. This func will stop iterating if an error is returned.
-func (m *Manifest) IteratePaths(f func(path string, digest Digest) error) error {
+// Range invokes a function for all the paths in the manifest, passing the path
+// and its digest. The order in which the paths are iterated is not guaranteed.
+// This func will stop iterating if an error is returned.
+func (m *Manifest) Range(f func(path string, digest Digest) error) error {
 	for path, digest := range m.pathToDigest {
 		if err := f(path, digest); err != nil {
 			return err

--- a/private/pkg/manifest/manifest_test.go
+++ b/private/pkg/manifest/manifest_test.go
@@ -207,7 +207,7 @@ func TestAllPaths(t *testing.T) {
 	assert.Equal(t, len(addedPaths), len(retPaths))
 	assert.ElementsMatch(t, addedPaths, retPaths)
 	var iteratedPaths []string
-	require.NoError(t, m.IteratePaths(func(path string, digest manifest.Digest) error {
+	require.NoError(t, m.Range(func(path string, digest manifest.Digest) error {
 		iteratedPaths = append(iteratedPaths, path)
 		assert.True(t, digest.Equal(*nilDigest))
 		return nil

--- a/private/pkg/manifest/manifest_test.go
+++ b/private/pkg/manifest/manifest_test.go
@@ -207,10 +207,11 @@ func TestAllPaths(t *testing.T) {
 	assert.Equal(t, len(addedPaths), len(retPaths))
 	assert.ElementsMatch(t, addedPaths, retPaths)
 	var iteratedPaths []string
-	m.IteratePaths(func(path string, digest manifest.Digest) {
+	require.NoError(t, m.IteratePaths(func(path string, digest manifest.Digest) error {
 		iteratedPaths = append(iteratedPaths, path)
 		assert.True(t, digest.Equal(*nilDigest))
-	})
+		return nil
+	}))
 	assert.ElementsMatch(t, addedPaths, iteratedPaths)
 }
 

--- a/private/pkg/manifest/manifest_test.go
+++ b/private/pkg/manifest/manifest_test.go
@@ -193,16 +193,25 @@ func testInvalidManifest(
 
 func TestAllPaths(t *testing.T) {
 	t.Parallel()
-	var m manifest.Manifest
-	var addedPaths []string
+	var (
+		m          manifest.Manifest
+		addedPaths []string
+		nilDigest  = mustDigestShake256(t, nil)
+	)
 	for i := 0; i < 20; i++ {
 		path := fmt.Sprintf("path/to/file%0d", i)
-		require.NoError(t, m.AddEntry(path, *mustDigestShake256(t, nil)))
+		require.NoError(t, m.AddEntry(path, *nilDigest))
 		addedPaths = append(addedPaths, path)
 	}
 	retPaths := m.Paths()
 	assert.Equal(t, len(addedPaths), len(retPaths))
 	assert.ElementsMatch(t, addedPaths, retPaths)
+	var iteratedPaths []string
+	m.IteratePaths(func(path string, digest manifest.Digest) {
+		iteratedPaths = append(iteratedPaths, path)
+		assert.True(t, digest.Equal(*nilDigest))
+	})
+	assert.ElementsMatch(t, addedPaths, iteratedPaths)
 }
 
 func TestManifestZeroValue(t *testing.T) {

--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -151,22 +151,13 @@ func (s *BlobSet) BlobFor(digest string) (Blob, bool) {
 	return blob, true
 }
 
-// Blobs returns a slice of the blobs in the set. If you want to iterate the
-// blobs consider using `IterateBlobs` instead.
+// Blobs returns a slice of the blobs in the set.
 func (s *BlobSet) Blobs() []Blob {
 	blobs := make([]Blob, 0, len(s.digestToBlob))
 	for _, b := range s.digestToBlob {
 		blobs = append(blobs, b)
 	}
 	return blobs
-}
-
-// IterateBlobs invokes a function for all the blobs in the set, passing the
-// blob. The order in which the blobs are iterated is not guaranteed.
-func (s *BlobSet) IterateBlobs(f func(Blob)) {
-	for _, b := range s.digestToBlob {
-		f(b)
-	}
 }
 
 // NewMemoryBlobFromReader creates a memory blob from content, which is read

--- a/private/pkg/manifest/module.go
+++ b/private/pkg/manifest/module.go
@@ -151,13 +151,22 @@ func (s *BlobSet) BlobFor(digest string) (Blob, bool) {
 	return blob, true
 }
 
-// Blobs returns a slice of the blobs in the set.
+// Blobs returns a slice of the blobs in the set. If you want to iterate the
+// blobs consider using `IterateBlobs` instead.
 func (s *BlobSet) Blobs() []Blob {
 	blobs := make([]Blob, 0, len(s.digestToBlob))
 	for _, b := range s.digestToBlob {
 		blobs = append(blobs, b)
 	}
 	return blobs
+}
+
+// IterateBlobs invokes a function for all the blobs in the set, passing the
+// blob. The order in which the blobs are iterated is not guaranteed.
+func (s *BlobSet) IterateBlobs(f func(Blob)) {
+	for _, b := range s.digestToBlob {
+		f(b)
+	}
 }
 
 // NewMemoryBlobFromReader creates a memory blob from content, which is read

--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -334,8 +334,8 @@ func newBlobsArray(t *testing.T) []manifest.Blob {
 	return blobs
 }
 
-// assertBlobsAreEqual makes sure blobs digest are the same (assuming they're
-// correctly built), regardless the order in the passed arrays.
+// assertBlobsAreEqual makes sure all the blobs digests in the array are the
+// same (assuming they're correctly built), ignoring order in the blobs arrays.
 func assertBlobsAreEqual(t *testing.T, expectedBlobs []manifest.Blob, actualBlobs []manifest.Blob) {
 	expectedDigests := make(map[string]struct{}, len(expectedBlobs))
 	for _, expectedBlob := range expectedBlobs {

--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -107,6 +107,20 @@ func TestNewBlobInvalidDuplicates(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestAllBlobs(t *testing.T) {
+	t.Parallel()
+	blobs := newBlobsArray(t)
+	set, err := manifest.NewBlobSet(context.Background(), blobs)
+	require.NoError(t, err)
+	retBlobs := set.Blobs()
+	assertBlobsAreEqual(t, blobs, retBlobs)
+	var iteratedBlobs []manifest.Blob
+	set.IterateBlobs(func(b manifest.Blob) {
+		iteratedBlobs = append(iteratedBlobs, b)
+	})
+	assertBlobsAreEqual(t, blobs, retBlobs)
+}
+
 type mockBlob struct {
 	digest  *manifest.Digest
 	content io.Reader
@@ -323,4 +337,18 @@ func newBlobsArray(t *testing.T) []manifest.Blob {
 		blobs = append(blobs, blob)
 	}
 	return blobs
+}
+
+// assertBlobsAreEqual makes sure blobs digest are the same (assuming they're
+// correctly built), regardless the order in the passed arrays.
+func assertBlobsAreEqual(t *testing.T, expectedBlobs []manifest.Blob, actualBlobs []manifest.Blob) {
+	expectedDigests := make(map[string]struct{}, len(expectedBlobs))
+	for _, expectedBlob := range expectedBlobs {
+		expectedDigests[expectedBlob.Digest().String()] = struct{}{}
+	}
+	actualDigests := make(map[string]struct{}, len(actualBlobs))
+	for _, actualBlob := range actualBlobs {
+		actualDigests[actualBlob.Digest().String()] = struct{}{}
+	}
+	assert.Equal(t, expectedDigests, actualDigests)
 }

--- a/private/pkg/manifest/module_test.go
+++ b/private/pkg/manifest/module_test.go
@@ -114,11 +114,6 @@ func TestAllBlobs(t *testing.T) {
 	require.NoError(t, err)
 	retBlobs := set.Blobs()
 	assertBlobsAreEqual(t, blobs, retBlobs)
-	var iteratedBlobs []manifest.Blob
-	set.IterateBlobs(func(b manifest.Blob) {
-		iteratedBlobs = append(iteratedBlobs, b)
-	})
-	assertBlobsAreEqual(t, blobs, retBlobs)
 }
 
 type mockBlob struct {

--- a/private/pkg/manifest/storage.go
+++ b/private/pkg/manifest/storage.go
@@ -110,7 +110,7 @@ func NewBucket(m Manifest, blobs BlobSet, opts ...BucketOption) (storage.ReadBuc
 		option(&config)
 	}
 	if config.allManifestBlobs {
-		if err := m.IteratePaths(func(path string, digest Digest) error {
+		if err := m.Range(func(path string, digest Digest) error {
 			if _, ok := blobs.BlobFor(digest.String()); !ok {
 				return fmt.Errorf("manifest path %q with digest %q has no associated blob", path, digest.String())
 			}

--- a/private/pkg/manifest/storage.go
+++ b/private/pkg/manifest/storage.go
@@ -110,15 +110,13 @@ func NewBucket(m Manifest, blobs BlobSet, opts ...BucketOption) (storage.ReadBuc
 		option(&config)
 	}
 	if config.allManifestBlobs {
-		for _, path := range m.Paths() {
-			pathDigest, ok := m.DigestFor(path)
-			if !ok {
-				// we're iterating manifest paths, this should never happen.
-				return nil, fmt.Errorf("path %q not present in manifest", path)
+		if err := m.IteratePaths(func(path string, digest Digest) error {
+			if _, ok := blobs.BlobFor(digest.String()); !ok {
+				return fmt.Errorf("manifest path %q with digest %q has no associated blob", path, digest.String())
 			}
-			if _, ok := blobs.BlobFor(pathDigest.String()); !ok {
-				return nil, fmt.Errorf("manifest path %q with digest %q has no associated blob", path, pathDigest.String())
-			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if config.noExtraBlobs {


### PR DESCRIPTION
Range function for the manifest entries, so we can reduce the appearances of `.Paths()` usages like:

```go
for _, path := range m.Paths() {
  digest, ok := m.DigestFor(path)
  if !ok {
    // this will never happen
    return nil, fmt.Errorf("digest not found for path: %s", path)
  }
  // do something with path and digest...
}
```

into:

```go
m.Range(func(path string, digest manifest.Digest) error {
  // do something with path and digest...
})
```