### PR TITLE
Delete bufmodulebuild.BuildForBucket

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -812,7 +812,8 @@ func WellKnownTypeImage(ctx context.Context, logger *zap.Logger, wellKnownType s
 	if err != nil {
 		return nil, err
 	}
-	module, err := bufmodulebuild.BuildForBucket(
+
+	module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		datawkt.ReadBucket,
 		sourceConfig.Build,

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -213,7 +213,7 @@ func (s *syncer) visitCommit(
 		)
 		return nil
 	}
-	builtModule, err := bufmodulebuild.BuildForBucket(
+	builtModule, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		sourceBucket,
 		sourceConfig.Build,

--- a/private/buf/bufwire/file_lister.go
+++ b/private/buf/bufwire/file_lister.go
@@ -256,7 +256,7 @@ func (e *fileLister) sourceFileInfosForDirectory(
 	if err != nil {
 		return nil, err
 	}
-	module, err := bufmodulebuild.BuildForBucket(
+	module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		mappedReadBucket,
 		config.Build,

--- a/private/buf/bufwire/module_config_reader.go
+++ b/private/buf/bufwire/module_config_reader.go
@@ -618,7 +618,7 @@ func (m *moduleConfigReader) getSourceModuleConfig(
 		}
 		buildOptions = append(buildOptions, bufmodulebuild.WithExcludePaths(bucketRelPaths))
 	}
-	module, err := bufmodulebuild.BuildForBucket(
+	module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		mappedReadBucket,
 		moduleConfig.Build,

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -136,7 +136,7 @@ func (w *workspaceBuilder) BuildWorkspace(
 		if err != nil {
 			return nil, err
 		}
-		module, err := bufmodulebuild.BuildForBucket(
+		module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 			ctx,
 			readBucketForDirectory,
 			moduleConfig.Build,

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -181,7 +181,7 @@ func run(
 		return err
 	}
 	moduleIdentity := sourceConfig.ModuleIdentity
-	builtModule, err := bufmodulebuild.BuildForBucket(
+	builtModule, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		sourceBucket,
 		sourceConfig.Build,

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -737,7 +737,7 @@ func testBreaking(
 	previousConfig := testGetConfig(t, previousReadWriteBucket)
 	config := testGetConfig(t, readWriteBucket)
 
-	previousModule, err := bufmodulebuild.BuildForBucket(
+	previousModule, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		previousReadWriteBucket,
 		previousConfig.Build,
@@ -755,7 +755,7 @@ func testBreaking(
 	require.Empty(t, previousFileAnnotations)
 	previousImage = bufimage.ImageWithoutImports(previousImage)
 
-	module, err := bufmodulebuild.BuildForBucket(
+	module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config.Build,

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -925,7 +925,7 @@ func testLintConfigModifier(
 		configModifier(config)
 	}
 
-	module, err := bufmodulebuild.BuildForBucket(
+	module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config.Build,

--- a/private/bufpkg/bufimage/bufimagebuild/bufimagebuildtesting/bufimagebuildtesting.go
+++ b/private/bufpkg/bufimage/bufimagebuild/bufimagebuildtesting/bufimagebuildtesting.go
@@ -115,7 +115,7 @@ func fuzzGetModule(ctx context.Context, dirPath string) (bufmodule.Module, error
 	if err != nil {
 		return nil, err
 	}
-	return bufmodulebuild.BuildForBucket(
+	return bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		readWriteBucket,
 		config,

--- a/private/bufpkg/bufimage/bufimagebuild/builder_test.go
+++ b/private/bufpkg/bufimage/bufimagebuild/builder_test.go
@@ -356,7 +356,7 @@ func testGetModule(t *testing.T, dirPath string) bufmodule.Module {
 	require.NoError(t, err)
 	config, err := bufmoduleconfig.NewConfigV1(bufmoduleconfig.ExternalConfigV1{})
 	require.NoError(t, err)
-	module, err := bufmodulebuild.BuildForBucket(
+	module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
@@ -353,7 +353,7 @@ lint:
 		bufmoduleconfig.ExternalConfigV1{},
 	)
 	require.NoError(t, err)
-	module, err := BuildForBucket(
+	module, err := NewModuleBucketBuilder().BuildForBucket(
 		ctx,
 		bucket,
 		config,
@@ -406,7 +406,7 @@ func testBucketGetFileInfos(
 		storageos.ReadWriteBucketWithSymlinksIfSupported(),
 	)
 	require.NoError(t, err)
-	module, err := BuildForBucket(
+	module, err := NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -429,7 +429,7 @@ func testBucketGetFileInfos(
 			require.NoError(t, err)
 			bucketRelPaths[i] = bucketRelPath
 		}
-		module, err := BuildForBucket(
+		module, err := NewModuleBucketBuilder().BuildForBucket(
 			context.Background(),
 			readWriteBucket,
 			config,
@@ -458,7 +458,7 @@ func testBucketGetAllFileInfosError(
 		storageos.ReadWriteBucketWithSymlinksIfSupported(),
 	)
 	require.NoError(t, err)
-	module, err := BuildForBucket(
+	module, err := NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -492,7 +492,7 @@ func testBucketGetFileInfosForExternalPathsError(
 		require.NoError(t, err)
 		bucketRelPaths[i] = bucketRelPath
 	}
-	_, err = BuildForBucket(
+	_, err = NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -517,7 +517,7 @@ func testDocumentationBucket(
 		bufmoduleconfig.ExternalConfigV1{},
 	)
 	require.NoError(t, err)
-	module, err := BuildForBucket(
+	module, err := NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,
@@ -551,7 +551,7 @@ func testLicenseBucket(
 		bufmoduleconfig.ExternalConfigV1{},
 	)
 	require.NoError(t, err)
-	module, err := BuildForBucket(
+	module, err := NewModuleBucketBuilder().BuildForBucket(
 		context.Background(),
 		readWriteBucket,
 		config,


### PR DESCRIPTION
This function should never have existed - it doesn't fit in with the pattern of the rest of the codebase, it should have been in `bufmodulebuild.go`, `BuildOptions` should not be passed to its constructor, etc. This has been a longstanding thorn, and this just cleans it up.