### PR TITLE
Ignore b1/b3 buf.lock digests only

### DIFF
--- a/private/bufpkg/buflock/buflock.go
+++ b/private/bufpkg/buflock/buflock.go
@@ -17,9 +17,9 @@ package buflock
 
 import (
 	"context"
+	"strings"
 	"time"
 
-	"github.com/bufbuild/buf/private/pkg/manifest"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
@@ -85,9 +85,9 @@ type ExternalConfigDependencyV1 struct {
 
 // DependencyForExternalConfigDependencyV1 returns the Dependency representation of a ExternalConfigDependencyV1.
 func DependencyForExternalConfigDependencyV1(dep ExternalConfigDependencyV1) Dependency {
-	// Don't consume old buf digests.
+	// Don't consume old b1/b3 buf digests.
 	digest := dep.Digest
-	if !isValidDigest(digest) {
+	if strings.HasPrefix(digest, "b1-") || strings.HasPrefix(digest, "b3-") {
 		digest = ""
 	}
 	return Dependency{
@@ -151,11 +151,4 @@ func ExternalConfigDependencyV1Beta1ForDependency(dep Dependency) ExternalConfig
 // file versions that is used to determine the version.
 type ExternalConfigVersion struct {
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
-}
-
-// isValidDigest returns true when the digest string is successfully parsed
-// by the `manifest` pkg. Older buf digests are not considered valid (b1/b3).
-func isValidDigest(digest string) bool {
-	_, err := manifest.NewDigestFromString(digest)
-	return err == nil
 }

--- a/private/bufpkg/buflock/buflock.go
+++ b/private/bufpkg/buflock/buflock.go
@@ -85,8 +85,8 @@ type ExternalConfigDependencyV1 struct {
 
 // DependencyForExternalConfigDependencyV1 returns the Dependency representation of a ExternalConfigDependencyV1.
 func DependencyForExternalConfigDependencyV1(dep ExternalConfigDependencyV1) Dependency {
-	// Don't consume old b1/b3 buf digests.
 	digest := dep.Digest
+	// Don't consume old b1/b3 buf digests.
 	if strings.HasPrefix(digest, "b1-") || strings.HasPrefix(digest, "b3-") {
 		digest = ""
 	}

--- a/private/bufpkg/buflock/buflock_test.go
+++ b/private/bufpkg/buflock/buflock_test.go
@@ -267,6 +267,24 @@ func TestDependencyForExternalConfigDependencyV1(t *testing.T) {
 			Commit:     "aabbccd",
 		},
 	)
+	testDependencyForExternalConfigDependencyV1(
+		t,
+		"don't filter out non-b1/b3 invalid hashes",
+		buflock.ExternalConfigDependencyV1{
+			Remote:     "remote",
+			Owner:      "owner",
+			Repository: "repository",
+			Commit:     "aabbccd",
+			Digest:     "shake256:abcd",
+		},
+		buflock.Dependency{
+			Remote:     "remote",
+			Owner:      "owner",
+			Repository: "repository",
+			Commit:     "aabbccd",
+			Digest:     "shake256:abcd",
+		},
+	)
 }
 
 func testDependencyForExternalConfigDependencyV1(


### PR DESCRIPTION
Update the code that reads a buf.lock file from disk to only ignore previous b1/b3 module digests. If the lock file has an invalid manifest digest, we want to error early.

Fixes #2110.