### PR TITLE
Convert storage to use fs.ErrNotExist and fs.PathErrors

### DIFF
--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -807,7 +808,7 @@ func getTerminateFileProviderForOS(
 	fileInfo, err := os.Stat(normalpath.Unnormalize(subDirPath))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, storage.NewErrNotExist(subDirPath)
+			return nil, &fs.PathError{Op: "stat", Path: subDirPath, Err: fs.ErrNotExist}
 		}
 		return nil, err
 	}

--- a/private/buf/bufgen/provider_test.go
+++ b/private/buf/bufgen/provider_test.go
@@ -16,11 +16,12 @@ package bufgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"testing"
 
-	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,7 @@ func TestProviderError(t *testing.T) {
 
 	provider := NewProvider(zap.NewNop())
 	_, err = provider.GetConfig(context.Background(), readWriteBucket)
-	require.True(t, storage.IsNotExist(err))
+	require.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func testProvider(t *testing.T, version string) {

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -348,7 +348,7 @@ func TestFail11(t *testing.T) {
 		t,
 		nil,
 		bufcli.ExitCodeFileAnnotation,
-		fmt.Sprintf("%v:5:8:buf/buf.proto: does not exist", filepath.FromSlash("testdata/fail2/buf/buf2.proto")),
+		fmt.Sprintf("%v:5:8:read buf/buf.proto: file does not exist", filepath.FromSlash("testdata/fail2/buf/buf2.proto")),
 		"lint",
 		"--path",
 		filepath.Join("testdata", "fail2", "buf", "buf2.proto"),

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"strings"
@@ -476,7 +477,7 @@ func unzipPluginToSourceBucket(ctx context.Context, pluginZip string, size int64
 
 func loadDockerImage(ctx context.Context, bucket storage.ReadBucket) (storage.ReadObjectCloser, error) {
 	image, err := bucket.Get(ctx, bufplugindocker.ImagePath)
-	if storage.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("unable to find a %s plugin image: %w", bufplugindocker.ImagePath, err)
 	}
 	return image, nil

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -229,7 +229,7 @@ plugins:
 		nil,
 		1,
 		``,
-		`Failure: plugin insertion-point-writer: test.txt: does not exist`,
+		`Failure: plugin insertion-point-writer: read test.txt: file does not exist`,
 		filepath.Join("testdata", "simple"), // The input directory is irrelevant for these insertion points.
 		"--template",
 		successTemplate,
@@ -324,7 +324,7 @@ plugins:
 		nil,
 		1,
 		``,
-		`Failure: plugin insertion-point-writer: test.txt: does not exist`,
+		`Failure: plugin insertion-point-writer: read test.txt: file does not exist`,
 		filepath.Join("testdata", "simple"), // The input directory is irrelevant for these insertion points.
 		"--template",
 		fmt.Sprintf(successTemplate, receiverOut, writerOut),

--- a/private/buf/cmd/buf/imports_test.go
+++ b/private/buf/cmd/buf/imports_test.go
@@ -65,7 +65,7 @@ func TestInvalidNonexistentImport(t *testing.T) {
 	t.Parallel()
 	testRunStderrWithCache(
 		t, nil, 100,
-		[]string{filepath.FromSlash(`testdata/imports/failure/people/people/v1/people1.proto:5:8:nonexistent.proto: does not exist`)},
+		[]string{filepath.FromSlash(`testdata/imports/failure/people/people/v1/people1.proto:5:8:read nonexistent.proto: file does not exist`)},
 		"build",
 		filepath.Join("testdata", "imports", "failure", "people"),
 	)
@@ -75,7 +75,7 @@ func TestInvalidNonexistentImportFromDirectDep(t *testing.T) {
 	t.Parallel()
 	testRunStderrWithCache(
 		t, nil, 100,
-		[]string{filepath.FromSlash(`testdata/imports/failure/students/students/v1/students.proto:6:8:`) + `people/v1/people_nonexistent.proto: does not exist`},
+		[]string{filepath.FromSlash(`testdata/imports/failure/students/students/v1/students.proto:6:8:`) + `read people/v1/people_nonexistent.proto: file does not exist`},
 		"build",
 		filepath.Join("testdata", "imports", "failure", "students"),
 	)

--- a/private/buf/cmd/buf/workspace_unix_test.go
+++ b/private/buf/cmd/buf/workspace_unix_test.go
@@ -32,7 +32,7 @@ func TestWorkspaceSymlinkFail(t *testing.T) {
 		nil,
 		bufcli.ExitCodeFileAnnotation,
 		``,
-		filepath.FromSlash(`testdata/workspace/fail/symlink/b/b.proto:5:8:c.proto: does not exist`),
+		filepath.FromSlash(`testdata/workspace/fail/symlink/b/b.proto:5:8:read c.proto: file does not exist`),
 		"build",
 		filepath.Join("testdata", "workspace", "fail", "symlink"),
 	)

--- a/private/bufpkg/bufapimodule/module_reader.go
+++ b/private/bufpkg/bufapimodule/module_reader.go
@@ -17,6 +17,7 @@ package bufapimodule
 import (
 	"context"
 	"errors"
+	"io/fs"
 
 	"connectrpc.com/connect"
 	"github.com/bufbuild/buf/private/bufpkg/bufcas"
@@ -24,7 +25,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
-	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 type moduleReader struct {
@@ -91,7 +91,7 @@ func (m *moduleReader) downloadManifestAndBlobs(
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			// Required by ModuleReader interface spec
-			return nil, storage.NewErrNotExist(modulePin.String())
+			return nil, &fs.PathError{Op: "read", Path: modulePin.String(), Err: fs.ErrNotExist}
 		}
 		return nil, err
 	}

--- a/private/bufpkg/bufapimodule/module_resolver.go
+++ b/private/bufpkg/bufapimodule/module_resolver.go
@@ -17,11 +17,11 @@ package bufapimodule
 import (
 	"context"
 	"errors"
+	"io/fs"
 
 	"connectrpc.com/connect"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
-	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/zap"
 )
 
@@ -53,7 +53,7 @@ func (m *moduleResolver) GetModulePin(ctx context.Context, moduleReference bufmo
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			// Required by ModuleResolver interface spec
-			return nil, storage.NewErrNotExist(moduleReference.String())
+			return nil, &fs.PathError{Op: "read", Path: moduleReference.String(), Err: fs.ErrNotExist}
 		}
 		return nil, err
 	}

--- a/private/bufpkg/buflock/lock_file.go
+++ b/private/bufpkg/buflock/lock_file.go
@@ -16,7 +16,9 @@ package buflock
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/bufbuild/buf/private/pkg/storage"
@@ -25,7 +27,7 @@ import (
 func readConfig(ctx context.Context, readBucket storage.ReadBucket) (_ *Config, retErr error) {
 	configBytes, err := storage.ReadPath(ctx, readBucket, ExternalConfigFilePath)
 	if err != nil {
-		if storage.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// If the lock file doesn't exist, just return no dependencies.
 			return &Config{}, nil
 		}

--- a/private/bufpkg/bufmodule/bufmodule.go
+++ b/private/bufpkg/bufmodule/bufmodule.go
@@ -97,7 +97,7 @@ type Module interface {
 	SourceFileInfos(ctx context.Context) ([]bufmoduleref.FileInfo, error)
 	// GetModuleFile gets the source file for the given path.
 	//
-	// Returns storage.IsNotExist error if the file does not exist.
+	// Returns fs.ErrNotExist error if the file does not exist.
 	GetModuleFile(ctx context.Context, path string) (ModuleFile, error)
 	// DeclaredDirectDependencies returns the direct dependencies declared in the configuration file.
 	//
@@ -287,11 +287,11 @@ func ModuleWithExcludePathsAllowNotExist(
 type ModuleResolver interface {
 	// GetModulePin resolves the provided ModuleReference to a ModulePin.
 	//
-	// Returns an error that fufills storage.IsNotExist if the named Module does not exist.
+	// Returns an error with fs.ErrNotExist if the named Module does not exist.
 	GetModulePin(ctx context.Context, moduleReference bufmoduleref.ModuleReference) (bufmoduleref.ModulePin, error)
 }
 
-// NewNopModuleResolver returns a new ModuleResolver that always returns a storage.IsNotExist error.
+// NewNopModuleResolver returns a new ModuleResolver that always returns a fs.ErrNotExist error.
 func NewNopModuleResolver() ModuleResolver {
 	return newNopModuleResolver()
 }
@@ -300,11 +300,11 @@ func NewNopModuleResolver() ModuleResolver {
 type ModuleReader interface {
 	// GetModule gets the Module for the ModulePin.
 	//
-	// Returns an error that fulfills storage.IsNotExist if the Module does not exist.
+	// Returns an error with fs.ErrNotExist if the Module does not exist.
 	GetModule(ctx context.Context, modulePin bufmoduleref.ModulePin) (Module, error)
 }
 
-// NewNopModuleReader returns a new ModuleReader that always returns a storage.IsNotExist error.
+// NewNopModuleReader returns a new ModuleReader that always returns a fs.ErrNotExist error.
 func NewNopModuleReader() ModuleReader {
 	return newNopModuleReader()
 }

--- a/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
+++ b/private/bufpkg/bufmodule/bufmodulebuild/module_bucket_builder.go
@@ -16,6 +16,8 @@ package bufmodulebuild
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/buflock"
@@ -173,7 +175,7 @@ func getFileReadBucket(
 ) (storage.ReadBucket, error) {
 	fileData, err := storage.ReadPath(ctx, readBucket, filePath)
 	if err != nil {
-		if storage.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, err

--- a/private/bufpkg/bufmodule/bufmodulecache/cas_module_cacher.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/cas_module_cacher.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufcas"
@@ -202,7 +204,7 @@ func (c *casModuleCacher) writeBlob(
 	if err == nil && valid {
 		return nil
 	}
-	if !storage.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		c.logger.Debug(
 			"repairing cache entry",
 			zap.String("basedir", moduleBasedir),

--- a/private/bufpkg/bufmodule/bufmoduleprotocompile/path_resolver.go
+++ b/private/bufpkg/bufmodule/bufmoduleprotocompile/path_resolver.go
@@ -16,14 +16,15 @@ package bufmoduleprotocompile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"sync"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/gen/data/datawkt"
-	"github.com/bufbuild/buf/private/pkg/storage"
 	"go.uber.org/multierr"
 )
 
@@ -59,7 +60,7 @@ func newParserAccessorHandler(
 func (p *parserAccessorHandler) Open(path string) (_ io.ReadCloser, retErr error) {
 	moduleFile, moduleErr := p.moduleFileReader.GetModuleFile(p.ctx, path)
 	if moduleErr != nil {
-		if !storage.IsNotExist(moduleErr) {
+		if !errors.Is(moduleErr, fs.ErrNotExist) {
 			return nil, moduleErr
 		}
 		if wktModuleFile, wktErr := datawkt.ReadBucket.Get(p.ctx, path); wktErr == nil {

--- a/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
+++ b/private/bufpkg/bufmodule/bufmoduleref/bufmoduleref.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"sort"
 	"strings"
 
@@ -368,7 +369,7 @@ func ValidateModulePinsConsistentDigests(
 ) error {
 	currentConfig, err := buflock.ReadConfig(ctx, bucket)
 	if err != nil {
-		if storage.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return err

--- a/private/bufpkg/bufmodule/bufmoduletesting/test_module_reader.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/test_module_reader.go
@@ -16,10 +16,10 @@ package bufmoduletesting
 
 import (
 	"context"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 type testModuleReader struct {
@@ -35,7 +35,7 @@ func newTestModuleReader(moduleIdentityStringToModule map[string]bufmodule.Modul
 func (r *testModuleReader) GetModule(ctx context.Context, modulePin bufmoduleref.ModulePin) (bufmodule.Module, error) {
 	module, ok := r.moduleIdentityStringToModule[modulePin.IdentityString()]
 	if !ok {
-		return nil, storage.NewErrNotExist(modulePin.String())
+		return nil, &fs.PathError{Op: "read", Path: modulePin.String(), Err: fs.ErrNotExist}
 	}
 	return module, nil
 }

--- a/private/bufpkg/bufmodule/multi_module_read_bucket.go
+++ b/private/bufpkg/bufmodule/multi_module_read_bucket.go
@@ -16,6 +16,8 @@ package bufmodule
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/pkg/storage"
 )
@@ -43,14 +45,14 @@ func (m *multiModuleReadBucket) StatModuleFile(ctx context.Context, path string)
 	for _, delegate := range m.delegates {
 		objectInfo, err := delegate.StatModuleFile(ctx, path)
 		if err != nil {
-			if storage.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 			return nil, err
 		}
 		return objectInfo, nil
 	}
-	return nil, storage.NewErrNotExist(path)
+	return nil, &fs.PathError{Op: "stat", Path: path, Err: fs.ErrNotExist}
 }
 
 func (m *multiModuleReadBucket) WalkModuleFiles(ctx context.Context, prefix string, f func(*moduleObjectInfo) error) error {

--- a/private/bufpkg/bufmodule/nop_module_reader.go
+++ b/private/bufpkg/bufmodule/nop_module_reader.go
@@ -16,9 +16,9 @@ package bufmodule
 
 import (
 	"context"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 type nopModuleReader struct{}
@@ -28,5 +28,5 @@ func newNopModuleReader() *nopModuleReader {
 }
 
 func (*nopModuleReader) GetModule(_ context.Context, modulePin bufmoduleref.ModulePin) (Module, error) {
-	return nil, storage.NewErrNotExist(modulePin.String())
+	return nil, &fs.PathError{Op: "read", Path: modulePin.String(), Err: fs.ErrNotExist}
 }

--- a/private/bufpkg/bufmodule/nop_module_resolver.go
+++ b/private/bufpkg/bufmodule/nop_module_resolver.go
@@ -16,9 +16,9 @@ package bufmodule
 
 import (
 	"context"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/pkg/storage"
 )
 
 type nopModuleResolver struct{}
@@ -28,5 +28,5 @@ func newNopModuleResolver() *nopModuleResolver {
 }
 
 func (*nopModuleResolver) GetModulePin(_ context.Context, moduleReference bufmoduleref.ModuleReference) (bufmoduleref.ModulePin, error) {
-	return nil, storage.NewErrNotExist(moduleReference.String())
+	return nil, &fs.PathError{Op: "read", Path: moduleReference.String(), Err: fs.ErrNotExist}
 }

--- a/private/bufpkg/bufmodule/targeting_module.go
+++ b/private/bufpkg/bufmodule/targeting_module.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
@@ -88,7 +89,7 @@ func (m *targetingModule) TargetFileInfos(ctx context.Context) (fileInfos []bufm
 			} else {
 				objectInfo, err := sourceReadBucket.Stat(ctx, targetPath)
 				if err != nil {
-					if !storage.IsNotExist(err) {
+					if !errors.Is(err, fs.ErrNotExist) {
 						return nil, err
 					}
 					// we do not have a file, so even though this path ends

--- a/private/bufpkg/bufmodule/util.go
+++ b/private/bufpkg/bufmodule/util.go
@@ -16,7 +16,9 @@ package bufmodule
 
 import (
 	"context"
+	"errors"
 	"io"
+	"io/fs"
 	"sort"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
@@ -65,7 +67,7 @@ func getFileContentForBucket(
 ) (string, error) {
 	data, err := storage.ReadPath(ctx, readBucket, path)
 	if err != nil {
-		if storage.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
 		}
 		return "", err

--- a/private/pkg/app/appproto/response_writer.go
+++ b/private/pkg/app/appproto/response_writer.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/fs"
 	"unicode"
 	"unicode/utf8"
 
@@ -53,7 +54,7 @@ func (h *responseWriter) WriteResponse(
 	for _, file := range response.File {
 		if file.GetInsertionPoint() != "" {
 			if writeResponseOptions.insertionPointReadBucket == nil {
-				return storage.NewErrNotExist(file.GetName())
+				return &fs.PathError{Op: "stat", Path: file.GetName(), Err: fs.ErrNotExist}
 			}
 			if err := applyInsertionPoint(ctx, file, writeResponseOptions.insertionPointReadBucket, writeBucket); err != nil {
 				return err

--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -17,6 +17,7 @@ package git
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"net/http/cgi"
 	"net/http/httptest"
 	"os"
@@ -51,9 +52,9 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 2", string(content), "expected the commit on local-branch to be checked out")
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 		_, err = storage.ReadPath(ctx, readBucket, "submodule/test.proto")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("default_submodule", func(t *testing.T) {
@@ -64,7 +65,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 2", string(content), "expected the commit on local-branch to be checked out")
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 		content, err = storage.ReadPath(ctx, readBucket, "submodule/test.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// submodule", string(content))
@@ -78,7 +79,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 1", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("origin/main", func(t *testing.T) {
@@ -89,7 +90,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 3", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("origin/remote-branch", func(t *testing.T) {
@@ -100,7 +101,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 4", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("remote-tag", func(t *testing.T) {
@@ -111,7 +112,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 4", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("branch_and_main_ref", func(t *testing.T) {
@@ -122,7 +123,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 0", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("branch_and_ref", func(t *testing.T) {
@@ -133,7 +134,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 1", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("HEAD", func(t *testing.T) {
@@ -144,7 +145,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 2", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("commit-local", func(t *testing.T) {
@@ -157,7 +158,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 1", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("commit-remote", func(t *testing.T) {
@@ -170,7 +171,7 @@ func TestGitCloner(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "// commit 3", string(content))
 		_, err = readBucket.Stat(ctx, "nonexistent")
-		assert.True(t, storage.IsNotExist(err))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 }
 

--- a/private/pkg/storage/errors.go
+++ b/private/pkg/storage/errors.go
@@ -17,9 +17,8 @@ package storage
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
-
-	"github.com/bufbuild/buf/private/pkg/normalpath"
 )
 
 var (
@@ -27,19 +26,21 @@ var (
 	ErrClosed = errors.New("already closed")
 	// ErrSetExternalPathUnsupported is the error returned if a bucket does not support SetExternalPath.
 	ErrSetExternalPathUnsupported = errors.New("setting the external path is unsupported for this bucket")
-
-	// errNotExist is the error returned if a path does not exist.
-	errNotExist = errors.New("does not exist")
 )
 
 // NewErrNotExist returns a new error for a path not existing.
+//
+// Deprecated: use &fs.PathError{Op: "Operation", Path: path, Err: fs.ErrNotExist} instead.
 func NewErrNotExist(path string) error {
-	return normalpath.NewError(path, errNotExist)
+	// fs.PathErrors should also have Op, but we don't have an obvious one here.
+	return &fs.PathError{Path: path, Err: fs.ErrNotExist}
 }
 
 // IsNotExist returns true for a error that is for a path not existing.
+//
+// Deprecated: Use errors.Is(err, fs.ErrNotExist) instead.
 func IsNotExist(err error) bool {
-	return errors.Is(err, errNotExist)
+	return errors.Is(err, fs.ErrNotExist)
 }
 
 // NewErrExistsMultipleLocations returns a new error if a path exists in multiple locations.

--- a/private/pkg/storage/storagemem/bucket.go
+++ b/private/pkg/storage/storagemem/bucket.go
@@ -17,6 +17,7 @@ package storagemem
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"sort"
 	"sync"
 
@@ -105,7 +106,7 @@ func (b *bucket) Delete(ctx context.Context, path string) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	if _, ok := b.pathToImmutableObject[path]; !ok {
-		return storage.NewErrNotExist(path)
+		return &fs.PathError{Op: "stat", Path: path, Err: fs.ErrNotExist}
 	}
 	// Note that if there is an existing reader for an object of the same path,
 	// that reader will continue to read the original file, but we accept this
@@ -153,7 +154,7 @@ func (b *bucket) readLockAndGetImmutableObject(ctx context.Context, path string)
 		// the issue is here: we don't know the external path for memory buckets
 		// because we store external paths individually, so if we do not have
 		// an object, we do not have an external path
-		return nil, storage.NewErrNotExist(path)
+		return nil, &fs.PathError{Op: "read", Path: path, Err: fs.ErrNotExist}
 	}
 	return immutableObject, nil
 }

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -18,8 +18,10 @@ package storagetesting
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -61,7 +63,7 @@ func AssertNotExist(
 ) {
 	_, err := readBucket.Stat(context.Background(), path)
 	assert.Error(t, err)
-	assert.True(t, storage.IsNotExist(err))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 // AssertObjectInfo asserts the path has the expected ObjectInfo.
@@ -1176,7 +1178,7 @@ func RunTestSuite(
 		t.Parallel()
 		writeBucket := newWriteBucket(t, defaultProvider)
 		err := writeBucket.Delete(context.Background(), "hello")
-		require.True(t, storage.IsNotExist(err))
+		require.True(t, errors.Is(err, fs.ErrNotExist))
 		writeObjectCloser, err := writeBucket.Put(
 			context.Background(),
 			"hello",
@@ -1188,7 +1190,7 @@ func RunTestSuite(
 		err = writeBucket.Delete(context.Background(), "hello")
 		require.NoError(t, err)
 		err = writeBucket.Delete(context.Background(), "hello")
-		require.True(t, storage.IsNotExist(err))
+		require.True(t, errors.Is(err, fs.ErrNotExist))
 		writeObjectCloser, err = writeBucket.Put(
 			context.Background(),
 			"hello",
@@ -1200,7 +1202,7 @@ func RunTestSuite(
 		err = writeBucket.Delete(context.Background(), "hello")
 		require.NoError(t, err)
 		err = writeBucket.Delete(context.Background(), "hello")
-		require.True(t, storage.IsNotExist(err))
+		require.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
 	t.Run("write-bucket-put-delete-all", func(t *testing.T) {


### PR DESCRIPTION
This converts the `storage` package to use `*fs.PathError` and `fs.ErrNotExist` instead of a custom `storage.NewErrNotExist` and `storage.IsNotExist`. This leans into the standard library, using the same `errors` as other codebases. This makes it easier to express not-exist errors in `Bucket` derivatives.

`*fs.PathError` is expected to have a value for `Op` - the stdlib annoyingly does not handle an empty value for `Op` in its printout of `Error()`:

```go
func (e *PathError) Error() string { return e.Op + " " + e.Path + ": " + e.Err.Error() }
```

We might want to file an issue for it to do so by not printing the leading space. Regardless, for now, we lean into this and set the `Op` to either `read` or `stat`, depending on what is most appropriate. This is somewhat congruent with what the stdlib does itself. It seems that the benefit of leaning into this stdlib error outweighs this slight weirdness.

Q: Why didn't `storage` do this when it was written?
A: `storage` predates `io/fs`, so this didn't exist. Now that `io/fs` is more of a standard (`os` uses it as well), this seems appropriate.