### PR TITLE
Add Utility Functions for Detecting Map Fields from Files and Messages

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
@@ -226,7 +226,7 @@ func checkFieldSameCType(add addFunc, corpus *corpus, previousField protosource.
 	if previousField.CType() != field.CType() {
 		// otherwise prints as hex
 		numberString := strconv.FormatInt(int64(field.Number()), 10)
-		add(field, nil, withBackupLocation(field.CTypeLocation(), field.Location()), `Field %q with name %q on message %q changed option "ctype" from %q to %q.`, numberString, field.Name(), field.Message().Name(), previousField.CType().String(), field.CType().String())
+		add(field, nil, withBackupLocation(field.CTypeLocation(), field.Location()), `Field %q with name %q on message %q changed option "ctype" from %q to %q.`, numberString, field.Name(), field.ParentMessage().Name(), previousField.CType().String(), field.CType().String())
 	}
 	return nil
 }
@@ -238,7 +238,7 @@ func checkFieldSameJSONName(add addFunc, corpus *corpus, previousField protosour
 	if previousField.JSONName() != field.JSONName() {
 		// otherwise prints as hex
 		numberString := strconv.FormatInt(int64(field.Number()), 10)
-		add(field, nil, withBackupLocation(field.JSONNameLocation(), field.Location()), `Field %q with name %q on message %q changed option "json_name" from %q to %q.`, numberString, field.Name(), field.Message().Name(), previousField.JSONName(), field.JSONName())
+		add(field, nil, withBackupLocation(field.JSONNameLocation(), field.Location()), `Field %q with name %q on message %q changed option "json_name" from %q to %q.`, numberString, field.Name(), field.ParentMessage().Name(), previousField.JSONName(), field.JSONName())
 	}
 	return nil
 }
@@ -250,7 +250,7 @@ func checkFieldSameJSType(add addFunc, corpus *corpus, previousField protosource
 	if previousField.JSType() != field.JSType() {
 		// otherwise prints as hex
 		numberString := strconv.FormatInt(int64(field.Number()), 10)
-		add(field, nil, withBackupLocation(field.JSTypeLocation(), field.Location()), `Field %q with name %q on message %q changed option "jstype" from %q to %q.`, numberString, field.Name(), field.Message().Name(), previousField.JSType().String(), field.JSType().String())
+		add(field, nil, withBackupLocation(field.JSTypeLocation(), field.Location()), `Field %q with name %q on message %q changed option "jstype" from %q to %q.`, numberString, field.Name(), field.ParentMessage().Name(), previousField.JSType().String(), field.JSType().String())
 	}
 	return nil
 }
@@ -263,7 +263,7 @@ func checkFieldSameLabel(add addFunc, corpus *corpus, previousField protosource.
 		// otherwise prints as hex
 		numberString := strconv.FormatInt(int64(field.Number()), 10)
 		// TODO: specific label location
-		add(field, nil, field.Location(), `Field %q on message %q changed label from %q to %q.`, numberString, field.Message().Name(), protodescriptor.FieldDescriptorProtoLabelPrettyString(previousField.Label()), protodescriptor.FieldDescriptorProtoLabelPrettyString(field.Label()))
+		add(field, nil, field.Location(), `Field %q on message %q changed label from %q to %q.`, numberString, field.ParentMessage().Name(), protodescriptor.FieldDescriptorProtoLabelPrettyString(previousField.Label()), protodescriptor.FieldDescriptorProtoLabelPrettyString(field.Label()))
 	}
 	return nil
 }
@@ -275,7 +275,7 @@ func checkFieldSameName(add addFunc, corpus *corpus, previousField protosource.F
 	if previousField.Name() != field.Name() {
 		// otherwise prints as hex
 		numberString := strconv.FormatInt(int64(field.Number()), 10)
-		add(field, nil, field.NameLocation(), `Field %q on message %q changed name from %q to %q.`, numberString, field.Message().Name(), previousField.Name(), field.Name())
+		add(field, nil, field.NameLocation(), `Field %q on message %q changed name from %q to %q.`, numberString, field.ParentMessage().Name(), previousField.Name(), field.Name())
 	}
 	return nil
 }
@@ -295,7 +295,7 @@ func checkFieldSameOneof(add addFunc, corpus *corpus, previousField protosource.
 		if previousOneof.Name() != oneof.Name() {
 			// otherwise prints as hex
 			numberString := strconv.FormatInt(int64(field.Number()), 10)
-			add(field, nil, field.Location(), `Field %q on message %q moved from oneof %q to oneof %q.`, numberString, field.Message().Name(), previousOneof.Name(), oneof.Name())
+			add(field, nil, field.Location(), `Field %q on message %q moved from oneof %q to oneof %q.`, numberString, field.ParentMessage().Name(), previousOneof.Name(), oneof.Name())
 		}
 		return nil
 	}
@@ -308,7 +308,7 @@ func checkFieldSameOneof(add addFunc, corpus *corpus, previousField protosource.
 	}
 	// otherwise prints as hex
 	numberString := strconv.FormatInt(int64(field.Number()), 10)
-	add(field, nil, field.Location(), `Field %q on message %q moved from %s to %s a oneof.`, numberString, field.Message().Name(), previous, current)
+	add(field, nil, field.Location(), `Field %q on message %q moved from %s to %s a oneof.`, numberString, field.ParentMessage().Name(), previous, current)
 	return nil
 }
 
@@ -493,7 +493,7 @@ func addFieldChangedType(add addFunc, previousField protosource.Field, field pro
 		fieldLocation,
 		`Field %q on message %q changed type from %q to %q.%s`,
 		previousNumberString,
-		field.Message().Name(),
+		field.ParentMessage().Name(),
 		protodescriptor.FieldDescriptorProtoTypePrettyString(previousField.Type()),
 		protodescriptor.FieldDescriptorProtoTypePrettyString(field.Type()),
 		combinedExtraMessage,
@@ -509,7 +509,7 @@ func addEnumGroupMessageFieldChangedTypeName(add addFunc, previousField protosou
 		field.TypeNameLocation(),
 		`Field %q on message %q changed type from %q to %q.`,
 		numberString,
-		field.Message().Name(),
+		field.ParentMessage().Name(),
 		strings.TrimPrefix(previousField.TypeName(), "."),
 		strings.TrimPrefix(field.TypeName(), "."),
 	)

--- a/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
@@ -266,7 +266,7 @@ func checkEnumZeroValueSuffix(add addFunc, enumValue protosource.EnumValue, suff
 var CheckFieldLowerSnakeCase = newFieldCheckFunc(checkFieldLowerSnakeCase)
 
 func checkFieldLowerSnakeCase(add addFunc, field protosource.Field) error {
-	message := field.Message()
+	message := field.ParentMessage()
 	if message == nil {
 		// just a sanity check
 		return errors.New("field.Message() was nil")
@@ -284,7 +284,7 @@ func checkFieldLowerSnakeCase(add addFunc, field protosource.Field) error {
 			// also check the message for this comment ignore
 			// this allows users to set this "globally" for a message
 			[]protosource.Location{
-				field.Message().Location(),
+				field.ParentMessage().Location(),
 			},
 			"Field name %q should be lower_snake_case, such as %q.",
 			name,
@@ -306,7 +306,7 @@ func checkFieldNoDescriptor(add addFunc, field protosource.Field) error {
 			// also check the message for this comment ignore
 			// this allows users to set this "globally" for a message
 			[]protosource.Location{
-				field.Message().Location(),
+				field.ParentMessage().Location(),
 			},
 			`Field name %q cannot be any capitalization of "descriptor" with any number of prefix or suffix underscores.`,
 			name,

--- a/private/pkg/protosource/field.go
+++ b/private/pkg/protosource/field.go
@@ -112,7 +112,7 @@ func (f *field) ParentMessage() Message {
 }
 
 func (f *field) IsMap() bool {
-	isMap, err := IsFieldAMapFromFiles(f, f.File())
+	isMap, err := isFieldAMapFromFiles(f, f.File())
 	if err != nil {
 		return false
 	}

--- a/private/pkg/protosource/field.go
+++ b/private/pkg/protosource/field.go
@@ -111,6 +111,14 @@ func (f *field) ParentMessage() Message {
 	return f.message
 }
 
+func (f *field) IsMap() bool {
+	isMap, err := IsFieldAMapFromFiles(f, f.File())
+	if err != nil {
+		return false
+	}
+	return isMap
+}
+
 func (f *field) Number() int {
 	return f.number
 }

--- a/private/pkg/protosource/field.go
+++ b/private/pkg/protosource/field.go
@@ -20,11 +20,11 @@ type field struct {
 	namedDescriptor
 	optionExtensionDescriptor
 
-	message  Message
-	number   int
-	label    descriptorpb.FieldDescriptorProto_Label
-	typ      descriptorpb.FieldDescriptorProto_Type
-	typeName string
+	parentMessage Message
+	number        int
+	label         descriptorpb.FieldDescriptorProto_Label
+	typ           descriptorpb.FieldDescriptorProto_Type
+	typeName      string
 	// if the field is an extension, this is the type being extended
 	extendee string
 	// this has to be the pointer to the private struct or you have the bug where the
@@ -52,7 +52,7 @@ type field struct {
 func newField(
 	namedDescriptor namedDescriptor,
 	optionExtensionDescriptor optionExtensionDescriptor,
-	message Message,
+	parentMessage Message,
 	number int,
 	label descriptorpb.FieldDescriptorProto_Label,
 	typ descriptorpb.FieldDescriptorProto_Type,
@@ -80,7 +80,7 @@ func newField(
 	return &field{
 		namedDescriptor:           namedDescriptor,
 		optionExtensionDescriptor: optionExtensionDescriptor,
-		message:                   message,
+		parentMessage:             parentMessage,
 		number:                    number,
 		label:                     label,
 		typ:                       typ,
@@ -108,7 +108,7 @@ func newField(
 }
 
 func (f *field) ParentMessage() Message {
-	return f.message
+	return f.parentMessage
 }
 
 func (f *field) IsMap() bool {

--- a/private/pkg/protosource/field.go
+++ b/private/pkg/protosource/field.go
@@ -107,7 +107,7 @@ func newField(
 	}
 }
 
-func (f *field) Message() Message {
+func (f *field) ParentMessage() Message {
 	return f.message
 }
 

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -1282,11 +1282,6 @@ func getMessageFromFiles(field Field, files ...File) (Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	return getMessageFromField(field, fullNameToMessage)
-}
-
-// getMessageFromField retrieves the Message associated with a field from a map of full names to Messages.
-func getMessageFromField(field Field, fullNameToMessage map[string]Message) (Message, error) {
 	out, ok := fullNameToMessage[field.TypeName()]
 	if !ok {
 		return nil, fmt.Errorf("message not found for field: %s", field.TypeName())

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -90,12 +90,12 @@ type LocationDescriptor interface {
 type NamedDescriptor interface {
 	LocationDescriptor
 
-	// FullName returns the fully-qualified name, i.e. some.pkg.Nested.Message.FooEnum.ENUM_VALUE.
+	// FullName returns the fully-qualified name, i.e. some.pkg.Nested.ParentMessage.FooEnum.ENUM_VALUE.
 	//
 	// Always non-empty.
 	FullName() string
-	// NestedName returns the full nested name without the package, i.e. Nested.Message.FooEnum
-	// or Nested.Message.FooEnum.ENUM_VALUE.
+	// NestedName returns the full nested name without the package, i.e. Nested.ParentMessage.FooEnum
+	// or Nested.ParentMessage.FooEnum.ENUM_VALUE.
 	//
 	// Always non-empty.
 	NestedName() string
@@ -388,7 +388,7 @@ type Field interface {
 	OptionExtensionDescriptor
 
 	// May be nil if this is attached to a file.
-	Message() Message
+	ParentMessage() Message
 	Number() int
 	Label() descriptorpb.FieldDescriptorProto_Label
 	Type() descriptorpb.FieldDescriptorProto_Type


### PR DESCRIPTION
Add utility functions for checking if a field is a map field using file and message information.

These functions provide the ability to determine whether a given field is a map field based on both file and message contexts. They utilize the provided field and file/message information to determine whether the field is a map entry. The functions also handle the necessary checks for field type and labeling to accurately identify map fields.

The added functions are as follows:
- `isFieldAMapFromFiles`: Checks if the field is a map field using file information.
- `isFieldAMapFromMessages`: Checks if the field is a map field using message information.
- `getMessageFromFiles`: Retrieves the Message associated with a field from a list of files.

These functions enhance the capability to work with map fields in the codebase.

Furthermore, I changed `protosource.Field.Message()` to `ParentMessage()` which better describes the result/responsibility of this function