### PR TITLE
Add module identity to external path

### DIFF
--- a/private/bufpkg/bufmodule/module_object_info.go
+++ b/private/bufpkg/bufmodule/module_object_info.go
@@ -15,6 +15,8 @@
 package bufmodule
 
 import (
+	"fmt"
+
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
@@ -45,4 +47,11 @@ func (o *moduleObjectInfo) ModuleIdentity() bufmoduleref.ModuleIdentity {
 
 func (o *moduleObjectInfo) Commit() string {
 	return o.commit
+}
+
+func (o *moduleObjectInfo) ExternalPath() string {
+	if o.moduleIdentity != nil {
+		return fmt.Sprintf("%s/%s", o.moduleIdentity, o.ObjectInfo.ExternalPath())
+	}
+	return o.ObjectInfo.ExternalPath()
 }

--- a/private/bufpkg/bufmodule/single_module_read_bucket.go
+++ b/private/bufpkg/bufmodule/single_module_read_bucket.go
@@ -40,6 +40,10 @@ func newSingleModuleReadBucket(
 	}
 }
 
+func (r *singleModuleReadBucket) Stat(ctx context.Context, path string) (storage.ObjectInfo, error) {
+	return r.StatModuleFile(ctx, path)
+}
+
 func (r *singleModuleReadBucket) StatModuleFile(ctx context.Context, path string) (*moduleObjectInfo, error) {
 	objectInfo, err := r.ReadBucket.Stat(ctx, path)
 	if err != nil {


### PR DESCRIPTION
The `ExternalPath` of an `ObjectInfo` "is not necessarily a file path, and should only be used to uniquely identify this file as compared to other assets, for display to users." ([doc](https://github.com/bufbuild/buf/blob/dac9471b15301ea7d7ddaafd95250244fa26d104/private/pkg/storage/bucket.go#L171-L173)) - Currently when a compile error happens due to duplicate file paths the context of which modules those files come from is not provided.
```
{
    "path": "b.proto",
    "start_line": 5,
    "start_column": 8,
    "end_line": 5,
    "end_column": 8,
    "type": "COMPILE",
    "message": "google/type/datetime.proto exists in multiple locations: google/type/datetime.proto google/type/datetime.proto"
}
```

This change adds the module identity to the external path to make it clearer for users that are experiencing the `errorExistsMultipleLocations` compile error:
```json
{
    "path": "b.proto",
    "start_line": 5,
    "start_column": 8,
    "end_line": 5,
    "end_column": 8,
    "type": "COMPILE",
    "message": "google/type/datetime.proto exists in multiple locations: bufbuild.internal/googleapis/googleapis:3a85c4762b07439aa574260257696aea/google/type/datetime.proto bufbuild.internal/rhenderson/googleapis:cc0a1eae8c714a5e9b590b84315ed810/google/type/datetime.proto"
}
```

I'm cautious to merge this change as `ExternalPath` appears to be used in some contexts where it is definitely expected to be a file path: https://github.com/bufbuild/buf/blob/4d59b5eacf91c675e4231c15fdf4a550a62452bf/private/buf/cmd/buf/command/format/format.go#L526