### PR TITLE
Add `buf mod` commands to pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,9 +22,15 @@
   entry: buf format -w --exit-code
   types: [proto]
   pass_filenames: false
-- id: buf-mod
-  name: buf mod
+- id: buf-mod-update
+  name: buf mod update
   language: golang
-  entry: buf mod
+  entry: buf mod update
+  files: '(buf\.lock|buf\.yaml)'
+  pass_filenames: false
+- id: buf-mod-prune
+  name: buf mod prune
+  language: golang
+  entry: buf mod prune
   files: '(buf\.lock|buf\.yaml)'
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,3 +22,9 @@
   entry: buf format -w --exit-code
   types: [proto]
   pass_filenames: false
+- id: buf-mod
+  name: buf mod
+  language: golang
+  entry: buf mod
+  files: '(buf\.lock|buf\.yaml)'
+  pass_filenames: false


### PR DESCRIPTION
The motivation is to be able to use `buf mod update` and `buf mod prune` as a pre-commit hook upon changes in the buf module and lock files. We currently have to do it with a repo local hook with system language.