### PR TITLE
Fix path handling in storagegit

### DIFF
--- a/private/pkg/storage/storagegit/bucket.go
+++ b/private/pkg/storage/storagegit/bucket.go
@@ -187,7 +187,7 @@ func (b *bucket) walkTree(
 	return nil
 }
 
-// path is expected to be normalized by calling cunrions
+// path is expected to be normalized by calling functions
 func (b *bucket) newObjectInfo(path string) storage.ObjectInfo {
 	return storageutil.NewObjectInfo(
 		path,

--- a/private/pkg/storage/storagegit/storagegit_test.go
+++ b/private/pkg/storage/storagegit/storagegit_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/bufbuild/buf/private/pkg/git"
 	"github.com/bufbuild/buf/private/pkg/git/gittest"
-	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/storage/storagetesting"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +57,7 @@ func TestNewBucketAtTreeHash(t *testing.T) {
 		t,
 		bucket,
 		"proto/acme/grocerystore/v1/c.proto",
-		normalpath.Unnormalize("proto/acme/grocerystore/v1/c.proto"),
+		"proto/acme/grocerystore/v1/c.proto",
 	)
 	storagetesting.AssertNotExist(t, bucket, "random-path")
 	storagetesting.AssertPathToContent(


### PR DESCRIPTION
- All paths should have `storageutil.Validate{Path,Prefix}` called on them at the entrypoint.
- `ExternalPath` being used potentially incorrectly here, it's a gray area, changing to `Path` for now.
- A few other normalization fixes.