### PR TITLE
Improve error message for invalid remotes

### DIFF
--- a/private/buf/bufcli/errors.go
+++ b/private/buf/bufcli/errors.go
@@ -181,10 +181,9 @@ func wrapError(err error) error {
 			}
 			return errors.New(msg)
 		}
-		return fmt.Errorf("Failure: %s", connectErr.Message())
 	}
 
-	// Error was not a Connect error
+	// Error was not a known Connect error, so return it as-is.
 	return fmt.Errorf("Failure: %w", err)
 }
 

--- a/private/buf/bufcli/errors.go
+++ b/private/buf/bufcli/errors.go
@@ -141,7 +141,10 @@ func NewTokenNotFoundError(tokenID string) error {
 	return fmt.Errorf("a token with ID %q does not exist", tokenID)
 }
 
-func NewUnimplementedRemoteError(err error, remote string, moduleIdentity string) error {
+func NewInvalidRemoteError(err error, remote string, moduleIdentity string) error {
+	if connectErr, ok := asConnectError(err); ok {
+		err = connectErr.Unwrap()
+	}
 	return fmt.Errorf("%w. Are you sure %q (derived from module name %q) is a Buf Schema Registry?", err, remote, moduleIdentity)
 }
 
@@ -181,6 +184,7 @@ func wrapError(err error) error {
 			}
 			return errors.New(msg)
 		}
+		err = connectErr.Unwrap()
 	}
 
 	// Error was not a known Connect error, so return it as-is.

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -125,8 +125,8 @@ func run(
 			}),
 		)
 		if err != nil {
-			if connect.CodeOf(err) == connect.CodeUnimplemented && remote != bufconnect.DefaultRemote {
-				return bufcli.NewUnimplementedRemoteError(err, remote, config.ModuleIdentity.IdentityString())
+			if remote != bufconnect.DefaultRemote {
+				return bufcli.NewInvalidRemoteError(err, remote, config.ModuleIdentity.IdentityString())
 			}
 			return err
 		}

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -268,7 +268,8 @@ func getDependencies(
 		}),
 	)
 	if err != nil {
-		if connect.CodeOf(err) == connect.CodeUnimplemented && remote != bufconnect.DefaultRemote {
+		code := connect.CodeOf(err)
+		if (code == connect.CodeUnimplemented || code == connect.CodePermissionDenied) && remote != bufconnect.DefaultRemote {
 			return nil, bufcli.NewUnimplementedRemoteError(err, remote, moduleConfig.ModuleIdentity.IdentityString())
 		}
 		return nil, err

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -268,9 +268,8 @@ func getDependencies(
 		}),
 	)
 	if err != nil {
-		code := connect.CodeOf(err)
-		if (code == connect.CodeUnimplemented || code == connect.CodePermissionDenied) && remote != bufconnect.DefaultRemote {
-			return nil, bufcli.NewUnimplementedRemoteError(err, remote, moduleConfig.ModuleIdentity.IdentityString())
+		if remote != bufconnect.DefaultRemote {
+			return nil, bufcli.NewInvalidRemoteError(err, remote, moduleConfig.ModuleIdentity.IdentityString())
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Extends error handling for invalid remotes to include `permission_denied` (is it safe to drop the code check?). Connect errors were being unwrapped back to simple form removing the message, so avoid unwrapping if not handled in the connect check. 

Before: 
```diff
-Failure: 403 Forbidden
+Failure: 403 Forbidden. Are you sure "github.com" (derived from module name "github.com/tmc/buf-fhir-example") is a Buf Schema Registry?
```
Issue: https://bufbuild.slack.com/archives/CRZ680FUH/p1695882656754589