### PR TITLE
Update --type flag docs

### DIFF
--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -41,6 +41,7 @@ const (
 	configFlagName              = "config"
 	excludePathsFlagName        = "exclude-path"
 	disableSymlinksFlagName     = "disable-symlinks"
+	typeFlagName                = "type"
 )
 
 // NewCommand returns a new Command.
@@ -118,9 +119,9 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	)
 	flagSet.StringSliceVar(
 		&f.Types,
-		"type",
+		typeFlagName,
 		nil,
-		"The types (message, enum, service) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types",
+		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types",
 	)
 }
 

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -275,7 +275,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.TypesDeprecated,
 		typeDeprecatedFlagName,
 		nil,
-		"The types (message, enum, service) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
+		"The types (package, message, enum, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
 	)
 	_ = flagSet.MarkDeprecated(typeDeprecatedFlagName, fmt.Sprintf("Use --%s instead", typeFlagName))
 	_ = flagSet.MarkHidden(typeDeprecatedFlagName)

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -269,13 +269,13 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Types,
 		typeFlagName,
 		nil,
-		"The types (message, enum, service) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
+		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
 	)
 	flagSet.StringSliceVar(
 		&f.TypesDeprecated,
 		typeDeprecatedFlagName,
 		nil,
-		"The types (package, message, enum, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
+		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
 	)
 	_ = flagSet.MarkDeprecated(typeDeprecatedFlagName, fmt.Sprintf("Use --%s instead", typeFlagName))
 	_ = flagSet.MarkHidden(typeDeprecatedFlagName)


### PR DESCRIPTION
Per @jhump, packages and methods are supported now. We could do more to clean up this flag doc, but this at least makes it accurate.