### PR TITLE
Resume sync from last sync point

### DIFF
--- a/private/buf/bufsync/syncable_module.go
+++ b/private/buf/bufsync/syncable_module.go
@@ -15,6 +15,8 @@
 package bufsync
 
 import (
+	"fmt"
+
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 )
@@ -22,6 +24,7 @@ import (
 type syncableModule struct {
 	dir            string
 	remoteIdentity bufmoduleref.ModuleIdentity
+	formatted      string
 }
 
 func newSyncableModule(
@@ -35,6 +38,7 @@ func newSyncableModule(
 	return &syncableModule{
 		dir:            normalized,
 		remoteIdentity: remoteIdentity,
+		formatted:      fmt.Sprintf("%s:%s", dir, remoteIdentity.IdentityString()),
 	}, nil
 }
 
@@ -44,4 +48,8 @@ func (s *syncableModule) Dir() string {
 
 func (s *syncableModule) RemoteIdentity() bufmoduleref.ModuleIdentity {
 	return s.remoteIdentity
+}
+
+func (s *syncableModule) String() string {
+	return s.formatted
 }

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -157,7 +157,7 @@ func (s *syncer) Sync(ctx context.Context, syncFunc SyncFunc) error {
 		}); err != nil {
 			return fmt.Errorf("process commits: %w", err)
 		}
-		// If we have any sync points left, they were not encountered during sync, which is unexpected behaviour.
+		// If we have any sync points left, they were not encountered during sync, which is unexpected behavior.
 		for module, syncPoint := range syncPoints {
 			if err := s.errorHandler.SyncPointNotEncountered(module, branch, syncPoint); err != nil {
 				return err

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -32,6 +32,7 @@ type syncer struct {
 	storageGitProvider storagegit.Provider
 	errorHandler       ErrorHandler
 	modulesToSync      []Module
+	syncPointResolver  SyncPointResolver
 
 	knownTagsByCommitHash map[string][]string
 }
@@ -56,32 +57,111 @@ func newSyncer(
 	return s, nil
 }
 
+// resolveSyncPoints resolves sync points for all known modules for the specified branch,
+// returning all modules for which sync points were found, along with their sync points.
+//
+// If a SyncPointResolver is not configured, this returns an empty map immediately.
+func (s *syncer) resolveSyncPoints(ctx context.Context, branch string) (map[Module]git.Hash, error) {
+	syncPoints := map[Module]git.Hash{}
+	// If resumption is not enabled, we can bail early.
+	if s.syncPointResolver == nil {
+		return syncPoints, nil
+	}
+	for _, module := range s.modulesToSync {
+		syncPoint, err := s.resolveSyncPoint(ctx, module, branch)
+		if err != nil {
+			return nil, err
+		}
+		if syncPoint != nil {
+			s.logger.Debug(
+				"resolved sync point, will sync after this commit",
+				zap.String("branch", branch),
+				zap.Stringer("module", module),
+				zap.Stringer("syncPoint", syncPoint),
+			)
+			syncPoints[module] = syncPoint
+		} else {
+			s.logger.Debug(
+				"no sync point, syncing from the beginning",
+				zap.String("branch", branch),
+				zap.Stringer("module", module),
+			)
+		}
+	}
+	return syncPoints, nil
+}
+
+// resolveSyncPoint resolves a sync point for a particular module and branch. It assumes
+// that a SyncPointResolver is configured.
+func (s *syncer) resolveSyncPoint(ctx context.Context, module Module, branch string) (git.Hash, error) {
+	syncPoint, err := s.syncPointResolver(ctx, module.RemoteIdentity(), branch)
+	if err != nil {
+		return nil, fmt.Errorf("resolve syncPoint for module %s: %w", module.RemoteIdentity(), err)
+	}
+	if syncPoint != nil {
+		// Validate that the commit pointed to by the sync point exists.
+		if _, err := s.repo.Objects().Commit(syncPoint); err != nil {
+			return nil, s.errorHandler.InvalidSyncPoint(module, branch, syncPoint, err)
+		}
+		return syncPoint, nil
+	}
+	return nil, nil
+}
+
 func (s *syncer) Sync(ctx context.Context, syncFunc SyncFunc) error {
 	s.knownTagsByCommitHash = map[string][]string{}
 	if err := s.repo.ForEachTag(func(tag string, commitHash git.Hash) error {
 		s.knownTagsByCommitHash[commitHash.Hex()] = append(s.knownTagsByCommitHash[commitHash.Hex()], tag)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("process tags: %w", err)
+		return fmt.Errorf("load tags: %w", err)
 	}
 	// TODO: sync other branches
 	for _, branch := range []string{s.repo.BaseBranch()} {
-		// TODO: resume from last sync point
+		syncPoints, err := s.resolveSyncPoints(ctx, branch)
+		if err != nil {
+			return err
+		}
+		// We sync all modules in a commit before advancing to the next commit so that
+		// inter-module dependencies across commits can be resolved.
 		if err := s.repo.ForEachCommit(branch, func(commit git.Commit) error {
 			for _, module := range s.modulesToSync {
-				if err := s.visitCommit(
-					ctx,
-					module,
-					branch,
-					commit,
-					syncFunc,
-				); err != nil {
-					return fmt.Errorf("process commit %s: %w", commit.Hash().Hex(), err)
+				if syncPoint := syncPoints[module]; syncPoint != nil {
+					// This module has a sync point. We need to check if we've encountered the sync point.
+					if syncPoint.Hex() == commit.Hash().Hex() {
+						// We have found the syncPoint! We can resume syncing _after_ this point.
+						delete(syncPoints, module)
+						s.logger.Debug(
+							"syncPoint encountered, skipping commit",
+							zap.Stringer("commit", commit.Hash()),
+							zap.Stringer("module", module),
+							zap.Stringer("syncPoint", syncPoint),
+						)
+					} else {
+						// We have not encountered the syncPoint yet. Skip this commit and keep looking
+						// for the syncPoint.
+						s.logger.Debug(
+							"syncPoint not encountered, skipping commit",
+							zap.Stringer("commit", commit.Hash()),
+							zap.Stringer("module", module),
+							zap.Stringer("syncPoint", syncPoint),
+						)
+					}
+					continue
+				}
+				if err := s.visitCommit(ctx, module, branch, commit, syncFunc); err != nil {
+					return fmt.Errorf("process commit %s (%s): %w", commit.Hash().Hex(), branch, err)
 				}
 			}
 			return nil
 		}); err != nil {
 			return fmt.Errorf("process commits: %w", err)
+		}
+		// If we have any sync points left, they were not encountered during sync, which is unexpected behaviour.
+		for module, syncPoint := range syncPoints {
+			if err := s.errorHandler.SyncPointNotEncountered(module, branch, syncPoint); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -115,21 +195,21 @@ func (s *syncer) visitCommit(
 		// We did not find a module. Carry on to the next commit.
 		s.logger.Debug(
 			"module not found, skipping commit",
-			zap.String("commit", commit.Hash().String()),
-			zap.String("module", module.Dir()),
+			zap.Stringer("commit", commit.Hash()),
+			zap.Stringer("module", module),
 		)
 		return nil
 	}
 	sourceConfig, err := bufconfig.GetConfigForBucket(ctx, sourceBucket)
 	if err != nil {
-		return s.errorHandler.InvalidModuleConfig(module.Dir(), commit, err)
+		return s.errorHandler.InvalidModuleConfig(module, commit, err)
 	}
 	if sourceConfig.ModuleIdentity == nil {
 		// Unnamed module. Carry on.
 		s.logger.Debug(
 			"unnamed module, skipping commit",
-			zap.String("commit", commit.Hash().String()),
-			zap.String("module", module.Dir()),
+			zap.Stringer("commit", commit.Hash()),
+			zap.Stringer("module", module),
 		)
 		return nil
 	}
@@ -139,7 +219,7 @@ func (s *syncer) visitCommit(
 		sourceConfig.Build,
 	)
 	if err != nil {
-		return s.errorHandler.BuildFailure(module.Dir(), module.RemoteIdentity(), commit, err)
+		return s.errorHandler.BuildFailure(module, commit, err)
 	}
 	return syncFunc(
 		ctx,

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -98,14 +98,14 @@ func (s *syncer) resolveSyncPoint(ctx context.Context, module Module, branch str
 	if err != nil {
 		return nil, fmt.Errorf("resolve syncPoint for module %s: %w", module.RemoteIdentity(), err)
 	}
-	if syncPoint != nil {
-		// Validate that the commit pointed to by the sync point exists.
-		if _, err := s.repo.Objects().Commit(syncPoint); err != nil {
-			return nil, s.errorHandler.InvalidSyncPoint(module, branch, syncPoint, err)
-		}
-		return syncPoint, nil
+	if syncPoint == nil {
+		return nil, nil
 	}
-	return nil, nil
+	// Validate that the commit pointed to by the sync point exists.
+	if _, err := s.repo.Objects().Commit(syncPoint); err != nil {
+		return nil, s.errorHandler.InvalidSyncPoint(module, branch, syncPoint, err)
+	}
+	return syncPoint, nil
 }
 
 func (s *syncer) Sync(ctx context.Context, syncFunc SyncFunc) error {

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
@@ -298,7 +298,7 @@ func (s *syncErrorHandler) InvalidSyncPoint(
 	// sync those commits if we continue. So we now we simply error.
 	if errors.Is(err, git.ErrObjectNotFound) {
 		return fmt.Errorf(
-			"last known commit %s was not found for module %s; did you rebase?",
+			"last synced commit %s was not found for module %s; did you rebase?",
 			syncPoint,
 			module,
 		)

--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -46,7 +46,10 @@ const (
 	ModeSubmodule ObjectMode = 016_0000
 )
 
-var ErrTreeNodeNotFound = errors.New("node not found")
+var (
+	ErrTreeNodeNotFound = errors.New("node not found")
+	ErrObjectNotFound   = errors.New("object not found")
+)
 
 // ObjectMode is how to interpret a tree node's object. See the Mode* constants
 // for how to interpret each mode value.

--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -47,8 +47,12 @@ const (
 )
 
 var (
+	// ErrTreeNodeNotFound is an error found in the error chain when
+	// Tree#Descendant is unable to find the target tree node.
 	ErrTreeNodeNotFound = errors.New("node not found")
-	ErrObjectNotFound   = errors.New("object not found")
+	// ErrTreeNodeNotFound is an error found in the error chain when
+	// ObjectReader is unable to find the target object.
+	ErrObjectNotFound = errors.New("object not found")
 )
 
 // ObjectMode is how to interpret a tree node's object. See the Mode* constants

--- a/private/pkg/git/object_reader.go
+++ b/private/pkg/git/object_reader.go
@@ -121,7 +121,9 @@ func (o *objectReader) read(objectType string, id Hash) ([]byte, error) {
 	parts := strings.Split(headerStr, " ")
 	if len(parts) == 2 && parts[1] == "missing" {
 		return nil, fmt.Errorf(
-			"git-cat-file: object not found: %s", parts[0],
+			"git-cat-file: %s: %w",
+			parts[0],
+			ErrObjectNotFound,
 		)
 	}
 	if len(parts) != 3 {


### PR DESCRIPTION
There are some important considerations:
- Sync is resumed _after_ the last known commit for a particular branch.
- Repositories that previously called `buf push` can still take advantage of resumption with `buf sync` if the BSR can find a sync point. The BSR currently looks for a tag on the BSR commit that _looks like_ a Git commit hash. In some cases this may not be correct, and users will have to manually create a new tag with the correct Git commit hash.
- Rebasing is not supported and currently fails the entire sync in a partial state.
- Sync points _must_ be encountered, otherwise sync fails after completion.