### PR TITLE
Specify 'binpb' instead of 'bin' in the convert cmd help

### DIFF
--- a/private/buf/bufconvert/bufconvert.go
+++ b/private/buf/bufconvert/bufconvert.go
@@ -33,11 +33,12 @@ const (
 	// MessageEncodingJSON is the JSON image encoding.
 	MessageEncodingJSON
 	// formatBinpb is the binary format.
-	formatBinpb = "bin"
+	formatBinpb = "binpb"
 	// formatJSON is the JSON format.
 	formatJSON = "json"
+
 	// formatBin is the binary format's old form, now deprecated.
-	formatBin = "binpb"
+	formatBin = "bin"
 )
 
 var (


### PR DESCRIPTION
By fixing the constants.

Prev help output:
![image](https://github.com/bufbuild/buf/assets/4567082/a908cbfd-aeae-488f-9f5d-884ce75dcf0c)
New output:
![image](https://github.com/bufbuild/buf/assets/4567082/b4edac46-4ed1-4df7-a58f-27f62b9c9b0f)
