### PR TITLE
Expose ModuleIdentity and Commit functions on Module

### DIFF
--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -259,6 +259,9 @@ func newModule(
 	for _, option := range options {
 		option(module)
 	}
+	if module.moduleIdentity == nil && module.commit != "" {
+		return nil, fmt.Errorf("module was constructed with commit %q but no associated ModuleIdentity", module.commit)
+	}
 	return module, nil
 }
 
@@ -352,16 +355,16 @@ func (m *module) BlobSet() *manifest.BlobSet {
 	return m.blobSet
 }
 
-func (m *module) getModuleIdentity() bufmoduleref.ModuleIdentity {
+func (m *module) ModuleIdentity() bufmoduleref.ModuleIdentity {
 	return m.moduleIdentity
+}
+
+func (m *module) Commit() string {
+	return m.commit
 }
 
 func (m *module) getSourceReadBucket() storage.ReadBucket {
 	return m.sourceReadBucket
-}
-
-func (m *module) getCommit() string {
-	return m.commit
 }
 
 func (m *module) isModule() {}

--- a/private/bufpkg/bufmodule/module_file_set.go
+++ b/private/bufpkg/bufmodule/module_file_set.go
@@ -43,8 +43,8 @@ func newModuleFileSet(
 	moduleReadBuckets := []moduleReadBucket{
 		newSingleModuleReadBucket(
 			module.getSourceReadBucket(),
-			module.getModuleIdentity(),
-			module.getCommit(),
+			module.ModuleIdentity(),
+			module.Commit(),
 		),
 	}
 	for _, dependency := range dependencies {
@@ -52,8 +52,8 @@ func newModuleFileSet(
 			moduleReadBuckets,
 			newSingleModuleReadBucket(
 				dependency.getSourceReadBucket(),
-				dependency.getModuleIdentity(),
-				dependency.getCommit(),
+				dependency.ModuleIdentity(),
+				dependency.Commit(),
 			),
 		)
 	}

--- a/private/bufpkg/bufmodule/targeting_module.go
+++ b/private/bufpkg/bufmodule/targeting_module.go
@@ -104,8 +104,8 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufm
 							objectInfo.Path(),
 							objectInfo.ExternalPath(),
 							false,
-							m.Module.getModuleIdentity(),
-							m.Module.getCommit(),
+							m.Module.ModuleIdentity(),
+							m.Module.Commit(),
 						)
 						if err != nil {
 							return nil, err
@@ -196,8 +196,8 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufm
 					objectInfo.Path(),
 					objectInfo.ExternalPath(),
 					false,
-					m.Module.getModuleIdentity(),
-					m.Module.getCommit(),
+					m.Module.ModuleIdentity(),
+					m.Module.Commit(),
 				)
 				if err != nil {
 					return err


### PR DESCRIPTION
In service of https://github.com/bufbuild/buf/pull/2151. This exposes these two previously-private functions. In our code, wherever we build Modules, we end up providing these values, and they are very useful to have on a `bufmodule.Module` if you need them.