### PR TITLE
Validate no duplicate module targets across directories

### DIFF
--- a/private/buf/bufsync/prepare_sync_test.go
+++ b/private/buf/bufsync/prepare_sync_test.go
@@ -1,0 +1,114 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufsync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/bufbuild/buf/private/pkg/storage/storagegit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestPrepareSyncDuplicateIdentities(t *testing.T) {
+	t.Parallel()
+	moduleDirs := map[string]struct{}{
+		"dir1": {},
+		"dir2": {},
+		"dir3": {},
+	}
+	var (
+		moduleDirsToDuplicatedIdentities = make(map[string]bufmoduleref.ModuleIdentity, len(moduleDirs))
+		moduleDirsToDifferentIdentities  = make(map[string]bufmoduleref.ModuleIdentity, len(moduleDirs))
+		moduleDirsToNilIdentities        = make(map[string]bufmoduleref.ModuleIdentity, len(moduleDirs))
+	)
+	repeatedIdentity, err := bufmoduleref.NewModuleIdentity("buf.build", "acme", "foo")
+	require.NoError(t, err)
+	for moduleDir := range moduleDirs {
+		moduleDirsToDuplicatedIdentities[moduleDir] = repeatedIdentity
+		differentIdentity, err := bufmoduleref.NewModuleIdentity("buf.build", "acme", moduleDir)
+		require.NoError(t, err)
+		moduleDirsToDifferentIdentities[moduleDir] = differentIdentity
+		moduleDirsToNilIdentities[moduleDir] = nil
+	}
+	type testCase struct {
+		name                    string
+		modulesIdentitiesInHEAD map[string]bufmoduleref.ModuleIdentity
+		modulesOverrides        map[string]bufmoduleref.ModuleIdentity
+	}
+	testCases := []testCase{
+		{
+			name:                    "when_dirs_have_duplicated_identities_in_HEAD_no_overrides",
+			modulesIdentitiesInHEAD: moduleDirsToDuplicatedIdentities,
+			modulesOverrides:        moduleDirsToNilIdentities,
+		},
+		{
+			name:                    "when_dirs_have_different_identities_in_HEAD_but_duplicated_overrides",
+			modulesIdentitiesInHEAD: moduleDirsToDifferentIdentities,
+			modulesOverrides:        moduleDirsToDuplicatedIdentities,
+		},
+	}
+	for _, tc := range testCases {
+		func(tc testCase) {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				const defaultBranchName = "main"
+				repo, repoDir := scaffoldGitRepository(t, defaultBranchName)
+				prepareGitRepoMultiModule(t, repoDir, tc.modulesIdentitiesInHEAD)
+				var moduleDirs []string
+				for moduleDir := range tc.modulesIdentitiesInHEAD {
+					moduleDirs = append(moduleDirs, moduleDir)
+				}
+				testSyncer := syncer{
+					repo:                                  repo,
+					storageGitProvider:                    storagegit.NewProvider(repo.Objects()),
+					logger:                                zaptest.NewLogger(t),
+					sortedModulesDirsForSync:              moduleDirs,
+					modulesDirsToIdentityOverrideForSync:  tc.modulesOverrides,
+					commitsToTags:                         make(map[string][]string),
+					modulesDirsToBranchesToIdentities:     make(map[string]map[string]bufmoduleref.ModuleIdentity),
+					modulesToBranchesExpectedSyncPoints:   make(map[string]map[string]string),
+					modulesIdentitiesToCommitsSyncedCache: make(map[string]map[string]struct{}),
+					errorHandler:                          &mockErrorHandler{},
+				}
+				prepareErr := testSyncer.prepareSync(context.Background())
+				require.Error(t, prepareErr)
+				assert.Contains(t, prepareErr.Error(), repeatedIdentity.IdentityString())
+				assert.Contains(t, prepareErr.Error(), defaultBranchName)
+				for _, moduleDir := range moduleDirs {
+					assert.Contains(t, prepareErr.Error(), moduleDir)
+				}
+			})
+		}(tc)
+	}
+}
+
+// prepareGitRepoMultiModule commits valid modules to the passed directories and module identities.
+func prepareGitRepoMultiModule(t *testing.T, repoDir string, moduleDirsToIdentities map[string]bufmoduleref.ModuleIdentity) {
+	runner := command.NewRunner()
+	for moduleDir, moduleIdentity := range moduleDirsToIdentities {
+		writeFiles(t, repoDir, map[string]string{
+			moduleDir + "/buf.yaml":         fmt.Sprintf("version: v1\nname: %s\n", moduleIdentity.IdentityString()),
+			moduleDir + "/foo/v1/foo.proto": "syntax = \"proto3\";\n\npackage foo.v1;\n\nmessage Foo {}\n",
+		})
+	}
+	runInDir(t, runner, repoDir, "git", "add", ".")
+	runInDir(t, runner, repoDir, "git", "commit", "-m", "commit")
+}

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -258,11 +258,11 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 	for _, branch := range s.sortedBranchesForSync {
 		identitiesInBranch := make(map[string][]string) // moduleIdentity:[]moduleDir
 		for _, moduleDir := range s.sortedModulesDirsForSync {
-			branchesToIdentities, ok := s.modulesDirsToBranchesToIdentities[moduleDir]
+			branchToIdentity, ok := s.modulesDirsToBranchesToIdentities[moduleDir]
 			if !ok {
 				continue // this module directory won't be synced by any branch
 			}
-			identity, ok := branchesToIdentities[branch]
+			identity, ok := branchToIdentity[branch]
 			if !ok || identity == nil {
 				continue // this module directory won't be synced by this branch
 			}

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -272,7 +272,7 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 			if len(moduleDirs) > 1 {
 				duplicatedIdentitiesErr = multierr.Append(duplicatedIdentitiesErr, fmt.Errorf(
 					"module identity %s cannot be synced in branch %s: present in multiple module directories: [%s]",
-					moduleIdentity, branch, strings.Join(moduleDirs, ","),
+					moduleIdentity, branch, strings.Join(moduleDirs, ", "),
 				))
 			}
 		}

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
@@ -28,6 +29,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagegit"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -126,7 +128,7 @@ func (s *syncer) Sync(ctx context.Context, syncFunc SyncFunc) error {
 	for _, moduleDir := range s.sortedModulesDirsForSync {
 		branchesToIdentities, shouldSyncModuleDir := s.modulesDirsToBranchesToIdentities[moduleDir]
 		if !shouldSyncModuleDir {
-			s.logger.Warn("module directory has no branches to sync", zap.String("module directory", moduleDir))
+			s.logger.Warn("module directory has no module identity target in any branch", zap.String("module directory", moduleDir))
 			continue
 		}
 		// for each branch in the right sync order
@@ -134,7 +136,7 @@ func (s *syncer) Sync(ctx context.Context, syncFunc SyncFunc) error {
 			moduleIdentity, branchHasIdentity := branchesToIdentities[branch]
 			if !branchHasIdentity || moduleIdentity == nil {
 				s.logger.Warn(
-					"module directory has no module identity in branch",
+					"module directory has no module identity target for branch",
 					zap.String("module directory", moduleDir),
 					zap.String("branch", branch),
 				)
@@ -175,7 +177,7 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("looping over repository branches: %w", err)
 	}
-	// sync default git branch, make sure it's present in all the branches
+	// sync default git branch, make sure it's present
 	defaultBranch := s.repo.DefaultBranch()
 	if _, defaultBranchPresent := allBranches[defaultBranch]; !defaultBranchPresent {
 		return fmt.Errorf("default branch %s is not present in all branches", defaultBranch)
@@ -186,7 +188,7 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 		// sync all branches
 		branchesToSync = stringutil.MapToSlice(allBranches)
 	} else {
-		// sync current branch, make sure it's present in all the branches
+		// sync current branch, make sure it's present
 		currentBranch := s.repo.CurrentBranch()
 		if _, currentBranchPresent := allBranches[currentBranch]; !currentBranchPresent {
 			return fmt.Errorf("current branch %s is not present in all branches", currentBranch)
@@ -250,6 +252,33 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 				s.modulesToBranchesExpectedSyncPoints[targetModuleIdentityString][branch] = moduleBranchSyncPoint.Hex()
 			}
 		}
+	}
+	// make sure no duplicate identities for different directories in the same branch
+	var duplicatedIdentitiesErr error
+	for _, branch := range s.sortedBranchesForSync {
+		identitiesInBranch := make(map[string][]string) // moduleIdentity:[]moduleDir
+		for _, moduleDir := range s.sortedModulesDirsForSync {
+			branchesToIdentities, ok := s.modulesDirsToBranchesToIdentities[moduleDir]
+			if !ok {
+				continue // this module directory won't be synced by any branch
+			}
+			identity, ok := branchesToIdentities[branch]
+			if !ok || identity == nil {
+				continue // this module directory won't be synced by this branch
+			}
+			identitiesInBranch[identity.IdentityString()] = append(identitiesInBranch[identity.IdentityString()], moduleDir)
+		}
+		for moduleIdentity, moduleDirs := range identitiesInBranch {
+			if len(moduleDirs) > 1 {
+				duplicatedIdentitiesErr = multierr.Append(duplicatedIdentitiesErr, fmt.Errorf(
+					"module identity %s cannot be synced in branch %s: present in multiple module directories: [%s]",
+					moduleIdentity, branch, strings.Join(moduleDirs, ","),
+				))
+			}
+		}
+	}
+	if duplicatedIdentitiesErr != nil {
+		return duplicatedIdentitiesErr
 	}
 	// (4) Populate default branches for all module identities (from all branches).
 	if s.moduleDefaultBranchGetter != nil {


### PR DESCRIPTION
Make sure that in a branch scope, each module directory has a unique module target.