### PR TITLE
Remove IsImport from bufmoduleref.FileInfo and move to bufimage.ImageFile

### DIFF
--- a/private/buf/cmd/buf/command/export/export.go
+++ b/private/buf/cmd/buf/command/export/export.go
@@ -350,7 +350,9 @@ func run(
 			}
 			// If the file is not an import in some ModuleFileSet, it will
 			// eventually be written via the iteration over moduleFileSets.
-			if fileInfo.IsImport() {
+			// TODO: fix
+			if true {
+				//if fileInfo.IsImport() {
 				if flags.ExcludeImports {
 					// Exclude imports, don't output here
 					continue

--- a/private/bufpkg/bufanalysis/bufanalysistesting/bufanalysistesting.go
+++ b/private/bufpkg/bufanalysis/bufanalysistesting/bufanalysistesting.go
@@ -93,7 +93,6 @@ func newFileAnnotation(
 		fileInfo, err = bufmoduleref.NewFileInfo(
 			path,
 			"",
-			false,
 			nil,
 			"",
 		)
@@ -145,7 +144,6 @@ func normalizeFileAnnotations(
 			fileInfo, err = bufmoduleref.NewFileInfo(
 				fileInfo.Path(),
 				"",
-				false,
 				nil,
 				"",
 			)

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -30,6 +30,7 @@ import (
 // ImageFile is a Protobuf file within an image.
 type ImageFile interface {
 	bufmoduleref.FileInfo
+
 	// Proto is the backing *descriptorpb.FileDescriptorProto for this File.
 	//
 	// FileDescriptor should be preferred to Proto. We keep this method around
@@ -43,6 +44,8 @@ type ImageFile interface {
 	// This will never be nil.
 	// The value Path() is equal to FileDescriptor.GetName() .
 	FileDescriptor() protodescriptor.FileDescriptor
+	// IsImport returns true if this file is an import.
+	IsImport() bool
 	// IsSyntaxUnspecified will be true if the syntax was not explicitly specified.
 	IsSyntaxUnspecified() bool
 	// UnusedDependencyIndexes returns the indexes of the unused dependencies within

--- a/private/bufpkg/bufimage/image_file.go
+++ b/private/bufpkg/bufimage/image_file.go
@@ -27,6 +27,7 @@ type imageFile struct {
 
 	fileDescriptorProto *descriptorpb.FileDescriptorProto
 
+	isImport                      bool
 	isSyntaxUnspecified           bool
 	storedUnusedDependencyIndexes []int32
 }
@@ -46,7 +47,6 @@ func newImageFile(
 	fileInfo, err := bufmoduleref.NewFileInfo(
 		fileDescriptor.GetName(),
 		externalPath,
-		isImport,
 		moduleIdentity,
 		commit,
 	)
@@ -62,6 +62,7 @@ func newImageFile(
 		// protodescriptor.FileDescriptorProtoForFileDescriptor is a no-op if fileDescriptor
 		// is already a *descriptorpb.FileDescriptorProto
 		fileDescriptorProto:           protodescriptor.FileDescriptorProtoForFileDescriptor(fileDescriptor),
+		isImport:                      isImport,
 		isSyntaxUnspecified:           isSyntaxUnspecified,
 		storedUnusedDependencyIndexes: unusedDependencyIndexes,
 	}, nil
@@ -73,6 +74,10 @@ func (f *imageFile) Proto() *descriptorpb.FileDescriptorProto {
 
 func (f *imageFile) FileDescriptor() protodescriptor.FileDescriptor {
 	return f.fileDescriptorProto
+}
+
+func (f *imageFile) IsImport() bool {
+	return f.isImport
 }
 
 func (f *imageFile) IsSyntaxUnspecified() bool {
@@ -88,8 +93,9 @@ func (f *imageFile) ImageFileWithIsImport(isImport bool) ImageFile {
 		return f
 	}
 	return &imageFile{
-		FileInfo:                      f.FileInfo.FileInfoWithIsImport(isImport),
+		FileInfo:                      f.FileInfo,
 		fileDescriptorProto:           f.fileDescriptorProto,
+		isImport:                      isImport,
 		isSyntaxUnspecified:           f.isSyntaxUnspecified,
 		storedUnusedDependencyIndexes: f.storedUnusedDependencyIndexes,
 	}

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_test.go
@@ -47,15 +47,15 @@ func TestBucketGetFileInfos1(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "proto/a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/c/1.proto", "testdata/1/proto/a/c/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/c/2.proto", "testdata/1/proto/a/c/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/c/3.proto", "testdata/1/proto/a/c/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/c/1.proto", "testdata/1/proto/a/c/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/c/2.proto", "testdata/1/proto/a/c/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/c/3.proto", "testdata/1/proto/a/c/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -71,12 +71,12 @@ func TestBucketGetFileInfos2(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "proto/b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -92,15 +92,15 @@ func TestBucketGetFileInfo3(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "proto/a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -119,12 +119,12 @@ func TestBucketGetFileInfos4(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "proto/a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
 	)
 }
 
@@ -158,15 +158,15 @@ func TestConfigV1Beta1BucketGetFileInfos1(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/c/1.proto", "testdata/1/proto/a/c/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/c/2.proto", "testdata/1/proto/a/c/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/c/3.proto", "testdata/1/proto/a/c/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/c/1.proto", "testdata/1/proto/a/c/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/c/2.proto", "testdata/1/proto/a/c/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/c/3.proto", "testdata/1/proto/a/c/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -187,12 +187,12 @@ func TestConfigV1Beta1BucketGetFileInfos2(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -213,15 +213,15 @@ func TestConfigV1Beta1BucketGetFileInfo3(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -243,12 +243,12 @@ func TestConfigV1Beta1BucketGetFileInfos4(t *testing.T) {
 		t,
 		"testdata/1",
 		config,
-		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
 	)
 }
 
@@ -319,8 +319,8 @@ func TestDocumentation(t *testing.T) {
 		t,
 		"testdata/4",
 		bufmodule.DefaultDocumentationPath,
-		bufmoduletesting.NewFileInfo(t, "proto/1.proto", "testdata/4/proto/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/4/proto/a/2.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/1.proto", "testdata/4/proto/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/4/proto/a/2.proto", nil, ""),
 	)
 }
 
@@ -330,8 +330,8 @@ func TestLicense(t *testing.T) {
 		t,
 		"testdata/5",
 		"Test Module License",
-		bufmoduletesting.NewFileInfo(t, "proto/1.proto", "testdata/5/proto/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/5/proto/a/2.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/1.proto", "testdata/5/proto/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/5/proto/a/2.proto", nil, ""),
 	)
 }
 

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_unix_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder_unix_test.go
@@ -29,7 +29,7 @@ func TestLicenseSymlink(t *testing.T) {
 		t,
 		"testdata/6",
 		"Test Module License", // expecting the same license with testdata/5 as it symlink to the license there
-		bufmoduletesting.NewFileInfo(t, "proto/1.proto", "testdata/6/proto/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/6/proto/a/2.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/1.proto", "testdata/6/proto/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "proto/a/2.proto", "testdata/6/proto/a/2.proto", nil, ""),
 	)
 }

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_include_builder_test.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_include_builder_test.go
@@ -37,18 +37,18 @@ func TestIncludeGetFileInfos1(t *testing.T) {
 		[]string{
 			"proto",
 		},
-		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/c/1.proto", "testdata/1/proto/a/c/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/c/2.proto", "testdata/1/proto/a/c/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "a/c/3.proto", "testdata/1/proto/a/c/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", false, nil, ""),
-		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", false, nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/1.proto", "testdata/1/proto/a/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/2.proto", "testdata/1/proto/a/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/3.proto", "testdata/1/proto/a/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/c/1.proto", "testdata/1/proto/a/c/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/c/2.proto", "testdata/1/proto/a/c/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "a/c/3.proto", "testdata/1/proto/a/c/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/1.proto", "testdata/1/proto/b/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/2.proto", "testdata/1/proto/b/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "b/3.proto", "testdata/1/proto/b/3.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/1.proto", "testdata/1/proto/d/1.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/2.proto", "testdata/1/proto/d/2.proto", nil, ""),
+		bufmoduletesting.NewFileInfo(t, "d/3.proto", "testdata/1/proto/d/3.proto", nil, ""),
 	)
 }
 
@@ -189,7 +189,6 @@ func fileInfosToAbs(t *testing.T, fileInfos []bufmoduleref.FileInfo) []bufmodule
 			t,
 			fileInfo.Path(),
 			absExternalPath,
-			fileInfo.IsImport(),
 			nil,
 			"",
 		)

--- a/private/bufpkg/bufmodule/bufmoduleprotocompile/bufmoduleprotocompile.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotocompile/bufmoduleprotocompile.go
@@ -35,8 +35,6 @@ type ParserAccessorHandler interface {
 	//
 	// Returns the input path if the external path is not known.
 	ExternalPath(path string) string
-	// IsImport returns true if the path is an import.
-	IsImport(path string) bool
 	// ModuleIdentity returns nil if not available.
 	ModuleIdentity(path string) bufmoduleref.ModuleIdentity
 	// Commit returns empty if not available.
@@ -98,7 +96,6 @@ func GetFileAnnotation(
 		fileInfo, err = bufmoduleref.NewFileInfo(
 			path,
 			parserAccessorHandler.ExternalPath(path),
-			parserAccessorHandler.IsImport(path),
 			nil,
 			"",
 		)

--- a/private/bufpkg/bufmodule/bufmoduleprotocompile/path_resolver.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotocompile/path_resolver.go
@@ -67,7 +67,7 @@ func (p *parserAccessorHandler) Open(path string) (_ io.ReadCloser, retErr error
 				// this should never happen, but just in case
 				return nil, fmt.Errorf("parser accessor requested path %q but got %q", path, wktModuleFile.Path())
 			}
-			if err := p.addPath(path, path, true, nil, ""); err != nil {
+			if err := p.addPath(path, path, nil, ""); err != nil {
 				return nil, err
 			}
 			return wktModuleFile, nil
@@ -86,7 +86,6 @@ func (p *parserAccessorHandler) Open(path string) (_ io.ReadCloser, retErr error
 	if err := p.addPath(
 		path,
 		moduleFile.ExternalPath(),
-		moduleFile.IsImport(),
 		moduleFile.ModuleIdentity(),
 		moduleFile.Commit(),
 	); err != nil {
@@ -104,13 +103,6 @@ func (p *parserAccessorHandler) ExternalPath(path string) string {
 	return path
 }
 
-func (p *parserAccessorHandler) IsImport(path string) bool {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	_, isNotImport := p.nonImportPaths[path]
-	return !isNotImport
-}
-
 func (p *parserAccessorHandler) ModuleIdentity(path string) bufmoduleref.ModuleIdentity {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
@@ -126,7 +118,6 @@ func (p *parserAccessorHandler) Commit(path string) string {
 func (p *parserAccessorHandler) addPath(
 	path string,
 	externalPath string,
-	isImport bool,
 	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 ) error {
@@ -139,9 +130,6 @@ func (p *parserAccessorHandler) addPath(
 		}
 	} else {
 		p.pathToExternalPath[path] = externalPath
-	}
-	if !isImport {
-		p.nonImportPaths[path] = struct{}{}
 	}
 	if moduleIdentity != nil {
 		p.pathToModuleIdentity[path] = moduleIdentity

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -51,8 +51,6 @@ type FileInfo interface {
 	//   RootDirPath: proto
 	//   ExternalPath: /foo/bar/proto/one/one.proto
 	ExternalPath() string
-	// IsImport returns true if this file is an import.
-	IsImport() bool
 	// ModuleIdentity is the module that this file came from.
 	//
 	// Note this *can* be nil if we did not build from a named module.
@@ -65,8 +63,6 @@ type FileInfo interface {
 	// even if ModuleIdentity is set, that is commit is optional information
 	// even if we know what module this file came from.
 	Commit() string
-	// FileInfoWithIsImport returns this FileInfo with the given IsImport value.
-	FileInfoWithIsImport(isImport bool) FileInfo
 
 	isFileInfo()
 }
@@ -78,14 +74,12 @@ type FileInfo interface {
 func NewFileInfo(
 	path string,
 	externalPath string,
-	isImport bool,
 	moduleIdentity ModuleIdentity,
 	commit string,
 ) (FileInfo, error) {
 	return newFileInfo(
 		path,
 		externalPath,
-		isImport,
 		moduleIdentity,
 		commit,
 	)

--- a/private/bufpkg/bufmodule/bufmoduleref/file_info.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/file_info.go
@@ -23,7 +23,6 @@ var _ FileInfo = &fileInfo{}
 type fileInfo struct {
 	path           string
 	externalPath   string
-	isImport       bool
 	moduleIdentity ModuleIdentity
 	commit         string
 }
@@ -31,7 +30,6 @@ type fileInfo struct {
 func newFileInfo(
 	path string,
 	externalPath string,
-	isImport bool,
 	moduleIdentity ModuleIdentity,
 	commit string,
 ) (*fileInfo, error) {
@@ -44,7 +42,6 @@ func newFileInfo(
 	return newFileInfoNoValidate(
 		path,
 		externalPath,
-		isImport,
 		moduleIdentity,
 		commit,
 	), nil
@@ -53,14 +50,12 @@ func newFileInfo(
 func newFileInfoNoValidate(
 	path string,
 	externalPath string,
-	isImport bool,
 	moduleIdentity ModuleIdentity,
 	commit string,
 ) *fileInfo {
 	return &fileInfo{
 		path:           path,
 		externalPath:   externalPath,
-		isImport:       isImport,
 		moduleIdentity: moduleIdentity,
 		commit:         commit,
 	}
@@ -74,26 +69,12 @@ func (f *fileInfo) ExternalPath() string {
 	return f.externalPath
 }
 
-func (f *fileInfo) IsImport() bool {
-	return f.isImport
-}
-
 func (f *fileInfo) ModuleIdentity() ModuleIdentity {
 	return f.moduleIdentity
 }
 
 func (f *fileInfo) Commit() string {
 	return f.commit
-}
-
-func (f *fileInfo) FileInfoWithIsImport(isImport bool) FileInfo {
-	return newFileInfoNoValidate(
-		f.path,
-		f.externalPath,
-		isImport,
-		f.moduleIdentity,
-		f.commit,
-	)
 }
 
 func (*fileInfo) isFileInfo() {}

--- a/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_unix.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_unix.go
@@ -32,14 +32,12 @@ func NewFileInfo(
 	t *testing.T,
 	path string,
 	externalPath string,
-	isImport bool,
 	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 ) bufmoduleref.FileInfo {
 	fileInfo, err := bufmoduleref.NewFileInfo(
 		path,
 		externalPath,
-		isImport,
 		moduleIdentity,
 		commit,
 	)

--- a/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_windows.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting_windows.go
@@ -30,14 +30,12 @@ func NewFileInfo(
 	t *testing.T,
 	path string,
 	externalPath string,
-	isImport bool,
 	moduleIdentity bufmoduleref.ModuleIdentity,
 	commit string,
 ) bufmoduleref.FileInfo {
 	fileInfo, err := bufmoduleref.NewFileInfo(
 		path,
 		filepath.Clean(filepath.FromSlash(externalPath)),
-		isImport,
 		moduleIdentity,
 		commit,
 	)

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -276,7 +276,6 @@ func (m *module) SourceFileInfos(ctx context.Context) ([]bufmoduleref.FileInfo, 
 		fileInfo, err := bufmoduleref.NewFileInfo(
 			objectInfo.Path(),
 			objectInfo.ExternalPath(),
-			false,
 			m.moduleIdentity,
 			m.commit,
 		)
@@ -304,7 +303,6 @@ func (m *module) GetModuleFile(ctx context.Context, path string) (ModuleFile, er
 	fileInfo, err := bufmoduleref.NewFileInfo(
 		readObjectCloser.Path(),
 		readObjectCloser.ExternalPath(),
-		false,
 		m.moduleIdentity,
 		m.commit,
 	)

--- a/private/bufpkg/bufmodule/module_file_set.go
+++ b/private/bufpkg/bufmodule/module_file_set.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 var _ ModuleFileSet = &moduleFileSet{}
@@ -69,14 +68,9 @@ func (m *moduleFileSet) AllFileInfos(ctx context.Context) ([]bufmoduleref.FileIn
 		if err := bufmoduleref.ValidateModuleFilePath(moduleObjectInfo.Path()); err != nil {
 			return err
 		}
-		isNotImport, err := storage.Exists(ctx, m.Module.getSourceReadBucket(), moduleObjectInfo.Path())
-		if err != nil {
-			return err
-		}
 		fileInfo, err := bufmoduleref.NewFileInfo(
 			moduleObjectInfo.Path(),
 			moduleObjectInfo.ExternalPath(),
-			!isNotImport,
 			moduleObjectInfo.ModuleIdentity(),
 			moduleObjectInfo.Commit(),
 		)
@@ -100,10 +94,6 @@ func (m *moduleFileSet) GetModuleFile(ctx context.Context, path string) (ModuleF
 	if err != nil {
 		return nil, err
 	}
-	isNotImport, err := storage.Exists(ctx, m.Module.getSourceReadBucket(), path)
-	if err != nil {
-		return nil, err
-	}
 	moduleObjectInfo, err := m.allModuleReadBucket.StatModuleFile(ctx, path)
 	if err != nil {
 		return nil, err
@@ -111,7 +101,6 @@ func (m *moduleFileSet) GetModuleFile(ctx context.Context, path string) (ModuleF
 	fileInfo, err := bufmoduleref.NewFileInfo(
 		readObjectCloser.Path(),
 		readObjectCloser.ExternalPath(),
-		!isNotImport,
 		moduleObjectInfo.ModuleIdentity(),
 		moduleObjectInfo.Commit(),
 	)

--- a/private/bufpkg/bufmodule/targeting_module.go
+++ b/private/bufpkg/bufmodule/targeting_module.go
@@ -104,7 +104,6 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufm
 						fileInfo, err := bufmoduleref.NewFileInfo(
 							objectInfo.Path(),
 							objectInfo.ExternalPath(),
-							false,
 							m.Module.ModuleIdentity(),
 							m.Module.Commit(),
 						)
@@ -196,7 +195,6 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufm
 				fileInfo, err := bufmoduleref.NewFileInfo(
 					objectInfo.Path(),
 					objectInfo.ExternalPath(),
-					false,
 					m.Module.ModuleIdentity(),
 					m.Module.Commit(),
 				)

--- a/private/bufpkg/bufmodule/targeting_module_test.go
+++ b/private/bufpkg/bufmodule/targeting_module_test.go
@@ -67,12 +67,12 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "a/a.proto", "a/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "a/b.proto", "a/b.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "c/c.proto/b.proto", "c/c.proto/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "a/a.proto", "a/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "a/b.proto", "a/b.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "c/c.proto/b.proto", "c/c.proto/b.proto", nil, ""),
 		},
 		fileInfos,
 	)
@@ -91,8 +91,8 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
 		},
 		targetFileInfos,
 		false,
@@ -111,8 +111,8 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
 		},
 		targetFileInfos,
 	)
@@ -131,8 +131,8 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
 		},
 		targetFileInfos,
 	)
@@ -151,10 +151,10 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "a/a.proto", "a/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "a/b.proto", "a/b.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "a/a.proto", "a/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "a/b.proto", "a/b.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
 		},
 		targetFileInfos,
 	)
@@ -187,8 +187,8 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
 		},
 		targetFileInfos,
 	)
@@ -207,10 +207,10 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", false, nil, ""),
-			bufmoduletesting.NewFileInfo(t, "c/c.proto/b.proto", "c/c.proto/b.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/a.proto", "b/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "b/b.proto", "b/b.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", nil, ""),
+			bufmoduletesting.NewFileInfo(t, "c/c.proto/b.proto", "c/c.proto/b.proto", nil, ""),
 		},
 		targetFileInfos,
 	)
@@ -228,7 +228,7 @@ func TestTargetingModuleBasic(t *testing.T) {
 	assert.Equal(
 		t,
 		[]bufmoduleref.FileInfo{
-			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", false, nil, ""),
+			bufmoduletesting.NewFileInfo(t, "c/c.proto/a.proto", "c/c.proto/a.proto", nil, ""),
 		},
 		targetFileInfos,
 	)


### PR DESCRIPTION
As usual, works everywhere except `buf export`. Perhaps we can come up with a workaround in `buf export` (likely by tracking the dependency files outside of `ModuleFileSet`)? There's a TODO there, otherwise this is good to go.