### PR TITLE
Pass imports to buflint.Handler and filter imports internally

### DIFF
--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -23,7 +23,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint"
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint/buflintconfig"
-	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/command"
@@ -156,7 +155,7 @@ func run(
 		fileAnnotations, err := buflint.NewHandler(container.Logger()).Check(
 			ctx,
 			imageConfig.Config().Lint,
-			bufimage.ImageWithoutImports(imageConfig.Image()),
+			imageConfig.Image(),
 		)
 		if err != nil {
 			return err

--- a/private/buf/cmd/protoc-gen-buf-lint/lint.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint.go
@@ -107,8 +107,6 @@ func handle(
 	if err != nil {
 		return err
 	}
-	// We don't want to lint transitive dependencies, only the files specified.
-	image = bufimage.ImageWithoutImports(image)
 	fileAnnotations, err := buflint.NewHandler(logger).Check(
 		ctx,
 		config.Lint,

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -43,7 +43,7 @@ type Handler interface {
 	//
 	// The image should have source code info for this to work properly.
 	//
-	// Images should be filtered with regards to imports before passing to this function.
+	// Images should *not* be filtered with regards to imports before passing to this function.
 	Check(
 		ctx context.Context,
 		config *buflintconfig.Config,

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -459,10 +459,26 @@ func TestRunPackageLowerSnakeCase(t *testing.T) {
 
 func TestRunPackageNoImportCycle(t *testing.T) {
 	t.Parallel()
-	testLint(
+	testLintWithModifiers(
 		t,
 		"package_no_import_cycle",
-		bufanalysistesting.NewFileAnnotation(t, "b1.proto", 5, 1, 5, 19, "PACKAGE_NO_IMPORT_CYCLE"),
+		nil,
+		func(image bufimage.Image) bufimage.Image {
+			// Testing that import cycles are still detected via imports, but are
+			// not reported for imports, only for non-imports.
+			var newImageFiles []bufimage.ImageFile
+			for _, imageFile := range image.Files() {
+				if imageFile.FileDescriptor().GetPackage() == "b" {
+					newImageFiles = append(newImageFiles, imageFile.ImageFileWithIsImport(true))
+				} else {
+					require.False(t, imageFile.IsImport())
+					newImageFiles = append(newImageFiles, imageFile)
+				}
+			}
+			newImage, err := bufimage.NewImage(newImageFiles)
+			require.NoError(t, err)
+			return newImage
+		},
 		bufanalysistesting.NewFileAnnotation(t, "c1.proto", 5, 1, 5, 19, "PACKAGE_NO_IMPORT_CYCLE"),
 		bufanalysistesting.NewFileAnnotation(t, "d1.proto", 5, 1, 5, 19, "PACKAGE_NO_IMPORT_CYCLE"),
 	)
@@ -873,12 +889,13 @@ func TestCommentIgnoresOff(t *testing.T) {
 
 func TestCommentIgnoresOn(t *testing.T) {
 	t.Parallel()
-	testLintConfigModifier(
+	testLintWithModifiers(
 		t,
 		"comment_ignores",
 		func(config *bufconfig.Config) {
 			config.Lint.AllowCommentIgnores = true
 		},
+		nil,
 	)
 }
 
@@ -925,12 +942,13 @@ func TestCommentIgnoresCascadeOff(t *testing.T) {
 
 func TestCommentIgnoresCascadeOn(t *testing.T) {
 	t.Parallel()
-	testLintConfigModifier(
+	testLintWithModifiers(
 		t,
 		"comment_ignores_cascade",
 		func(config *bufconfig.Config) {
 			config.Lint.AllowCommentIgnores = true
 		},
+		nil,
 	)
 }
 
@@ -939,18 +957,20 @@ func testLint(
 	relDirPath string,
 	expectedFileAnnotations ...bufanalysis.FileAnnotation,
 ) {
-	testLintConfigModifier(
+	testLintWithModifiers(
 		t,
 		relDirPath,
+		nil,
 		nil,
 		expectedFileAnnotations...,
 	)
 }
 
-func testLintConfigModifier(
+func testLintWithModifiers(
 	t *testing.T,
 	relDirPath string,
 	configModifier func(*bufconfig.Config),
+	imageModifier func(bufimage.Image) bufimage.Image,
 	expectedFileAnnotations ...bufanalysis.FileAnnotation,
 ) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -986,7 +1006,9 @@ func testLintConfigModifier(
 	)
 	require.NoError(t, err)
 	require.Empty(t, fileAnnotations)
-	image = bufimage.ImageWithoutImports(image)
+	if imageModifier != nil {
+		image = imageModifier(image)
+	}
 
 	handler := buflint.NewHandler(logger)
 	fileAnnotations, err = handler.Check(

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -51,8 +51,13 @@ type ImageFile interface {
 	// All indexes will be valid.
 	// Will return nil if empty.
 	UnusedDependencyIndexes() []int32
+	// ImageFileWithIsImport returns a copy of the ImageFile with the new ImageFile
+	// now marked as an import.
+	//
+	// If the original ImageFile was already an import, this returns
+	// the original ImageFile.
+	ImageFileWithIsImport(isImport bool) ImageFile
 
-	withIsImport(isImport bool) ImageFile
 	isImageFile()
 }
 

--- a/private/bufpkg/bufimage/image_file.go
+++ b/private/bufpkg/bufimage/image_file.go
@@ -83,12 +83,12 @@ func (f *imageFile) UnusedDependencyIndexes() []int32 {
 	return f.storedUnusedDependencyIndexes
 }
 
-func (f *imageFile) withIsImport(isImport bool) ImageFile {
+func (f *imageFile) ImageFileWithIsImport(isImport bool) ImageFile {
 	if f.IsImport() == isImport {
 		return f
 	}
 	return &imageFile{
-		FileInfo:                      f.FileInfo.WithIsImport(isImport),
+		FileInfo:                      f.FileInfo.FileInfoWithIsImport(isImport),
 		fileDescriptorProto:           f.fileDescriptorProto,
 		isSyntaxUnspecified:           f.isSyntaxUnspecified,
 		storedUnusedDependencyIndexes: f.storedUnusedDependencyIndexes,

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -270,7 +270,7 @@ func addFileWithImports(
 	_, isNotImport := nonImportPaths[path]
 	accumulator = append(
 		accumulator,
-		imageFile.withIsImport(!isNotImport),
+		imageFile.ImageFileWithIsImport(!isNotImport),
 	)
 	return accumulator
 }

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -66,8 +66,8 @@ type FileInfo interface {
 	// even if ModuleIdentity is set, that is commit is optional information
 	// even if we know what module this file came from.
 	Commit() string
-	// WithIsImport returns this FileInfo with the given IsImport value.
-	WithIsImport(isImport bool) FileInfo
+	// FileInfoWithIsImport returns this FileInfo with the given IsImport value.
+	FileInfoWithIsImport(isImport bool) FileInfo
 
 	isFileInfo()
 }

--- a/private/bufpkg/bufmodule/bufmoduleref/file_info.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/file_info.go
@@ -86,7 +86,7 @@ func (f *fileInfo) Commit() string {
 	return f.commit
 }
 
-func (f *fileInfo) WithIsImport(isImport bool) FileInfo {
+func (f *fileInfo) FileInfoWithIsImport(isImport bool) FileInfo {
 	return newFileInfoNoValidate(
 		f.path,
 		f.externalPath,

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -206,6 +206,8 @@ type FileInfo interface {
 	// even if ModuleIdentity is set, that is commit is optional information
 	// even if we know what module this file came from.
 	Commit() string
+	// IsImport returns true if this file is an import.
+	IsImport() bool
 }
 
 // File is a file descriptor.


### PR DESCRIPTION
Our linters should not consider imports when reporting lint errors. For almost all of our linters, this means that we do not need access to the import descriptors when performing lint checks. However, this is not the case for a couple:

- `PACKAGE_NO_IMPORT_CYCLE` - this should report an import cycle even if it involves imports. It is a bug that we were not reporting this up until this point.
- Our upcoming linters for `protovalidate` - some require access to import descriptors.

This moves the import filtering to below the `buflint.Handler` level. The vast majority of our linters remain the same, and so do the helpers they call, however we have one helper, `newFilesWithImportsCheckFunc`, that passes import `protosource.Files` to the lint checker. When this is used, errors should still not be reported for imports, however this does give full access to all files.

Note that this means that `buflint.Handler` and `bufbreaking.Handler` have different calling requirements, but they were always meant (and have APIs exposed as) to be independent packages that happened to call the same backing infrastructure via `internal` packages under the hood.