### PR TITLE
use docker cmd

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -23,4 +23,4 @@ RUN apk add --update --no-cache \
 
 COPY --from=builder /go/bin/buf /usr/local/bin/buf
 
-ENTRYPOINT ["/usr/local/bin/buf"]
+CMD ["/usr/local/bin/buf"]


### PR DESCRIPTION
CMD is preferred for projects such as buf, as it allows using a single container for multiple commands. 
Inspired by https://github.com/golangci/golangci-lint/blob/master/build/Dockerfile.