### PR TITLE
Pkg dependenciestree to handle topological sort

### DIFF
--- a/private/pkg/dependenciestree/dependenciestree.go
+++ b/private/pkg/dependenciestree/dependenciestree.go
@@ -1,0 +1,216 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A dependencies tree implements helpers to better handle nodes depending on each other. For
+// example, for a workspace module that wants to be pushed or synced, the order in which we iterate
+// the modules is important:
+//
+// - module a depends on b
+// - module b depends on c
+//
+// We should iterate in the order [c, b, a].
+//
+// This is also useful for managed modules sync jobs in the BSR. Some of the third-party modules
+// depend on each other, so we need to make sure that the dependencies modules sync first, before
+// syncing the parent modules.
+//
+// The dependencies tree is one level deep, and contain multiple root nodes. The implementation
+// protects the tree against circular dependencies. Some examples:
+//
+// Valid tree:
+// - a: [b, c, d]
+// - b: [c, d]
+// - c: none
+// - d: none
+//
+// Invalid tree:
+// - a: [a] // dependency on self, circular dependency: a.a
+// - b: [c]
+// - c: [d]
+// - d: [b] // circular dependency: b.c.d.b
+
+package dependenciestree
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bufbuild/buf/private/pkg/stringutil"
+)
+
+// DependenciesTree is a tree that holds nodes depending on other nodes. One level deep.
+type DependenciesTree interface {
+	// NewRootNode adds a new node at the root of the tree, with its dependencies. Both root node name
+	// and dependencies names need to have values. Adding root nodes with invalid dependencies
+	// (external or circular) is possible, tree should be checked against the Validate func.
+	NewRootNode(rootNode string, dependencies map[string]struct{}) error
+	// Validate checks that the tree nodes have valid dependencies, with no circular dependencies.
+	Validate() error
+	// Sort validates that the tree is valid, and then returns the tree in topological order, leafs
+	// first. Useful for installation or update order.
+	Sort() ([]string, error)
+}
+
+// New initializes a new dependencies tree, ready to have root nodes added to it.
+func New(opts ...NewDependenciesTreeOption) DependenciesTree {
+	var config newDependenciesTreeOptions
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return &depsTree{
+		tree:                      make(map[string]map[string]struct{}),
+		allowExternalDependencies: config.allowExternalDependencies,
+	}
+}
+
+// NewDependenciesTreeOption are options that can be passed when instantiating a new dependencies tree.
+type NewDependenciesTreeOption func(*newDependenciesTreeOptions)
+
+// NewDependenciesTreeWithAllowExternalDeps allows a root node in the tree to depend on external
+// dependencies, not present in other root nodes.
+func NewDependenciesTreeWithAllowExternalDeps() NewDependenciesTreeOption {
+	return func(opts *newDependenciesTreeOptions) {
+		opts.allowExternalDependencies = true
+	}
+}
+
+func (t *depsTree) NewRootNode(rootNode string, dependencies map[string]struct{}) error {
+	if rootNode == "" {
+		return errors.New("empty root node")
+	}
+	if _, ok := t.tree[rootNode]; !ok {
+		t.tree[rootNode] = make(map[string]struct{})
+	}
+	for dep := range dependencies {
+		if dep == "" {
+			return errors.New("empty dependency node")
+		}
+		t.tree[rootNode][dep] = struct{}{}
+	}
+	return nil
+}
+
+func (t *depsTree) Validate() error {
+	for parent := range t.tree {
+		if err := t.validateDependencies(parent, []string{parent}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *depsTree) Sort() ([]string, error) {
+	if len(t.tree) == 0 {
+		return nil, nil
+	}
+	if err := t.Validate(); err != nil {
+		return nil, fmt.Errorf("cannot sort, invalid tree: %w", err)
+	}
+	pendingRootNodes := make(map[string]struct{}, len(t.tree))
+	for node := range t.tree {
+		pendingRootNodes[node] = struct{}{}
+	}
+	return t.sort(pendingRootNodes, nil)
+}
+
+type newDependenciesTreeOptions struct {
+	allowExternalDependencies bool
+}
+
+type depsTree struct {
+	tree                      map[string]map[string]struct{}
+	allowExternalDependencies bool
+}
+
+func (t *depsTree) validateDependencies(
+	node string,
+	parents []string,
+) error {
+	if node == "" {
+		// this shouldn't happen, nodes are only added via NewRootNode which checks this, but let's
+		// protect it here as well.
+		return errors.New("empty node")
+	}
+	nodeDeps, nodeInRoot := t.tree[node]
+	if !nodeInRoot && !t.allowExternalDependencies {
+		return fmt.Errorf("node %s is not present in tree root nodes", strings.Join(parents, "."))
+	}
+	for dep := range nodeDeps {
+		for _, parent := range parents {
+			if parent == dep {
+				return fmt.Errorf("circular dependency: %s.%s", strings.Join(parents, "."), dep)
+			}
+		}
+		if err := t.validateDependencies(dep, append(parents, dep)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *depsTree) sort(
+	pendingNodes map[string]struct{},
+	sortedNodes []string,
+) ([]string, error) {
+	if len(pendingNodes) == 0 {
+		// no more pending root nodes to sort
+		return sortedNodes, nil
+	}
+	iterationNodes := make([]string, 0)
+	for node, deps := range t.tree {
+		if _, pending := pendingNodes[node]; !pending {
+			// node was already sorted
+			continue
+		}
+		if len(deps) == 0 {
+			// node has no deps, it's a leaf, can be sorted now
+			iterationNodes = append(iterationNodes, node)
+			continue
+		}
+		var anyDependencyMissing bool
+		for dep := range deps {
+			if _, pending := pendingNodes[dep]; pending {
+				anyDependencyMissing = true
+				break
+			}
+		}
+		if anyDependencyMissing {
+			// node cannot be sorted this iteration, still has missing dependencies
+			continue
+		}
+		// all node deps, have been sorted already, node can be sorted now
+		iterationNodes = append(iterationNodes, node)
+	}
+	if len(iterationNodes) == 0 {
+		// finished the iteration w/out sorting anything, this shouldn't happen, let's break out of
+		// infinite loop
+		pending := stringutil.MapToSlice(pendingNodes)
+		sort.Strings(pending)
+		return nil, fmt.Errorf(
+			"cannot determine next node: sorted so far: [%s], pending [%s], complete tree: %v",
+			strings.Join(sortedNodes, ", "), pending, t.tree,
+		)
+	}
+	// now that the iteration is complete, we can clear those nodes from the pending map
+	for _, iterationNode := range iterationNodes {
+		delete(pendingNodes, iterationNode)
+	}
+	// sort iteration nodes lexicographically, so result is deterministic
+	sort.Strings(iterationNodes)
+	// add iteration nodes to all sorted nodes
+	sortedNodes = append(sortedNodes, iterationNodes...)
+	return t.sort(pendingNodes, sortedNodes)
+}

--- a/private/pkg/dependenciestree/dependenciestree_test.go
+++ b/private/pkg/dependenciestree/dependenciestree_test.go
@@ -1,0 +1,317 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependenciestree_test
+
+import (
+	"testing"
+
+	"github.com/bufbuild/buf/private/pkg/dependenciestree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRootNode(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name                    string
+		rootNode                string
+		deps                    map[string]struct{}
+		expectedErrMessageExact string
+	}
+	testCases := []testCase{
+		{
+			name:     "no_deps",
+			rootNode: "foo",
+		},
+		{
+			name:     "single_dep",
+			rootNode: "foo",
+			deps:     map[string]struct{}{"bar": {}},
+		},
+		{
+			name:     "multiple_deps",
+			rootNode: "foo",
+			deps: map[string]struct{}{
+				"bar": {},
+				"baz": {},
+			},
+		},
+		{
+			name:                    "empty_root_node",
+			expectedErrMessageExact: "empty root node",
+		},
+		{
+			name:                    "empty_deps",
+			rootNode:                "foo",
+			deps:                    map[string]struct{}{"": {}},
+			expectedErrMessageExact: "empty dependency node",
+		},
+	}
+	for _, tc := range testCases {
+		func(tc testCase) {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				tree := dependenciestree.New()
+				err := tree.NewRootNode(tc.rootNode, tc.deps)
+				if tc.expectedErrMessageExact == "" {
+					assert.NoError(t, err)
+				} else {
+					assert.EqualError(t, err, tc.expectedErrMessageExact)
+				}
+			})
+		}(tc)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name                       string
+		tree                       map[string]map[string]struct{}
+		allowExternalDependencies  bool
+		expectedErrMessageExact    string
+		expectedErrMessageContains []string
+	}
+	testCases := []testCase{
+		{
+			name: "nil",
+		},
+		{
+			name: "empty",
+			tree: make(map[string]map[string]struct{}),
+		},
+		{
+			name: "single_node",
+			tree: map[string]map[string]struct{}{
+				"foo": {},
+			},
+		},
+		{
+			name: "multiple_nodes_no_deps",
+			tree: map[string]map[string]struct{}{
+				"foo": {},
+				"bar": {},
+				"baz": {},
+			},
+		},
+		{
+			name: "single_dep",
+			tree: map[string]map[string]struct{}{
+				"foo": {"bar": {}},
+				"bar": {},
+			},
+		},
+		{
+			name: "multilevel_deps",
+			tree: map[string]map[string]struct{}{
+				"foo": {"bar": {}},
+				"bar": {"baz": {}},
+				"baz": {},
+			},
+		},
+		{
+			name: "external_deps_not_allowed",
+			tree: map[string]map[string]struct{}{
+				"foo": {"external_dep": {}},
+			},
+			expectedErrMessageExact: "node foo.external_dep is not present in tree root nodes",
+		},
+		{
+			name: "external_deps_allowed",
+			tree: map[string]map[string]struct{}{
+				"foo": {"external_dep": {}},
+			},
+			allowExternalDependencies: true,
+		},
+		{
+			name: "depend_on_self",
+			tree: map[string]map[string]struct{}{
+				"foo": {"foo": {}},
+			},
+			expectedErrMessageExact: "circular dependency: foo.foo",
+		},
+		{
+			name: "circular_dependency",
+			tree: map[string]map[string]struct{}{
+				"foo": {"bar": {}},
+				"bar": {"foo": {}},
+			},
+			expectedErrMessageContains: []string{ // map sorting is not deterministic
+				"circular dependency: ",
+				"foo.bar",
+				"bar.foo",
+			},
+		},
+		{
+			name: "multilevel_circular_dependency",
+			tree: map[string]map[string]struct{}{
+				"foo": {"bar": {}},
+				"bar": {"baz": {}},
+				"baz": {"foo": {}},
+			},
+			expectedErrMessageContains: []string{ // map sorting is not deterministic
+				"circular dependency: ",
+				"foo.bar",
+				"bar.baz",
+				"baz.foo",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		func(tc testCase) {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				newTreeDepsOpts := make([]dependenciestree.NewDependenciesTreeOption, 0)
+				if tc.allowExternalDependencies {
+					newTreeDepsOpts = append(newTreeDepsOpts, dependenciestree.NewDependenciesTreeWithAllowExternalDeps())
+				}
+				tree := dependenciestree.New(newTreeDepsOpts...)
+				for node, deps := range tc.tree {
+					require.NoError(t, tree.NewRootNode(node, deps))
+				}
+				validateErr := tree.Validate()
+				var expectErr bool
+				if tc.expectedErrMessageExact != "" {
+					expectErr = true
+					assert.EqualError(t, validateErr, tc.expectedErrMessageExact)
+				}
+				if len(tc.expectedErrMessageContains) > 0 {
+					expectErr = true
+					for _, partialErrMsg := range tc.expectedErrMessageContains {
+						assert.Contains(t, validateErr.Error(), partialErrMsg)
+					}
+				}
+				if expectErr {
+					assert.Error(t, validateErr)
+				} else {
+					assert.NoError(t, validateErr)
+				}
+			})
+		}(tc)
+	}
+}
+
+func TestSort(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name                      string
+		tree                      map[string]map[string]struct{}
+		expectedSortedNodes       []string
+		allowExternalDependencies bool
+	}
+	testCases := []testCase{
+		{
+			name: "nil",
+		},
+		{
+			name: "empty",
+			tree: make(map[string]map[string]struct{}),
+		},
+		{
+			name: "single_node",
+			tree: map[string]map[string]struct{}{
+				"foo": {},
+			},
+			expectedSortedNodes: []string{"foo"},
+		},
+		{
+			name: "multiple_nodes_no_deps",
+			tree: map[string]map[string]struct{}{
+				"foo": {},
+				"bar": {},
+				"baz": {},
+			},
+			expectedSortedNodes: []string{
+				"bar",
+				"baz",
+				"foo",
+			},
+		},
+		{
+			name: "single_dep",
+			tree: map[string]map[string]struct{}{
+				"foo": {"bar": {}},
+				"bar": {},
+			},
+			expectedSortedNodes: []string{
+				"bar",
+				"foo", // depends on bar
+			},
+		},
+		{
+			name: "external_deps",
+			tree: map[string]map[string]struct{}{
+				"foo": {"external_dep": {}},
+			},
+			allowExternalDependencies: true,
+			expectedSortedNodes:       []string{"foo"}, // does not include external deps
+		},
+		{
+			name: "multilevel_deps",
+			tree: map[string]map[string]struct{}{
+				// leafs
+				"z1": {},
+				"z2": {"external_dep": {}},
+				"z3": {},
+				// depends on z
+				"y1": {"z1": {}},
+				"y2": {
+					"z1":           {},
+					"z2":           {},
+					"external_dep": {},
+				},
+				// depends on y
+				"x1": {
+					"y1": {},
+					"z3": {},
+				},
+				// depends on x
+				"w1": {
+					"x1":           {},
+					"y1":           {},
+					"external_dep": {},
+				},
+			},
+			allowExternalDependencies: true,
+			expectedSortedNodes: []string{
+				"z1",
+				"z2",
+				"z3",
+				"y1",
+				"y2",
+				"x1",
+				"w1",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		func(tc testCase) {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				newTreeDepsOpts := make([]dependenciestree.NewDependenciesTreeOption, 0)
+				if tc.allowExternalDependencies {
+					newTreeDepsOpts = append(newTreeDepsOpts, dependenciestree.NewDependenciesTreeWithAllowExternalDeps())
+				}
+				tree := dependenciestree.New(newTreeDepsOpts...)
+				for node, deps := range tc.tree {
+					require.NoError(t, tree.NewRootNode(node, deps))
+				}
+				sortedNodes, err := tree.Sort()
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedSortedNodes, sortedNodes)
+			})
+		}(tc)
+	}
+}

--- a/private/pkg/dependenciestree/usage.gen.go
+++ b/private/pkg/dependenciestree/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package dependenciestree
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
For dealing with workspaces (push, sync), we need first to sort modules in topological order. This pkg will be useful in the BSR as well for syncing third party modules, where a similar logic lives, and will be replaced by this pkg.