### PR TITLE
Throw ctx cancelled error in `thread.Parallelize`

### DIFF
--- a/private/pkg/thread/thread.go
+++ b/private/pkg/thread/thread.go
@@ -16,6 +16,7 @@ package thread
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"sync"
 
@@ -73,11 +74,10 @@ func Parallelize(ctx context.Context, jobs []func(context.Context) error, option
 	var wg sync.WaitGroup
 	var lock sync.Mutex
 	var stop bool
-	for _, job := range jobs {
+	for jobIdx, job := range jobs {
 		if stop {
 			break
 		}
-		job := job
 		// We always want context cancellation/deadline expiration to take
 		// precedence over the semaphore unblocking, but select statements choose
 		// among the unblocked non-default cases pseudorandomly. To correctly
@@ -87,16 +87,19 @@ func Parallelize(ctx context.Context, jobs []func(context.Context) error, option
 		select {
 		case <-ctx.Done():
 			stop = true
+			retErr = multierr.Append(retErr, fmt.Errorf("jobs[%d]: context canceled", jobIdx))
 		case semaphoreC <- struct{}{}:
 			select {
 			case <-ctx.Done():
 				stop = true
+				retErr = multierr.Append(retErr, fmt.Errorf("jobs[%d]: context canceled", jobIdx))
 			default:
+				job, jobIdx := job, jobIdx
 				wg.Add(1)
 				go func() {
 					if err := job(ctx); err != nil {
 						lock.Lock()
-						retErr = multierr.Append(retErr, err)
+						retErr = multierr.Append(retErr, fmt.Errorf("jobs[%d]: %w", jobIdx, err))
 						lock.Unlock()
 						if parallelizeOptions.cancel != nil {
 							parallelizeOptions.cancel()

--- a/private/pkg/thread/thread_test.go
+++ b/private/pkg/thread/thread_test.go
@@ -26,17 +26,37 @@ func TestParallelizeWithImmediateCancellation(t *testing.T) {
 	t.Parallel()
 	// The bulk of the code relies on subtle timing that's difficult to
 	// reproduce, but we can test the most basic use case.
-	var executed atomic.Int64
-	var jobs []func(context.Context) error
-	for i := 0; i < 10; i++ {
-		jobs = append(jobs, func(_ context.Context) error {
-			executed.Inc()
-			return nil
-		})
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	err := Parallelize(ctx, jobs)
-	assert.Nil(t, err, "parallelize error")
-	assert.Equal(t, int64(0), executed.Load(), "jobs executed")
+	t.Run("RegularRun", func(t *testing.T) {
+		t.Parallel()
+		const jobsToExecute = 10
+		var (
+			executed atomic.Int64
+			jobs     = make([]func(context.Context) error, 0, jobsToExecute)
+		)
+		for i := 0; i < jobsToExecute; i++ {
+			jobs = append(jobs, func(_ context.Context) error {
+				executed.Inc()
+				return nil
+			})
+		}
+		err := Parallelize(context.Background(), jobs)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(jobsToExecute), executed.Load(), "jobs executed")
+	})
+	t.Run("WithCtxCancellation", func(t *testing.T) {
+		t.Parallel()
+		var executed atomic.Int64
+		var jobs []func(context.Context) error
+		for i := 0; i < 10; i++ {
+			jobs = append(jobs, func(_ context.Context) error {
+				executed.Inc()
+				return nil
+			})
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := Parallelize(ctx, jobs)
+		assert.Error(t, err)
+		assert.Equal(t, int64(0), executed.Load(), "jobs executed")
+	})
 }


### PR DESCRIPTION
Found a panic in a test, caused because of a DX assumption. From users perspective, doing:

```go
foo := make([]Foo, someLen)
// jobs preparation... each job fills one item in []foo
if err := thread.Parallelize(
  ctx,
  jobs,
  thread.ParallelizeWithCancel(cancelGetBlobs), // if one job fails, stop all jobs
); err != nil {
  return nil, err
}
// at this point the user could assume that if no errors happened, then []foo was successfully
// populated... well, if the ctx was cancelled, some/all items in []foo might be empty/nil.
// Even if the ctx was cancelled not by an error trying to fill []foo, but upstream from
// another caller.
```

~I will test in a dependent repo before making this ready for review.~ Tested.