### PR TITLE
Fix usage of `tibdex/github-app-token` in Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
           app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repositories: >-
-            [ ${{ github.repository }} ]
+            [ "${{ github.repository }}" ]
           permissions: >-
             {"contents": "write"}
       - name: Set VERSION variable from tag
@@ -122,7 +122,7 @@ jobs:
           app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repositories: >-
-            [ ${{ github.repository }} ]
+            [ "${{ github.repository }}" ]
           permissions: >-
             {"contents": "write", "pull_requests": "write"}
       - name: Checkout repository code
@@ -172,7 +172,7 @@ jobs:
           app_id: ${{env.APP_ID}}
           private_key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
           repositories: >-
-            [ ${{ github.repository }} ]
+            [ "${{ github.repository }}" ]
           permissions: >-
             {"contents": "write", "pull_requests": "write"}
       - name: Checkout repository code


### PR DESCRIPTION
The argument needs to be JSON, so the string element in the array needs to be wrapped in `"`. See the [Github docs](https://docs.github.com/en/actions/learn-github-actions/variables), but doing `"${{ github.repository }}"` is valid.