### PR TITLE
Improve error message in plugin push command

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -422,7 +422,7 @@ func findExistingDigestForImageID(
 		structuredErr := new(transport.Error)
 		if errors.As(err, &structuredErr) {
 			if structuredErr.StatusCode == http.StatusUnauthorized {
-				return "", errors.New("Failure: you are not authenticated")
+				return "", errors.New("you are not authenticated. For details, visit https://buf.build/docs/bsr/authentication")
 			}
 			if structuredErr.StatusCode == http.StatusNotFound {
 				return "", nil

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -421,6 +421,9 @@ func findExistingDigestForImageID(
 	if err != nil {
 		structuredErr := new(transport.Error)
 		if errors.As(err, &structuredErr) {
+			if structuredErr.StatusCode == http.StatusUnauthorized {
+				return "", errors.New("Failure: you are not authenticated")
+			}
 			if structuredErr.StatusCode == http.StatusNotFound {
 				return "", nil
 			}


### PR DESCRIPTION
Small improvement to the error string we surface to unauthenticated users trying to interact with the OCI registry.

Instead of:

```
Failure: GET https://{remote}/v2/{name}/tags/list?n=1000: unexpected status code 401 Unauthorized
```

It's now:

```
Failure: you are not authenticated. For details, visit https://buf.build/docs/bsr/authentication
```