### PR TITLE
Change DeclaredDependencies functions to be prefixed with Expected and Declared

### DIFF
--- a/private/buf/bufwire/image_config_reader.go
+++ b/private/buf/bufwire/image_config_reader.go
@@ -152,7 +152,7 @@ func (i *imageConfigReader) getSourceOrModuleImageConfigs(
 			continue
 		}
 		buildOpts := []bufimagebuild.BuildOption{
-			bufimagebuild.WithDirectDependencies(moduleConfig.Module().DirectDependencies()),
+			bufimagebuild.WithExpectedDirectDependencies(moduleConfig.Module().DeclaredDirectDependencies()),
 			bufimagebuild.WithWorkspace(moduleConfig.Workspace()),
 		}
 		if excludeSourceCodeInfo {

--- a/private/bufpkg/bufimage/bufimagebuild/bufimagebuild.go
+++ b/private/bufpkg/bufimage/bufimagebuild/bufimagebuild.go
@@ -57,10 +57,12 @@ func WithExcludeSourceCodeInfo() BuildOption {
 	}
 }
 
-// WithDirectDependencies sets direct module dependencies, so transitive imports can be warned.
-func WithDirectDependencies(directDependencies []bufmoduleref.ModuleReference) BuildOption {
+// WithExpectedDirectDependencies sets the module dependencies that are expected, usually because
+// they are in a configuration file (buf.yaml). If the build detects that there are direct dependencies
+// outside of this list, a warning will be printed.
+func WithExpectedDirectDependencies(expectedDirectDependencies []bufmoduleref.ModuleReference) BuildOption {
 	return func(buildOptions *buildOptions) {
-		buildOptions.directDependencies = directDependencies
+		buildOptions.expectedDirectDependencies = expectedDirectDependencies
 	}
 }
 

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -99,14 +99,16 @@ type Module interface {
 	//
 	// Returns storage.IsNotExist error if the file does not exist.
 	GetModuleFile(ctx context.Context, path string) (ModuleFile, error)
-	// DirectDependencies returns the direct dependencies declared in the configuration file.
+	// DeclaredDirectDependencies returns the direct dependencies declared in the configuration file.
 	//
 	// The returned ModuleReferences are sorted by remote, owner, repository, and reference (if
 	// present). The returned ModulePins are unique by remote, owner, repository.
 	//
-	// This does not include any transitive dependencies, but it maps 1:1 to one of the dependencies
-	// from the DependencyModulePins.
-	DirectDependencies() []bufmoduleref.ModuleReference
+	// This does not include any transitive dependencies, but if the declarations are correct,
+	// this should be a subset of the dependencies from DependencyModulePins.
+	//
+	// TODO: validate that this is a subset? This may mess up construction.
+	DeclaredDirectDependencies() []bufmoduleref.ModuleReference
 	// DependencyModulePins gets the dependency ModulePins.
 	//
 	// The returned ModulePins are sorted by remote, owner, repository, branch, commit, and then digest.

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -32,18 +32,18 @@ import (
 )
 
 type module struct {
-	sourceReadBucket     storage.ReadBucket
-	directDependencies   []bufmoduleref.ModuleReference
-	dependencyModulePins []bufmoduleref.ModulePin
-	moduleIdentity       bufmoduleref.ModuleIdentity
-	commit               string
-	documentation        string
-	documentationPath    string
-	license              string
-	breakingConfig       *bufbreakingconfig.Config
-	lintConfig           *buflintconfig.Config
-	manifest             *manifest.Manifest
-	blobSet              *manifest.BlobSet
+	sourceReadBucket           storage.ReadBucket
+	declaredDirectDependencies []bufmoduleref.ModuleReference
+	dependencyModulePins       []bufmoduleref.ModulePin
+	moduleIdentity             bufmoduleref.ModuleIdentity
+	commit                     string
+	documentation              string
+	documentationPath          string
+	license                    string
+	breakingConfig             *bufbreakingconfig.Config
+	lintConfig                 *buflintconfig.Config
+	manifest                   *manifest.Manifest
+	blobSet                    *manifest.BlobSet
 }
 
 func newModuleForProto(
@@ -226,7 +226,7 @@ func newModule(
 	ctx context.Context,
 	// must only contain .proto files
 	sourceReadBucket storage.ReadBucket,
-	directDependencies []bufmoduleref.ModuleReference,
+	declaredDirectDependencies []bufmoduleref.ModuleReference,
 	dependencyModulePins []bufmoduleref.ModulePin,
 	moduleIdentity bufmoduleref.ModuleIdentity,
 	documentation string,
@@ -236,25 +236,25 @@ func newModule(
 	lintConfig *buflintconfig.Config,
 	options ...ModuleOption,
 ) (_ *module, retErr error) {
-	if err := bufmoduleref.ValidateModuleReferencesUniqueByIdentity(directDependencies); err != nil {
+	if err := bufmoduleref.ValidateModuleReferencesUniqueByIdentity(declaredDirectDependencies); err != nil {
 		return nil, err
 	}
 	if err := bufmoduleref.ValidateModulePinsUniqueByIdentity(dependencyModulePins); err != nil {
 		return nil, err
 	}
 	// we rely on this being sorted here
-	bufmoduleref.SortModuleReferences(directDependencies)
+	bufmoduleref.SortModuleReferences(declaredDirectDependencies)
 	bufmoduleref.SortModulePins(dependencyModulePins)
 	module := &module{
-		sourceReadBucket:     sourceReadBucket,
-		directDependencies:   directDependencies,
-		dependencyModulePins: dependencyModulePins,
-		moduleIdentity:       moduleIdentity,
-		documentation:        documentation,
-		documentationPath:    documentationPath,
-		license:              license,
-		breakingConfig:       breakingConfig,
-		lintConfig:           lintConfig,
+		sourceReadBucket:           sourceReadBucket,
+		declaredDirectDependencies: declaredDirectDependencies,
+		dependencyModulePins:       dependencyModulePins,
+		moduleIdentity:             moduleIdentity,
+		documentation:              documentation,
+		documentationPath:          documentationPath,
+		license:                    license,
+		breakingConfig:             breakingConfig,
+		lintConfig:                 lintConfig,
 	}
 	for _, option := range options {
 		option(module)
@@ -314,9 +314,9 @@ func (m *module) GetModuleFile(ctx context.Context, path string) (ModuleFile, er
 	return newModuleFile(fileInfo, readObjectCloser), nil
 }
 
-func (m *module) DirectDependencies() []bufmoduleref.ModuleReference {
+func (m *module) DeclaredDirectDependencies() []bufmoduleref.ModuleReference {
 	// already sorted in constructor
-	return m.directDependencies
+	return m.declaredDirectDependencies
 }
 
 func (m *module) DependencyModulePins() []bufmoduleref.ModulePin {


### PR DESCRIPTION
Pulled from https://github.com/bufbuild/buf/pull/2151

@unmultimedio was in favor of this https://github.com/bufbuild/buf/pull/2151#discussion_r1218221725 this naming says what is actually going on here. In neither case are we saying "these are the dependencies" or "use these dependencies", we're saying "these are the declared dependencies from buf.yaml" and "these are the dependencies we expect, warn otherwise".