### PR TITLE
Change `buf alpha package` -> `buf alpha sdk`

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -881,20 +881,20 @@ func ValidateErrorFormatFlagLint(errorFormatString string, errorFormatFlagName s
 
 // PackageVersionShortDescription returns the long description for the <package>-version command.
 func PackageVersionShortDescription(name string) string {
-	return fmt.Sprintf("Resolve module and %s plugin reference to a specific remote package version", name)
+	return fmt.Sprintf("Resolve module and %s plugin reference to a specific Generated SDK version", name)
 }
 
 // PackageVersionLongDescription returns the long description for the <package>-version command.
 func PackageVersionLongDescription(registryName, commandName, examplePlugin string) string {
-	return fmt.Sprintf(`This command returns the version of the %s asset to be used with the %s registry.
+	return fmt.Sprintf(`This command returns the version of the %s Generated SDK to be used with the %s registry.
 Examples:
 
 Get the version of the eliza module and the %s plugin for use with %s.
-    $ buf alpha package %s --module=buf.build/connectrpc/eliza --plugin=%s
+    $ buf alpha sdk %s --module=buf.build/connectrpc/eliza --plugin=%s
         v1.7.0-20230609151053-e682db0d9918.1
 
 Use a specific module version and plugin version.
-    $ buf alpha package %s --module=buf.build/connectrpc/eliza:233fca715f49425581ec0a1b660be886 --plugin=%s:v1.0.0
+    $ buf alpha sdk %s --module=buf.build/connectrpc/eliza:233fca715f49425581ec0a1b660be886 --plugin=%s:v1.0.0
         v1.0.0-20230609151053-e682db0d9918.1
 `, registryName, registryName, examplePlugin, registryName, commandName, examplePlugin, commandName, examplePlugin)
 }

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -232,8 +232,8 @@ func NewRootCommand(name string) *appcmd.Command {
 						},
 					},
 					{
-						Use:   "package",
-						Short: "Manage remote packages",
+						Use:   "sdk",
+						Short: "Manage Generated SDKs",
 						SubCommands: []*appcmd.Command{
 							goversion.NewCommand("go-version", builder),
 							mavenversion.NewCommand("maven-version", builder),


### PR DESCRIPTION
We've recently updated the language around this concept in the BSR - update it on the CLI as well.

Because this is an alpha command, I didn't bother to forward the old invocation to the new one, but I'm happy to add that. Also happy to add a CHANGELOG entry, but it doesn't look like we've typically mentioned changes to `alpha` commands in the past, with the exception of the removal of `alpha registry token create`.

There's a few other spots where we mention remote packages in comments or as field names in protos, but I don't think we want to include updates to those in the scope of this work?