### PR TITLE
Add support to "buf curl" for --user and --netrc credentials flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Remove `buf beta registry {plugin,template} {deprecate,undeprecate}`.
+- Add `--user` and `--netrc` flags to `buf curl`, providing the same behavior as the
+  flags of the same name in the cURL tool.
 
 ## [v1.17.0] - 2023-04-05
 

--- a/private/pkg/netrc/netrc.go
+++ b/private/pkg/netrc/netrc.go
@@ -90,7 +90,7 @@ func GetFilePath(envContainer app.EnvContainer) (string, error) {
 // GetMachineForNameAndFilePath returns the Machine for the given name from the
 // file at the given path.
 //
-// Returns nil if no such Machine.
+// Returns nil if no such Machine or no such file.
 func GetMachineForNameAndFilePath(name string, filePath string) (_ Machine, retErr error) {
 	if _, err := os.Stat(filePath); err != nil {
 		if os.IsNotExist(err) {

--- a/private/pkg/netrc/netrc.go
+++ b/private/pkg/netrc/netrc.go
@@ -52,7 +52,7 @@ func GetMachineForName(envContainer app.EnvContainer, name string) (_ Machine, r
 	if err != nil {
 		return nil, err
 	}
-	return getMachineForNameAndFilePath(name, filePath)
+	return GetMachineForNameAndFilePath(name, filePath)
 }
 
 // PutMachines adds the given Machines to the configured netrc file.
@@ -87,7 +87,11 @@ func GetFilePath(envContainer app.EnvContainer) (string, error) {
 	return filepath.Join(homeDirPath, netrcFilename), nil
 }
 
-func getMachineForNameAndFilePath(name string, filePath string) (_ Machine, retErr error) {
+// GetMachineForNameAndFilePath returns the Machine for the given name from the
+// file at the given path.
+//
+// Returns nil if no such Machine.
+func GetMachineForNameAndFilePath(name string, filePath string) (_ Machine, retErr error) {
 	if _, err := os.Stat(filePath); err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil


### PR DESCRIPTION
This adds support for `-u`/`--user`, `-n`/`--netrc`, and `--netrc-file` flags to `buf curl`. These flags work the same way in this context as the flags of the same name in `curl`.

Resolves #1997.
