### PR TITLE
Fix issue where txtpb was not properly recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix issue where `buf build -o` did not properly output files with the `.txtpb`
+  extension in Protobuf text format.
 
 ## [v1.26.0] - 2023-08-09
 

--- a/private/buf/bufconvert/bufconvert.go
+++ b/private/buf/bufconvert/bufconvert.go
@@ -32,8 +32,8 @@ const (
 	MessageEncodingBinpb MessageEncoding = iota + 1
 	// MessageEncodingJSON is the JSON image encoding.
 	MessageEncodingJSON
-	// MessageEncodingTextpb is the protobuf text image encoding.
-	MessageEncodingTextpb
+	// MessageEncodingTxtpb is the protobuf text image encoding.
+	MessageEncodingTxtpb
 	// formatBinpb is the binary format.
 	formatBinpb = "binpb"
 	// formatJSON is the JSON format.
@@ -118,7 +118,7 @@ func parseMessageEncodingExt(ext string, defaultEncoding MessageEncoding) Messag
 	case formatJSON:
 		return MessageEncodingJSON
 	case formatTxtpb:
-		return MessageEncodingTextpb
+		return MessageEncodingTxtpb
 	default:
 		return defaultEncoding
 	}
@@ -131,7 +131,7 @@ func parseMessageEncodingFormat(format string) (MessageEncoding, error) {
 	case formatJSON:
 		return MessageEncodingJSON, nil
 	case formatTxtpb:
-		return MessageEncodingTextpb, nil
+		return MessageEncodingTxtpb, nil
 	default:
 		return 0, fmt.Errorf("invalid format for message: %q", format)
 	}

--- a/private/buf/buffetch/ref_parser.go
+++ b/private/buf/buffetch/ref_parser.go
@@ -528,7 +528,7 @@ func processRawRefImage(rawRef *internal.RawRef) error {
 			format = formatBinpb
 		case ".json":
 			format = formatJSON
-		case ".textpb":
+		case ".txtpb":
 			format = formatTxtpb
 		case ".gz":
 			compressionType = internal.CompressionTypeGzip
@@ -537,7 +537,7 @@ func processRawRefImage(rawRef *internal.RawRef) error {
 				format = formatBinpb
 			case ".json":
 				format = formatJSON
-			case ".textpb":
+			case ".txtpb":
 				format = formatTxtpb
 			default:
 				return fmt.Errorf("path %q had .gz extension with unknown format", rawRef.Path)
@@ -549,7 +549,7 @@ func processRawRefImage(rawRef *internal.RawRef) error {
 				format = formatBinpb
 			case ".json":
 				format = formatJSON
-			case ".textpb":
+			case ".txtpb":
 				format = formatTxtpb
 			default:
 				return fmt.Errorf("path %q had .zst extension with unknown format", rawRef.Path)

--- a/private/buf/bufwire/proto_encoding_reader.go
+++ b/private/buf/bufwire/proto_encoding_reader.go
@@ -77,7 +77,7 @@ func (p *protoEncodingReader) GetMessage(
 		unmarshaler = protoencoding.NewWireUnmarshaler(resolver)
 	case bufconvert.MessageEncodingJSON:
 		unmarshaler = protoencoding.NewJSONUnmarshaler(resolver)
-	case bufconvert.MessageEncodingTextpb:
+	case bufconvert.MessageEncodingTxtpb:
 		unmarshaler = protoencoding.NewTxtpbUnmarshaler(resolver)
 	default:
 		return nil, errors.New("unknown message encoding type")

--- a/private/buf/bufwire/proto_encoding_writer.go
+++ b/private/buf/bufwire/proto_encoding_writer.go
@@ -65,7 +65,7 @@ func (p *protoEncodingWriter) PutMessage(
 		marshaler = protoencoding.NewWireMarshaler()
 	case bufconvert.MessageEncodingJSON:
 		marshaler = protoencoding.NewJSONMarshaler(resolver)
-	case bufconvert.MessageEncodingTextpb:
+	case bufconvert.MessageEncodingTxtpb:
 		marshaler = protoencoding.NewTxtpbMarshaler(resolver)
 	default:
 		return errors.New("unknown message encoding type")

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -232,7 +232,7 @@ func inverseEncoding(encoding bufconvert.MessageEncoding) (bufconvert.MessageEnc
 		return bufconvert.MessageEncodingJSON, nil
 	case bufconvert.MessageEncodingJSON:
 		return bufconvert.MessageEncodingBinpb, nil
-	case bufconvert.MessageEncodingTextpb:
+	case bufconvert.MessageEncodingTxtpb:
 		return bufconvert.MessageEncodingBinpb, nil
 	default:
 		return 0, fmt.Errorf("unknown message encoding %v", encoding)


### PR DESCRIPTION
Also fixes a naming inconsistency in `bufconvert` where `Textpb` was used instead of `Txtpb`.