### PR TITLE
Dogfooding `buf sync` operations

### DIFF
--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -2,6 +2,7 @@ name: Buf sync
 
 # TODO run in PRs? in merges/pushes to main?
 on:
+  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # set a HEAD for remote/origin, so buf sync can pickup the current default branch
+      - run: git remote set-head origin --auto
       - uses: bufbuild/buf-setup-action@v1.23.1
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -1,16 +1,14 @@
-name: Buf sync
+name: Buf shadow sync
 
-# TODO run in PRs? in merges/pushes to main? Probably we'd want the same config as buf's action
-# on:
-#   push:
-#     paths:
-#       - 'proto/**'
 on:
+  # Same config as buf.yaml workflow
   push:
-  workflow_dispatch:
+    paths:
+      - 'proto/**'
+  workflow_dispatch: # also allow manual trigger
 
 jobs:
-  push:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # fetch all branches and commits, so we can loop them
       # set a HEAD for remote/origin, so buf sync can pickup the current default branch
       - run: git remote set-head origin --auto
       - uses: bufbuild/buf-setup-action@v1.23.1

--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -1,6 +1,10 @@
 name: Buf sync
 
-# TODO run in PRs? in merges/pushes to main?
+# TODO run in PRs? in merges/pushes to main? Probably we'd want the same config as buf's action
+# on:
+#   push:
+#     paths:
+#       - 'proto/**'
 on:
   push:
   workflow_dispatch:
@@ -12,10 +16,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch all branches and commits, so we can loop them
-      # set a HEAD for remote/origin, so buf sync can pickup the current default branch
-      - run: git remote set-head origin --auto
+      - run: git remote set-head origin --auto # set a HEAD for remote/origin, so buf sync can pickup the current default branch
       - uses: bufbuild/buf-setup-action@v1.23.1
         with:
           github_token: ${{ github.token }}
+          buf_user: bufbot
+          buf_api_token: ${{ secrets.BUF_TOKEN }}
       - run: buf alpha repo sync -v --debug --timeout 0 --module proto:buf.build/buftest/buf-shadow-sync --create --create-visibility private
-        # TODO: how do I auth?

--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1.23.1
         with:
           github_token: ${{ github.token }}
-      - run: buf alpha repo sync -v --debug --timeout 0 --module proto:buf.build/bufbuild/buf-sync-shadow --create --create-visibility private
+      - run: buf alpha repo sync -v --debug --timeout 0 --module proto:buf.build/buftest/buf-shadow-sync --create --create-visibility private
         # TODO: how do I auth?

--- a/.github/workflows/buf-sync-shadow.yaml
+++ b/.github/workflows/buf-sync-shadow.yaml
@@ -1,0 +1,16 @@
+name: Buf sync
+
+# TODO run in PRs? in merges/pushes to main?
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1.23.1
+        with:
+          github_token: ${{ github.token }}
+      - run: buf alpha repo sync -v --debug --timeout 0 --module proto:buf.build/bufbuild/buf-sync-shadow --create --create-visibility private
+        # TODO: how do I auth?


### PR DESCRIPTION
This PR adds a workflow with the same rules as `buf.yaml`, to sync the repo in a private shadow repo under buftest org. This is with the purpose of dogfooding `buf sync` command.