### PR TITLE
Fix changelog formatting and flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
-- Fixed a bug in `buf build` and `buf generate` where the use of type filtering (via
+- Fix issue in `buf build` and `buf generate` where the use of type filtering (via
   `--type` flags) would cause the resulting image to have no source code info, even
   when `--exclude-source-info` was not specified. The main impact of the bug was that
   generated code would be missing comments.
--- Add `--create` flag to `buf push` to create the repository if it does not exist. The user
+- Add `--create` flag to `buf push` to create a repository if it does not exist. The user
   is also required to specify the visibility using `--create-visibility`.
 
 ## [v1.18.0] - 2023-05-05

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -279,7 +279,7 @@ func BindVisibility(flagSet *pflag.FlagSet, addr *string, flagName string) {
 		addr,
 		flagName,
 		"",
-		fmt.Sprintf(`The repository's visibility setting. Must be one of %s.`, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The repository's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
 	)
 }
 
@@ -290,7 +290,7 @@ func BindCreateVisibility(flagSet *pflag.FlagSet, addr *string, flagName string,
 		addr,
 		flagName,
 		"",
-		fmt.Sprintf(`The repository's visibility setting, if created. Must be set if --%s is set. Must be one of %s.`, createFlagName, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The repository's visibility setting, if created. Must be set if --%s is set. Must be one of %s`, createFlagName, stringutil.SliceToString(allVisibiltyStrings)),
 	)
 }
 


### PR DESCRIPTION
![image](https://github.com/bufbuild/buf/assets/4228796/5e5c6e57-9611-420e-bb7f-d0e1bd1accbe)

Also slight wording changes.

Also makes flags in `bufcli` not have trailing periods like the rest of our flags, to be consistent (although we might want to make the opposite choice in a refactor sometime).