### PR TITLE
Change ModuleConfigReader to return an interface with a single Workspace

### DIFF
--- a/private/buf/bufwire/bufwire.go
+++ b/private/buf/bufwire/bufwire.go
@@ -75,22 +75,28 @@ func NewImageConfigReader(
 	)
 }
 
-// ModuleConfig is an module and configuration.
+// ModuleConfig is a Module and configuration.
 type ModuleConfig interface {
 	Module() bufmodule.Module
 	Config() *bufconfig.Config
+}
+
+// ModuleConfigSet is a set of ModuleConfigs with a potentially associated Workspace.
+type ModuleConfigSet interface {
+	ModuleConfigs() []ModuleConfig
+	// Optional. May be nil.
 	Workspace() bufmodule.Workspace
 }
 
 // ModuleConfigReader is a ModuleConfig reader.
 type ModuleConfigReader interface {
-	// GetModuleConfigs gets the ModuleConfig for the fetch value.
+	// GetModuleConfigSet gets the ModuleConfigSet for the fetch value.
 	//
 	// If externalDirOrFilePaths is empty, this builds all files under Buf control.
 	//
-	// Note that as opposed to ModuleReader, this will return a Module for either
+	// Note that as opposed to ModuleReader, this will return Modules for either
 	// a source or module reference, not just a module reference.
-	GetModuleConfigs(
+	GetModuleConfigSet(
 		ctx context.Context,
 		container app.EnvStdinContainer,
 		sourceOrModuleRef buffetch.SourceOrModuleRef,
@@ -98,7 +104,7 @@ type ModuleConfigReader interface {
 		externalDirOrFilePaths []string,
 		externalExcludeDirOrFilePaths []string,
 		externalDirOrFilePathsAllowNotExist bool,
-	) ([]ModuleConfig, error)
+	) (ModuleConfigSet, error)
 }
 
 // NewModuleConfigReader returns a new ModuleConfigReader

--- a/private/buf/bufwire/image_config_reader.go
+++ b/private/buf/bufwire/image_config_reader.go
@@ -127,7 +127,7 @@ func (i *imageConfigReader) getSourceOrModuleImageConfigs(
 	externalDirOrFilePathsAllowNotExist bool,
 	excludeSourceCodeInfo bool,
 ) ([]ImageConfig, []bufanalysis.FileAnnotation, error) {
-	moduleConfigs, err := i.moduleConfigReader.GetModuleConfigs(
+	moduleConfigSet, err := i.moduleConfigReader.GetModuleConfigSet(
 		ctx,
 		container,
 		sourceOrModuleRef,
@@ -139,6 +139,7 @@ func (i *imageConfigReader) getSourceOrModuleImageConfigs(
 	if err != nil {
 		return nil, nil, err
 	}
+	moduleConfigs := moduleConfigSet.ModuleConfigs()
 	imageConfigs := make([]ImageConfig, 0, len(moduleConfigs))
 	var allFileAnnotations []bufanalysis.FileAnnotation
 	for _, moduleConfig := range moduleConfigs {
@@ -153,7 +154,7 @@ func (i *imageConfigReader) getSourceOrModuleImageConfigs(
 		}
 		buildOpts := []bufimagebuild.BuildOption{
 			bufimagebuild.WithExpectedDirectDependencies(moduleConfig.Module().DeclaredDirectDependencies()),
-			bufimagebuild.WithWorkspace(moduleConfig.Workspace()),
+			bufimagebuild.WithWorkspace(moduleConfigSet.Workspace()),
 		}
 		if excludeSourceCodeInfo {
 			buildOpts = append(buildOpts, bufimagebuild.WithExcludeSourceCodeInfo())

--- a/private/buf/bufwire/module_config_set.go
+++ b/private/buf/bufwire/module_config_set.go
@@ -15,26 +15,25 @@
 package bufwire
 
 import (
-	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 )
 
-type moduleConfig struct {
-	module bufmodule.Module
-	config *bufconfig.Config
+type moduleConfigSet struct {
+	moduleConfigs []ModuleConfig
+	workspace     bufmodule.Workspace
 }
 
-func newModuleConfig(module bufmodule.Module, config *bufconfig.Config) *moduleConfig {
-	return &moduleConfig{
-		module: module,
-		config: config,
+func newModuleConfigSet(moduleConfigs []ModuleConfig, workspace bufmodule.Workspace) *moduleConfigSet {
+	return &moduleConfigSet{
+		moduleConfigs: moduleConfigs,
+		workspace:     workspace,
 	}
 }
 
-func (m *moduleConfig) Module() bufmodule.Module {
-	return m.module
+func (m *moduleConfigSet) ModuleConfigs() []ModuleConfig {
+	return m.moduleConfigs
 }
 
-func (m *moduleConfig) Config() *bufconfig.Config {
-	return m.config
+func (m *moduleConfigSet) Workspace() bufmodule.Workspace {
+	return m.workspace
 }

--- a/private/buf/bufwork/bufwork.go
+++ b/private/buf/bufwork/bufwork.go
@@ -101,6 +101,12 @@ type WorkspaceBuilder interface {
 	// BuildWorkspace builds a bufmodule.Workspace.
 	//
 	// The given targetSubDirPath is the only path that will have the configOverride applied to it.
+	// TODO: delete targetSubDirPath entirely. We are building a Workspace, we don't necessarily
+	// have a specific target directory within it. This would mean doing the config override at
+	// a higher level for any specific modules within the Workspace. The only thing in the config
+	// we care about is the build.excludes, so in theory we should be able to figure out a way
+	// to say "exclude these files from these modules when you are building". Even better, the
+	// WorkspaceBuilder has nothing to do with building modules.
 	BuildWorkspace(
 		ctx context.Context,
 		workspaceConfig *Config,

--- a/private/buf/cmd/buf/command/beta/price/price.go
+++ b/private/buf/cmd/buf/command/beta/price/price.go
@@ -145,7 +145,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	moduleConfigs, err := moduleConfigReader.GetModuleConfigs(
+	moduleConfigSet, err := moduleConfigReader.GetModuleConfigSet(
 		ctx,
 		container,
 		sourceOrModuleRef,
@@ -157,6 +157,7 @@ func run(
 	if err != nil {
 		return err
 	}
+	moduleConfigs := moduleConfigSet.ModuleConfigs()
 	statsSlice := make([]*protostat.Stats, len(moduleConfigs))
 	for i, moduleConfig := range moduleConfigs {
 		stats, err := protostat.GetStats(ctx, bufmodulestat.NewFileWalker(moduleConfig.Module()))

--- a/private/buf/cmd/buf/command/beta/stats/stats.go
+++ b/private/buf/cmd/buf/command/beta/stats/stats.go
@@ -116,7 +116,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	moduleConfigs, err := moduleConfigReader.GetModuleConfigs(
+	moduleConfigSet, err := moduleConfigReader.GetModuleConfigSet(
 		ctx,
 		container,
 		sourceOrModuleRef,
@@ -128,6 +128,7 @@ func run(
 	if err != nil {
 		return err
 	}
+	moduleConfigs := moduleConfigSet.ModuleConfigs()
 	statsSlice := make([]*protostat.Stats, len(moduleConfigs))
 	for i, moduleConfig := range moduleConfigs {
 		stats, err := protostat.GetStats(ctx, bufmodulestat.NewFileWalker(moduleConfig.Module()))

--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -162,7 +162,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	moduleConfigs, err := moduleConfigReader.GetModuleConfigs(
+	moduleConfigSet, err := moduleConfigReader.GetModuleConfigSet(
 		ctx,
 		container,
 		sourceOrModuleRef,
@@ -174,6 +174,7 @@ func run(
 	if err != nil {
 		return err
 	}
+	moduleConfigs := moduleConfigSet.ModuleConfigs()
 	moduleFileSetBuilder := bufmodulebuild.NewModuleFileSetBuilder(
 		container.Logger(),
 		moduleReader,
@@ -184,7 +185,7 @@ func run(
 		moduleFileSet, err := moduleFileSetBuilder.Build(
 			ctx,
 			moduleConfig.Module(),
-			bufmodulebuild.WithWorkspace(moduleConfig.Workspace()),
+			bufmodulebuild.WithWorkspace(moduleConfigSet.Workspace()),
 		)
 		if err != nil {
 			return err

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -80,16 +80,16 @@ Most people will want to rewrite the files defined in the current directory in-p
 
 Display a diff between the original and formatted content with -d
 Write a diff instead of the formatted file:
-    
+
     $ buf format simple/simple.proto -d
-    
+
     $ diff -u simple/simple.proto.orig simple/simple.proto
     --- simple/simple.proto.orig	2022-03-24 09:44:10.000000000 -0700
     +++ simple/simple.proto	2022-03-24 09:44:10.000000000 -0700
     @@ -2,8 +2,7 @@
-    
+
      package simple;
-    
+
     -
      message Object {
     -    string key = 1;
@@ -106,13 +106,13 @@ Use the --exit-code flag to exit with a non-zero exit code if there is a diff:
 
 Format a file, directory, or module reference by specifying a source e.g.
 Write the formatted file to stdout:
-    
+
     $ buf format simple/simple.proto
-    
+
     syntax = "proto3";
-    
+
     package simple;
-    
+
     message Object {
       string key = 1;
       bytes value = 2;
@@ -285,7 +285,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	moduleConfigs, err := moduleConfigReader.GetModuleConfigs(
+	moduleConfigSet, err := moduleConfigReader.GetModuleConfigSet(
 		ctx,
 		container,
 		sourceOrModuleRef,
@@ -297,6 +297,7 @@ func run(
 	if err != nil {
 		return err
 	}
+	moduleConfigs := moduleConfigSet.ModuleConfigs()
 	var outputDirectory string
 	var singleFileOutputFilename string
 	if flags.Output != "-" {


### PR DESCRIPTION
This changes `ModuleConfigReader` to return the new `ModuleConfigSet` interface, which has a `Workspace` function, and deletes `ModuleConfig.Workspace()`. This has the effect of returning 0 or 1 workspaces for the `ModuleConfigs` returned from the `ModuleConfigReader`.

There is no valid case where you can have an input to `ModuleConfigReader` that results in multiple logical workspaces, and this is by design - if you are building a set of `Modules`, this is because they came from a (single) workspace.

During this change, I believe a bug is fixed for where `--config` overrides were being applied to all `Modules` within a `Workspace`, even though the config override was only meant to apply to a single `Module`.

There's tons of cleanup work to do after this, and understanding we need to build for the `Workspace` code. I've added some comments to some key functions as I went through to help better understand what they do in the future.

@doriable, I manually QA'ed this extensively, with various inputs, and values for `--path, --exclude-path, --config`, and I wasn't able to break it. That, combined with the relatively-extensive testing we have for workspaces, gives me some level of confidence that this isn't making the situation worse. However, as with any edits we do to in the workspace code, this is still a relatively high-risk change.