### PR TITLE
Update interceptor to log server warnings on error

### DIFF
--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -17,6 +17,7 @@ package bufconnect
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/bufbuild/buf/private/pkg/app/applog"
@@ -60,7 +61,12 @@ func NewCLIWarningInterceptor(container applog.Container) connect.UnaryIntercept
 func logWarningFromHeader(container applog.Container, header http.Header) {
 	encoded := header.Get(CLIWarningHeaderName)
 	if encoded != "" {
-		if warning, err := connect.DecodeBinaryHeader(encoded); err == nil && len(warning) > 0 {
+		warning, err := connect.DecodeBinaryHeader(encoded)
+		if err != nil {
+			container.Logger().Debug(fmt.Errorf("failed to decode warning header: %w", err).Error())
+			return
+		}
+		if len(warning) > 0 {
 			container.Logger().Warn(string(warning))
 		}
 	}

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -44,7 +44,7 @@ func NewCLIWarningInterceptor(container applog.Container) connect.UnaryIntercept
 	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			resp, err := next(ctx, req)
-			if resp != nil && resp.Header() != nil {
+			if resp != nil {
 				logWarningFromHeader(container, resp.Header())
 			} else if err != nil {
 				if connectErr := new(connect.Error); errors.As(err, &connectErr) {

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -46,8 +46,7 @@ func NewCLIWarningInterceptor(container applog.Container) connect.UnaryIntercept
 			resp, err := next(ctx, req)
 			if resp != nil && resp.Header() != nil {
 				logWarningFromHeader(container, resp.Header())
-			}
-			if err != nil {
+			} else if err != nil {
 				if connectErr := new(connect.Error); errors.As(err, &connectErr) {
 					logWarningFromHeader(container, connectErr.Meta())
 				}


### PR DESCRIPTION
In https://github.com/bufbuild/buf/pull/2171 we added server warnings in the happy path (reading the warning message from the response header), this PR updates that implementation to also log server warnings from errors.