### PR TITLE
Remote module identity required for sync

### DIFF
--- a/private/buf/bufsync/syncable_module.go
+++ b/private/buf/bufsync/syncable_module.go
@@ -20,21 +20,21 @@ import (
 )
 
 type syncableModule struct {
-	dir              string
-	identityOverride bufmoduleref.ModuleIdentity
+	dir            string
+	remoteIdentity bufmoduleref.ModuleIdentity
 }
 
 func newSyncableModule(
 	dir string,
-	identityOverride bufmoduleref.ModuleIdentity,
+	remoteIdentity bufmoduleref.ModuleIdentity,
 ) (Module, error) {
 	normalized, err := normalpath.NormalizeAndValidate(dir)
 	if err != nil {
 		return nil, err
 	}
 	return &syncableModule{
-		dir:              normalized,
-		identityOverride: identityOverride,
+		dir:            normalized,
+		remoteIdentity: remoteIdentity,
 	}, nil
 }
 
@@ -42,6 +42,6 @@ func (s *syncableModule) Dir() string {
 	return s.dir
 }
 
-func (s *syncableModule) IdentityOverride() bufmoduleref.ModuleIdentity {
-	return s.identityOverride
+func (s *syncableModule) RemoteIdentity() bufmoduleref.ModuleIdentity {
+	return s.remoteIdentity
 }

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -133,22 +133,18 @@ func (s *syncer) visitCommit(
 		)
 		return nil
 	}
-	moduleIdentity := sourceConfig.ModuleIdentity
-	if module.IdentityOverride() != nil {
-		moduleIdentity = module.IdentityOverride()
-	}
 	builtModule, err := bufmodulebuild.BuildForBucket(
 		ctx,
 		sourceBucket,
 		sourceConfig.Build,
 	)
 	if err != nil {
-		return s.errorHandler.BuildFailure(module.Dir(), moduleIdentity, commit, err)
+		return s.errorHandler.BuildFailure(module.Dir(), module.RemoteIdentity(), commit, err)
 	}
 	return syncFunc(
 		ctx,
 		newModuleCommit(
-			moduleIdentity,
+			module.RemoteIdentity(),
 			builtModule.Bucket,
 			commit,
 			branch,


### PR DESCRIPTION
When we sync a local module to a remote, we need to know the remote identity. This is found in the local `buf.yaml`, but that value can change over a module's history. `sync` needs a stable remote identity that it can sync to, so we are making the identity override required.

The UX of this command will be re-evaluated later before we go to beta.