### PR TITLE
Fix branch docs

### DIFF
--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/repository_branch.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/repository_branch.pb.go
@@ -55,10 +55,10 @@ type RepositoryBranch struct {
 	// The ID of the user who updated the branch.
 	LastUpdateUserId string `protobuf:"bytes,6,opt,name=last_update_user_id,json=lastUpdateUserId,proto3" json:"last_update_user_id,omitempty"`
 	// The author name of the most recent associated git commit of the branch. May be an empty string
-	// if no commit in the branch history contains any git commit associated.
+	// if no commit in the branch history contains any associated git commit.
 	LastUpdateGitAuthorName string `protobuf:"bytes,7,opt,name=last_update_git_author_name,json=lastUpdateGitAuthorName,proto3" json:"last_update_git_author_name,omitempty"`
 	// The git commit hash of the most recent associated git commit of the branch. May be an empty
-	// string if no commit in the branch history contains any git commit associated.
+	// string if no commit in the branch history contains any associated git commit.
 	LastUpdateGitCommitHash string `protobuf:"bytes,8,opt,name=last_update_git_commit_hash,json=lastUpdateGitCommitHash,proto3" json:"last_update_git_commit_hash,omitempty"`
 }
 

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/repository_branch.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/repository_branch.pb.go
@@ -55,10 +55,10 @@ type RepositoryBranch struct {
 	// The ID of the user who updated the branch.
 	LastUpdateUserId string `protobuf:"bytes,6,opt,name=last_update_user_id,json=lastUpdateUserId,proto3" json:"last_update_user_id,omitempty"`
 	// The author name of the most recent associated git commit of the branch. May be an empty string
-	// if the last branch update doesn't have a git commit associated.
+	// if no commit in the branch history contains any git commit associated.
 	LastUpdateGitAuthorName string `protobuf:"bytes,7,opt,name=last_update_git_author_name,json=lastUpdateGitAuthorName,proto3" json:"last_update_git_author_name,omitempty"`
-	// The git commit hash of the most recent associated git commit of the branch. May be an empty string
-	// if the last branch update doesn't have a git commit associated.
+	// The git commit hash of the most recent associated git commit of the branch. May be an empty
+	// string if no commit in the branch history contains any git commit associated.
 	LastUpdateGitCommitHash string `protobuf:"bytes,8,opt,name=last_update_git_commit_hash,json=lastUpdateGitCommitHash,proto3" json:"last_update_git_commit_hash,omitempty"`
 }
 

--- a/proto/buf/alpha/registry/v1alpha1/repository_branch.proto
+++ b/proto/buf/alpha/registry/v1alpha1/repository_branch.proto
@@ -37,7 +37,7 @@ message RepositoryBranch {
   // if no commit in the branch history contains any associated git commit.
   string last_update_git_author_name = 7;
   // The git commit hash of the most recent associated git commit of the branch. May be an empty
-  // string if no commit in the branch history contains any git commit associated.
+  // string if no commit in the branch history contains any associated git commit.
   string last_update_git_commit_hash = 8;
 }
 

--- a/proto/buf/alpha/registry/v1alpha1/repository_branch.proto
+++ b/proto/buf/alpha/registry/v1alpha1/repository_branch.proto
@@ -34,7 +34,7 @@ message RepositoryBranch {
   // The ID of the user who updated the branch.
   string last_update_user_id = 6;
   // The author name of the most recent associated git commit of the branch. May be an empty string
-  // if no commit in the branch history contains any git commit associated.
+  // if no commit in the branch history contains any associated git commit.
   string last_update_git_author_name = 7;
   // The git commit hash of the most recent associated git commit of the branch. May be an empty
   // string if no commit in the branch history contains any git commit associated.

--- a/proto/buf/alpha/registry/v1alpha1/repository_branch.proto
+++ b/proto/buf/alpha/registry/v1alpha1/repository_branch.proto
@@ -34,10 +34,10 @@ message RepositoryBranch {
   // The ID of the user who updated the branch.
   string last_update_user_id = 6;
   // The author name of the most recent associated git commit of the branch. May be an empty string
-  // if the last branch update doesn't have a git commit associated.
+  // if no commit in the branch history contains any git commit associated.
   string last_update_git_author_name = 7;
-  // The git commit hash of the most recent associated git commit of the branch. May be an empty string
-  // if the last branch update doesn't have a git commit associated.
+  // The git commit hash of the most recent associated git commit of the branch. May be an empty
+  // string if no commit in the branch history contains any git commit associated.
   string last_update_git_commit_hash = 8;
 }
 


### PR DESCRIPTION
The git information is populated by the most recent commit in the branch history, not only from the branch latest commit.