### PR TITLE
Switch to explicit actions/cache usage

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,11 +11,21 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: go-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: setup-go
         uses: actions/setup-go@v4 # this contains a fix for Windows file extraction
         with:
           go-version: '1.20.x'
-      - name: cache
+          cache: false
+      - name: windows-cache
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
The built-in setup-go caching doesn't appear to use restore-keys, so if there are any changes to go.sum then the cache is bypassed. Update this to support restoring a cache even if the go.sum file changes.