### PR TITLE
Add connect interceptor to log server warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Add `buf-cli-warning-bin` header to detect and print server warning messages.
+- Add `buf-warning-bin` header to detect and print server warning messages.
 
 ## [v1.21.0] - 2023-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add `buf-cli-warning-bin` header to detect and print server warning messages.
 
 ## [v1.21.0] - 2023-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Add `buf-warning-bin` header to detect and print server warning messages.
+- No changes yet.
 
 ## [v1.21.0] - 2023-06-05
 

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -598,9 +598,10 @@ func newConnectClientConfigWithOptions(container appflag.Container, opts ...conn
 			}
 			return buftransport.PrependHTTPS(address)
 		}),
-		connectclient.WithInterceptors(
-			[]connect.Interceptor{bufconnect.NewSetCLIVersionInterceptor(Version)},
-		),
+		connectclient.WithInterceptors([]connect.Interceptor{
+			bufconnect.NewSetCLIVersionInterceptor(Version),
+			bufconnect.NewCLIWarningInterceptor(container),
+		}),
 	}
 	options = append(options, opts...)
 

--- a/private/bufpkg/bufconnect/bufconnect.go
+++ b/private/bufpkg/bufconnect/bufconnect.go
@@ -26,7 +26,7 @@ const (
 	CliVersionHeaderName = "buf-version"
 	// CLIWarningHeaderName is the name of the header carrying a base64-encoded warning message
 	// from the server to the CLI.
-	CLIWarningHeaderName = "buf-cli-warning-bin"
+	CLIWarningHeaderName = "buf-warning-bin"
 	// DefaultRemote is the default remote if none can be inferred from a module name.
 	DefaultRemote = "buf.build"
 )

--- a/private/bufpkg/bufconnect/bufconnect.go
+++ b/private/bufpkg/bufconnect/bufconnect.go
@@ -24,6 +24,9 @@ const (
 	AuthenticationTokenPrefix = "Bearer "
 	// CliVersionHeaderName is the name of the header carrying the buf CLI version.
 	CliVersionHeaderName = "buf-version"
+	// CLIWarningHeaderName is the name of the header carrying a base64-encoded warning message
+	// from the server to the CLI.
+	CLIWarningHeaderName = "buf-cli-warning-bin"
 	// DefaultRemote is the default remote if none can be inferred from a module name.
 	DefaultRemote = "buf.build"
 )

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 
-	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/app/applog"
 	"github.com/bufbuild/connect-go"
 )
 
@@ -39,7 +39,7 @@ func NewSetCLIVersionInterceptor(version string) connect.UnaryInterceptorFunc {
 }
 
 // NewCLIWarningInterceptor returns a new Connect Interceptor that logs CLI warnings returned by sever responses.
-func NewCLIWarningInterceptor(container appflag.Container) connect.UnaryInterceptorFunc {
+func NewCLIWarningInterceptor(container applog.Container) connect.UnaryInterceptorFunc {
 	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			resp, err := next(ctx, req)

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -16,7 +16,6 @@ package bufconnect
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/bufbuild/buf/private/pkg/app/applog"
 	"github.com/bufbuild/connect-go"
@@ -46,7 +45,7 @@ func NewCLIWarningInterceptor(container applog.Container) connect.UnaryIntercept
 			if resp != nil && resp.Header() != nil {
 				encoded := resp.Header().Get(CLIWarningHeaderName)
 				if encoded != "" {
-					if warning, err := base64.StdEncoding.DecodeString(encoded); err == nil && len(warning) > 0 {
+					if warning, err := connect.DecodeBinaryHeader(encoded); err == nil && len(warning) > 0 {
 						container.Logger().Warn(string(warning))
 					}
 				}

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -38,7 +38,7 @@ func NewSetCLIVersionInterceptor(version string) connect.UnaryInterceptorFunc {
 	return interceptor
 }
 
-// NewCLIWarningInterceptor returns a new Connect Interceptor that logs CLI warnings returned by sever responses.
+// NewCLIWarningInterceptor returns a new Connect Interceptor that logs CLI warnings returned by server responses.
 func NewCLIWarningInterceptor(container applog.Container) connect.UnaryInterceptorFunc {
 	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {


### PR DESCRIPTION
This PR adds a connect interceptor to log arbitrary server warnings.

The CLI will recognize the `buf-warning-bin` header, which is expected to be a base64-encoded message. It uses the applog container so users can ignore these messages with `--no-warn`. Do we want this behaviour, or should we always print the warning regardless of user preferences? Probably not.

There's one edge case in that a single command may call multiple RPC's, and if multiple RPC's return warnings they will all be printed. We could add some ctx-based print once logic, but I suspect if multiple RPC's return warnings, those errors will be different anyway, so it's unlikely we'll want to print only the first one.