### PR TITLE
Update Maven package version as part of release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,6 +203,23 @@ jobs:
         with:
           script:
             core.setOutput('version', "${{github.ref_name}}".replace("v", ""));
+  trigger-maven-update:
+    runs-on: ubuntu-latest
+    needs: post-release
+    steps:
+      - name: trigger maven update
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: github.repository_owner,
+              repo: "buf-maven-publish",
+              workflow_id: "update-buf-version.yml",
+              ref: "main",
+              inputs: {
+                version: "${{needs.post-release.outputs.version}}"
+              }
+            })
   trigger-npm-publish:
     runs-on: ubuntu-latest
     needs: post-release


### PR DESCRIPTION
We have a Maven package which ships the Buf CLI (that is in turn used by the buf-gradle-plugin). When releasing a new version of Buf, we should call a workflow to open a PR to update the version of the Maven package as well.