### PR TITLE
Add otel connect interceptor to CLI connect client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/bufbuild/connect-go v1.8.0
+	github.com/bufbuild/connect-opentelemetry-go v0.3.0
 	github.com/bufbuild/protocompile v0.5.1
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/go-chi/chi/v5 v5.0.8

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bufbuild/connect-go v1.8.0 h1:srluNkFkZBfSfg9Qb6DrO+5nMaxix//h2ctrHZhMGKc=
 github.com/bufbuild/connect-go v1.8.0/go.mod h1:GmMJYR6orFqD0Y6ZgX8pwQ8j9baizDrIQMm1/a6LnHk=
+github.com/bufbuild/connect-opentelemetry-go v0.3.0 h1:AuZi3asTDKmjGtd2aqpyP4p5QvBFG/YEaHopViLatnk=
+github.com/bufbuild/connect-opentelemetry-go v0.3.0/go.mod h1:r1ppyTtu1EWeRodk4Q/JbyQhIWtO7eR3GoRDzjeEcNU=
 github.com/bufbuild/protocompile v0.5.1 h1:mixz5lJX4Hiz4FpqFREJHIXLfaLBntfaJv1h+/jS+Qg=
 github.com/bufbuild/protocompile v0.5.1/go.mod h1:G5iLmavmF4NsYtpZFvE3B/zFch2GIY8+wjsYLR/lc40=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -133,6 +135,7 @@ go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26
 go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
 go.opentelemetry.io/otel/sdk v1.16.0 h1:Z1Ok1YsijYL0CSJpHt4cS3wDDh7p572grzNrBMiMWgE=
 go.opentelemetry.io/otel/sdk v1.16.0/go.mod h1:tMsIuKXuuIWPBAOrH+eHtvhTL+SntFtXF9QD68aP6p4=
+go.opentelemetry.io/otel/sdk/metric v0.39.0 h1:Kun8i1eYf48kHH83RucG93ffz0zGV1sh46FAScOTuDI=
 go.opentelemetry.io/otel/trace v1.16.0 h1:8JRpaObFoW0pxuVPapkgH8UhHQj+bJW8jJsCZEu5MQs=
 go.opentelemetry.io/otel/trace v1.16.0/go.mod h1:Yt9vYq1SdNz3xdjZZK7wcXv1qv2pwLkqr2QVwea0ef0=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -56,6 +56,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/bufbuild/buf/private/pkg/transport/http/httpclient"
 	"github.com/bufbuild/connect-go"
+	otelconnect "github.com/bufbuild/connect-opentelemetry-go"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"golang.org/x/term"
@@ -601,6 +602,7 @@ func newConnectClientConfigWithOptions(container appflag.Container, opts ...conn
 		connectclient.WithInterceptors([]connect.Interceptor{
 			bufconnect.NewSetCLIVersionInterceptor(Version),
 			bufconnect.NewCLIWarningInterceptor(container),
+			otelconnect.NewInterceptor(),
 		}),
 	}
 	options = append(options, opts...)

--- a/private/pkg/observabilityzap/zapexporter.go
+++ b/private/pkg/observabilityzap/zapexporter.go
@@ -43,7 +43,7 @@ func (z *zapExporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpa
 				zap.Duration("duration", span.EndTime().Sub(span.StartTime())),
 			}
 			for _, attribute := range span.Attributes() {
-				fields = append(fields, zap.Any(string(attribute.Key), attribute.Value))
+				fields = append(fields, zap.Any(string(attribute.Key), attribute.Value.AsInterface()))
 			}
 			checkedEntry.Write(fields...)
 		}


### PR DESCRIPTION
this bring back the RPC log when run with `--debug` flag

```
❯ buf build buf.build/bufbuild/buf --debug
DEBUG   get_ref {"duration": "316.541µs"}
DEBUG   buf.alpha.registry.v1alpha1.RepositoryCommitService/GetRepositoryCommitByReference      {"duration": "282.101875ms", "net.peer.name": "api.buf.build", "rpc.system": "connect_rpc", "rpc.service": "buf.alpha.registry.v1alpha1.RepositoryCommitService", "rpc.method": "GetRepositoryCommitByReference"}
DEBUG   get_config      {"duration": "1.213416ms"}
DEBUG   get_config      {"duration": "23.875µs"}
DEBUG   get_module_config       {"duration": "294.278542ms"}
DEBUG   get_image       {"duration": "79.459µs"}
DEBUG   build   {"duration": "31.261458ms"}
DEBUG   build_module    {"duration": "31.264375ms"}
DEBUG   get_image_ref   {"duration": "5.5µs"}
DEBUG   put_image       {"duration": "459ns"}
DEBUG   command {"duration": "327.622625ms"}
```