### PR TITLE
The curl sub-command should support `--http2-prior-knowledge` with "https" URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add support for the `--http2-prior-knowledge` flag when running `buf curl`
+  against secure "https" URLs. This can be used with gRPC servers, that only
+  support HTTP/2, when used with a network (layer 4) load balancer, that does
+  not support protocol negotiation in TLS handshake.
 
 ## [v1.25.1] - 2023-08-02
 

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -312,10 +312,10 @@ and port indicated in the URL`,
 		&f.HTTP2PriorKnowledge,
 		http2PriorKnowledgeFlagName,
 		false,
-		`This flag can be used with URLs that use the http scheme (as opposed to https) to indicate
-that HTTP/2 should be used. Without this, HTTP 1.1 will be used with URLs with an http
-scheme. For https scheme, HTTP/2 will be negotiate during the TLS handshake if the server
-supports it (otherwise HTTP 1.1 is used)`,
+		`This flag can be used to indicate that HTTP/2 should be used. Without this, HTTP 1.1
+will be used with URLs with an http scheme, and protocol negotiation will be used to
+choose either HTTP 1.1 or HTTP/2 for URLs with an https scheme. With this flag set,
+HTTP/2 is always used, even over plain-text.`,
 	)
 
 	flagSet.BoolVar(

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -496,9 +496,6 @@ func (f *flags) validate(isSecure bool) error {
 		return fmt.Errorf("if --%s is set, --%s should not be set as it is unused", insecureFlagName, caCertFlagName)
 	}
 
-	if f.HTTP2PriorKnowledge && isSecure {
-		return fmt.Errorf("--%s flag is not for use with secure URLs (https) since http/2 can be negotiated during TLS handshake", http2PriorKnowledgeFlagName)
-	}
 	if !isSecure && !f.HTTP2PriorKnowledge && f.Protocol == connect.ProtocolGRPC {
 		return fmt.Errorf("grpc protocol cannot be used with plain-text URLs (http) unless --%s flag is set", http2PriorKnowledgeFlagName)
 	}
@@ -987,35 +984,55 @@ func makeHTTPClient(f *flags, isSecure bool, authority string, printer verbose.P
 		}
 	}
 
+	var dialTLSFunc func(ctx context.Context, network, address string) (net.Conn, error)
+	if isSecure {
+		tlsConfig, err := bufcurl.MakeVerboseTLSConfig(&bufcurl.TLSSettings{
+			KeyFile:             f.Key,
+			CertFile:            f.Cert,
+			CACertFile:          f.CACert,
+			ServerName:          f.ServerName,
+			Insecure:            f.Insecure,
+			HTTP2PriorKnowledge: f.HTTP2PriorKnowledge,
+		}, authority, printer)
+		if err != nil {
+			return nil, err
+		}
+		dialTLSFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dialFunc(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			printer.Printf("* ALPN: offering %s", strings.Join(tlsConfig.NextProtos, ","))
+			tlsConn := tls.Client(conn, tlsConfig)
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				return nil, err
+			}
+			return tlsConn, nil
+		}
+	}
+
 	var transport http.RoundTripper
-	if !isSecure && f.HTTP2PriorKnowledge {
+	switch {
+	case f.HTTP2PriorKnowledge && isSecure:
+		transport = &http2.Transport{
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return dialTLSFunc(ctx, network, addr)
+			},
+		}
+	case f.HTTP2PriorKnowledge:
 		transport = &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 				return dialFunc(ctx, network, addr)
 			},
 		}
-	} else {
-		var tlsConfig *tls.Config
-		if isSecure {
-			var err error
-			tlsConfig, err = bufcurl.MakeVerboseTLSConfig(&bufcurl.TLSSettings{
-				KeyFile:    f.Key,
-				CertFile:   f.Cert,
-				CACertFile: f.CACert,
-				ServerName: f.ServerName,
-				Insecure:   f.Insecure,
-			}, authority, printer)
-			if err != nil {
-				return nil, err
-			}
-		}
+	default:
 		transport = &http.Transport{
 			Proxy:             http.ProxyFromEnvironment,
 			DialContext:       dialFunc,
+			DialTLSContext:    dialTLSFunc,
 			ForceAttemptHTTP2: true,
 			MaxIdleConns:      1,
-			TLSClientConfig:   tlsConfig,
 		}
 	}
 	return bufcurl.NewVerboseHTTPClient(transport, printer), nil


### PR DESCRIPTION
Previously, `buf curl` would complain if you tried to use `--http2-prior-knowledge` with secure "https" URLs.

Now, the flag is accepted and the client will _only_ use HTTP/2. This basically removes "http/1.1" from the set of supported protocols during ALPN, and if the server does not support ALPN (i.e. does not pick a protocol), it defaults to HTTP/2 (whereas it was previously defaulting to HTTP 1.1).

This can be used to work with secure servers that expect HTTP/2 but don't correctly implement ALPN to select "h2". This could be the case when using _network_ load balancers that terminate TLS (layer 4, instead of layer 7).

I tested this locally against a server using the grpc-go runtime (it does not use "net/http" and _only_ supports HTTP/2). I hacked the runtime so that it did _not_ use ALPN during the TLS handshake. Without `--http2-prior-knowledge`, a `buf curl` command fails since it is sending an HTTP 1.1 request to a server expecting HTTP/2. But with the flag, the request succeeds.