### PR TITLE
Enable all branches sync

### DIFF
--- a/.github/workflows/buf-shadow-sync.yaml
+++ b/.github/workflows/buf-shadow-sync.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' # TODO enable all refs once `main` is synced at least once
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We can enable all branches now that `main` synced once: https://github.com/bufbuild/buf/actions/runs/5822579536