### PR TITLE
Handle proto3 optionals better for breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix issue where incorrect breaking change errors were produced when updating proto3 `optional` fields.
 
 ## [v1.17.0] - 2023-04-05
 

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -35,6 +35,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// Hint on how to get these:
+// 1. cd ./private/bufpkg/bufcheck/bufbreaking/testdata
+// 2. cd into specific test directory name
+// 3. TEST_DIRECTORY_NAME=; buf breaking --against ../../testdata_previous/${TEST_DIRECTORY_NAME} --error-format=json | jq '[.path, .start_line, .start_column, .end_line, .end_column, .type] | @csv' --raw-output
+//      or
+//    TEST_DIRECTORY_NAME=; buf breaking --against ../../testdata_previous/${TEST_DIRECTORY_NAME} --error-format=json | jq -r '"bufanalysistesting.NewFileAnnotation(t, \"\(.path)\", \(.start_line|tostring), \(.start_column|tostring), \(.end_line|tostring), \(.end_column|tostring), \"\(.type)\"),"'
+
 func TestRunBreakingEnumNoDelete(t *testing.T) {
 	testBreaking(
 		t,
@@ -518,6 +525,15 @@ func TestRunBreakingPackageNoDelete(t *testing.T) {
 		bufanalysistesting.NewFileAnnotationNoLocation(t, "b1.proto", "PACKAGE_ENUM_NO_DELETE"),
 		bufanalysistesting.NewFileAnnotationNoLocation(t, "b1.proto", "PACKAGE_SERVICE_NO_DELETE"),
 		bufanalysistesting.NewFileAnnotation(t, "b2.proto", 7, 1, 21, 2, "PACKAGE_MESSAGE_NO_DELETE"),
+	)
+}
+
+func TestRunBreakingProto3OptionalChangeFieldName(t *testing.T) {
+	testBreaking(
+		t,
+		"breaking_proto3_optional_change_field_name",
+		bufanalysistesting.NewFileAnnotation(t, "1.proto", 4, 3, 4, 27, "FIELD_SAME_JSON_NAME"),
+		bufanalysistesting.NewFileAnnotation(t, "1.proto", 4, 19, 4, 22, "FIELD_SAME_NAME"),
 	)
 }
 

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -38,9 +38,7 @@ import (
 // Hint on how to get these:
 // 1. cd ./private/bufpkg/bufcheck/bufbreaking/testdata
 // 2. cd into specific test directory name
-// 3. TEST_DIRECTORY_NAME=; buf breaking --against ../../testdata_previous/${TEST_DIRECTORY_NAME} --error-format=json | jq '[.path, .start_line, .start_column, .end_line, .end_column, .type] | @csv' --raw-output
-//      or
-//    TEST_DIRECTORY_NAME=; buf breaking --against ../../testdata_previous/${TEST_DIRECTORY_NAME} --error-format=json | jq -r '"bufanalysistesting.NewFileAnnotation(t, \"\(.path)\", \(.start_line|tostring), \(.start_column|tostring), \(.end_line|tostring), \(.end_column|tostring), \"\(.type)\"),"'
+// 3. buf breaking --against "../../testdata_previous/$(basename "$(pwd)")" --error-format=json | jq -r '"bufanalysistesting.NewFileAnnotation(t, \"\(.path)\", \(.start_line|tostring), \(.start_column|tostring), \(.end_line|tostring), \(.end_column|tostring), \"\(.type)\"),"'
 
 func TestRunBreakingEnumNoDelete(t *testing.T) {
 	testBreaking(

--- a/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_proto3_optional_change_field_name/1.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_proto3_optional_change_field_name/1.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Foo {
+  optional string two = 1;
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_proto3_optional_change_field_name/buf.yaml
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_proto3_optional_change_field_name/buf.yaml
@@ -1,0 +1,7 @@
+version: v1
+breaking:
+  use:
+    - FIELD_SAME_JSON_NAME
+    - FIELD_SAME_NAME
+    - FIELD_SAME_ONEOF
+    - ONEOF_NO_DELETE

--- a/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_proto3_optional_change_field_name/1.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_proto3_optional_change_field_name/1.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Foo {
+  optional string one = 1;
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_proto3_optional_change_field_name/buf.yaml
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_proto3_optional_change_field_name/buf.yaml
@@ -1,0 +1,4 @@
+version: v1
+breaking:
+  use:
+    - ONEOF_NO_DELETE

--- a/private/pkg/protosource/oneof.go
+++ b/private/pkg/protosource/oneof.go
@@ -42,6 +42,20 @@ func (o *oneof) Fields() []Field {
 	return o.fields
 }
 
+func (o *oneof) IsProto3OptionalSyntheticOneof() bool {
+	if len(o.fields) != 1 {
+		return false
+	}
+	field := o.fields[0]
+	// We could also do this check, but the proto3_optional check should
+	// suffice, and this feels prone to error. Leaving the code commented
+	// out to demonstrate this potential check.
+	//if o.Name() != "_" + field.Name() {
+	//return false
+	//}
+	return field.Proto3Optional()
+}
+
 func (o *oneof) addField(field Field) {
 	o.fields = append(o.fields, field)
 }

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -409,6 +409,10 @@ type Oneof interface {
 
 	Message() Message
 	Fields() []Field
+
+	// IsProto3OptionalSyntheticOneof returns true if this Oneof is actually
+	// representing a proto3 optional field via a synthetic oneof.
+	IsProto3OptionalSyntheticOneof() bool
 }
 
 // Service is a service descriptor.


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/1906.

This suppresses a few breaking change errors that were produced when they shouldn't be, and updates the message for when oneof changes involve proto3 optionals.