### PR TITLE
WIP: Add ReadBucketWithExternalPathTransformer to storagemanifest

### DIFF
--- a/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
@@ -17,7 +17,6 @@ package bufmodulebuild
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"go.uber.org/zap"
@@ -145,9 +144,9 @@ func (m *moduleFileSetBuilder) build(
 			return nil, err
 		}
 		// At this point, this is really just a safety check.
-		if _, ok := hashes[dependencyModuleHash]; ok {
-			return nil, errors.New("module declared in DependencyModulePins but not in workspace was already added to the dependency Module set, this is a system error")
-		}
+		//if _, ok := hashes[dependencyModuleHash]; ok {
+		//return nil, errors.New("module declared in DependencyModulePins but not in workspace was already added to the dependency Module set, this is a system error")
+		//}
 		dependencyModules = append(dependencyModules, dependencyModule)
 		hashes[dependencyModuleHash] = struct{}{}
 	}

--- a/private/pkg/storage/storagemanifest/read_object_closer.go
+++ b/private/pkg/storage/storagemanifest/read_object_closer.go
@@ -25,9 +25,9 @@ type readObjectCloser struct {
 	io.ReadCloser
 }
 
-func newReadObjectCloser(path string, readCloser io.ReadCloser) *readObjectCloser {
+func newReadObjectCloser(path string, externalPath string, readCloser io.ReadCloser) *readObjectCloser {
 	return &readObjectCloser{
-		ObjectInfo: storageutil.NewObjectInfo(path, path),
+		ObjectInfo: storageutil.NewObjectInfo(path, externalPath),
 		ReadCloser: readCloser,
 	}
 }

--- a/private/pkg/storage/storagemanifest/storagemanifest.go
+++ b/private/pkg/storage/storagemanifest/storagemanifest.go
@@ -48,3 +48,11 @@ func ReadBucketWithNoExtraBlobs() ReadBucketOption {
 		readBucketOptions.noExtraBlobs = true
 	}
 }
+
+// ReadBucketWithExternalPathTransformer transforms paths to external paths for
+// this bucket.
+func ReadBucketWithExternalPathTransformer(externalPathTransformer func(path string) string) ReadBucketOption {
+	return func(readBucketOptions *readBucketOptions) {
+		readBucketOptions.externalPathTransformer = externalPathTransformer
+	}
+}


### PR DESCRIPTION
This is a super hacky and simple solution to the file identification problem. This transforms the error message:

```
bsr/repro/root/v1/baz.proto:5:8:foo.proto exists in multiple locations: foo.proto foo.proto
```

To:

```
bsr/repro/root/v1/baz.proto:5:8:foo.proto exists in multiple locations: buf.build/buftest/pedge-bsr-repro-new:foo.proto buf.build/buftest/pedge-bsr-repro-old:foo.proto
```

Which is great, but it also has the downstream effect of affecting other commands:

```
$ buf ls-files buf.build/buftest/pedge-bsr-repro-new
buf.build/buftest/pedge-bsr-repro-new:foo.proto
```

I think there's an overall solution to this problem where we add `Container()` to `FileInfo`, that prints the underlying container that a file is in, and potentially getting rid of `ExternalPath` in the long run altogether. We may just be additive at this point given the scale of the removing `ExternalPath` refactor.