### PR TITLE
Fix user-agent used by `buf curl`

### DIFF
--- a/private/buf/bufcurl/verbose_transport.go
+++ b/private/buf/bufcurl/verbose_transport.go
@@ -53,7 +53,7 @@ func DefaultUserAgent(protocol string, bufVersion string) string {
 	if strings.Contains(protocol, "grpc") {
 		libUserAgent = "grpc-go-connect"
 	}
-	return fmt.Sprintf("buf/%s %s/%s (%s)", bufVersion, libUserAgent, connect.Version, runtime.Version())
+	return fmt.Sprintf("%s/%s (%s) buf/%s", libUserAgent, connect.Version, runtime.Version(), bufVersion)
 }
 
 // NewVerboseHTTPClient creates a new HTTP client with the given transport and

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -814,11 +814,11 @@ func run(ctx context.Context, container appflag.Container, f *flags) (err error)
 	if err != nil {
 		return err
 	}
+	userAgent := f.UserAgent
+	if userAgent == "" {
+		userAgent = bufcurl.DefaultUserAgent(f.Protocol, bufcli.Version)
+	}
 	if len(requestHeaders.Values("user-agent")) == 0 {
-		userAgent := f.UserAgent
-		if userAgent == "" {
-			userAgent = bufcurl.DefaultUserAgent(f.Protocol, bufcli.Version)
-		}
 		requestHeaders.Set("user-agent", userAgent)
 	}
 	var basicCreds *string
@@ -884,6 +884,9 @@ func run(ctx context.Context, container appflag.Container, f *flags) (err error)
 			if creds != "" {
 				reflectHeaders.Set("authorization", creds)
 			}
+		}
+		if len(reflectHeaders.Values("user-agent")) == 0 {
+			reflectHeaders.Set("user-agent", userAgent)
 		}
 		reflectProtocol, err := bufcurl.ParseReflectProtocol(f.ReflectProtocol)
 		if err != nil {


### PR DESCRIPTION
According to [this page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent), it looks like I should add extensions to the user agent to the end, not the beginning. So this fixes the order to better comply with the way browsers construct user agent strings.

This also fixes a small bug: previously, the default Connect user-agent would be used for reflection requests, unless overridden with a `--reflect-header` argument. Now it uses the same user-agent as the other requests, which comes from the `--user-agent` argument and, lacking that, is the default Connect user-agent string plus `buf/<version>`. For example: `connect-go/1.11.1 (go1.20.1) buf/1.26.2-dev`.