### PR TITLE
Fix buf export with tamper proofing enabled

### DIFF
--- a/private/bufpkg/bufapimodule/module_resolver.go
+++ b/private/bufpkg/bufapimodule/module_resolver.go
@@ -66,7 +66,7 @@ func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmo
 		moduleReference.Repository(),
 		"", // branch
 		resp.Msg.RepositoryCommit.Name,
-		resp.Msg.RepositoryCommit.Digest,
+		resp.Msg.RepositoryCommit.ManifestDigest,
 		resp.Msg.RepositoryCommit.CreateTime.AsTime(),
 	)
 }

--- a/private/bufpkg/bufapimodule/module_resolver_test.go
+++ b/private/bufpkg/bufapimodule/module_resolver_test.go
@@ -104,7 +104,7 @@ func testGetModulePin(
 			assert.Equal(t, "repository", pin.Repository())
 			assert.Equal(t, "", pin.Branch())
 			assert.Equal(t, resp.RepositoryCommit.Name, pin.Commit())
-			assert.Equal(t, resp.RepositoryCommit.Digest, pin.Digest())
+			assert.Equal(t, resp.RepositoryCommit.ManifestDigest, pin.Digest())
 			assert.Equal(
 				t,
 				time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
Calls to buf export are failing with the tamper proofing feature enabled. We need to update to use the manifest digest from the response instead of the b3 digest.

Verified that buf export works both with and without the feature enabled.