### PR TITLE
Add string parser for module pin

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -299,6 +299,44 @@ func NewModulePin(
 	return newModulePin(remote, owner, repository, branch, commit, digest, createTime)
 }
 
+// NewModulePinForStringOption are options passed when creating a module pin from a string.
+type NewModulePinForStringOption func(*newModulePinForStringOptions)
+
+// NewModulePinForStringWithCreateTime sets a create time for a passed pin. Since the string
+// representation of a module pin does not include a create time value, the zero value will be set
+// by default. Use this option to set one if you know it.
+func NewModulePinForStringWithCreateTime(createTime time.Time) NewModulePinForStringOption {
+	return func(opts *newModulePinForStringOptions) {
+		opts.createTime = createTime
+	}
+}
+
+// NewModulePinForStringWithBranch sets a branch for a passed pin. Since the string representation
+// of a module pin does not include a branch value, "main" will be set by default. Use this option
+// to set a different one.
+func NewModulePinForStringWithBranch(branch string) NewModulePinForStringOption {
+	return func(opts *newModulePinForStringOptions) {
+		opts.branch = branch
+	}
+}
+
+// NewModulePinForStringWithDigest sets a digest for a passed pin. Since the string representation
+// of a module pin does not include a digest value, an empty string will be set by default. Use this
+// option to set one if you know it.
+func NewModulePinForStringWithDigest(digest string) NewModulePinForStringOption {
+	return func(opts *newModulePinForStringOptions) {
+		opts.digest = digest
+	}
+}
+
+// NewModulePinForString returns a new ModulePin for the string representation of a module pin.
+// Since the string representation of a pin is "remote/owner/repository:commit", remaining
+// properties of a pin are either the default or zero value: CreateTime: zero value, Branch: main,
+// Digest: empty.
+func NewModulePinForString(pin string, opts ...NewModulePinForStringOption) (ModulePin, error) {
+	return newModulePinForString(pin, opts...)
+}
+
 // NewModulePinForProto returns a new ModulePin for the given proto ModulePin.
 func NewModulePinForProto(protoModulePin *modulev1alpha1.ModulePin) (ModulePin, error) {
 	return newModulePinForProto(protoModulePin)

--- a/private/bufpkg/bufmodule/bufmoduleref/module_pin_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/module_pin_test.go
@@ -33,6 +33,23 @@ func TestNewModulePin(t *testing.T) {
 	testNewModulePin(t, "nominal digest", nullDigest.String(), false)
 }
 
+func TestNewModulePinForString(t *testing.T) {
+	testNewModulePinForString(t, "empty", "", true)
+	testNewModulePinForString(t, "missing pieces", "foo/foo", true)
+	testNewModulePinForString(t, "extra pieces", "foo/foo/foo/foo:foo:foo", true)
+	testNewModulePinForString(t, "missing remote", "/owner/repo:commit", true)
+	testNewModulePinForString(t, "missing owner", "remote//repo:commit", true)
+	testNewModulePinForString(t, "missing repo", "remote/owner/:commit", true)
+	testNewModulePinForString(t, "missing commit", "remote/owner/repo:", true)
+	testNewModulePinForString(t, "valid", "remote/owner/repo:commit", false)
+	testNewModulePinForString(
+		t, "valid with options", "remote/owner/repo:commit", false,
+		NewModulePinForStringWithBranch("branch"),
+		NewModulePinForStringWithCreateTime(time.Now()),
+		NewModulePinForStringWithDigest("digest"),
+	)
+}
+
 func testNewModulePin(
 	t *testing.T,
 	desc string,
@@ -56,6 +73,25 @@ func testNewModulePin(
 			assert.Equal(t, "", pin.Digest())
 		} else {
 			assert.Equal(t, digest, pin.Digest())
+		}
+	})
+}
+
+func testNewModulePinForString(
+	t *testing.T,
+	desc string,
+	pin string,
+	expectErr bool,
+	opts ...NewModulePinForStringOption,
+) {
+	t.Helper()
+	t.Run(desc, func(t *testing.T) {
+		t.Parallel()
+		_, err := newModulePinForString(pin, opts...)
+		if expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	})
 }


### PR DESCRIPTION
Add the possibility for a roundtrip `modulePin -> string -> modulePin`.