### PR TITLE
Make bufimagebuild.Builder take a Module instead of a ModuleFileSet

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -415,8 +415,7 @@ func NewWireImageConfigReader(
 		storageosProvider,
 		newFetchReader(logger, storageosProvider, runner, moduleResolver, moduleReader),
 		bufmodulebuild.NewModuleBucketBuilder(),
-		bufmodulebuild.NewModuleFileSetBuilder(logger, moduleReader),
-		bufimagebuild.NewBuilder(logger),
+		bufimagebuild.NewBuilder(logger, moduleReader),
 	), nil
 }
 
@@ -487,8 +486,7 @@ func NewWireFileLister(
 		storageosProvider,
 		newFetchReader(logger, storageosProvider, runner, moduleResolver, moduleReader),
 		bufmodulebuild.NewModuleBucketBuilder(),
-		bufmodulebuild.NewModuleFileSetBuilder(logger, moduleReader),
-		bufimagebuild.NewBuilder(logger),
+		bufimagebuild.NewBuilder(logger, moduleReader),
 	), nil
 }
 
@@ -825,7 +823,7 @@ func WellKnownTypeImage(ctx context.Context, logger *zap.Logger, wellKnownType s
 	if err != nil {
 		return nil, err
 	}
-	image, _, err := bufimagebuild.NewBuilder(logger).Build(ctx, bufmodule.NewModuleFileSet(module, nil))
+	image, _, err := bufimagebuild.NewBuilder(logger, bufmodule.NewNopModuleReader()).Build(ctx, module)
 	if err != nil {
 		return nil, err
 	}

--- a/private/buf/bufcli/bufcli_test.go
+++ b/private/buf/bufcli/bufcli_test.go
@@ -39,7 +39,13 @@ func (m *mockBucketProvider) NewReadWriteBucket(
 	_ string,
 	_ ...storageos.ReadWriteBucketOption,
 ) (storage.ReadWriteBucket, error) {
-	return storagemem.NewReadWriteBucketWithOptions(storagemem.WithFiles(m.files))
+	bucket := storagemem.NewReadWriteBucket()
+	for path, data := range m.files {
+		if err := storage.PutPath(context.Background(), bucket, path, data); err != nil {
+			return nil, err
+		}
+	}
+	return bucket, nil
 }
 
 func TestDiscoverRemote(t *testing.T) {

--- a/private/buf/bufwire/bufwire.go
+++ b/private/buf/bufwire/bufwire.go
@@ -64,7 +64,6 @@ func NewImageConfigReader(
 	storageosProvider storageos.Provider,
 	fetchReader buffetch.Reader,
 	moduleBucketBuilder bufmodulebuild.ModuleBucketBuilder,
-	moduleFileSetBuilder bufmodulebuild.ModuleFileSetBuilder,
 	imageBuilder bufimagebuild.Builder,
 ) ImageConfigReader {
 	return newImageConfigReader(
@@ -72,7 +71,6 @@ func NewImageConfigReader(
 		storageosProvider,
 		fetchReader,
 		moduleBucketBuilder,
-		moduleFileSetBuilder,
 		imageBuilder,
 	)
 }
@@ -140,7 +138,6 @@ func NewFileLister(
 	storageosProvider storageos.Provider,
 	fetchReader buffetch.Reader,
 	moduleBucketBuilder bufmodulebuild.ModuleBucketBuilder,
-	moduleFileSetBuilder bufmodulebuild.ModuleFileSetBuilder,
 	imageBuilder bufimagebuild.Builder,
 ) FileLister {
 	return newFileLister(
@@ -148,7 +145,6 @@ func NewFileLister(
 		storageosProvider,
 		fetchReader,
 		moduleBucketBuilder,
-		moduleFileSetBuilder,
 		imageBuilder,
 	)
 }

--- a/private/buf/bufwire/file_lister.go
+++ b/private/buf/bufwire/file_lister.go
@@ -49,7 +49,6 @@ func newFileLister(
 	storageosProvider storageos.Provider,
 	fetchReader buffetch.Reader,
 	moduleBucketBuilder bufmodulebuild.ModuleBucketBuilder,
-	moduleFileSetBuilder bufmodulebuild.ModuleFileSetBuilder,
 	imageBuilder bufimagebuild.Builder,
 ) *fileLister {
 	return &fileLister{
@@ -66,7 +65,6 @@ func newFileLister(
 			storageosProvider,
 			fetchReader,
 			moduleBucketBuilder,
-			moduleFileSetBuilder,
 			imageBuilder,
 		),
 	}

--- a/private/buf/cmd/buf/command/alpha/protoc/protoc.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/protoc.go
@@ -127,24 +127,14 @@ func run(
 	if err != nil {
 		return err
 	}
-	moduleFileSet, err := bufmodulebuild.NewModuleFileSetBuilder(
-		zap.NewNop(),
-		moduleReader,
-	).Build(
-		ctx,
-		module,
-	)
-	if err != nil {
-		return err
-	}
 	var buildOptions []bufimagebuild.BuildOption
 	// we always need source code info if we are doing generation
 	if len(env.PluginNameToPluginInfo) == 0 && !env.IncludeSourceInfo {
 		buildOptions = append(buildOptions, bufimagebuild.WithExcludeSourceCodeInfo())
 	}
-	image, fileAnnotations, err := bufimagebuild.NewBuilder(container.Logger()).Build(
+	image, fileAnnotations, err := bufimagebuild.NewBuilder(container.Logger(), moduleReader).Build(
 		ctx,
-		moduleFileSet,
+		module,
 		buildOptions...,
 	)
 	if err != nil {

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -64,7 +64,7 @@ Export proto files in <source> to an output directory.
 
     $ buf export <source> --output=<output-dir>
 
-Export current directory to another local directory. 
+Export current directory to another local directory.
 
     $ buf export . --output=<output-dir>
 
@@ -178,6 +178,7 @@ func run(
 		container.Logger(),
 		moduleReader,
 	)
+	// TODO: this is going to be a mess when we want to remove ModuleFileSet
 	moduleFileSets := make([]bufmodule.ModuleFileSet, len(moduleConfigs))
 	for i, moduleConfig := range moduleConfigs {
 		moduleFileSet, err := moduleFileSetBuilder.Build(
@@ -205,7 +206,7 @@ func run(
 	// We gate on flags.ExcludeImports/buffetch.ProtoFileRef so that we don't waste time building if the
 	// result of the build is not relevant.
 	if !flags.ExcludeImports {
-		imageBuilder := bufimagebuild.NewBuilder(container.Logger())
+		imageBuilder := bufimagebuild.NewBuilder(container.Logger(), moduleReader)
 		for _, moduleFileSet := range moduleFileSets {
 			targetFileInfos, err := moduleFileSet.TargetFileInfos(ctx)
 			if err != nil {

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -743,17 +743,12 @@ func testBreaking(
 		previousConfig.Build,
 	)
 	require.NoError(t, err)
-	previousModuleFileSet, err := bufmodulebuild.NewModuleFileSetBuilder(
+	previousImage, previousFileAnnotations, err := bufimagebuild.NewBuilder(
 		zap.NewNop(),
 		bufmodule.NewNopModuleReader(),
 	).Build(
-		context.Background(),
-		previousModule,
-	)
-	require.NoError(t, err)
-	previousImage, previousFileAnnotations, err := bufimagebuild.NewBuilder(zap.NewNop()).Build(
 		ctx,
-		previousModuleFileSet,
+		previousModule,
 		bufimagebuild.WithExcludeSourceCodeInfo(),
 	)
 	require.NoError(t, err)
@@ -766,17 +761,12 @@ func testBreaking(
 		config.Build,
 	)
 	require.NoError(t, err)
-	moduleFileSet, err := bufmodulebuild.NewModuleFileSetBuilder(
+	image, fileAnnotations, err := bufimagebuild.NewBuilder(
 		zap.NewNop(),
 		bufmodule.NewNopModuleReader(),
 	).Build(
-		context.Background(),
-		module,
-	)
-	require.NoError(t, err)
-	image, fileAnnotations, err := bufimagebuild.NewBuilder(zap.NewNop()).Build(
 		ctx,
-		moduleFileSet,
+		module,
 	)
 	require.NoError(t, err)
 	require.Empty(t, fileAnnotations)

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -931,17 +931,12 @@ func testLintConfigModifier(
 		config.Build,
 	)
 	require.NoError(t, err)
-	moduleFileSet, err := bufmodulebuild.NewModuleFileSetBuilder(
+	image, fileAnnotations, err := bufimagebuild.NewBuilder(
 		zap.NewNop(),
 		bufmodule.NewNopModuleReader(),
 	).Build(
-		context.Background(),
-		module,
-	)
-	require.NoError(t, err)
-	image, fileAnnotations, err := bufimagebuild.NewBuilder(zap.NewNop()).Build(
 		ctx,
-		moduleFileSet,
+		module,
 	)
 	require.NoError(t, err)
 	require.Empty(t, fileAnnotations)

--- a/private/bufpkg/bufimage/bufimagebuild/bufimagebuild.go
+++ b/private/bufpkg/bufimage/bufimagebuild/bufimagebuild.go
@@ -37,14 +37,14 @@ type Builder interface {
 	// FileAnnotations will use external file paths.
 	Build(
 		ctx context.Context,
-		moduleFileSet bufmodule.ModuleFileSet,
+		module bufmodule.Module,
 		options ...BuildOption,
 	) (bufimage.Image, []bufanalysis.FileAnnotation, error)
 }
 
 // NewBuilder returns a new Builder.
-func NewBuilder(logger *zap.Logger) Builder {
-	return newBuilder(logger)
+func NewBuilder(logger *zap.Logger, moduleReader bufmodule.ModuleReader) Builder {
+	return newBuilder(logger, moduleReader)
 }
 
 // BuildOption is an option for Build.
@@ -64,8 +64,8 @@ func WithDirectDependencies(directDependencies []bufmoduleref.ModuleReference) B
 	}
 }
 
-// WithLocalWorkspace sets a local workspace, so imports from it are not warned.
-func WithLocalWorkspace(workspace bufmodule.Workspace) BuildOption {
+// WithWorkspace sets the workspace to be read from instead of ModuleReader, and to not warn imports for.
+func WithWorkspace(workspace bufmodule.Workspace) BuildOption {
 	return func(buildOptions *buildOptions) {
 		buildOptions.workspace = workspace
 	}

--- a/private/bufpkg/bufimage/bufimagebuild/builder_test.go
+++ b/private/bufpkg/bufimage/bufimagebuild/builder_test.go
@@ -299,10 +299,10 @@ func TestDuplicateSyntheticOneofs(t *testing.T) {
 func TestOptionPanic(t *testing.T) {
 	t.Parallel()
 	require.NotPanics(t, func() {
-		moduleFileSet := testGetModuleFileSet(t, filepath.Join("testdata", "optionpanic"))
-		_, _, err := NewBuilder(zap.NewNop()).Build(
+		module := testGetModule(t, filepath.Join("testdata", "optionpanic"))
+		_, _, err := NewBuilder(zap.NewNop(), bufmodule.NewNopModuleReader()).Build(
 			context.Background(),
-			moduleFileSet,
+			module,
 		)
 		require.NoError(t, err)
 	})
@@ -333,21 +333,21 @@ func testBuildGoogleapis(t *testing.T, includeSourceInfo bool) bufimage.Image {
 }
 
 func testBuild(t *testing.T, includeSourceInfo bool, dirPath string) (bufimage.Image, []bufanalysis.FileAnnotation) {
-	moduleFileSet := testGetModuleFileSet(t, dirPath)
+	module := testGetModule(t, dirPath)
 	var options []BuildOption
 	if !includeSourceInfo {
 		options = append(options, WithExcludeSourceCodeInfo())
 	}
-	image, fileAnnotations, err := NewBuilder(zap.NewNop()).Build(
+	image, fileAnnotations, err := NewBuilder(zap.NewNop(), bufmodule.NewNopModuleReader()).Build(
 		context.Background(),
-		moduleFileSet,
+		module,
 		options...,
 	)
 	require.NoError(t, err)
 	return image, fileAnnotations
 }
 
-func testGetModuleFileSet(t *testing.T, dirPath string) bufmodule.ModuleFileSet {
+func testGetModule(t *testing.T, dirPath string) bufmodule.Module {
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	readWriteBucket, err := storageosProvider.NewReadWriteBucket(
 		dirPath,
@@ -362,15 +362,7 @@ func testGetModuleFileSet(t *testing.T, dirPath string) bufmodule.ModuleFileSet 
 		config,
 	)
 	require.NoError(t, err)
-	moduleFileSet, err := bufmodulebuild.NewModuleFileSetBuilder(
-		zap.NewNop(),
-		bufmodule.NewNopModuleReader(),
-	).Build(
-		context.Background(),
-		module,
-	)
-	require.NoError(t, err)
-	return moduleFileSet
+	return module
 }
 
 func testGetImageFilePaths(image bufimage.Image) []string {

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagebuild"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
@@ -154,9 +155,12 @@ func TestTransitivePublic(t *testing.T) {
 	require.NoError(t, err)
 	module, err := bufmodule.NewModuleForBucket(ctx, bucket)
 	require.NoError(t, err)
-	image, analysis, err := bufimagebuild.NewBuilder(zaptest.NewLogger(t)).Build(
+	image, analysis, err := bufimagebuild.NewBuilder(
+		zaptest.NewLogger(t),
+		bufmodule.NewNopModuleReader(),
+	).Build(
 		ctx,
-		bufmodule.NewModuleFileSet(module, nil),
+		module,
 		bufimagebuild.WithExcludeSourceCodeInfo(),
 	)
 	require.NoError(t, err)
@@ -173,25 +177,33 @@ func TestTypesFromMainModule(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	bucket, err := storagemem.NewReadBucket(map[string][]byte{
-		"a.proto": []byte(`syntax = "proto3";import "b.proto";package pkg;message Foo { dependency.Dep bar = 1;}`),
-	})
+	moduleIdentityString := "buf.build/repo/main"
+	moduleIdentity, err := bufmoduleref.ModuleIdentityForString(moduleIdentityString)
 	require.NoError(t, err)
-	moduleIdentity, err := bufmoduleref.NewModuleIdentity("buf.build", "repo", "main")
+	moduleIdentityDepString := "buf.build/repo/dep"
+	moduleIdentityDep, err := bufmoduleref.ModuleIdentityForString(moduleIdentityDepString)
 	require.NoError(t, err)
+	bucket := storagemem.NewReadWriteBucket()
+	require.NoError(t, storage.PutPath(ctx, bucket, "a.proto", []byte(`syntax = "proto3";import "b.proto";package pkg;message Foo { dependency.Dep bar = 1;}`)))
+	require.NoError(t, bufmoduletesting.WriteTestLockFileToBucket(ctx, bucket, moduleIdentityDepString))
 	module, err := bufmodule.NewModuleForBucket(ctx, bucket, bufmodule.ModuleWithModuleIdentity(moduleIdentity))
 	require.NoError(t, err)
 	bucketDep, err := storagemem.NewReadBucket(map[string][]byte{
 		"b.proto": []byte(`syntax = "proto3";package dependency; message Dep{}`),
 	})
 	require.NoError(t, err)
-	moduleIdentityDep, err := bufmoduleref.NewModuleIdentity("buf.build", "repo", "dep")
-	require.NoError(t, err)
 	moduleDep, err := bufmodule.NewModuleForBucket(ctx, bucketDep, bufmodule.ModuleWithModuleIdentity(moduleIdentityDep))
 	require.NoError(t, err)
-	image, analysis, err := bufimagebuild.NewBuilder(zaptest.NewLogger(t)).Build(
+	image, analysis, err := bufimagebuild.NewBuilder(
+		zaptest.NewLogger(t),
+		bufmoduletesting.NewTestModuleReader(
+			map[string]bufmodule.Module{
+				moduleIdentityDep.IdentityString(): moduleDep,
+			},
+		),
+	).Build(
 		ctx,
-		bufmodule.NewModuleFileSet(module, []bufmodule.Module{moduleDep}),
+		module,
 		bufimagebuild.WithExcludeSourceCodeInfo(),
 	)
 	require.NoError(t, err)
@@ -222,10 +234,10 @@ func getImage(ctx context.Context, logger *zap.Logger, testdataDir string, optio
 	if err != nil {
 		return nil, nil, err
 	}
-	builder := bufimagebuild.NewBuilder(logger)
+	builder := bufimagebuild.NewBuilder(logger, bufmodule.NewNopModuleReader())
 	image, analysis, err := builder.Build(
 		ctx,
-		bufmodule.NewModuleFileSet(module, nil),
+		module,
 		options...,
 	)
 	if err != nil {

--- a/private/bufpkg/bufmodule/bufmoduleprotocompile/bufmoduleprotocompile.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotocompile/bufmoduleprotocompile.go
@@ -45,12 +45,9 @@ type ParserAccessorHandler interface {
 
 // NewParserAccessorHandler returns a new ParserAccessorHandler.
 //
-// The given module should be a bufmodule.ModuleFileSet for image builds, as it needs
-// access to not just the target files, but all dependency files as well.
-//
-// For AST building, this can just be a bufmodule.Module.
-func NewParserAccessorHandler(ctx context.Context, module bufmodule.Module) ParserAccessorHandler {
-	return newParserAccessorHandler(ctx, module)
+// TODO: make this dependent on whatever derivative getter type we create to replace ModuleFileSet.
+func NewParserAccessorHandler(ctx context.Context, moduleFileSet bufmodule.ModuleFileSet) ParserAccessorHandler {
+	return newParserAccessorHandler(ctx, moduleFileSet)
 }
 
 // GetFileAnnotations gets the FileAnnotations for the ErrorWithPos errors.

--- a/private/bufpkg/bufmodule/bufmoduleprotocompile/path_resolver.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotocompile/path_resolver.go
@@ -27,9 +27,14 @@ import (
 	"go.uber.org/multierr"
 )
 
+// TODO: remove when we remove ModuleFileSet
+type moduleFileReader interface {
+	GetModuleFile(context.Context, string) (bufmodule.ModuleFile, error)
+}
+
 type parserAccessorHandler struct {
 	ctx                  context.Context
-	module               bufmodule.Module
+	moduleFileReader     moduleFileReader
 	pathToExternalPath   map[string]string
 	nonImportPaths       map[string]struct{}
 	pathToModuleIdentity map[string]bufmoduleref.ModuleIdentity
@@ -39,11 +44,11 @@ type parserAccessorHandler struct {
 
 func newParserAccessorHandler(
 	ctx context.Context,
-	module bufmodule.Module,
+	moduleFileReader moduleFileReader,
 ) *parserAccessorHandler {
 	return &parserAccessorHandler{
 		ctx:                  ctx,
-		module:               module,
+		moduleFileReader:     moduleFileReader,
 		pathToExternalPath:   make(map[string]string),
 		nonImportPaths:       make(map[string]struct{}),
 		pathToModuleIdentity: make(map[string]bufmoduleref.ModuleIdentity),
@@ -52,7 +57,7 @@ func newParserAccessorHandler(
 }
 
 func (p *parserAccessorHandler) Open(path string) (_ io.ReadCloser, retErr error) {
-	moduleFile, moduleErr := p.module.GetModuleFile(p.ctx, path)
+	moduleFile, moduleErr := p.moduleFileReader.GetModuleFile(p.ctx, path)
 	if moduleErr != nil {
 		if !storage.IsNotExist(moduleErr) {
 			return nil, moduleErr

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref_test.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref_test.go
@@ -156,9 +156,8 @@ func bucketWithBufLock(t *testing.T, pin ModulePin) storage.ReadWriteBucket {
 			},
 		},
 	}
-	bucket, err := storagemem.NewReadWriteBucketWithOptions()
-	require.NoError(t, err)
-	err = buflock.WriteConfig(context.Background(), bucket, bufLock)
+	bucket := storagemem.NewReadWriteBucket()
+	err := buflock.WriteConfig(context.Background(), bucket, bufLock)
 	require.NoError(t, err)
 	return bucket
 }

--- a/private/bufpkg/bufmodule/bufmoduletesting/test_module_reader.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/test_module_reader.go
@@ -1,0 +1,41 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufmoduletesting
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/pkg/storage"
+)
+
+type testModuleReader struct {
+	moduleIdentityStringToModule map[string]bufmodule.Module
+}
+
+func newTestModuleReader(moduleIdentityStringToModule map[string]bufmodule.Module) *testModuleReader {
+	return &testModuleReader{
+		moduleIdentityStringToModule: moduleIdentityStringToModule,
+	}
+}
+
+func (r *testModuleReader) GetModule(ctx context.Context, modulePin bufmoduleref.ModulePin) (bufmodule.Module, error) {
+	module, ok := r.moduleIdentityStringToModule[modulePin.IdentityString()]
+	if !ok {
+		return nil, storage.NewErrNotExist(modulePin.String())
+	}
+	return module, nil
+}

--- a/private/bufpkg/bufmodule/module_test.go
+++ b/private/bufpkg/bufmodule/module_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufmodule
+package bufmodule_test
 
 import (
 	"bytes"
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
 	"github.com/bufbuild/buf/private/pkg/manifest"
@@ -28,39 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func testNewModuleForBucket(
-	t *testing.T,
-	desc string,
-	files map[string][]byte,
-	isError bool,
-	isNil bool,
-	pins []bufmoduleref.ModulePin,
-	documentation string,
-	license string,
-) {
-	t.Run(desc, func(t *testing.T) {
-		t.Parallel()
-		ctx := context.Background()
-		bucket, err := storagemem.NewReadBucket(files)
-		require.NoError(t, err)
-		module, err := newModuleForBucket(ctx, bucket)
-		if isError {
-			assert.Error(t, err, "isError")
-			return
-		}
-		require.NoError(t, err)
-		if isNil {
-			assert.Nil(t, module, "isNil")
-			return
-		}
-		require.NotNil(t, module, "!isNil")
-
-		assert.Equal(t, pins, module.dependencyModulePins, "pins")
-		assert.Equal(t, documentation, module.documentation, "documentation")
-		assert.Equal(t, license, module.license, "license")
-	})
-}
 
 func TestNewModuleForBucket(t *testing.T) {
 	digester, err := manifest.NewDigester(manifest.DigestTypeShake256)
@@ -131,4 +99,37 @@ deps:
 		"",
 		"",
 	)
+}
+
+func testNewModuleForBucket(
+	t *testing.T,
+	desc string,
+	files map[string][]byte,
+	isError bool,
+	isNil bool,
+	pins []bufmoduleref.ModulePin,
+	documentation string,
+	license string,
+) {
+	t.Run(desc, func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		bucket, err := storagemem.NewReadBucket(files)
+		require.NoError(t, err)
+		module, err := bufmodule.NewModuleForBucket(ctx, bucket)
+		if isError {
+			assert.Error(t, err, "isError")
+			return
+		}
+		require.NoError(t, err)
+		if isNil {
+			assert.Nil(t, module, "isNil")
+			return
+		}
+		require.NotNil(t, module, "!isNil")
+
+		assert.Equal(t, pins, module.DependencyModulePins(), "pins")
+		assert.Equal(t, documentation, module.Documentation(), "documentation")
+		assert.Equal(t, license, module.License(), "license")
+	})
 }

--- a/private/bufpkg/bufwkt/cmd/wkt-go-data/main.go
+++ b/private/bufpkg/bufwkt/cmd/wkt-go-data/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagebuild"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimageutil"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
-	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmodulebuild"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
@@ -159,18 +158,12 @@ func getProtosourceFiles(
 	if err != nil {
 		return nil, err
 	}
-	moduleFileSet, err := bufmodulebuild.NewModuleFileSetBuilder(
+	image, fileAnnotations, err := bufimagebuild.NewBuilder(
 		container.Logger(),
 		bufmodule.NewNopModuleReader(),
 	).Build(
 		ctx,
 		module,
-	)
-	if err != nil {
-		return nil, err
-	}
-	image, fileAnnotations, err := bufimagebuild.NewBuilder(container.Logger()).Build(
-		ctx, moduleFileSet,
 		bufimagebuild.WithExcludeSourceCodeInfo(),
 	)
 	if err != nil {

--- a/private/pkg/storage/storagemem/storagemem.go
+++ b/private/pkg/storage/storagemem/storagemem.go
@@ -25,42 +25,15 @@ import (
 
 var errDuplicatePath = errors.New("duplicate path")
 
-type options struct {
-	pathToData map[string][]byte
-}
-
-// Option is provided by NewReadWriteBucketWithOptions options.
-type Option interface {
-	apply(*options)
-}
-
-type pathData map[string][]byte
-
-func (pd pathData) apply(opts *options) {
-	opts.pathToData = pd
-}
-
-// WithFiles adds files by path to their content into the bucket.
-func WithFiles(pathToData map[string][]byte) Option {
-	return (pathData)(pathToData)
-}
-
 // NewReadWriteBucket returns a new in-memory ReadWriteBucket.
-// Deprecated: Use NewReadWriteBucketWithOptions without any options.
 func NewReadWriteBucket() storage.ReadWriteBucket {
 	return newBucket(nil)
 }
 
-// NewReadWriteBucketWithOptions returns a new in-memory ReadWriteBucket.
-// Errors are returned with invalid options.
-func NewReadWriteBucketWithOptions(opts ...Option) (storage.ReadWriteBucket, error) {
-	opt := options{}
-	for _, o := range opts {
-		o.apply(&opt)
-	}
-
-	pathToImmutableObject := make(map[string]*internal.ImmutableObject, len(opt.pathToData))
-	for path, data := range opt.pathToData {
+// NewReadBucket returns a new ReadBucket.
+func NewReadBucket(pathToData map[string][]byte) (storage.ReadBucket, error) {
+	pathToImmutableObject := make(map[string]*internal.ImmutableObject, len(pathToData))
+	for path, data := range pathToData {
 		path, err := storageutil.ValidatePath(path)
 		if err != nil {
 			return nil, err
@@ -72,9 +45,4 @@ func NewReadWriteBucketWithOptions(opts ...Option) (storage.ReadWriteBucket, err
 		pathToImmutableObject[path] = internal.NewImmutableObject(path, "", data)
 	}
 	return newBucket(pathToImmutableObject), nil
-}
-
-// NewReadBucket returns a new ReadBucket.
-func NewReadBucket(pathToData map[string][]byte) (storage.ReadBucket, error) {
-	return NewReadWriteBucketWithOptions(WithFiles(pathToData))
 }


### PR DESCRIPTION
A very common operation we want to do throughout our codebases is go from a `Module` to an `Image`. However, you can't - the question would be, why not?

The answer is that we have an intermediate state, a `ModuleFileSet`, that "flattens" a `Module` from what amounts to a set of .proto files and a lock file, to a set of combined .proto files that represent both the module's .proto files and the dependencies' .proto files. This is what we pass to i.e. `protocompile`. Currently, to compile a `Module`, you first need to make a `ModuleFileSet`, and then pass the `ModuleFileSet` to the `bufimagebuild.Builder`.

This can make some kind of sense in the abstract, but in practice, 99.9% of our usage of `bufimagebuild.Image` is someone creating a `ModuleFileSetBuilder` right before, creating a `ModuleFileSet`, and then creating an `Image`. This is wasteful and confusing to those who don't fully understand the (convoluted) type system in `bufmodule` - you should be able to go right from a `Module` to an `Image`.

On top of this, confusingly, `ModuleFileSet` inherits from `Module`, which causes a host of issues. There are places in the code where one might be expecting a `Module`, but are instead passed a `ModuleFileSet`, which stealthily modifies the behavior of `GetModuleFile` such that files from both the sources and dependencies will  be returned. You could, in fact, also create a `ModuleFileSet` from a `ModuleFileSet`, recursive behavior that our code does not actually handle (and will result in a bug from duplicate files).

It's been a longstanding TODO in the codebase to eliminate `ModuleFileSet` altogether, and instead just use `Modules`, perhaps with a function on `Module` `AllFiles()` that returns what amounts to a `ModuleFileBucket`, a type that will be completely distinct from `Module`.

This PR does the first step of this: it changes `bufimagebuild.Builder` to take a `Module` instead of a `ModuleFileSet`, and then just inlines the (very) simple operation that `ModuleFileSet` does. To do this, `bufimagebuild.Builder` now takes a `ModuleReader` directly. In practice, in our codebase, this eliminates a lot of extra code to use a `ModuleFileSet`, and makes it easier for future developers to understand how to do from `Modules` to `Images`.

One thing that is a little more complicated with this is some unit testing we do around modules and their dependencies - often, you want to pass a manually-built `ModuleFileSet` to the `bufimagebuild.Builder`. To help with this, new functions have been added to `bufmoduletesting` with examples to provide functionality to build test lock files and test `ModuleReaders`.

One pain point is `buf export`, which actually needs both the equivalent of `ModuleFileSets`, and the ability to build an `Image`, but this is minor and can be dealt with when `ModuleFileSets` are actually eliminated. However, for now during this migration, `bufimagebuild.Builder` handles the case if a `Module` is actually a `ModuleFileSet`, and does not call the `ModuleFileSetBuilder` in this case.

A PR in core will be done in conjunction with this PR to handle the new behavior.

This PR also reverts the addition of `NewReadWriteBucketWithOptions` in `storagemem`, which isn't consistent with the rest of our codebase.