### PR TITLE
Workspace directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix issue in v1.27.0 where `--path` did not work with workspaces under certain scenarios.
 
 ## [v1.27.0] - 2023-10-04
 

--- a/private/buf/bufwire/module_config_reader.go
+++ b/private/buf/bufwire/module_config_reader.go
@@ -611,6 +611,7 @@ func (m *moduleConfigReader) getSourceModuleConfig(
 			}
 		}
 	}
+	buildOptions = append(buildOptions, bufmodulebuild.WithWorkspaceDirectory(subDirPath))
 	if len(externalExcludeDirOrFilePaths) > 0 {
 		bucketRelPaths := make([]string, len(externalExcludeDirOrFilePaths))
 		for i, excludeDirOrFilePath := range externalExcludeDirOrFilePaths {

--- a/private/buf/bufwork/workspace_builder.go
+++ b/private/buf/bufwork/workspace_builder.go
@@ -136,6 +136,7 @@ func (w *workspaceBuilder) BuildWorkspace(
 		if err != nil {
 			return nil, err
 		}
+		buildOptions = append(buildOptions, bufmodulebuild.WithWorkspaceDirectory(directory))
 		module, err := bufmodulebuild.NewModuleBucketBuilder().BuildForBucket(
 			ctx,
 			readBucketForDirectory,

--- a/private/buf/cmd/buf/testdata/workspace/success/breaking/a/proto/a/v1/a.proto
+++ b/private/buf/cmd/buf/testdata/workspace/success/breaking/a/proto/a/v1/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package a.v1;
+
+message A {}

--- a/private/buf/cmd/buf/testdata/workspace/success/breaking/a/proto/buf.yaml
+++ b/private/buf/cmd/buf/testdata/workspace/success/breaking/a/proto/buf.yaml
@@ -1,0 +1,1 @@
+version: v1

--- a/private/buf/cmd/buf/testdata/workspace/success/breaking/buf.work.yaml
+++ b/private/buf/cmd/buf/testdata/workspace/success/breaking/buf.work.yaml
@@ -1,4 +1,5 @@
 version: v1
 directories:
+  - a/proto
   - other/proto
   - proto

--- a/private/buf/cmd/buf/testdata/workspace/success/dir/a/proto/a/v1/a.proto
+++ b/private/buf/cmd/buf/testdata/workspace/success/dir/a/proto/a/v1/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package a.v1;
+
+message A {}

--- a/private/buf/cmd/buf/testdata/workspace/success/dir/a/proto/buf.yaml
+++ b/private/buf/cmd/buf/testdata/workspace/success/dir/a/proto/buf.yaml
@@ -1,0 +1,1 @@
+version: v1

--- a/private/buf/cmd/buf/testdata/workspace/success/dir/buf.work.yaml
+++ b/private/buf/cmd/buf/testdata/workspace/success/dir/buf.work.yaml
@@ -1,4 +1,5 @@
 version: v1
 directories:
+  - a/proto
   - other/proto
   - proto

--- a/private/buf/cmd/buf/testdata/workspace/success/dir_buf_work/a/proto/a/v1/a.proto
+++ b/private/buf/cmd/buf/testdata/workspace/success/dir_buf_work/a/proto/a/v1/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package a.v1;
+
+message A {}

--- a/private/buf/cmd/buf/testdata/workspace/success/dir_buf_work/a/proto/buf.yaml
+++ b/private/buf/cmd/buf/testdata/workspace/success/dir_buf_work/a/proto/buf.yaml
@@ -1,0 +1,1 @@
+version: v1

--- a/private/buf/cmd/buf/testdata/workspace/success/dir_buf_work/buf.work
+++ b/private/buf/cmd/buf/testdata/workspace/success/dir_buf_work/buf.work
@@ -1,4 +1,5 @@
 version: v1
 directories:
+  - a/proto
   - other/proto
   - proto

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -116,7 +116,8 @@ func TestWorkspaceDir(t *testing.T) {
 			t,
 			nil,
 			0,
-			filepath.FromSlash(`testdata/workspace/success/`+baseDirPath+`/other/proto/request.proto
+			filepath.FromSlash(`testdata/workspace/success/`+baseDirPath+`/a/proto/a/v1/a.proto
+		    testdata/workspace/success/`+baseDirPath+`/other/proto/request.proto
 		    testdata/workspace/success/`+baseDirPath+`/proto/rpc.proto`),
 			"ls-files",
 			filepath.Join("testdata", "workspace", "success", baseDirPath),
@@ -144,7 +145,8 @@ func TestWorkspaceDir(t *testing.T) {
 			t,
 			nil,
 			0,
-			filepath.FromSlash(`testdata/workspace/success/breaking/other/proto/request.proto
+			filepath.FromSlash(`testdata/workspace/success/breaking/a/proto/a/v1/a.proto
+		    testdata/workspace/success/breaking/other/proto/request.proto
 		    testdata/workspace/success/breaking/proto/rpc.proto`),
 			"ls-files",
 			filepath.Join("testdata", "workspace", "success", "breaking"),
@@ -900,7 +902,7 @@ func TestWorkspaceBreakingFail(t *testing.T) {
 		nil,
 		1,
 		``,
-		`Failure: input contained 1 images, whereas against contained 2 images`,
+		`Failure: input contained 1 images, whereas against contained 3 images`,
 		"breaking",
 		filepath.Join("testdata", "workspace", "fail", "breaking"),
 		"--against",

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -304,48 +304,6 @@ func TestWorkspaceNestedArchive(t *testing.T) {
 	)
 }
 
-func TestWorkspaceGit(t *testing.T) {
-	t.Skip("skip until the move to private/buf is merged")
-	// Directory paths specified as a git reference within a workspace.
-	t.Parallel()
-	testRunStdout(
-		t,
-		nil,
-		0,
-		``,
-		"build",
-		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
-	)
-	testRunStdout(
-		t,
-		nil,
-		0,
-		filepath.FromSlash(`private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto`),
-		"ls-files",
-		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
-	)
-	testRunStdout(
-		t,
-		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".
-        private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Package name "example" should be suffixed with a correctly formed version, such as "example.v1".`),
-		"lint",
-		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
-	)
-	testRunStdout(
-		t,
-		nil,
-		bufcli.ExitCodeFileAnnotation,
-		filepath.FromSlash(`private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".
-        private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Package name "example" should be suffixed with a correctly formed version, such as "example.v1".`),
-		"lint",
-		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
-		"--path",
-		filepath.Join("internal", "buf", "cmd", "buf", "testdata", "workspace", "success", "dir", "proto", "rpc.proto"),
-	)
-}
-
 func TestWorkspaceDetached(t *testing.T) {
 	// The workspace doesn't include the 'proto' directory, so
 	// its contents aren't included in the workspace.

--- a/private/buf/cmd/buf/workspace_unix_test.go
+++ b/private/buf/cmd/buf/workspace_unix_test.go
@@ -87,3 +87,58 @@ func TestWorkspaceAbsoluteFail(t *testing.T) {
 		filepath.Join("testdata", "workspace", "fail", "absolute"),
 	)
 }
+
+// TODO: Move this back to workspace_test.go. after resolving the issue where git
+// clone failed with "unable to create file filename too long" on Windows CI.
+// Workflow run: https://github.com/bufbuild/buf/actions/runs/6510804063/job/17685247791.
+// Potential fix: https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows.
+func TestWorkspaceGit(t *testing.T) {
+	// Directory paths specified as a git reference within a workspace.
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		0,
+		``,
+		"build",
+		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		``,
+		"build",
+		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
+		"--path",
+		filepath.Join("private", "buf", "cmd", "buf", "testdata", "workspace", "success", "dir", "proto", "rpc.proto"),
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		filepath.FromSlash(`private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto`),
+		"ls-files",
+		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
+	)
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".
+        private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Package name "example" should be suffixed with a correctly formed version, such as "example.v1".`),
+		"lint",
+		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
+	)
+	testRunStdout(
+		t,
+		nil,
+		bufcli.ExitCodeFileAnnotation,
+		filepath.FromSlash(`private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".
+        private/buf/cmd/buf/testdata/workspace/success/dir/proto/rpc.proto:3:1:Package name "example" should be suffixed with a correctly formed version, such as "example.v1".`),
+		"lint",
+		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
+		"--path",
+		filepath.Join("private", "buf", "cmd", "buf", "testdata", "workspace", "success", "dir", "proto", "rpc.proto"),
+	)
+}

--- a/private/bufpkg/bufgraph/bufgraph_test.go
+++ b/private/bufpkg/bufgraph/bufgraph_test.go
@@ -105,6 +105,9 @@ func testBuildWorkspace(ctx context.Context, workspacePath string) (bufmodule.Wo
 			bufmodulebuild.WithModuleIdentity(
 				moduleConfig.ModuleIdentity,
 			),
+			bufmodulebuild.WithWorkspaceDirectory(
+				directory,
+			),
 		)
 		if err != nil {
 			return nil, err

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -148,8 +148,6 @@ type Module interface {
 	// of every file in the module, which is useful for caching or recreating a module's
 	// original files.
 	BlobSet() *manifest.BlobSet
-
-	getSourceReadBucket() storage.ReadBucket
 	// ModuleIdentity returns the ModuleIdentity for the Module, if it was
 	// provided at construction time via ModuleWithModuleIdentity or ModuleWithModuleIdentityAndCommit.
 	//
@@ -165,6 +163,17 @@ type Module interface {
 	// even if ModuleIdentity is set, that is commit is optional information
 	// even if we know what module this file came from.
 	Commit() string
+	// WorkspaceDirectory returns the directory within the workspace that this Module was constructed from,
+	// if this Module was constructed from a Workspace. If the Module was not constructed from a Workspace,
+	// This value will be empty.
+	//
+	// This is needed for now because we need to determine if the input for ModuleFileSetBuilder is equal
+	// to any Modules within the given optional Workspace. This is terrible. Once we have refactored
+	// the CLI to have Workspaces as a first-class citizen, where the typical case is a Workspace with
+	// a single Module, we will no longer need to do this type of check, and this can be removed.
+	WorkspaceDirectory() string
+
+	getSourceReadBucket() storage.ReadBucket
 	isModule()
 }
 
@@ -186,6 +195,15 @@ func ModuleWithModuleIdentityAndCommit(moduleIdentity bufmoduleref.ModuleIdentit
 	return func(module *module) {
 		module.moduleIdentity = moduleIdentity
 		module.commit = commit
+	}
+}
+
+// ModuleWithWorkspaceDirectory returns a new ModuleOption that sets the workspace directory.
+//
+// See the comment on Module.WorkspaceDirectory() for more details.
+func ModuleWithWorkspaceDirectory(workspaceDirectory string) ModuleOption {
+	return func(module *module) {
+		module.workspaceDirectory = workspaceDirectory
 	}
 }
 

--- a/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
@@ -173,3 +173,12 @@ func WithExcludePathsAllowNotExist(excludePaths []string) BuildOption {
 		buildOptions.pathsAllowNotExist = true
 	}
 }
+
+// WithWorkspaceDirectory returns a new BuildOption that specifies the workspace directory.
+//
+// See the comment on Module.WorkspaceDirectory() for more details.
+func WithWorkspaceDirectory(workspaceDirectory string) BuildOption {
+	return func(buildOptions *buildOptions) {
+		buildOptions.workspaceDirectory = workspaceDirectory
+	}
+}

--- a/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/bufmodulebuild.go
@@ -16,7 +16,6 @@ package bufmodulebuild
 
 import (
 	"context"
-	"errors"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleconfig"
@@ -25,10 +24,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"go.uber.org/zap"
 )
-
-// ErrDuplicateDependency is the error returned if a two modules have the same set of Protobuf file
-// paths.
-var ErrDuplicateDependency = errors.New("module declared in DependencyModulePins but not in workspace was already added to the dependency Module set")
 
 // ModuleFileSetBuilder builds ModuleFileSets from Modules.
 type ModuleFileSetBuilder interface {

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
@@ -141,6 +141,9 @@ func (b *moduleBucketBuilder) buildForBucket(
 		bufmodule.ModuleWithModuleIdentity(
 			buildOptions.moduleIdentity, // This may be nil
 		),
+		bufmodule.ModuleWithWorkspaceDirectory(
+			buildOptions.workspaceDirectory,
+		),
 	)
 	if err != nil {
 		return nil, err

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
@@ -114,14 +114,14 @@ func (m *moduleFileSetBuilder) build(
 		// used. We already get this for free in Image construction, so it's simplest and
 		// most efficient to bundle all of the modules together like so.
 		for _, potentialDependencyModule := range workspace.GetModules() {
+			if module.WorkspaceDirectory() != potentialDependencyModule.WorkspaceDirectory() {
+				dependencyModules = append(dependencyModules, potentialDependencyModule)
+			}
 			potentialDependencyModuleHash, err := protoPathsHash(ctx, potentialDependencyModule)
 			if err != nil {
 				return nil, err
 			}
-			if _, ok := hashes[potentialDependencyModuleHash]; !ok {
-				dependencyModules = append(dependencyModules, potentialDependencyModule)
-				hashes[potentialDependencyModuleHash] = struct{}{}
-			}
+			hashes[potentialDependencyModuleHash] = struct{}{}
 		}
 	}
 	// We know these are unique by remote, owner, repository and

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_file_set_builder.go
@@ -73,7 +73,7 @@ func (m *moduleFileSetBuilder) build(
 		// The ModuleFileSet expects a Module, and its dependency Modules, but it is not OK for
 		// a Module to both be the input Module and a dependency Module. This means we need to check
 		// each module in the workspace to see if it is the same as the input module, and only add
-		// it as a depedency if it's not the same as the input module. We determine this by comparing
+		// it as a dependency if it's not the same as the input module. We determine this by comparing
 		// each workspace module's WorkspaceDirectory with the input module's WorkspaceDirectory,
 		// where having the same WorkspaceDirectory means being the same module. This is correct
 		// because each module in a workspace are constructed with its WorkspaceDirectory set to its

--- a/private/bufpkg/bufmodule/bufmodulebuild/util.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/util.go
@@ -113,7 +113,8 @@ type buildOptions struct {
 	pathsAllowNotExist bool
 	// Paths that will be excluded from the module build process. This is handled in conjunction
 	// with `paths`.
-	excludePaths []string
+	excludePaths       []string
+	workspaceDirectory string
 }
 
 type buildModuleFileSetOptions struct {

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -45,6 +45,7 @@ type module struct {
 	lintConfig                 *buflintconfig.Config
 	manifest                   *manifest.Manifest
 	blobSet                    *manifest.BlobSet
+	workspaceDirectory         string
 }
 
 func newModuleForProto(
@@ -362,6 +363,10 @@ func (m *module) ModuleIdentity() bufmoduleref.ModuleIdentity {
 
 func (m *module) Commit() string {
 	return m.commit
+}
+
+func (m *module) WorkspaceDirectory() string {
+	return m.workspaceDirectory
 }
 
 func (m *module) getSourceReadBucket() storage.ReadBucket {


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/2480
This fixes the problem where in some occasions dependencies from workspace are not loaded correctly when `--path` is passed. For example, `buf build workspacedir/a --path workspacedir/a/foo.proto` when `workspacedir/b` and `workspacedir/c` also exist. In `module_file_set_builder.go` module b and module c would be hashed based on their `TargetFileInfos`, which are both empty slices due to the `--path` filter. Same hash means only one of them gets added to the list of potential dependencies.

In this PR, workspace modules are distinguished by their directories relative to the workspace directory. This is accomplished by adding `WorkspaceDirectory` to interface `bufmodule.Module`.