### PR TITLE
Buf sync: support module identity overrides

### DIFF
--- a/private/buf/bufsync/bufsync.go
+++ b/private/buf/bufsync/bufsync.go
@@ -61,13 +61,20 @@ type ReadModuleError struct {
 }
 
 // Code returns the error code for this read module error.
-func (err *ReadModuleError) Code() ReadModuleErrorCode {
-	return err.code
+func (e *ReadModuleError) Code() ReadModuleErrorCode {
+	return e.code
 }
 
 // Code returns the module directory in which this error code was thrown.
-func (err *ReadModuleError) ModuleDir() string {
-	return err.moduleDir
+func (e *ReadModuleError) ModuleDir() string {
+	return e.moduleDir
+}
+
+func (e *ReadModuleError) Error() string {
+	return fmt.Sprintf(
+		"read module in branch %s, commit %s, directory %s: %s",
+		e.branch, e.commit, e.moduleDir, e.err.Error(),
+	)
 }
 
 const (
@@ -89,13 +96,6 @@ const (
 // LookbackDecisionCode is the decision made by the ErrorHandler when finding a commit that throws
 // an error reading a module.
 type LookbackDecisionCode int
-
-func (e *ReadModuleError) Error() string {
-	return fmt.Sprintf(
-		"read module in branch %s, commit %s, directory %s: %s",
-		e.branch, e.commit, e.moduleDir, e.err.Error(),
-	)
-}
 
 // ErrorHandler handles errors reported by the Syncer before or during the sync process.
 type ErrorHandler interface {

--- a/private/buf/bufsync/bufsync.go
+++ b/private/buf/bufsync/bufsync.go
@@ -148,19 +148,24 @@ func NewSyncer(
 // SyncerOption configures the creation of a new Syncer.
 type SyncerOption func(*syncer) error
 
-// SyncerWithModuleDirectory configures a Syncer to sync a module in the specified module directory.
+// SyncerWithModule configures a Syncer to sync a module in the specified module directory, with an
+// optional module override.
+//
+// If a not-nil module identity is passed, it will be used as the expected module target for the
+// module directory. On the other hand, if a nil module identity is passed, then the module identity
+// target for that module directory is read from the HEAD commit on each git branch.
 //
 // This option can be provided multiple times to sync multiple distinct modules. The order in which
-// the module directories are passed is preserved, and those modules are synced in the same order.
-// If the same module directory is passed multiple times this option errors, since the order cannot
-// be preserved anymore.
-func SyncerWithModuleDirectory(moduleDir string) SyncerOption {
+// the module are passed is preserved, and those modules are synced in the same order. If the same
+// module directory is passed multiple times this option errors, since the order cannot be preserved
+// anymore.
+func SyncerWithModule(moduleDir string, identityOverride bufmoduleref.ModuleIdentity) SyncerOption {
 	return func(s *syncer) error {
 		moduleDir = normalpath.Normalize(moduleDir)
-		if _, alreadyAdded := s.modulesDirsForSync[moduleDir]; alreadyAdded {
+		if _, alreadyAdded := s.modulesForSync[moduleDir]; alreadyAdded {
 			return fmt.Errorf("module directory %s already added", moduleDir)
 		}
-		s.modulesDirsForSync[moduleDir] = struct{}{}
+		s.modulesForSync[moduleDir] = identityOverride
 		s.sortedModulesDirsForSync = append(s.sortedModulesDirsForSync, moduleDir)
 		return nil
 	}

--- a/private/buf/bufsync/bufsync.go
+++ b/private/buf/bufsync/bufsync.go
@@ -162,10 +162,10 @@ type SyncerOption func(*syncer) error
 func SyncerWithModule(moduleDir string, identityOverride bufmoduleref.ModuleIdentity) SyncerOption {
 	return func(s *syncer) error {
 		moduleDir = normalpath.Normalize(moduleDir)
-		if _, alreadyAdded := s.modulesForSync[moduleDir]; alreadyAdded {
+		if _, alreadyAdded := s.modulesDirsToIdentityOverrideForSync[moduleDir]; alreadyAdded {
 			return fmt.Errorf("module directory %s already added", moduleDir)
 		}
-		s.modulesForSync[moduleDir] = identityOverride
+		s.modulesDirsToIdentityOverrideForSync[moduleDir] = identityOverride
 		s.sortedModulesDirsForSync = append(s.sortedModulesDirsForSync, moduleDir)
 		return nil
 	}

--- a/private/buf/bufsync/commits_to_sync_test.go
+++ b/private/buf/bufsync/commits_to_sync_test.go
@@ -50,7 +50,7 @@ func TestCommitsToSyncWithNoPreviousSyncPoints(t *testing.T) {
 		repo:                                  repo,
 		storageGitProvider:                    storagegit.NewProvider(repo.Objects()),
 		logger:                                zaptest.NewLogger(t),
-		modulesDirsToIdentityOverrideForSync:  map[string]struct{}{".": {}},
+		modulesDirsToIdentityOverrideForSync:  map[string]bufmoduleref.ModuleIdentity{".": nil},
 		sortedModulesDirsForSync:              []string{"."},
 		syncAllBranches:                       true,
 		syncedGitCommitChecker:                mockBSRChecker.checkFunc(),

--- a/private/buf/bufsync/commits_to_sync_test.go
+++ b/private/buf/bufsync/commits_to_sync_test.go
@@ -50,7 +50,7 @@ func TestCommitsToSyncWithNoPreviousSyncPoints(t *testing.T) {
 		repo:                                  repo,
 		storageGitProvider:                    storagegit.NewProvider(repo.Objects()),
 		logger:                                zaptest.NewLogger(t),
-		modulesForSync:                        map[string]struct{}{".": {}},
+		modulesDirsToIdentityOverrideForSync:  map[string]struct{}{".": {}},
 		sortedModulesDirsForSync:              []string{"."},
 		syncAllBranches:                       true,
 		syncedGitCommitChecker:                mockBSRChecker.checkFunc(),

--- a/private/buf/bufsync/commits_to_sync_test.go
+++ b/private/buf/bufsync/commits_to_sync_test.go
@@ -50,7 +50,7 @@ func TestCommitsToSyncWithNoPreviousSyncPoints(t *testing.T) {
 		repo:                                  repo,
 		storageGitProvider:                    storagegit.NewProvider(repo.Objects()),
 		logger:                                zaptest.NewLogger(t),
-		modulesDirsForSync:                    map[string]struct{}{".": {}},
+		modulesForSync:                        map[string]struct{}{".": {}},
 		sortedModulesDirsForSync:              []string{"."},
 		syncAllBranches:                       true,
 		syncedGitCommitChecker:                mockBSRChecker.checkFunc(),

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -438,7 +438,7 @@ func (s *syncer) branchSyncableCommits(ctx context.Context, branch string) ([]*s
 						return fmt.Errorf("cannot override commit, no built module: %w", readErr)
 					}
 					// rebuild the module with the target identity, and add it to the queue
-					rebuiltModule, err := rebuildModule(ctx, *builtModule, pendingModule.targetModuleIdentity)
+					rebuiltModule, err := rebuildModule(ctx, builtModule, pendingModule.targetModuleIdentity)
 					if err != nil {
 						return fmt.Errorf("override module in commit: %s, rebuild module: %w", readErr.Error(), err)
 					}
@@ -687,15 +687,18 @@ type moduleTarget struct {
 // rebuildModule takes a built module, and rebuilds it with a new module identity.
 func rebuildModule(
 	ctx context.Context,
-	builtModule bufmodulebuild.BuiltModule,
+	builtModule *bufmodulebuild.BuiltModule,
 	identityOverride bufmoduleref.ModuleIdentity,
 ) (*bufmodulebuild.BuiltModule, error) {
+	if builtModule == nil {
+		return nil, errors.New("no built module to rebuild")
+	}
 	if identityOverride == nil {
 		return nil, errors.New("no new identity to apply")
 	}
 	if builtModule.ModuleIdentity().IdentityString() == identityOverride.IdentityString() {
 		// same identity, no need to rebuild anything
-		return &builtModule, nil
+		return builtModule, nil
 	}
 	sourceConfig, err := bufconfig.GetConfigForBucket(ctx, builtModule.Bucket)
 	if err != nil {

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -312,6 +312,15 @@ func (s *syncer) syncBranch(ctx context.Context, branch string, syncFunc SyncFun
 				)
 				continue
 			}
+			if builtModule == nil {
+				s.logger.Debug(
+					"module directory has no module to sync, skipping module in commit",
+					zap.String("branch", branch),
+					zap.String("commit", commitHash),
+					zap.String("module directory", moduleDir),
+				)
+				continue
+			}
 			modIdentity := builtModule.ModuleIdentity().IdentityString()
 			if err := syncFunc(
 				ctx,

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -440,7 +440,7 @@ func (s *syncer) branchSyncableCommits(ctx context.Context, branch string) ([]*s
 					// rebuild the module with the target identity, and add it to the queue
 					rebuiltModule, err := rebuildModule(ctx, *builtModule, pendingModule.targetModuleIdentity)
 					if err != nil {
-						return fmt.Errorf("override module in commit: %w, rebuild module: %w", readErr, err)
+						return fmt.Errorf("override module in commit: %s, rebuild module: %w", readErr.Error(), err)
 					}
 					syncModules[moduleDir] = rebuiltModule
 				default:

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -426,7 +426,7 @@ func (s *syncer) branchSyncableCommits(ctx context.Context, branch string) ([]*s
 				decision := s.errorHandler.HandleReadModuleError(readErr)
 				switch decision {
 				case LookbackDecisionCodeFail:
-					return fmt.Errorf("read module error: %w", err)
+					return fmt.Errorf("read module error: %w", readErr)
 				case LookbackDecisionCodeSkip:
 					logger.Debug("read module at commit failed, skipping commit", zap.Error(readErr))
 				case LookbackDecisionCodeStop:
@@ -437,14 +437,14 @@ func (s *syncer) branchSyncableCommits(ctx context.Context, branch string) ([]*s
 					if builtModule == nil {
 						return fmt.Errorf("cannot override commit, no built module: %w", readErr)
 					}
-					// rebuild the module with the target identity
+					// rebuild the module with the target identity, and add it to the queue
 					rebuiltModule, err := rebuildModule(ctx, *builtModule, pendingModule.targetModuleIdentity)
 					if err != nil {
 						return fmt.Errorf("override module in commit: %w, rebuild module: %w", readErr, err)
 					}
 					syncModules[moduleDir] = rebuiltModule
 				default:
-					return fmt.Errorf("unexpected decision code %d for read module error %w", decision, err)
+					return fmt.Errorf("unexpected decision code %d for read module error %w", decision, readErr)
 				}
 				continue
 			}

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -41,7 +41,7 @@ type syncer struct {
 
 	// flags received on creation
 	sortedModulesDirsForSync []string
-	modulesDirsForSync       map[string]struct{}
+	modulesForSync           map[string]bufmoduleref.ModuleIdentity // moduleDir:moduleIdentityOverride
 	syncAllBranches          bool
 
 	commitsToTags                   map[string][]string                               // commits:[]tags
@@ -67,7 +67,7 @@ func newSyncer(
 		repo:                                  repo,
 		storageGitProvider:                    storageGitProvider,
 		errorHandler:                          errorHandler,
-		modulesDirsForSync:                    make(map[string]struct{}),
+		modulesForSync:                        make(map[string]bufmoduleref.ModuleIdentity),
 		commitsToTags:                         make(map[string][]string),
 		branchesToModulesForSync:              make(map[string]map[string]bufmoduleref.ModuleIdentity),
 		modulesToBranchesLastSyncPoints:       make(map[string]map[string]string),
@@ -164,7 +164,7 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("reading head commit for branch %s: %w", branch, err)
 		}
-		for moduleDir := range s.modulesDirsForSync {
+		for moduleDir := range s.modulesForSync {
 			builtModule, readErr := s.readModuleAt(ctx, branch, headCommit, moduleDir)
 			if readErr != nil {
 				// any error reading module in HEAD, skip syncing that module in that branch
@@ -611,7 +611,7 @@ func readModuleAtWithExpectedModuleIdentity(moduleIdentity string) readModuleAtO
 func (s *syncer) printSyncPreparation() {
 	s.logger.Debug(
 		"sync preparation",
-		zap.Any("modulesDirsToSync", s.modulesDirsForSync),
+		zap.Any("modulesDirsToSync", s.modulesForSync),
 		zap.Any("commitsTags", s.commitsToTags),
 		zap.Any("branchesModulesToSync", s.branchesToModulesForSync),
 		zap.Any("modulesBranchesSyncPoints", s.modulesToBranchesLastSyncPoints),

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
@@ -357,8 +357,8 @@ func (h *syncErrorHandler) HandleReadModuleError(err *bufsync.ReadModuleError) b
 		return bufsync.LookbackDecisionCodeSkip
 	case bufsync.ReadModuleErrorCodeUnnamedModule,
 		bufsync.ReadModuleErrorCodeUnexpectedName:
-		// if the module has an unexpected or no name, we should override the module identity if it was
-		// passed explicitly as an override, otherwise skip them.
+		// if the module has an unexpected or no name, we should override the module identity only if it
+		// was passed explicitly as an identity override, otherwise skip the commit.
 		if _, hasExplicitOverride := h.modulesDirsWithIdentityOverride[err.ModuleDir()]; hasExplicitOverride {
 			return bufsync.LookbackDecisionCodeOverride
 		}

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
@@ -368,7 +368,7 @@ func (h *syncErrorHandler) HandleReadModuleError(err *bufsync.ReadModuleError) b
 	return bufsync.LookbackDecisionCodeFail
 }
 
-func (s *syncErrorHandler) InvalidRemoteSyncPoint(
+func (h *syncErrorHandler) InvalidRemoteSyncPoint(
 	module bufmoduleref.ModuleIdentity,
 	branch string,
 	syncPoint git.Hash,
@@ -392,7 +392,7 @@ func (s *syncErrorHandler) InvalidRemoteSyncPoint(
 				syncPoint.Hex(), branch, module.IdentityString(),
 			)
 		}
-		s.logger.Warn(
+		h.logger.Warn(
 			"last synced git commit not found in the git repo for a non-default branch",
 			zap.String("module", module.IdentityString()),
 			zap.String("branch", branch),


### PR DESCRIPTION
Accept an **optional** module identity override for the module flag. This is useful when syncing a repository, to set a target module identity, regardless of what HEAD content has.

This will be useful for dog fooding the sync command on our own repos, or other community repositories with valid Buf modules, in case we don't want or can't write to the git history, but still want to sync all activity across all branches.

Before:

```sh
buf alpha repo sync \
  # This would read the module name in the HEAD commit,
  # and only sync commits back in time that matched that name.
  --module my/proto/dir
```

Now:

```sh
buf alpha repo sync \
  # This will read the module name in the HEAD commit,
  # and only sync commits back in time that matched that name.
  --module my/proto/dir
  # This will use "buf.build/acme/foo" as the module target
  # identity for all branches, regardless of the module name
  # they have in the git commits, or even if they are unnamed.
  --module other/proto/dir:buf.build/acme/foo
```