### PR TITLE
Allow preserving java_multiple_files setting

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -562,6 +562,7 @@ func newModifier(
 		sweeper,
 		javaMultipleFilesValue,
 		managedConfig.Override[bufimagemodify.JavaMultipleFilesID],
+		false, // preserveExistingValue
 	)
 	if err != nil {
 		return nil, err

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -129,18 +129,20 @@ func GoPackage(
 
 // JavaMultipleFiles returns a Modifier that sets the java_multiple_files
 // file option to the given value in all of the files contained in
-// the Image.
+// the Image. If the preserveExistingValue is set to true, then the
+// java_multiple_files option will be preserved if set.
 func JavaMultipleFiles(
 	logger *zap.Logger,
 	sweeper Sweeper,
 	value bool,
 	overrides map[string]string,
+	preserveExistingValue bool,
 ) (Modifier, error) {
 	validatedOverrides, err := stringOverridesToBoolOverrides(overrides)
 	if err != nil {
 		return nil, fmt.Errorf("invalid override for %s: %w", JavaMultipleFilesID, err)
 	}
-	return javaMultipleFiles(logger, sweeper, value, validatedOverrides), nil
+	return javaMultipleFiles(logger, sweeper, value, validatedOverrides, preserveExistingValue), nil
 }
 
 // JavaOuterClassname returns a Modifier that sets the java_outer_classname file option

--- a/private/bufpkg/bufimage/bufimagemodify/java_multiple_files_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_multiple_files_test.go
@@ -33,7 +33,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -59,7 +59,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, false)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -81,7 +81,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"}, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -107,7 +107,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"}, false)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -133,7 +133,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -159,7 +159,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, false)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -180,7 +180,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"}, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -210,7 +210,32 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, map[string]string{"a.proto": "false"}, false)
+		require.NoError(t, err)
+		err = javaMultipleFilesModifier.Modify(
+			context.Background(),
+			image,
+		)
+		require.NoError(t, err)
+
+		for _, imageFile := range image.Files() {
+			descriptor := imageFile.Proto()
+			if imageFile.Path() == "a.proto" {
+				assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
+				continue
+			}
+			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
+		}
+		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
+	})
+
+	t.Run("with preserveExistingValue", func(t *testing.T) {
+		t.Parallel()
+		image := testGetImage(t, dirPath, false)
+		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
+
+		sweeper := NewFileOptionSweeper()
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, true)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -239,7 +264,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -264,7 +289,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil, false)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -289,7 +314,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaMultipleFilesPath)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, map[string]string{"override.proto": "true"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, map[string]string{"override.proto": "true"}, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -317,7 +342,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, map[string]string{"override.proto": "true"})
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, map[string]string{"override.proto": "true"}, false)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),
@@ -335,6 +360,27 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
 	})
+
+	t.Run("with preserveExistingValue", func(t *testing.T) {
+		t.Parallel()
+		image := testGetImage(t, dirPath, false)
+		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
+
+		sweeper := NewFileOptionSweeper()
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, false, nil, true)
+		require.NoError(t, err)
+		err = javaMultipleFilesModifier.Modify(
+			context.Background(),
+			image,
+		)
+		require.NoError(t, err)
+
+		for _, imageFile := range image.Files() {
+			descriptor := imageFile.Proto()
+			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
+		}
+		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
+	})
 }
 
 func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
@@ -345,7 +391,7 @@ func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, false)
 		require.NoError(t, err)
 		modifier := NewMultiModifier(
 			javaMultipleFilesModifier,
@@ -367,7 +413,7 @@ func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil)
+		javaMultipleFilesModifier, err := JavaMultipleFiles(zap.NewNop(), sweeper, true, nil, false)
 		require.NoError(t, err)
 		err = javaMultipleFilesModifier.Modify(
 			context.Background(),


### PR DESCRIPTION
Currently, the JavaMultipleFiles image modifier will skip setting the value if it already matches the desired value (with `GetJavaMultipleFiles()`), however in some cases we want to preserve any settings specified in the source .proto files, and only overwrite it if unset.