### PR TITLE
Add WithAllowV0 to PackageVersion construction

### DIFF
--- a/private/pkg/protoversion/package_version.go
+++ b/private/pkg/protoversion/package_version.go
@@ -29,7 +29,7 @@ type packageVersion struct {
 	suffix         string
 }
 
-func newPackageVersionForPackage(pkg string) (*packageVersion, bool) {
+func newPackageVersionForPackage(pkg string, options ...PackageVersionOption) (*packageVersion, bool) {
 	if pkg == "" {
 		return nil, false
 	}
@@ -37,10 +37,19 @@ func newPackageVersionForPackage(pkg string) (*packageVersion, bool) {
 	if len(parts) < 2 {
 		return nil, false
 	}
-	return newPackageVersionForComponent(parts[len(parts)-1])
+	return newPackageVersionForComponent(parts[len(parts)-1], options...)
 }
 
-func newPackageVersionForComponent(component string) (*packageVersion, bool) {
+func newPackageVersionForComponent(component string, options ...PackageVersionOption) (*packageVersion, bool) {
+	packageVersionOptions := newPackageVersionOptions()
+	for _, option := range options {
+		option(packageVersionOptions)
+	}
+	minMajorVersionNumber := 1
+	if packageVersionOptions.allowV0 {
+		minMajorVersionNumber = 0
+	}
+
 	if strings.Contains(component, ".") {
 		return nil, false
 	}
@@ -63,7 +72,7 @@ func newPackageVersionForComponent(component string) (*packageVersion, bool) {
 		if len(split) != 2 {
 			return nil, false
 		}
-		major, ok := positiveNumber(split[0])
+		major, ok := getNumber(split[0], minMajorVersionNumber)
 		if !ok {
 			return nil, false
 		}
@@ -94,12 +103,12 @@ func newPackageVersionForComponent(component string) (*packageVersion, bool) {
 		minor := 0
 		var ok bool
 		if split[1] != "" {
-			minor, ok = positiveNumber(split[1])
+			minor, ok = getNumber(split[1], 1)
 			if !ok {
 				return nil, false
 			}
 		}
-		major, patch, ok := getAlphaBetaMajorPatch(split[0])
+		major, patch, ok := getAlphaBetaMajorPatch(split[0], minMajorVersionNumber)
 		if !ok {
 			return nil, false
 		}
@@ -107,7 +116,7 @@ func newPackageVersionForComponent(component string) (*packageVersion, bool) {
 	}
 
 	// no suffix that is valid, make sure we just have a number
-	major, ok := positiveNumber(version)
+	major, ok := getNumber(version, minMajorVersionNumber)
 	if !ok {
 		return nil, false
 	}
@@ -170,32 +179,32 @@ func (p *packageVersion) String() string {
 
 func (p *packageVersion) isPackageVersion() {}
 
-func getAlphaBetaMajorPatch(remainder string) (int, int, bool) {
+func getAlphaBetaMajorPatch(remainder string, minMajorVersionNumber int) (int, int, bool) {
 	if strings.Contains(remainder, "p") {
 		// 1p1 -> [1, 1]
 		patchSplit := strings.SplitN(remainder, "p", 2)
 		if len(patchSplit) != 2 {
 			return 0, 0, false
 		}
-		major, ok := positiveNumber(patchSplit[0])
+		major, ok := getNumber(patchSplit[0], minMajorVersionNumber)
 		if !ok {
 			return 0, 0, false
 		}
-		patch, ok := positiveNumber(patchSplit[1])
+		patch, ok := getNumber(patchSplit[1], 1)
 		if !ok {
 			return 0, 0, false
 		}
 		return major, patch, true
 	}
 	// no patch, make sure just a number
-	major, ok := positiveNumber(remainder)
+	major, ok := getNumber(remainder, minMajorVersionNumber)
 	if !ok {
 		return 0, 0, false
 	}
 	return major, 0, true
 }
 
-func positiveNumber(s string) (int, bool) {
+func getNumber(s string, min int) (int, bool) {
 	if s == "" {
 		return 0, false
 	}
@@ -203,8 +212,16 @@ func positiveNumber(s string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
-	if value < 1 {
+	if value < int64(min) {
 		return 0, false
 	}
 	return int(value), true
+}
+
+type packageVersionOptions struct {
+	allowV0 bool
+}
+
+func newPackageVersionOptions() *packageVersionOptions {
+	return &packageVersionOptions{}
 }

--- a/private/pkg/protoversion/protoversion.go
+++ b/private/pkg/protoversion/protoversion.go
@@ -66,7 +66,7 @@ type PackageVersion interface {
 	fmt.Stringer
 
 	// Required.
-	// Will always be >=1.
+	// Will always be >=0.
 	Major() int
 	// Required.
 	StabilityLevel() StabilityLevel
@@ -88,8 +88,8 @@ type PackageVersion interface {
 // NewPackageVersionForPackage returns the PackageVersion for the package.
 //
 // Returns false if the package has no package version per the specifications.
-func NewPackageVersionForPackage(pkg string) (PackageVersion, bool) {
-	return newPackageVersionForPackage(pkg)
+func NewPackageVersionForPackage(pkg string, options ...PackageVersionOption) (PackageVersion, bool) {
+	return newPackageVersionForPackage(pkg, options...)
 }
 
 // NewPackageVersionForCompoonent returns the PackageVersion for the package component.
@@ -99,6 +99,18 @@ func NewPackageVersionForPackage(pkg string) (PackageVersion, bool) {
 //
 // Also returns false if the input is not a component.
 // That is, the input "foo.bar" is not a component, this is a package.
-func NewPackageVersionForComponent(component string) (PackageVersion, bool) {
-	return newPackageVersionForComponent(component)
+func NewPackageVersionForComponent(component string, options ...PackageVersionOption) (PackageVersion, bool) {
+	return newPackageVersionForComponent(component, options...)
+}
+
+// PackageVersionOption is an option when constructing a new PackageVersion.
+type PackageVersionOption func(*packageVersionOptions)
+
+// WithAllowV0 returns a new PackageVersionOption that allows major version numbers to be 0.
+//
+// The default is to only allow 1+ major version numbers.
+func WithAllowV0() PackageVersionOption {
+	return func(packageVersionOptions *packageVersionOptions) {
+		packageVersionOptions.allowV0 = true
+	}
 }

--- a/private/pkg/protoversion/protoversion_test.go
+++ b/private/pkg/protoversion/protoversion_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPackageVersionForPackage(t *testing.T) {
@@ -82,6 +83,15 @@ func TestNewPackageVersionForPackage(t *testing.T) {
 	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1aalpha1")
 	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1p1test")
 	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1p1testfoo")
+	testNewPackageVersionForPackage(t, newPackageVersion(0, StabilityLevelStable, 0, 0, ""), true, "foo.bar.v0", WithAllowV0())
+	testNewPackageVersionForPackage(t, newPackageVersion(0, StabilityLevelAlpha, 1, 0, ""), true, "foo.bar.v0alpha1", WithAllowV0())
+	testNewPackageVersionForPackage(t, newPackageVersion(0, StabilityLevelBeta, 1, 0, ""), true, "foo.bar.v0beta1", WithAllowV0())
+	testNewPackageVersionForPackage(t, newPackageVersion(0, StabilityLevelTest, 0, 0, ""), true, "foo.bar.v0test", WithAllowV0())
+	testNewPackageVersionForPackage(t, newPackageVersion(0, StabilityLevelTest, 0, 0, "foo"), true, "foo.bar.v0testfoo", WithAllowV0())
+	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1alpha0", WithAllowV0())
+	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1beta0", WithAllowV0())
+	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1p0alpha1", WithAllowV0())
+	testNewPackageVersionForPackage(t, nil, false, "foo.bar.v1p0beta1", WithAllowV0())
 }
 
 func TestNewPackageVersionForComponent(t *testing.T) {
@@ -126,8 +136,6 @@ func TestNewPackageVersionForComponent(t *testing.T) {
 	testNewPackageVersionForComponent(t, nil, false, "v1beta0")
 	testNewPackageVersionForComponent(t, nil, false, "v1p1alpha0")
 	testNewPackageVersionForComponent(t, nil, false, "v1p1beta0")
-	testNewPackageVersionForComponent(t, nil, false, "v1p0alpha1")
-	testNewPackageVersionForComponent(t, nil, false, "v1p0beta1")
 	testNewPackageVersionForComponent(t, nil, false, "vv1")
 	testNewPackageVersionForComponent(t, nil, false, "vv1alpha1")
 	testNewPackageVersionForComponent(t, nil, false, "vv1alpha2")
@@ -142,12 +150,22 @@ func TestNewPackageVersionForComponent(t *testing.T) {
 	testNewPackageVersionForComponent(t, nil, false, "v1aalpha1")
 	testNewPackageVersionForComponent(t, nil, false, "v1p1test")
 	testNewPackageVersionForComponent(t, nil, false, "v1p1testfoo")
+	testNewPackageVersionForComponent(t, newPackageVersion(0, StabilityLevelStable, 0, 0, ""), true, "v0", WithAllowV0())
+	testNewPackageVersionForComponent(t, newPackageVersion(0, StabilityLevelAlpha, 1, 0, ""), true, "v0alpha1", WithAllowV0())
+	testNewPackageVersionForComponent(t, newPackageVersion(0, StabilityLevelBeta, 1, 0, ""), true, "v0beta1", WithAllowV0())
+	testNewPackageVersionForComponent(t, newPackageVersion(0, StabilityLevelTest, 0, 0, ""), true, "v0test", WithAllowV0())
+	testNewPackageVersionForComponent(t, newPackageVersion(0, StabilityLevelTest, 0, 0, "foo"), true, "v0testfoo", WithAllowV0())
+	testNewPackageVersionForComponent(t, nil, false, "v1alpha0", WithAllowV0())
+	testNewPackageVersionForComponent(t, nil, false, "v1beta0", WithAllowV0())
+	testNewPackageVersionForComponent(t, nil, false, "v1p0alpha1", WithAllowV0())
+	testNewPackageVersionForComponent(t, nil, false, "v1p0beta1", WithAllowV0())
 }
 
-func testNewPackageVersionForPackage(t *testing.T, expectedPackageVersion PackageVersion, expectedOK bool, pkg string) {
-	packageVersion, ok := NewPackageVersionForPackage(pkg)
+func testNewPackageVersionForPackage(t *testing.T, expectedPackageVersion PackageVersion, expectedOK bool, pkg string, options ...PackageVersionOption) {
+	packageVersion, ok := NewPackageVersionForPackage(pkg, options...)
 	assert.Equal(t, expectedOK, ok, pkg)
 	if expectedOK {
+		require.NotNil(t, packageVersion)
 		assert.Equal(t, expectedPackageVersion, packageVersion, pkg)
 		split := strings.Split(pkg, ".")
 		assert.Equal(t, split[len(split)-1], packageVersion.String(), pkg)
@@ -156,8 +174,8 @@ func testNewPackageVersionForPackage(t *testing.T, expectedPackageVersion Packag
 	}
 }
 
-func testNewPackageVersionForComponent(t *testing.T, expectedPackageVersion PackageVersion, expectedOK bool, component string) {
-	packageVersion, ok := NewPackageVersionForComponent(component)
+func testNewPackageVersionForComponent(t *testing.T, expectedPackageVersion PackageVersion, expectedOK bool, component string, options ...PackageVersionOption) {
+	packageVersion, ok := NewPackageVersionForComponent(component, options...)
 	assert.Equal(t, expectedOK, ok, component)
 	if expectedOK {
 		assert.Equal(t, expectedPackageVersion, packageVersion, component)


### PR DESCRIPTION
Needed for an external case where we need to be able to parse `v0`'s.