### PR TITLE
buf generate: go_package_prefix implemented package_depth option

### DIFF
--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -275,7 +275,8 @@ type GoPackagePrefixConfig struct {
 	Default string
 	Except  []bufmoduleref.ModuleIdentity
 	// bufmoduleref.ModuleIdentity -> go_package prefix.
-	Override map[bufmoduleref.ModuleIdentity]string
+	Override     map[bufmoduleref.ModuleIdentity]string
+	PackageDepth map[string]uint
 }
 
 // ObjcClassPrefixConfig is the objc_class_prefix configuration.
@@ -492,9 +493,10 @@ func (e *ExternalOptimizeForConfigV1) unmarshalWith(unmarshal func(interface{}) 
 
 // ExternalGoPackagePrefixConfigV1 is the external go_package prefix configuration.
 type ExternalGoPackagePrefixConfigV1 struct {
-	Default  string            `json:"default,omitempty" yaml:"default,omitempty"`
-	Except   []string          `json:"except,omitempty" yaml:"except,omitempty"`
-	Override map[string]string `json:"override,omitempty" yaml:"override,omitempty"`
+	Default      string            `json:"default,omitempty" yaml:"default,omitempty"`
+	Except       []string          `json:"except,omitempty" yaml:"except,omitempty"`
+	Override     map[string]string `json:"override,omitempty" yaml:"override,omitempty"`
+	PackageDepth map[string]uint   `json:"package_depth,omitempty" yaml:"package_depth,omitempty"`
 }
 
 // IsEmpty returns true if the config is empty.

--- a/private/buf/bufgen/config.go
+++ b/private/buf/bufgen/config.go
@@ -446,10 +446,16 @@ func newGoPackagePrefixConfigV1(externalGoPackagePrefixConfig ExternalGoPackageP
 		seenModuleIdentities[moduleIdentity.IdentityString()] = struct{}{}
 		override[moduleIdentity] = normalizedGoPackagePrefix
 	}
+
+	packageDepth := make(map[string]uint, len(externalGoPackagePrefixConfig.PackageDepth))
+	for pkgName, depth := range externalGoPackagePrefixConfig.PackageDepth {
+		packageDepth[pkgName] = depth
+	}
 	return &GoPackagePrefixConfig{
-		Default:  defaultGoPackagePrefix,
-		Except:   except,
-		Override: override,
+		Default:      defaultGoPackagePrefix,
+		Except:       except,
+		Override:     override,
+		PackageDepth: packageDepth,
 	}, nil
 }
 

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -522,14 +522,7 @@ func newModifier(
 		)
 	}
 	if managedConfig.GoPackagePrefixConfig != nil {
-		goPackageModifier, err := bufimagemodify.GoPackage(
-			logger,
-			sweeper,
-			managedConfig.GoPackagePrefixConfig.Default,
-			managedConfig.GoPackagePrefixConfig.Except,
-			managedConfig.GoPackagePrefixConfig.Override,
-			managedConfig.Override[bufimagemodify.GoPackageID],
-		)
+		goPackageModifier, err := bufimagemodify.GoPackage(logger, sweeper, managedConfig.GoPackagePrefixConfig.Default, managedConfig.GoPackagePrefixConfig.Except, managedConfig.GoPackagePrefixConfig.Override, managedConfig.GoPackagePrefixConfig.PackageDepth, managedConfig.Override[bufimagemodify.GoPackageID])
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct go_package modifier: %w", err)
 		}

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -207,41 +207,22 @@ func OptimizeFor(
 
 // GoPackageImportPathForFile returns the go_package import path for the given
 // ImageFile. If the package contains a version suffix, and if there are more
-// than two components, concatenate the final two components. Otherwise, we
-// exclude the ';' separator and adopt the default behavior from the import path.
-//
-// For example, an ImageFile with `package acme.weather.v1;` will include `;weatherv1`
-// in the `go_package` declaration so that the generated package is named as such.
-func GoPackageImportPathForFile(imageFile bufimage.ImageFile, importPathPrefix string) string {
-	goPackageImportPath := path.Join(importPathPrefix, path.Dir(imageFile.Path()))
-	packageName := imageFile.FileDescriptor().GetPackage()
-	if _, ok := protoversion.NewPackageVersionForPackage(packageName); ok {
-		parts := strings.Split(packageName, ".")
-		if len(parts) >= 2 {
-			goPackageImportPath += ";" + parts[len(parts)-2] + parts[len(parts)-1]
-		}
-	}
-	return goPackageImportPath
-}
-
-// GoPackageImportPathForFileParted returns the go_package import path for the given
-// ImageFile. If the package contains a version suffix, and if there are more
 // than input parts number components, concatenate the final parts components. Otherwise, we
 // exclude the ';' separator and adopt the default behavior from the import path.
 //
-// For example, an ImageFile with `package acme.weather.v1;` partsNumber 2 will include `;weatherv1`
+// For example, an ImageFile with `package acme.weather.v1;` parts 2 will include `;weatherv1`
 // If the package is more deeply nested, i.e. 'package acme.weather.admin.v1;'
-// with partsNumber 3 will include `;weatheradminv1`
+// with parts 3 will include `;weatheradminv1`
 // in the `go_package` declaration so that the generated package is named as such.
-func GoPackageImportPathForFileParted(imageFile bufimage.ImageFile, importPathPrefix string, partsNumber uint) string {
+func GoPackageImportPathForFile(imageFile bufimage.ImageFile, importPathPrefix string, parts uint) string {
 	goPackageImportPath := path.Join(importPathPrefix, path.Dir(imageFile.Path()))
 	packageName := imageFile.FileDescriptor().GetPackage()
 	if _, ok := protoversion.NewPackageVersionForPackage(packageName); ok {
-		parts := strings.Split(packageName, ".")
-		if len(parts) >= int(partsNumber) {
+		pkgParts := strings.Split(packageName, ".")
+		if len(pkgParts) >= int(parts) {
 			goPackageImportPath += ";"
-			for i := len(parts) - int(partsNumber); i < len(parts); i++ {
-				goPackageImportPath += parts[i]
+			for i := len(pkgParts) - int(parts); i < len(pkgParts); i++ {
+				goPackageImportPath += pkgParts[i]
 			}
 		}
 	}

--- a/private/bufpkg/bufimage/bufimagemodify/go_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/go_package.go
@@ -83,7 +83,7 @@ func goPackage(
 
 				}
 
-				goPackageValue := GoPackageImportPathForFileParted(imageFile, importPathPrefix, depth)
+				goPackageValue := GoPackageImportPathForFile(imageFile, importPathPrefix, depth)
 				if overrideValue, ok := overrides[imageFile.Path()]; ok {
 					goPackageValue = overrideValue
 					seenOverrideFiles[imageFile.Path()] = struct{}{}

--- a/private/bufpkg/bufimage/bufimagemodify/go_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/go_package_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestGoPackageError(t *testing.T) {
 	t.Parallel()
-	_, err := GoPackage(zap.NewNop(), NewFileOptionSweeper(), "", nil, nil, nil)
+	_, err := GoPackage(zap.NewNop(), NewFileOptionSweeper(), "", nil, nil, nil, nil)
 	require.Error(t, err)
 }
 
@@ -42,7 +42,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -69,7 +69,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -94,7 +94,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{"a.proto": "override"})
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -118,7 +118,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{"a.proto": "override"})
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -144,7 +144,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, goPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{})
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -170,7 +170,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -194,7 +194,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, goPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{"a.proto": "override"})
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -217,7 +217,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{"a.proto": "override"})
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -237,13 +237,15 @@ func TestGoPackagePackageVersion(t *testing.T) {
 	t.Parallel()
 	dirPath := filepath.Join("testdata", "packageversion")
 	packageSuffix := "weatherv1alpha1"
+	adminPackageSuffix := "adminv1alpha1"
+	adminPartedPackageSuffix := "weatheradminv1alpha1"
 	t.Run("with SourceCodeInfo", func(t *testing.T) {
 		t.Parallel()
 		image := testGetImage(t, dirPath, true)
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, goPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -256,10 +258,14 @@ func TestGoPackagePackageVersion(t *testing.T) {
 
 		for _, imageFile := range image.Files() {
 			descriptor := imageFile.Proto()
+			suffix := packageSuffix
+			if imageFile.Path() == "admin/c.proto" {
+				suffix = adminPackageSuffix
+			}
 			assert.Equal(t,
 				fmt.Sprintf("%s;%s",
 					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
-					packageSuffix,
+					suffix,
 				),
 				descriptor.GetOptions().GetGoPackage(),
 			)
@@ -273,7 +279,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -284,10 +290,14 @@ func TestGoPackagePackageVersion(t *testing.T) {
 
 		for _, imageFile := range image.Files() {
 			descriptor := imageFile.Proto()
+			suffix := packageSuffix
+			if imageFile.Path() == "admin/c.proto" {
+				suffix = adminPackageSuffix
+			}
 			assert.Equal(t,
 				fmt.Sprintf("%s;%s",
 					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
-					packageSuffix,
+					suffix,
 				),
 				descriptor.GetOptions().GetGoPackage(),
 			)
@@ -301,7 +311,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, goPackagePath)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{"a.proto": "override"})
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -318,10 +328,14 @@ func TestGoPackagePackageVersion(t *testing.T) {
 				assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 				continue
 			}
+			suffix := packageSuffix
+			if imageFile.Path() == "admin/c.proto" {
+				suffix = adminPackageSuffix
+			}
 			assert.Equal(t,
 				fmt.Sprintf("%s;%s",
 					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
-					packageSuffix,
+					suffix,
 				),
 				descriptor.GetOptions().GetGoPackage(),
 			)
@@ -335,7 +349,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]string{"a.proto": "override"})
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -350,15 +364,54 @@ func TestGoPackagePackageVersion(t *testing.T) {
 				assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 				continue
 			}
+			suffix := packageSuffix
+			if imageFile.Path() == "admin/c.proto" {
+				suffix = adminPackageSuffix
+			}
 			assert.Equal(t,
 				fmt.Sprintf("%s;%s",
 					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
-					packageSuffix,
+					suffix,
 				),
 				descriptor.GetOptions().GetGoPackage(),
 			)
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
+	})
+
+	t.Run("with SourceCodeInfo and per-package depth overrides", func(t *testing.T) {
+		t.Parallel()
+		image := testGetImage(t, dirPath, true)
+		assertFileOptionSourceCodeInfoNotEmpty(t, image, goPackagePath)
+
+		sweeper := NewFileOptionSweeper()
+
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, map[string]uint{"weather.admin.v1alpha1": 3}, nil)
+		require.NoError(t, err)
+
+		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
+		err = modifier.Modify(
+			context.Background(),
+			image,
+		)
+		require.NoError(t, err)
+		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
+
+		for _, imageFile := range image.Files() {
+			descriptor := imageFile.Proto()
+			suffix := packageSuffix
+			if imageFile.Path() == "admin/c.proto" {
+				suffix = adminPartedPackageSuffix
+			}
+			assert.Equal(t,
+				fmt.Sprintf("%s;%s",
+					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
+					suffix,
+				),
+				descriptor.GetOptions().GetGoPackage(),
+			)
+		}
+		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 	})
 }
 
@@ -371,7 +424,7 @@ func TestGoPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -404,7 +457,7 @@ func TestGoPackageWellKnownTypes(t *testing.T) {
 		image := testGetImage(t, dirPath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, nil, nil, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -447,14 +500,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
-			nil,
-			nil,
-		)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, []bufmoduleref.ModuleIdentity{testModuleIdentity}, nil, nil, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -473,14 +519,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
-			nil,
-			nil,
-		)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, []bufmoduleref.ModuleIdentity{testModuleIdentity}, nil, nil, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -497,14 +536,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
-			nil,
-			map[string]string{"a.proto": "override"},
-		)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, []bufmoduleref.ModuleIdentity{testModuleIdentity}, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -522,14 +554,7 @@ func TestGoPackageWithExcept(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			[]bufmoduleref.ModuleIdentity{testModuleIdentity},
-			nil,
-			map[string]string{"a.proto": "override"},
-		)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, []bufmoduleref.ModuleIdentity{testModuleIdentity}, nil, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -557,16 +582,9 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			nil,
-			map[bufmoduleref.ModuleIdentity]string{
-				testModuleIdentity: overrideGoPackagePrefix,
-			},
-			nil,
-		)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, map[bufmoduleref.ModuleIdentity]string{
+			testModuleIdentity: overrideGoPackagePrefix,
+		}, nil, nil)
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -593,16 +611,9 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			nil,
-			map[bufmoduleref.ModuleIdentity]string{
-				testModuleIdentity: overrideGoPackagePrefix,
-			},
-			nil,
-		)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, map[bufmoduleref.ModuleIdentity]string{
+			testModuleIdentity: overrideGoPackagePrefix,
+		}, nil, nil)
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),
@@ -627,16 +638,9 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
 
 		sweeper := NewFileOptionSweeper()
-		goPackageModifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			nil,
-			map[bufmoduleref.ModuleIdentity]string{
-				testModuleIdentity: overrideGoPackagePrefix,
-			},
-			map[string]string{"a.proto": "override"},
-		)
+		goPackageModifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, map[bufmoduleref.ModuleIdentity]string{
+			testModuleIdentity: overrideGoPackagePrefix,
+		}, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 
 		modifier := NewMultiModifier(goPackageModifier, ModifierFunc(sweeper.Sweep))
@@ -660,16 +664,9 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
 
 		sweeper := NewFileOptionSweeper()
-		modifier, err := GoPackage(
-			zap.NewNop(),
-			sweeper,
-			testImportPathPrefix,
-			nil,
-			map[bufmoduleref.ModuleIdentity]string{
-				testModuleIdentity: overrideGoPackagePrefix,
-			},
-			map[string]string{"a.proto": "override"},
-		)
+		modifier, err := GoPackage(zap.NewNop(), sweeper, testImportPathPrefix, nil, map[bufmoduleref.ModuleIdentity]string{
+			testModuleIdentity: overrideGoPackagePrefix,
+		}, nil, map[string]string{"a.proto": "override"})
 		require.NoError(t, err)
 		err = modifier.Modify(
 			context.Background(),

--- a/private/bufpkg/bufimage/bufimagemodify/testdata/packageversion/admin/c.proto
+++ b/private/bufpkg/bufimage/bufimagemodify/testdata/packageversion/admin/c.proto
@@ -1,0 +1,3 @@
+package weather.admin.v1alpha1;
+
+option go_package = "weather";


### PR DESCRIPTION
This PR implements an option for generating Golang files, for the versioned protobuf packages.
It allows changing the depth of the package name generation for more nested `proto` packages.

Currently buf treats file:
```a.proto

package weather.v1alpha;
``` 

and generates its identity go_package as =";weatherv1alpha" which is perfectly fine and directly describes what this package does and what is its version.

However in a situation where the proto file package is more deeply nested i.e.:
```b.proto

package weather.admin.v1alpha;
```

This generates go_package as: `";adminv1alpha"`. For modules with more nested proto packages this makes golang package names a little not descriptive enough.

This PR provides `buf` generate option to override protobuf package name generation depths. By default, it takes a depth of **2** (i.e. `weather.v1alpha` -> `weatherv1alpha`). This PR allows modifying this depth manually, i.e.:

```buf.gen.yaml
version: v1
managed:
  enabled: true
  go_package_prefix:
    default: github.com/acme/weather/private/gen/proto/go
    except:
      - buf.build/googleapis/googleapis
    package_depth:
      weather.admin.v1alpha: 3
plugins:
  - plugin: go
    out: gen/proto/go
    opt: paths=source_relative
```

With these options the `proto` package `weather.admin.v1alpha` will result with a `Golang` package identity => `weatheradmingv1alpha`, and thus option go_package = ";weatheradmingv1alpha"


This PR solves the problem of complex repositories with different submodules.
It also relates to the #1263.

The changes in this package breaks the API of the Golang function: 
`private/bufpkg/bufimage/bufimagemodify.GoPackage` by adding additional argument `packageDepthOverride map[string]uint`. If this argument has no value, this doesn't change a logic of the function.
The value for that argument is taken from the configurations, and provided in the `buf/private/buf/bufgen/generator.go:525` directly out of the configuration.

The configuration field `bufgen.GoPackagePrefixConfig.PackageDepth` is also affected by the `bufgen.ExternalGoPackagePrefixConfig.PackageDepth` field.

It also breaks the API of the Golang function:
`private/buf/pkg/bufimage/bufimagemodify.GoPackageImportPathForFile` by adding the number of the version parts to split. By default it takes the previous value of `2`.

Generation also logs a Warning message if none of the package_depth entries were used during generation.

The new options are included in the test cases of the `buf/private/bufpkg/bufimage/bufimagemodify` as well as in the e2e test on manually compiled `buf` CLI on real data.