### PR TITLE
Only cache Go artifacts once

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -6,10 +6,8 @@ permissions: read-all
 jobs:
   test:
     env:
-      GOMODCACHE: 'd:\gomodcache'
-      GOCACHE: 'd:\gocache'
       DOWNLOAD_CACHE: 'd:\downloadcache'
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -21,10 +19,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.GOCACHE }}
-            ${{ env.GOMODCACHE }}
             ${{ env.DOWNLOAD_CACHE }}
-          key: ${{ runner.os }}-buf-windows-${{ hashFiles('**/go.sum', 'windows/**') }}
+          key: ${{ runner.os }}-buf-windows-${{ hashFiles('windows/**') }}
           restore-keys: |
             ${{ runner.os }}-buf-windows-
       - name: test


### PR DESCRIPTION
Right now, we're caching GOMODCACHE and GOCACHE in two places - our own cache rule and in actions/setup-go. Remove our custom caching and just use the built-in caching in setup-go.