### PR TITLE
Update `repository` to `repositories` in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
-          repository: ${{ github.repository }}
+          repositories: [ ${{ github.repository }} ]
           permissions: >-
             {"contents": "write"}
       - name: Set VERSION variable from tag
@@ -120,7 +120,7 @@ jobs:
         with:
           app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
-          repository: ${{ github.repository }}
+          repositories: [ ${{ github.repository }} ]
           permissions: >-
             {"contents": "write", "pull_requests": "write"}
       - name: Checkout repository code
@@ -169,7 +169,7 @@ jobs:
         with:
           app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
-          repository: ${{ github.repository }}
+          repositories: [ ${{ github.repository }} ]
           permissions: >-
             {"contents": "write", "pull_requests": "write"}
       - name: Checkout repository code
@@ -212,7 +212,7 @@ jobs:
         with:
           app_id: ${{secrets.BUF_MAVEN_PUBLISH_APP_ID}}
           private_key: ${{ secrets.BUF_MAVEN_PUBLISH_APP_PRIVATE_KEY }}
-          repository: "bufbuild/buf-maven-publish"
+          repositories: [ "bufbuild/buf-maven-publish" ]
           permissions: >-
             {"actions": "write"}
       - name: trigger maven update
@@ -239,7 +239,7 @@ jobs:
         with:
           app_id: ${{secrets.BUF_NPM_PUBLISH_RELEASE_APP_ID}}
           private_key: ${{ secrets.BUF_NPM_PUBLISH_RELEASE_APP_PRIVATE_KEY }}
-          repository: "bufbuild/buf-npm-publish"
+          repositories: [ "bufbuild/buf-npm-publish" ]
           permissions: >-
             {"actions": "write"}
       - name: trigger npm publish
@@ -266,7 +266,7 @@ jobs:
         with:
           app_id: ${{secrets.HOMEBREW_RELEASE_APP_ID}}
           private_key: ${{ secrets.HOMEBREW_RELEASE_APP_PRIVATE_KEY }}
-          repository: "bufbuild/homebrew-buf"
+          repositories: [ "bufbuild/homebrew-buf" ]
           permissions: >-
             {"actions": "write"}
       - name: trigger homebrew-buf release
@@ -293,7 +293,7 @@ jobs:
         with:
           app_id: ${{secrets.VIM_BUF_RELEASE_APP_ID}}
           private_key: ${{ secrets.VIM_BUF_RELEASE_APP_PRIVATE_KEY }}
-          repository: "bufbuild/vim-buf"
+          repositories: [ "bufbuild/vim-buf" ]
           permissions: >-
             {"actions": "write"}
       - name: trigger vim-buf release
@@ -320,7 +320,7 @@ jobs:
         with:
           app_id: ${{secrets.BUF_BUILD_RELEASE_APP_ID}}
           private_key: ${{ secrets.BUF_BUILD_RELEASE_APP_PRIVATE_KEY }}
-          repository: "bufbuild/buf.build"
+          repositories: [ "bufbuild/buf.build" ]
           permissions: >-
             {"actions": "write"}
       - name: trigger buf.build release
@@ -347,7 +347,7 @@ jobs:
         with:
           app_id: ${{secrets.BUF_SETUP_ACTION_RELEASE_APP_ID}}
           private_key: ${{ secrets.BUF_SETUP_ACTION_RELEASE_APP_PRIVATE_KEY }}
-          repository: "bufbuild/buf-setup-action"
+          repositories: [ "bufbuild/buf-setup-action" ]
           permissions: >-
             {"actions": "write"}
       - name: trigger buf-setup-action release


### PR DESCRIPTION
There was a [breaking change](https://github.com/tibdex/github-app-token/releases/tag/v2.0.0) in the `v2.0.0` release of `tibdex/github-app-token` that removes the `repository` key. Instead, an array of `repositories` are accepted. This change updates our release action configurations.