### PR TITLE
Support .binproto/.textproto files in convert

### DIFF
--- a/private/buf/bufconvert/bufconvert.go
+++ b/private/buf/bufconvert/bufconvert.go
@@ -30,10 +30,16 @@ import (
 const (
 	// MessageEncodingBin is the binary image encoding.
 	MessageEncodingBin MessageEncoding = iota + 1
+	// MessageEncodingText is the text image encoding.
+	MessageEncodingText
 	// MessageEncodingJSON is the JSON image encoding.
 	MessageEncodingJSON
 	// formatBin is the binary format.
 	formatBin = "bin"
+	// formatBinProto is also used for binary proto format.
+	formatBinProto = "binproto"
+	// formatText is the proto text format.
+	formatTextProto = "textproto"
 	// formatJSON is the JSON format.
 	formatJSON = "json"
 )
@@ -46,6 +52,8 @@ var (
 	// sorted
 	messageEncodingFormats = []string{
 		formatBin,
+		formatBinProto,
+		formatTextProto,
 		formatJSON,
 	}
 )
@@ -105,8 +113,10 @@ func getPathAndMessageEncoding(
 
 func parseMessageEncodingExt(ext string, defaultEncoding MessageEncoding) MessageEncoding {
 	switch strings.TrimPrefix(ext, ".") {
-	case formatBin:
+	case formatBin, formatBinProto:
 		return MessageEncodingBin
+	case formatTextProto:
+		return MessageEncodingText
 	case formatJSON:
 		return MessageEncodingJSON
 	default:
@@ -116,8 +126,10 @@ func parseMessageEncodingExt(ext string, defaultEncoding MessageEncoding) Messag
 
 func parseMessageEncodingFormat(format string) (MessageEncoding, error) {
 	switch format {
-	case formatBin:
+	case formatBin, formatBinProto:
 		return MessageEncodingBin, nil
+	case formatTextProto:
+		return MessageEncodingText, nil
 	case formatJSON:
 		return MessageEncodingJSON, nil
 	default:

--- a/private/buf/bufconvert/bufconvert.go
+++ b/private/buf/bufconvert/bufconvert.go
@@ -38,7 +38,7 @@ const (
 	formatBin = "bin"
 	// formatBinProto is also used for binary proto format.
 	formatBinProto = "binproto"
-	// formatText is the proto text format.
+	// formatTextProto is the proto text format.
 	formatTextProto = "textproto"
 	// formatJSON is the JSON format.
 	formatJSON = "json"

--- a/private/buf/bufwire/bufwire.go
+++ b/private/buf/bufwire/bufwire.go
@@ -242,6 +242,7 @@ type ProtoEncodingWriter interface {
 		image bufimage.Image,
 		message proto.Message,
 		messageRef bufconvert.MessageEncodingRef,
+		indent bool,
 	) error
 }
 

--- a/private/buf/bufwire/proto_encoding_reader.go
+++ b/private/buf/bufwire/proto_encoding_reader.go
@@ -75,6 +75,8 @@ func (p *protoEncodingReader) GetMessage(
 	switch messageRef.MessageEncoding() {
 	case bufconvert.MessageEncodingBin:
 		unmarshaler = protoencoding.NewWireUnmarshaler(resolver)
+	case bufconvert.MessageEncodingText:
+		unmarshaler = protoencoding.NewTextUnmarshaler(resolver)
 	case bufconvert.MessageEncodingJSON:
 		unmarshaler = protoencoding.NewJSONUnmarshaler(resolver)
 	default:

--- a/private/buf/bufwire/proto_encoding_writer.go
+++ b/private/buf/bufwire/proto_encoding_writer.go
@@ -49,6 +49,7 @@ func (p *protoEncodingWriter) PutMessage(
 	image bufimage.Image,
 	message proto.Message,
 	messageRef bufconvert.MessageEncodingRef,
+	indent bool,
 ) (retErr error) {
 	// Currently, this support bin and JSON format.
 	resolver, err := protoencoding.NewResolver(
@@ -64,10 +65,17 @@ func (p *protoEncodingWriter) PutMessage(
 	case bufconvert.MessageEncodingBin:
 		marshaler = protoencoding.NewWireMarshaler()
 	case bufconvert.MessageEncodingText:
-		// TODO: Make indent configurable.
-		marshaler = protoencoding.NewTextMarshaler(resolver, protoencoding.TextMarshalerWithIndent())
+		if indent {
+			marshaler = protoencoding.NewTextMarshaler(resolver, protoencoding.TextMarshalerWithIndent())
+		} else {
+			marshaler = protoencoding.NewTextMarshaler(resolver)
+		}
 	case bufconvert.MessageEncodingJSON:
-		marshaler = protoencoding.NewJSONMarshaler(resolver)
+		if indent {
+			marshaler = protoencoding.NewJSONMarshaler(resolver, protoencoding.JSONMarshalerWithIndent())
+		} else {
+			marshaler = protoencoding.NewJSONMarshaler(resolver)
+		}
 	default:
 		return errors.New("unknown message encoding type")
 	}

--- a/private/buf/bufwire/proto_encoding_writer.go
+++ b/private/buf/bufwire/proto_encoding_writer.go
@@ -63,6 +63,9 @@ func (p *protoEncodingWriter) PutMessage(
 	switch messageRef.MessageEncoding() {
 	case bufconvert.MessageEncodingBin:
 		marshaler = protoencoding.NewWireMarshaler()
+	case bufconvert.MessageEncodingText:
+		// TODO: Make indent configurable.
+		marshaler = protoencoding.NewTextMarshaler(resolver, protoencoding.TextMarshalerWithIndent())
 	case bufconvert.MessageEncodingJSON:
 		marshaler = protoencoding.NewJSONMarshaler(resolver)
 	default:

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -36,6 +36,7 @@ const (
 	typeFlagName        = "type"
 	fromFlagName        = "from"
 	outputFlagName      = "to"
+	indentFlagName      = "indent"
 )
 
 // NewCommand returns a new Command.
@@ -94,6 +95,7 @@ type flags struct {
 	Type        string
 	From        string
 	To          string
+	Indent      bool
 
 	// special
 	InputHashtag string
@@ -137,6 +139,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			`The output location of the conversion. Supported formats are %s`,
 			bufconvert.MessageEncodingFormatsString,
 		),
+	)
+	flagSet.BoolVar(
+		&f.Indent,
+		indentFlagName,
+		false,
+		`If set, the output will be indented, if the format supports it.`,
 	)
 }
 
@@ -221,6 +229,7 @@ func run(
 		image,
 		message,
 		outputMessageRef,
+		flags.Indent,
 	)
 }
 

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -205,7 +205,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	defaultToEncoding, err := inverseEncoding(fromMessageRef.MessageEncoding())
+	defaultToEncoding, err := getDefaultEncoding(fromMessageRef.MessageEncoding())
 	if err != nil {
 		return err
 	}
@@ -226,10 +226,12 @@ func run(
 
 // inverseEncoding returns the opposite encoding of the provided encoding,
 // which will be the default output encoding for a given payload encoding.
-func inverseEncoding(encoding bufconvert.MessageEncoding) (bufconvert.MessageEncoding, error) {
+func getDefaultEncoding(encoding bufconvert.MessageEncoding) (bufconvert.MessageEncoding, error) {
 	switch encoding {
 	case bufconvert.MessageEncodingBin:
 		return bufconvert.MessageEncodingJSON, nil
+	case bufconvert.MessageEncodingText:
+		return bufconvert.MessageEncodingBin, nil
 	case bufconvert.MessageEncodingJSON:
 		return bufconvert.MessageEncodingBin, nil
 	default:

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -47,7 +47,7 @@ func NewCommand(
 	flags := newFlags()
 	return &appcmd.Command{
 		Use:   name + " <input>",
-		Short: "Convert a message from binary to JSON or vice versa",
+		Short: "Convert a message between binary, text, and JSON",
 		Long: `
 Use an input proto to interpret a proto/json message and convert it to a different format.
 

--- a/private/buf/cmd/buf/command/convert/convert_test.go
+++ b/private/buf/cmd/buf/command/convert/convert_test.go
@@ -59,7 +59,7 @@ func TestConvertDir(t *testing.T) {
 			t,
 			cmd,
 			0,
-			`one: 55`,
+			`one:  55`,
 			nil,
 			nil,
 			"--type",

--- a/private/buf/cmd/buf/command/convert/convert_test.go
+++ b/private/buf/cmd/buf/command/convert/convert_test.go
@@ -59,7 +59,7 @@ func TestConvertDir(t *testing.T) {
 			t,
 			cmd,
 			0,
-			`one:  55`,
+			`one:55`,
 			nil,
 			nil,
 			"--type",
@@ -68,7 +68,6 @@ func TestConvertDir(t *testing.T) {
 			"testdata/convert/bin_json/payload.bin",
 			"--to",
 			"-#format=textproto",
-			"--indent",
 		)
 	})
 	t.Run("from-stdin", func(t *testing.T) {

--- a/private/buf/cmd/buf/command/convert/convert_test.go
+++ b/private/buf/cmd/buf/command/convert/convert_test.go
@@ -68,6 +68,7 @@ func TestConvertDir(t *testing.T) {
 			"testdata/convert/bin_json/payload.bin",
 			"--to",
 			"-#format=textproto",
+			"--indent",
 		)
 	})
 	t.Run("from-stdin", func(t *testing.T) {

--- a/private/buf/cmd/buf/command/convert/convert_test.go
+++ b/private/buf/cmd/buf/command/convert/convert_test.go
@@ -40,6 +40,36 @@ func TestConvertDir(t *testing.T) {
 			"testdata/convert/bin_json/payload.bin",
 		)
 	})
+	t.Run("binproto-input", func(t *testing.T) {
+		appcmdtesting.RunCommandExitCodeStdout(
+			t,
+			cmd,
+			0,
+			`{"one":"55"}`,
+			nil,
+			nil,
+			"--type",
+			"buf.Foo",
+			"--from",
+			"testdata/convert/bin_json/payload.bin#format=binproto",
+		)
+	})
+	t.Run("textproto-out", func(t *testing.T) {
+		appcmdtesting.RunCommandExitCodeStdout(
+			t,
+			cmd,
+			0,
+			`one: 55`,
+			nil,
+			nil,
+			"--type",
+			"buf.Foo",
+			"--from",
+			"testdata/convert/bin_json/payload.bin",
+			"--to",
+			"-#format=textproto",
+		)
+	})
 	t.Run("from-stdin", func(t *testing.T) {
 		appcmdtesting.RunCommandExitCodeStdoutStdinFile(
 			t,

--- a/private/pkg/protoencoding/protoencoding.go
+++ b/private/pkg/protoencoding/protoencoding.go
@@ -76,7 +76,6 @@ type TextMarshalerOption func(*textMarshaler)
 // TextMarshalerWithIndent says to use an indent of two spaces.
 func TextMarshalerWithIndent() TextMarshalerOption {
 	return func(textMarshaler *textMarshaler) {
-		textMarshaler.indent = "  "
 		textMarshaler.multiline = true
 	}
 }

--- a/private/pkg/protoencoding/protoencoding.go
+++ b/private/pkg/protoencoding/protoencoding.go
@@ -77,6 +77,7 @@ type TextMarshalerOption func(*textMarshaler)
 func TextMarshalerWithIndent() TextMarshalerOption {
 	return func(textMarshaler *textMarshaler) {
 		textMarshaler.multiline = true
+		textMarshaler.indent = "  "
 	}
 }
 

--- a/private/pkg/protoencoding/protoencoding.go
+++ b/private/pkg/protoencoding/protoencoding.go
@@ -67,6 +67,24 @@ func NewWireMarshaler() Marshaler {
 //
 // This has the potential to be unstable over time.
 // resolver can be nil if unknown and are only needed for extensions.
+func NewTextMarshaler(resolver Resolver, options ...TextMarshalerOption) Marshaler {
+	return newTextMarshaler(resolver, options...)
+}
+
+type TextMarshalerOption func(*textMarshaler)
+
+// TextMarshalerWithIndent says to use an indent of two spaces.
+func TextMarshalerWithIndent() TextMarshalerOption {
+	return func(textMarshaler *textMarshaler) {
+		textMarshaler.indent = "  "
+		textMarshaler.multiline = true
+	}
+}
+
+// NewJSONMarshaler returns a new Marshaler for JSON.
+//
+// This has the potential to be unstable over time.
+// resolver can be nil if unknown and are only needed for extensions.
 func NewJSONMarshaler(resolver Resolver, options ...JSONMarshalerOption) Marshaler {
 	return newJSONMarshaler(resolver, options...)
 }
@@ -105,6 +123,13 @@ type Unmarshaler interface {
 // resolver can be nil if unknown and are only needed for extensions.
 func NewWireUnmarshaler(resolver Resolver) Unmarshaler {
 	return newWireUnmarshaler(resolver)
+}
+
+// NewTextUnmarshaler returns a new Unmarshaler for prototext.
+//
+// resolver can be nil if unknown and are only needed for extensions.
+func NewTextUnmarshaler(resolver Resolver) Unmarshaler {
+	return newTextUnmarshaler(resolver)
 }
 
 // NewJSONUnmarshaler returns a new Unmarshaler for json.

--- a/private/pkg/protoencoding/text_marshaler.go
+++ b/private/pkg/protoencoding/text_marshaler.go
@@ -1,0 +1,48 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoencoding
+
+import (
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+type textMarshaler struct {
+	resolver  Resolver
+	indent    string
+	multiline bool
+}
+
+func newTextMarshaler(resolver Resolver, options ...TextMarshalerOption) Marshaler {
+	textMarshaler := &textMarshaler{
+		resolver: resolver,
+	}
+	for _, option := range options {
+		option(textMarshaler)
+	}
+	return textMarshaler
+}
+
+func (m *textMarshaler) Marshal(message proto.Message) ([]byte, error) {
+	if err := ReparseUnrecognized(m.resolver, message.ProtoReflect()); err != nil {
+		return nil, err
+	}
+	options := prototext.MarshalOptions{
+		Resolver:  m.resolver,
+		Indent:    m.indent,
+		Multiline: m.multiline,
+	}
+	return options.Marshal(message)
+}

--- a/private/pkg/protoencoding/text_unmarshaler.go
+++ b/private/pkg/protoencoding/text_unmarshaler.go
@@ -1,0 +1,39 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoencoding
+
+import (
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+type textUnmarshaler struct {
+	resolver Resolver
+}
+
+func newTextUnmarshaler(resolver Resolver) Unmarshaler {
+	return &textUnmarshaler{
+		resolver: resolver,
+	}
+}
+
+func (m *textUnmarshaler) Unmarshal(data []byte, message proto.Message) error {
+	options := prototext.UnmarshalOptions{
+		Resolver: m.resolver,
+		// TODO: make this an option
+		DiscardUnknown: true,
+	}
+	return options.Unmarshal(data, message)
+}


### PR DESCRIPTION
These file types are used for CEL conformance tests; however, prototext support is a somewhat rare feature. This command lets .textproto files be converted to .json or .binproto files for implementations that cannot read prototext.

Example output:
```
% buf convert buf.build/alfus/cel --type dev.cel.expr.conformance.SimpleTestFile --from ../cel-spec/tests/simple/testdata/basic.textproto --to -#format=json --indent
{
  "name": "basic",
  "description": "Basic conformance tests that all implementations should pass.",
  "section": [
    {
      "name": "self_eval_zeroish",
      "description": "Simple self-evaluating forms to zero-ish values.",
      "test": [
        {
          "name": "self_eval_int_zero",
          "expr": "0",
          "value": {
            "int64Value": "0"
          }
        },
        ...
```