### PR TITLE
Clean up bufimage.ImageFile

### DIFF
--- a/private/buf/bufgen/features.go
+++ b/private/buf/bufgen/features.go
@@ -43,13 +43,13 @@ var allFeatures = map[pluginpb.CodeGeneratorResponse_Feature]featureChecker{
 func computeRequiredFeatures(image bufimage.Image) requiredFeatures {
 	features := requiredFeatures{}
 	for feature, checker := range allFeatures {
-		for _, file := range image.Files() {
-			if file.IsImport() {
+		for _, imageFile := range image.Files() {
+			if imageFile.IsImport() {
 				// we only want to check the sources in the module, not their dependencies
 				continue
 			}
-			if checker(file.Proto()) {
-				features[feature] = append(features[feature], file.Path())
+			if checker(imageFile.FileDescriptorProto()) {
+				features[feature] = append(features[feature], imageFile.Path())
 			}
 		}
 	}

--- a/private/buf/bufwire/image_config_reader.go
+++ b/private/buf/bufwire/image_config_reader.go
@@ -278,7 +278,7 @@ func filterImageConfigs(imageConfigs []ImageConfig, protoFileRef buffetch.ProtoF
 			// provided as the ref. This is expected since `PathForExternalPath` is meant to return the relative
 			// path based on the reference, which in this case will always be a specific file.
 			if _, err := protoFileRef.PathForExternalPath(imageFile.ExternalPath()); err == nil {
-				pkg = imageFile.Proto().GetPackage()
+				pkg = imageFile.FileDescriptorProto().GetPackage()
 				path = imageFile.Path()
 				config = imageConfig.Config()
 				break
@@ -298,7 +298,7 @@ func filterImageConfigs(imageConfigs []ImageConfig, protoFileRef buffetch.ProtoF
 	var paths []string
 	if protoFileRef.IncludePackageFiles() {
 		for _, imageFile := range image.Files() {
-			if imageFile.Proto().GetPackage() == pkg {
+			if imageFile.FileDescriptorProto().GetPackage() == pkg {
 				paths = append(paths, imageFile.Path())
 			}
 		}

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -468,8 +468,8 @@ func TestRunPackageNoImportCycle(t *testing.T) {
 			// not reported for imports, only for non-imports.
 			var newImageFiles []bufimage.ImageFile
 			for _, imageFile := range image.Files() {
-				if imageFile.FileDescriptor().GetPackage() == "b" {
-					newImageFiles = append(newImageFiles, imageFile.ImageFileWithIsImport(true))
+				if imageFile.FileDescriptorProto().GetPackage() == "b" {
+					newImageFiles = append(newImageFiles, bufimage.ImageFileWithIsImport(imageFile, true))
 				} else {
 					require.False(t, imageFile.IsImport())
 					newImageFiles = append(newImageFiles, imageFile)

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -91,7 +91,7 @@ func ImageFileWithIsImport(imageFile ImageFile, isImport bool) ImageFile {
 	return newImageFileNoValidate(
 		imageFile.FileDescriptorProto(),
 		imageFile,
-		imageFile.IsImport(),
+		isImport,
 		imageFile.IsSyntaxUnspecified(),
 		imageFile.UnusedDependencyIndexes(),
 	)

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -34,7 +34,7 @@ type ImageFile interface {
 	// FileDescriptorProto is the backing *descriptorpb.FileDescriptorProto for this File.
 	//
 	// This will never be nil.
-	// The value Path() is equal to Proto.GetName() .
+	// The value Path() is equal to FileDescriptorProto().GetName() .
 	FileDescriptorProto() *descriptorpb.FileDescriptorProto
 	// IsImport returns true if this file is an import.
 	IsImport() bool

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -33,9 +33,6 @@ type ImageFile interface {
 
 	// FileDescriptorProto is the backing *descriptorpb.FileDescriptorProto for this File.
 	//
-	// FileDescriptor should be preferred to Proto. We keep this method around
-	// because we have code that does modification to the ImageFile via this.
-	//
 	// This will never be nil.
 	// The value Path() is equal to Proto.GetName() .
 	FileDescriptorProto() *descriptorpb.FileDescriptorProto

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -31,14 +31,14 @@ import (
 type ImageFile interface {
 	bufmoduleref.FileInfo
 
-	// Proto is the backing *descriptorpb.FileDescriptorProto for this File.
+	// FileDescriptorProto is the backing *descriptorpb.FileDescriptorProto for this File.
 	//
 	// FileDescriptor should be preferred to Proto. We keep this method around
 	// because we have code that does modification to the ImageFile via this.
 	//
 	// This will never be nil.
 	// The value Path() is equal to Proto.GetName() .
-	Proto() *descriptorpb.FileDescriptorProto
+	FileDescriptorProto() *descriptorpb.FileDescriptorProto
 	// FileDescriptor is the backing FileDescriptor for this File.
 	//
 	// This will never be nil.

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -220,7 +220,7 @@ func OptimizeFor(
 // in the `go_package` declaration so that the generated package is named as such.
 func GoPackageImportPathForFile(imageFile bufimage.ImageFile, importPathPrefix string) string {
 	goPackageImportPath := path.Join(importPathPrefix, path.Dir(imageFile.Path()))
-	packageName := imageFile.FileDescriptor().GetPackage()
+	packageName := imageFile.FileDescriptorProto().GetPackage()
 	if _, ok := protoversion.NewPackageVersionForPackage(packageName); ok {
 		parts := strings.Split(packageName, ".")
 		if len(parts) >= 2 {

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -38,7 +38,7 @@ const (
 
 func assertFileOptionSourceCodeInfoEmpty(t *testing.T, image bufimage.Image, fileOptionPath []int32, includeSourceInfo bool) {
 	for _, imageFile := range image.Files() {
-		descriptor := imageFile.Proto()
+		descriptor := imageFile.FileDescriptorProto()
 
 		if !includeSourceInfo {
 			assert.Empty(t, descriptor.SourceCodeInfo)
@@ -58,7 +58,7 @@ func assertFileOptionSourceCodeInfoEmpty(t *testing.T, image bufimage.Image, fil
 
 func assertFileOptionSourceCodeInfoNotEmpty(t *testing.T, image bufimage.Image, fileOptionPath []int32) {
 	for _, imageFile := range image.Files() {
-		descriptor := imageFile.Proto()
+		descriptor := imageFile.FileDescriptorProto()
 
 		var hasFileOption bool
 		for _, location := range descriptor.SourceCodeInfo.Location {

--- a/private/bufpkg/bufimage/bufimagemodify/cc_enable_arenas.go
+++ b/private/bufpkg/bufimage/bufimagemodify/cc_enable_arenas.go
@@ -65,7 +65,7 @@ func ccEnableArenasForFile(
 	imageFile bufimage.ImageFile,
 	value bool,
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	options := descriptor.GetOptions()
 	switch {
 	case isWellKnownType(ctx, imageFile):

--- a/private/bufpkg/bufimage/bufimagemodify/cc_enable_arenas_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/cc_enable_arenas_test.go
@@ -46,7 +46,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetCcEnableArenas())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, true)
@@ -67,7 +67,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetCcEnableArenas())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
@@ -92,7 +92,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.True(t, descriptor.GetOptions().GetCcEnableArenas())
 				continue
@@ -117,7 +117,7 @@ func TestCcEnableArenasEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.True(t, descriptor.GetOptions().GetCcEnableArenas())
 				continue
@@ -151,7 +151,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetCcEnableArenas())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, true)
@@ -172,7 +172,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetCcEnableArenas())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
@@ -198,7 +198,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetCcEnableArenas())
 				continue
@@ -223,7 +223,7 @@ func TestCcEnableArenasAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetCcEnableArenas())
 				continue
@@ -257,7 +257,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetCcEnableArenas())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, true)
@@ -279,7 +279,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetCcEnableArenas())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, ccEnableArenasPath, false)
@@ -304,7 +304,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetCcEnableArenas())
 				continue
@@ -329,7 +329,7 @@ func TestCcEnableArenasCcOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetCcEnableArenas())
 				continue
@@ -361,7 +361,7 @@ func TestCcEnableArenasWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			assert.True(t, imageFile.Proto().GetOptions().GetCcEnableArenas())
+			assert.True(t, imageFile.FileDescriptorProto().GetOptions().GetCcEnableArenas())
 		}
 	})
 
@@ -379,7 +379,7 @@ func TestCcEnableArenasWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			assert.True(t, imageFile.Proto().GetOptions().GetCcEnableArenas())
+			assert.True(t, imageFile.FileDescriptorProto().GetOptions().GetCcEnableArenas())
 		}
 	})
 }

--- a/private/bufpkg/bufimage/bufimagemodify/csharp_namespace.go
+++ b/private/bufpkg/bufimage/bufimagemodify/csharp_namespace.go
@@ -104,7 +104,7 @@ func csharpNamespaceForFile(
 		// value, so this is a no-op.
 		return nil
 	}
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if descriptor.Options == nil {
 		descriptor.Options = &descriptorpb.FileOptions{}
 	}
@@ -139,7 +139,7 @@ func shouldSkipCsharpNamespaceForFile(
 // package declaration. If the image file doesn't have a package declaration, an
 // empty string is returned.
 func csharpNamespaceValue(imageFile bufimage.ImageFile) string {
-	pkg := imageFile.Proto().GetPackage()
+	pkg := imageFile.FileDescriptorProto().GetPackage()
 	if pkg == "" {
 		return ""
 	}

--- a/private/bufpkg/bufimage/bufimagemodify/csharp_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/csharp_namespace_test.go
@@ -79,7 +79,7 @@ func TestCsharpNamespaceEmptyOptions(t *testing.T) {
 		// Overwritten with "foo" in the namespace
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, true)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "foo", descriptor.GetOptions().GetCsharpNamespace())
 	})
 
@@ -97,7 +97,7 @@ func TestCsharpNamespaceEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 		// Overwritten with "foo" in the namespace
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "foo", descriptor.GetOptions().GetCsharpNamespace())
 	})
 }
@@ -121,7 +121,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetCsharpNamespace())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, csharpNamespacePath)
@@ -141,7 +141,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetCsharpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
@@ -163,7 +163,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			// Overwritten with "bar" in the namespace
 			assert.Equal(t, "bar", descriptor.GetOptions().GetCsharpNamespace())
 		}
@@ -184,7 +184,7 @@ func TestCsharpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			// Overwritten with "bar" in the namespace
 			assert.Equal(t, "bar", descriptor.GetOptions().GetCsharpNamespace())
 		}
@@ -218,7 +218,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetCsharpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, true)
@@ -239,7 +239,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetCsharpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, csharpNamespacePath, false)
@@ -262,7 +262,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "Acme.Override.V1", descriptor.GetOptions().GetCsharpNamespace())
 				continue
@@ -287,7 +287,7 @@ func testCsharpNamespaceOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "Acme.Override.V1", descriptor.GetOptions().GetCsharpNamespace())
 				continue
@@ -317,7 +317,7 @@ func TestCsharpNamespaceWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetCsharpNamespace())
 				assert.NotEqual(t, modifiedCsharpNamespace, descriptor.GetOptions().GetCsharpNamespace())
@@ -343,7 +343,7 @@ func TestCsharpNamespaceWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetCsharpNamespace())
 				assert.NotEqual(t, modifiedCsharpNamespace, descriptor.GetOptions().GetCsharpNamespace())
@@ -436,7 +436,7 @@ func TestCsharpNamespaceWithExcept(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "", descriptor.GetOptions().GetCsharpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
@@ -463,7 +463,7 @@ func TestCsharpNamespaceWithExcept(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "", descriptor.GetOptions().GetCsharpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
@@ -506,7 +506,7 @@ func TestCsharpNamespaceWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				strings.ReplaceAll(normalpath.Dir(overrideCsharpNamespacePrefix+"/"+imageFile.Path()), "/", "."),
 				descriptor.GetOptions().GetCsharpNamespace(),
@@ -540,7 +540,7 @@ func TestCsharpNamespaceWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				strings.ReplaceAll(normalpath.Dir(overrideCsharpNamespacePrefix+"/"+imageFile.Path()), "/", "."),
 				descriptor.GetOptions().GetCsharpNamespace(),
@@ -574,8 +574,8 @@ func TestCsharpNamespaceWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
-			if imageFile.Proto().Name != nil && *imageFile.Proto().Name == "a.proto" {
+			descriptor := imageFile.FileDescriptorProto()
+			if imageFile.FileDescriptorProto().Name != nil && *imageFile.FileDescriptorProto().Name == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetCsharpNamespace())
 				continue
 			}
@@ -612,8 +612,8 @@ func TestCsharpNamespaceWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
-			if imageFile.Proto().Name != nil && *imageFile.Proto().Name == "a.proto" {
+			descriptor := imageFile.FileDescriptorProto()
+			if imageFile.FileDescriptorProto().Name != nil && *imageFile.FileDescriptorProto().Name == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetCsharpNamespace())
 				continue
 			}

--- a/private/bufpkg/bufimage/bufimagemodify/file_option_sweeper.go
+++ b/private/bufpkg/bufimage/bufimagemodify/file_option_sweeper.go
@@ -54,7 +54,7 @@ func (s *fileOptionSweeper) mark(imageFilePath string, path []int32) {
 // Sweep applies all of the marks and sweeps the file option SourceCodeInfo_Locations.
 func (s *fileOptionSweeper) Sweep(ctx context.Context, image bufimage.Image) error {
 	for _, imageFile := range image.Files() {
-		descriptor := imageFile.Proto()
+		descriptor := imageFile.FileDescriptorProto()
 		if descriptor.SourceCodeInfo == nil {
 			continue
 		}

--- a/private/bufpkg/bufimage/bufimagemodify/go_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/go_package.go
@@ -106,7 +106,7 @@ func goPackageForFile(
 	if shouldSkipGoPackageForFile(ctx, imageFile, exceptModuleIdentityStrings) {
 		return nil
 	}
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if descriptor.Options == nil {
 		descriptor.Options = &descriptorpb.FileOptions{}
 	}
@@ -122,7 +122,7 @@ func shouldSkipGoPackageForFile(
 	imageFile bufimage.ImageFile,
 	exceptModuleIdentityStrings map[string]struct{},
 ) bool {
-	if isWellKnownType(ctx, imageFile) && imageFile.Proto().GetOptions().GetGoPackage() != "" {
+	if isWellKnownType(ctx, imageFile) && imageFile.FileDescriptorProto().GetOptions().GetGoPackage() != "" {
 		// The well-known type defines the go_package option, so this is a no-op.
 		// If a well-known type ever omits the go_package option, we make sure
 		// to include it.

--- a/private/bufpkg/bufimage/bufimagemodify/go_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/go_package_test.go
@@ -54,7 +54,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
 				descriptor.GetOptions().GetGoPackage(),
@@ -79,7 +79,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
 				descriptor.GetOptions().GetGoPackage(),
@@ -106,7 +106,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
@@ -128,7 +128,7 @@ func TestGoPackageEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
@@ -155,7 +155,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
 				descriptor.GetOptions().GetGoPackage(),
@@ -179,7 +179,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
 				descriptor.GetOptions().GetGoPackage(),
@@ -205,7 +205,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
@@ -226,7 +226,7 @@ func TestGoPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)
@@ -255,7 +255,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				fmt.Sprintf("%s;%s",
 					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
@@ -283,7 +283,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				fmt.Sprintf("%s;%s",
 					normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
@@ -313,7 +313,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 				continue
@@ -345,7 +345,7 @@ func TestGoPackagePackageVersion(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 				continue
@@ -386,7 +386,7 @@ func TestGoPackageWellKnownTypes(t *testing.T) {
 				normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
 				packageSuffix,
 			)
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetGoPackage())
 				assert.NotEqual(t, modifiedGoPackage, descriptor.GetOptions().GetGoPackage())
@@ -417,7 +417,7 @@ func TestGoPackageWellKnownTypes(t *testing.T) {
 				normalpath.Dir(testImportPathPrefix+"/"+imageFile.Path()),
 				packageSuffix,
 			)
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetGoPackage())
 				assert.NotEqual(t, modifiedGoPackage, descriptor.GetOptions().GetGoPackage())
@@ -578,7 +578,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				normalpath.Dir(overrideGoPackagePrefix+"/"+imageFile.Path()),
 				descriptor.GetOptions().GetGoPackage(),
@@ -612,7 +612,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				normalpath.Dir(overrideGoPackagePrefix+"/"+imageFile.Path()),
 				descriptor.GetOptions().GetGoPackage(),
@@ -648,7 +648,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, true)
@@ -679,7 +679,7 @@ func TestGoPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetGoPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, goPackagePath, false)

--- a/private/bufpkg/bufimage/bufimagemodify/java_multiple_files.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_multiple_files.go
@@ -72,7 +72,7 @@ func javaMultipleFilesForFile(
 	value bool,
 	preserveExistingValue bool,
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	options := descriptor.GetOptions()
 	switch {
 	case isWellKnownType(ctx, imageFile):

--- a/private/bufpkg/bufimage/bufimagemodify/java_multiple_files_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_multiple_files_test.go
@@ -47,7 +47,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
@@ -69,7 +69,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
@@ -95,7 +95,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
@@ -117,7 +117,7 @@ func TestJavaMultipleFilesEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
@@ -147,7 +147,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
@@ -168,7 +168,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
@@ -194,7 +194,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
 				continue
@@ -219,7 +219,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
 				continue
@@ -244,7 +244,7 @@ func TestJavaMultipleFilesAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
 				continue
@@ -277,7 +277,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, true)
@@ -298,7 +298,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 				continue
@@ -327,7 +327,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 				continue
@@ -351,7 +351,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 				continue
@@ -376,7 +376,7 @@ func TestJavaMultipleFilesJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaMultipleFiles())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaMultipleFilesPath, false)
@@ -404,7 +404,7 @@ func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			assert.True(t, imageFile.Proto().GetOptions().GetJavaMultipleFiles())
+			assert.True(t, imageFile.FileDescriptorProto().GetOptions().GetJavaMultipleFiles())
 		}
 	})
 
@@ -422,7 +422,7 @@ func TestJavaMultipleFilesWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			assert.True(t, imageFile.Proto().GetOptions().GetJavaMultipleFiles())
+			assert.True(t, imageFile.FileDescriptorProto().GetOptions().GetJavaMultipleFiles())
 		}
 	})
 }

--- a/private/bufpkg/bufimage/bufimagemodify/java_outer_classname.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_outer_classname.go
@@ -72,7 +72,7 @@ func javaOuterClassnameForFile(
 		// The file is a well-known type - don't override the value.
 		return nil
 	}
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	options := descriptor.GetOptions()
 	if options != nil && options.JavaOuterClassname != nil && preserveExistingValue {
 		// The option is explicitly set in the file - don't override it if we want to preserve the existing value.

--- a/private/bufpkg/bufimage/bufimagemodify/java_outer_classname_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_outer_classname_test.go
@@ -47,7 +47,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "AProto", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, true)
@@ -67,7 +67,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "AProto", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
@@ -91,7 +91,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, true)
@@ -111,7 +111,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
@@ -135,7 +135,7 @@ func TestJavaOuterClassnameEmptyOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "AProto", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, true)
@@ -163,7 +163,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "AProto", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, true)
@@ -182,7 +182,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "AProto", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
@@ -206,7 +206,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, true)
@@ -225,7 +225,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
@@ -249,7 +249,7 @@ func TestJavaOuterClassnameAllOptions(t *testing.T) {
 		assert.Equal(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaOuterClassnamePath)
@@ -276,7 +276,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, stringutil.ToPascalCase(normalpath.Base(imageFile.Path())), descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, true)
@@ -295,7 +295,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, stringutil.ToPascalCase(normalpath.Base(imageFile.Path())), descriptor.GetOptions().GetJavaOuterClassname())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaOuterClassnamePath, false)
@@ -318,7 +318,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetJavaOuterClassname())
 				continue
@@ -341,7 +341,7 @@ func TestJavaOuterClassnameJavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetJavaOuterClassname())
 				continue
@@ -371,7 +371,7 @@ func TestJavaOuterClassnameWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.Equal(t, javaOuterClassnameValue(imageFile), descriptor.GetOptions().GetJavaOuterClassname())
 				continue
@@ -395,7 +395,7 @@ func TestJavaOuterClassnameWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.Equal(t, javaOuterClassnameValue(imageFile), descriptor.GetOptions().GetJavaOuterClassname())
 				continue

--- a/private/bufpkg/bufimage/bufimagemodify/java_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_package.go
@@ -111,7 +111,7 @@ func javaPackageForFile(
 	if shouldSkipJavaPackageForFile(ctx, imageFile, javaPackageValue, exceptModuleIdentityStrings) {
 		return nil
 	}
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if descriptor.Options == nil {
 		descriptor.Options = &descriptorpb.FileOptions{}
 	}
@@ -146,7 +146,7 @@ func shouldSkipJavaPackageForFile(
 // package declaration. If the image file doesn't have a package declaration, an
 // empty string is returned.
 func javaPackageValue(imageFile bufimage.ImageFile, packagePrefix string) string {
-	if pkg := imageFile.Proto().GetPackage(); pkg != "" {
+	if pkg := imageFile.FileDescriptorProto().GetPackage(); pkg != "" {
 		return packagePrefix + "." + pkg
 	}
 	return ""

--- a/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_package_test.go
@@ -86,7 +86,7 @@ func TestJavaPackageEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 	})
 
@@ -104,7 +104,7 @@ func TestJavaPackageEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 	})
 }
@@ -129,7 +129,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetJavaPackage())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaPackagePath)
@@ -150,7 +150,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetJavaPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
@@ -173,7 +173,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 				continue
@@ -198,7 +198,7 @@ func TestJavaPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 				continue
@@ -231,7 +231,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, modifiedJavaPackage, descriptor.GetOptions().GetJavaPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, true)
@@ -253,7 +253,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, modifiedJavaPackage, descriptor.GetOptions().GetJavaPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)
@@ -277,7 +277,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 				continue
@@ -303,7 +303,7 @@ func TestJavaPackageJavaOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 				continue
@@ -335,7 +335,7 @@ func TestJavaPackageWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetJavaPackage())
 				assert.NotEqual(t, modifiedJavaPackage, descriptor.GetOptions().GetJavaPackage())
@@ -362,7 +362,7 @@ func TestJavaPackageWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetJavaPackage())
 				assert.NotEqual(t, modifiedJavaPackage, descriptor.GetOptions().GetJavaPackage())
@@ -523,7 +523,7 @@ func TestJavaPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				overrideJavaPackagePrefix+"."+descriptor.GetPackage(),
 				descriptor.GetOptions().GetJavaPackage(),
@@ -557,7 +557,7 @@ func TestJavaPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				overrideJavaPackagePrefix+"."+descriptor.GetPackage(),
 				descriptor.GetOptions().GetJavaPackage(),
@@ -593,7 +593,7 @@ func TestJavaPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, true)
@@ -624,7 +624,7 @@ func TestJavaPackageWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "override", descriptor.GetOptions().GetJavaPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaPackagePath, false)

--- a/private/bufpkg/bufimage/bufimagemodify/java_string_check_utf8.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_string_check_utf8.go
@@ -65,7 +65,7 @@ func javaStringCheckUtf8ForFile(
 	imageFile bufimage.ImageFile,
 	value bool,
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	options := descriptor.GetOptions()
 	switch {
 	case isWellKnownType(ctx, imageFile):

--- a/private/bufpkg/bufimage/bufimagemodify/java_string_check_utf8_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_string_check_utf8_test.go
@@ -75,7 +75,7 @@ func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.True(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 	})
 
@@ -93,7 +93,7 @@ func TestJavaStringCheckUtf8EmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.True(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 	})
 }
@@ -117,7 +117,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, javaStringCheckUtf8Path)
@@ -138,7 +138,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.False(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
@@ -160,7 +160,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.True(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 				continue
@@ -185,7 +185,7 @@ func TestJavaStringCheckUtf8AllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.True(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 				continue
@@ -216,7 +216,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, true)
@@ -238,7 +238,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.True(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, javaStringCheckUtf8Path, false)
@@ -260,7 +260,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.False(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 				continue
@@ -284,7 +284,7 @@ func TestJavaStringCheckUtf8JavaOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.False(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 				continue
@@ -312,7 +312,7 @@ func TestJavaStringCheckUtf8WellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.False(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 				continue
@@ -335,7 +335,7 @@ func TestJavaStringCheckUtf8WellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.False(t, descriptor.GetOptions().GetJavaStringCheckUtf8())
 				continue

--- a/private/bufpkg/bufimage/bufimagemodify/objc_class_prefix.go
+++ b/private/bufpkg/bufimage/bufimagemodify/objc_class_prefix.go
@@ -98,7 +98,7 @@ func objcClassPrefixForFile(
 	objcClassPrefixValue string,
 	exceptModuleIdentityStrings map[string]struct{},
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if isWellKnownType(ctx, imageFile) || objcClassPrefixValue == "" {
 		// This is a well-known type or we could not resolve a non-empty objc_class_prefix
 		// value, so this is a no-op.
@@ -123,7 +123,7 @@ func objcClassPrefixForFile(
 // package declaration. If the image file doesn't have a package declaration, an
 // empty string is returned.
 func objcClassPrefixValue(imageFile bufimage.ImageFile) string {
-	pkg := imageFile.Proto().GetPackage()
+	pkg := imageFile.FileDescriptorProto().GetPackage()
 	if pkg == "" {
 		return ""
 	}

--- a/private/bufpkg/bufimage/bufimagemodify/objc_class_prefix_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/objc_class_prefix_test.go
@@ -75,7 +75,7 @@ func TestObjcClassPrefixEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		require.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 	})
 
@@ -92,7 +92,7 @@ func TestObjcClassPrefixEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		require.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 	})
 }
@@ -116,7 +116,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, objcClassPrefixPath)
@@ -136,7 +136,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
@@ -158,7 +158,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -182,7 +182,7 @@ func TestObjcClassPrefixAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -220,7 +220,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, true)
@@ -241,7 +241,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
@@ -264,7 +264,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -289,7 +289,7 @@ func testObjcClassPrefixOptions(t *testing.T, dirPath string, classPrefix string
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -319,7 +319,7 @@ func TestObjcClassPrefixWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetObjcClassPrefix())
 				assert.NotEqual(t, modifiedObjcClassPrefix, descriptor.GetOptions().GetObjcClassPrefix())
@@ -345,7 +345,7 @@ func TestObjcClassPrefixWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				assert.NotEmpty(t, descriptor.GetOptions().GetObjcClassPrefix())
 				assert.NotEqual(t, modifiedObjcClassPrefix, descriptor.GetOptions().GetObjcClassPrefix())
@@ -384,7 +384,7 @@ func TestObjcClassPrefixWithDefault(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, defaultClassPrefix, descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, true)
@@ -411,7 +411,7 @@ func TestObjcClassPrefixWithDefault(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, defaultClassPrefix, descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
@@ -438,7 +438,7 @@ func TestObjcClassPrefixWithDefault(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -469,7 +469,7 @@ func TestObjcClassPrefixWithDefault(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -621,7 +621,7 @@ func TestObjcClassPrefixWithOverride(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, overrideClassPrefix, descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, true)
@@ -648,7 +648,7 @@ func TestObjcClassPrefixWithOverride(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, overrideClassPrefix, descriptor.GetOptions().GetObjcClassPrefix())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, objcClassPrefixPath, false)
@@ -675,7 +675,7 @@ func TestObjcClassPrefixWithOverride(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue
@@ -706,7 +706,7 @@ func TestObjcClassPrefixWithOverride(t *testing.T) {
 		)
 		require.NoError(t, err)
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetObjcClassPrefix())
 				continue

--- a/private/bufpkg/bufimage/bufimagemodify/optimize_for.go
+++ b/private/bufpkg/bufimage/bufimagemodify/optimize_for.go
@@ -100,7 +100,7 @@ func optimizeForForFile(
 	value descriptorpb.FileOptions_OptimizeMode,
 	exceptModuleIdentityStrings map[string]struct{},
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	options := descriptor.GetOptions()
 	switch {
 	case isWellKnownType(ctx, imageFile):

--- a/private/bufpkg/bufimage/bufimagemodify/optimize_for_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/optimize_for_test.go
@@ -48,7 +48,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_LITE_RUNTIME, descriptor.GetOptions().GetOptimizeFor())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
@@ -69,7 +69,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_LITE_RUNTIME, descriptor.GetOptions().GetOptimizeFor())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
@@ -94,7 +94,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 				continue
@@ -119,7 +119,7 @@ func TestOptimizeForEmptyOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 				continue
@@ -153,7 +153,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_LITE_RUNTIME, descriptor.GetOptions().GetOptimizeFor())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
@@ -174,7 +174,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_LITE_RUNTIME, descriptor.GetOptions().GetOptimizeFor())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
@@ -199,7 +199,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 				continue
@@ -224,7 +224,7 @@ func TestOptimizeForAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 				continue
@@ -258,7 +258,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, true)
@@ -280,7 +280,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, optimizeForPath, false)
@@ -305,7 +305,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, descriptorpb.FileOptions_LITE_RUNTIME, descriptor.GetOptions().GetOptimizeFor())
 				continue
@@ -329,7 +329,7 @@ func TestOptimizeForCcOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, descriptorpb.FileOptions_LITE_RUNTIME, descriptor.GetOptions().GetOptimizeFor())
 				continue
@@ -361,7 +361,7 @@ func TestOptimizeForWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 		}
 	})
@@ -380,7 +380,7 @@ func TestOptimizeForWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, descriptorpb.FileOptions_SPEED, descriptor.GetOptions().GetOptimizeFor())
 		}
 	})
@@ -541,7 +541,7 @@ func TestOptimizeForWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				overrideOptimizeFor,
 				descriptor.GetOptions().GetOptimizeFor(),
@@ -577,7 +577,7 @@ func TestOptimizeForWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				overrideOptimizeFor,
 				descriptor.GetOptions().GetOptimizeFor(),
@@ -615,7 +615,7 @@ func TestOptimizeForWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				descriptorpb.FileOptions_CODE_SIZE,
 				descriptor.GetOptions().GetOptimizeFor(),
@@ -653,7 +653,7 @@ func TestOptimizeForWithOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t,
 				descriptorpb.FileOptions_CODE_SIZE,
 				descriptor.GetOptions().GetOptimizeFor(),

--- a/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace.go
@@ -66,7 +66,7 @@ func phpMetadataNamespaceForFile(
 	imageFile bufimage.ImageFile,
 	phpMetadataNamespaceValue string,
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if isWellKnownType(ctx, imageFile) || phpMetadataNamespaceValue == "" {
 		// This is a well-known type or we could not resolve a non-empty php_metadata_namespace
 		// value, so this is a no-op.

--- a/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_metadata_namespace_test.go
@@ -74,7 +74,7 @@ func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		require.Equal(t, "override", descriptor.GetOptions().GetPhpMetadataNamespace())
 	})
 
@@ -91,7 +91,7 @@ func TestPhpMetadataNamespaceEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		require.Equal(t, "override", descriptor.GetOptions().GetPhpMetadataNamespace())
 	})
 }
@@ -115,7 +115,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetPhpMetadataNamespace())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpMetadataNamespacePath)
@@ -135,7 +135,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpMetadataNamespace())
 				continue
@@ -161,7 +161,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetPhpMetadataNamespace())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpMetadataNamespacePath)
@@ -181,7 +181,7 @@ func TestPhpMetadataNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpMetadataNamespace())
 				continue
@@ -218,7 +218,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetPhpMetadataNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, true)
@@ -239,7 +239,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetPhpMetadataNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpMetadataNamespacePath, false)
@@ -262,7 +262,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpMetadataNamespace())
 				continue
@@ -287,7 +287,7 @@ func testPhpMetadataNamespaceOptions(t *testing.T, dirPath string, classPrefix s
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpMetadataNamespace())
 				continue
@@ -317,7 +317,7 @@ func TestPhpMetadataNamespaceWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				// php_namespace is unset for the well-known types
 				assert.Empty(t, descriptor.GetOptions().GetPhpMetadataNamespace())
@@ -343,7 +343,7 @@ func TestPhpMetadataNamespaceWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				// php_namespace is unset for the well-known types
 				assert.Empty(t, descriptor.GetOptions().GetPhpMetadataNamespace())

--- a/private/bufpkg/bufimage/bufimagemodify/php_namespace.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_namespace.go
@@ -166,7 +166,7 @@ func phpNamespaceForFile(
 	imageFile bufimage.ImageFile,
 	phpNamespaceValue string,
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if isWellKnownType(ctx, imageFile) || phpNamespaceValue == "" {
 		// This is a well-known type or we could not resolve a non-empty php_namespace
 		// value, so this is a no-op.
@@ -186,7 +186,7 @@ func phpNamespaceForFile(
 // package declaration. If the image file doesn't have a package declaration, an
 // empty string is returned.
 func phpNamespaceValue(imageFile bufimage.ImageFile) string {
-	pkg := imageFile.Proto().GetPackage()
+	pkg := imageFile.FileDescriptorProto().GetPackage()
 	if pkg == "" {
 		return ""
 	}

--- a/private/bufpkg/bufimage/bufimagemodify/php_namespace_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/php_namespace_test.go
@@ -74,7 +74,7 @@ func TestPhpNamespaceEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "override", descriptor.GetOptions().GetPhpNamespace())
 	})
 
@@ -91,7 +91,7 @@ func TestPhpNamespaceEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "override", descriptor.GetOptions().GetPhpNamespace())
 	})
 }
@@ -115,7 +115,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetPhpNamespace())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, phpNamespacePath)
@@ -135,7 +135,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetPhpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
@@ -157,7 +157,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpNamespace())
 				continue
@@ -181,7 +181,7 @@ func TestPhpNamespaceAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpNamespace())
 				continue
@@ -219,7 +219,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetPhpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, true)
@@ -240,7 +240,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetPhpNamespace())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, phpNamespacePath, false)
@@ -263,7 +263,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpNamespace())
 				continue
@@ -288,7 +288,7 @@ func testPhpNamespaceOptions(t *testing.T, dirPath string, classPrefix string) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetPhpNamespace())
 				continue
@@ -318,7 +318,7 @@ func TestPhpNamespaceWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				// php_namespace is unset for the well-known types
 				assert.Empty(t, descriptor.GetOptions().GetPhpNamespace())
@@ -344,7 +344,7 @@ func TestPhpNamespaceWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				// php_namespace is unset for the well-known types
 				assert.Empty(t, descriptor.GetOptions().GetPhpNamespace())

--- a/private/bufpkg/bufimage/bufimagemodify/ruby_package.go
+++ b/private/bufpkg/bufimage/bufimagemodify/ruby_package.go
@@ -99,7 +99,7 @@ func rubyPackageForFile(
 	rubyPackageValue string,
 	exceptModuleIdentityStrings map[string]struct{},
 ) error {
-	descriptor := imageFile.Proto()
+	descriptor := imageFile.FileDescriptorProto()
 	if isWellKnownType(ctx, imageFile) || rubyPackageValue == "" {
 		// This is a well-known type or we could not resolve a non-empty ruby_package
 		// value, so this is a no-op.
@@ -124,7 +124,7 @@ func rubyPackageForFile(
 // package declaration. If the image file doesn't have a package declaration, an
 // empty string is returned.
 func rubyPackageValue(imageFile bufimage.ImageFile) string {
-	pkg := imageFile.Proto().GetPackage()
+	pkg := imageFile.FileDescriptorProto().GetPackage()
 	if pkg == "" {
 		return ""
 	}

--- a/private/bufpkg/bufimage/bufimagemodify/ruby_package_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/ruby_package_test.go
@@ -75,7 +75,7 @@ func TestRubyPackageEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 	})
 
@@ -92,7 +92,7 @@ func TestRubyPackageEmptyOptions(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(image.Files()))
-		descriptor := image.Files()[0].Proto()
+		descriptor := image.Files()[0].FileDescriptorProto()
 		assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 	})
 }
@@ -116,7 +116,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetRubyPackage())
 		}
 		assertFileOptionSourceCodeInfoNotEmpty(t, image, rubyPackagePath)
@@ -136,7 +136,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, "foo", descriptor.GetOptions().GetRubyPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
@@ -158,7 +158,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 				continue
@@ -182,7 +182,7 @@ func TestRubyPackageAllOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "a.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 				continue
@@ -219,7 +219,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetRubyPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, true)
@@ -240,7 +240,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, classPrefix, descriptor.GetOptions().GetRubyPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
@@ -262,7 +262,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 				continue
@@ -286,7 +286,7 @@ func testRubyPackageOptions(t *testing.T, dirPath string, classPrefix string) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 				continue
@@ -316,7 +316,7 @@ func TestRubyPackageWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				// php_namespace is unset for the well-known types
 				assert.Empty(t, descriptor.GetOptions().GetRubyPackage())
@@ -342,7 +342,7 @@ func TestRubyPackageWellKnownTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if isWellKnownType(context.Background(), imageFile) {
 				// php_namespace is unset for the well-known types
 				assert.Empty(t, descriptor.GetOptions().GetRubyPackage())
@@ -490,7 +490,7 @@ func TestRubyPackageOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, overrideRubyPackage, descriptor.GetOptions().GetRubyPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, true)
@@ -517,7 +517,7 @@ func TestRubyPackageOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			assert.Equal(t, overrideRubyPackage, descriptor.GetOptions().GetRubyPackage())
 		}
 		assertFileOptionSourceCodeInfoEmpty(t, image, rubyPackagePath, false)
@@ -544,7 +544,7 @@ func TestRubyPackageOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, true), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 				continue
@@ -575,7 +575,7 @@ func TestRubyPackageOverride(t *testing.T) {
 		assert.NotEqual(t, testGetImage(t, dirPath, false), image)
 
 		for _, imageFile := range image.Files() {
-			descriptor := imageFile.Proto()
+			descriptor := imageFile.FileDescriptorProto()
 			if imageFile.Path() == "override.proto" {
 				assert.Equal(t, "override", descriptor.GetOptions().GetRubyPackage())
 				continue

--- a/private/bufpkg/bufimage/bufimagetesting/bufimagetesting.go
+++ b/private/bufpkg/bufimage/bufimagetesting/bufimagetesting.go
@@ -102,8 +102,8 @@ func normalizeImageFiles(t testing.TB, imageFiles []bufimage.ImageFile) []bufima
 			t,
 			NewProtoImageFile(
 				t,
-				imageFile.FileDescriptor().GetName(),
-				imageFile.FileDescriptor().GetDependency()...,
+				imageFile.FileDescriptorProto().GetName(),
+				imageFile.FileDescriptorProto().GetDependency()...,
 			),
 			imageFile.ModuleIdentity(),
 			imageFile.Commit(),

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -255,7 +255,7 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 			continue
 		}
 		includedFiles = append(includedFiles, imageFile)
-		imageFileDescriptor := imageFile.Proto()
+		imageFileDescriptor := imageFile.FileDescriptorProto()
 
 		importsRequired := closure.imports[imageFile.Path()]
 		// If the file has source code info, we need to remap paths to correctly

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -340,7 +340,7 @@ func runSourceCodeInfoTest(t *testing.T, typename string, expectedFile string, o
 	require.NoError(t, err)
 
 	imageFile := filteredImage.GetFile("test.proto")
-	sourceCodeInfo := imageFile.FileDescriptor().GetSourceCodeInfo()
+	sourceCodeInfo := imageFile.FileDescriptorProto().GetSourceCodeInfo()
 	actual, err := protoencoding.NewJSONMarshaler(nil, protoencoding.JSONMarshalerWithIndent()).Marshal(sourceCodeInfo)
 	require.NoError(t, err)
 

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -355,13 +355,13 @@ func runSourceCodeInfoTest(t *testing.T, typename string, expectedFile string, o
 
 func imageIsDependencyOrdered(image bufimage.Image) bool {
 	seen := make(map[string]struct{})
-	for _, file := range image.Files() {
-		for _, importName := range file.Proto().Dependency {
+	for _, imageFile := range image.Files() {
+		for _, importName := range imageFile.FileDescriptorProto().Dependency {
 			if _, ok := seen[importName]; !ok {
 				return false
 			}
 		}
-		seen[file.Path()] = struct{}{}
+		seen[imageFile.Path()] = struct{}{}
 	}
 	return true
 }
@@ -479,8 +479,8 @@ func benchmarkFilterImage(b *testing.B, opts ...bufimagebuild.BuildOption) {
 				// filtering is destructive, so we have to make a copy
 				b.StopTimer()
 				imageFiles := make([]bufimage.ImageFile, len(benchmarkCase.image.Files()))
-				for j, file := range benchmarkCase.image.Files() {
-					clone, ok := proto.Clone(file.Proto()).(*descriptorpb.FileDescriptorProto)
+				for j, imageFile := range benchmarkCase.image.Files() {
+					clone, ok := proto.Clone(imageFile.FileDescriptorProto()).(*descriptorpb.FileDescriptorProto)
 					require.True(b, ok)
 					var err error
 					imageFiles[j], err = bufimage.NewImageFile(clone, nil, "", "", false, false, nil)

--- a/private/bufpkg/bufimage/bufimageutil/image_index.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_index.go
@@ -92,7 +92,7 @@ func newImageIndexForImage(image bufimage.Image, opts *imageFilterOptions) (*ima
 	}
 
 	for _, imageFile := range image.Files() {
-		pkg := addPackageToIndex(imageFile.FileDescriptor().GetPackage(), index)
+		pkg := addPackageToIndex(imageFile.FileDescriptorProto().GetPackage(), index)
 		pkg.files = append(pkg.files, imageFile)
 		fileName := imageFile.Path()
 		fileDescriptorProto := imageFile.FileDescriptorProto()

--- a/private/bufpkg/bufimage/bufimageutil/image_index.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_index.go
@@ -91,11 +91,11 @@ func newImageIndexForImage(image bufimage.Image, opts *imageFilterOptions) (*ima
 		index.NameToExtensions = make(map[string][]*descriptorpb.FieldDescriptorProto)
 	}
 
-	for _, file := range image.Files() {
-		pkg := addPackageToIndex(file.FileDescriptor().GetPackage(), index)
-		pkg.files = append(pkg.files, file)
-		fileName := file.Path()
-		fileDescriptorProto := file.Proto()
+	for _, imageFile := range image.Files() {
+		pkg := addPackageToIndex(imageFile.FileDescriptor().GetPackage(), index)
+		pkg.files = append(pkg.files, imageFile)
+		fileName := imageFile.Path()
+		fileDescriptorProto := imageFile.FileDescriptorProto()
 		index.Files[fileName] = fileDescriptorProto
 		err := walk.DescriptorProtos(fileDescriptorProto, func(name protoreflect.FullName, msg proto.Message) error {
 			if existing := index.ByName[string(name)]; existing != nil {

--- a/private/bufpkg/bufimage/image.go
+++ b/private/bufpkg/bufimage/image.go
@@ -110,7 +110,7 @@ func orderImageFilesRec(
 		return outputImageFiles
 	}
 	alreadySeen[path] = struct{}{}
-	for _, dependency := range inputImageFile.FileDescriptor().GetDependency() {
+	for _, dependency := range inputImageFile.FileDescriptorProto().GetDependency() {
 		dependencyImageFile, ok := pathToImageFile[dependency]
 		if ok {
 			outputImageFiles = orderImageFilesRec(

--- a/private/bufpkg/bufimage/image_file.go
+++ b/private/bufpkg/bufimage/image_file.go
@@ -68,7 +68,7 @@ func newImageFile(
 	}, nil
 }
 
-func (f *imageFile) Proto() *descriptorpb.FileDescriptorProto {
+func (f *imageFile) FileDescriptorProto() *descriptorpb.FileDescriptorProto {
 	return f.fileDescriptorProto
 }
 

--- a/private/bufpkg/bufimage/image_file.go
+++ b/private/bufpkg/bufimage/image_file.go
@@ -87,10 +87,6 @@ func (f *imageFile) FileDescriptorProto() *descriptorpb.FileDescriptorProto {
 	return f.fileDescriptorProto
 }
 
-func (f *imageFile) FileDescriptor() protodescriptor.FileDescriptor {
-	return f.fileDescriptorProto
-}
-
 func (f *imageFile) IsImport() bool {
 	return f.isImport
 }

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -311,14 +311,14 @@ func imageFilesToFileDescriptors(imageFiles []ImageFile) []protodescriptor.FileD
 func imageFilesToFileDescriptorProtos(imageFiles []ImageFile) []*descriptorpb.FileDescriptorProto {
 	fileDescriptorProtos := make([]*descriptorpb.FileDescriptorProto, len(imageFiles))
 	for i, imageFile := range imageFiles {
-		fileDescriptorProtos[i] = imageFile.Proto()
+		fileDescriptorProtos[i] = imageFile.FileDescriptorProto()
 	}
 	return fileDescriptorProtos
 }
 
 func imageFileToProtoImageFile(imageFile ImageFile) *imagev1.ImageFile {
 	return fileDescriptorProtoToProtoImageFile(
-		imageFile.Proto(),
+		imageFile.FileDescriptorProto(),
 		imageFile.IsImport(),
 		imageFile.IsSyntaxUnspecified(),
 		imageFile.UnusedDependencyIndexes(),
@@ -441,7 +441,7 @@ func imageToCodeGeneratorRequest(
 		request.Parameter = proto.String(parameter)
 	}
 	for i, imageFile := range imageFiles {
-		request.ProtoFile[i] = imageFile.Proto()
+		request.ProtoFile[i] = imageFile.FileDescriptorProto()
 		if isFileToGenerate(
 			imageFile,
 			alreadyUsedPaths,

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -253,7 +253,7 @@ func addFileWithImports(
 	seenPaths[path] = struct{}{}
 
 	// then, add imports first, for proper ordering
-	for _, importPath := range imageFile.FileDescriptor().GetDependency() {
+	for _, importPath := range imageFile.FileDescriptorProto().GetDependency() {
 		if importFile := image.GetFile(importPath); importFile != nil {
 			accumulator = addFileWithImports(
 				accumulator,
@@ -270,7 +270,7 @@ func addFileWithImports(
 	_, isNotImport := nonImportPaths[path]
 	accumulator = append(
 		accumulator,
-		imageFile.ImageFileWithIsImport(!isNotImport),
+		ImageFileWithIsImport(imageFile, !isNotImport),
 	)
 	return accumulator
 }
@@ -303,7 +303,7 @@ func protoImageFilesToFileDescriptors(protoImageFiles []*imagev1.ImageFile) []pr
 func imageFilesToFileDescriptors(imageFiles []ImageFile) []protodescriptor.FileDescriptor {
 	fileDescriptors := make([]protodescriptor.FileDescriptor, len(imageFiles))
 	for i, imageFile := range imageFiles {
-		fileDescriptors[i] = imageFile.FileDescriptor()
+		fileDescriptors[i] = imageFile.FileDescriptorProto()
 	}
 	return fileDescriptors
 }

--- a/private/pkg/protosource/file.go
+++ b/private/pkg/protosource/file.go
@@ -233,16 +233,16 @@ func (f *file) SyntaxLocation() Location {
 // does not validation of the fileDescriptorProto - this is assumed to be done elsewhere
 // does no duplicate checking by name - could just have maps ie importToFileImport, enumNameToEnum, etc
 func newFile(inputFile InputFile) (*file, error) {
-	locationStore := newLocationStore(inputFile.FileDescriptor().GetSourceCodeInfo().GetLocation())
+	locationStore := newLocationStore(inputFile.FileDescriptorProto().GetSourceCodeInfo().GetLocation())
 	f := &file{
 		FileInfo:       inputFile,
-		fileDescriptor: inputFile.FileDescriptor(),
+		fileDescriptor: inputFile.FileDescriptorProto(),
 		optionExtensionDescriptor: newOptionExtensionDescriptor(
-			inputFile.FileDescriptor().GetOptions(),
+			inputFile.FileDescriptorProto().GetOptions(),
 			[]int32{8},
 			locationStore,
 		),
-		edition: inputFile.FileDescriptor().GetEdition(),
+		edition: inputFile.FileDescriptorProto().GetEdition(),
 	}
 	descriptor := newDescriptor(
 		f,

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -470,7 +470,7 @@ type InputFile interface {
 	// FileDescriptorProto is the backing FileDescriptorProto for this File.
 	//
 	// This will never be nil.
-	// The value Path() is equal to FileDescriptor().GetName() .
+	// The value Path() is equal to FileDescriptorProto().GetName() .
 	FileDescriptorProto() *descriptorpb.FileDescriptorProto
 	// IsSyntaxUnspecified will be true if the syntax was not explicitly specified.
 	IsSyntaxUnspecified() bool

--- a/private/pkg/protosource/protosource.go
+++ b/private/pkg/protosource/protosource.go
@@ -467,11 +467,11 @@ type Method interface {
 // InputFile is an input file for NewFile.
 type InputFile interface {
 	FileInfo
-	// FileDescriptor is the backing FileDescriptor for this File.
+	// FileDescriptorProto is the backing FileDescriptorProto for this File.
 	//
 	// This will never be nil.
 	// The value Path() is equal to FileDescriptor().GetName() .
-	FileDescriptor() protodescriptor.FileDescriptor
+	FileDescriptorProto() *descriptorpb.FileDescriptorProto
 	// IsSyntaxUnspecified will be true if the syntax was not explicitly specified.
 	IsSyntaxUnspecified() bool
 	// UnusedDependencyIndexes returns the indexes of the unused dependencies within


### PR DESCRIPTION
This PR does a few things:

- Removes `ImageFile.FileDescriptor`.
- Renames `ImageFile.Proto` to `ImageFile.FileDescriptorProto`.
- Moves `ImageFile.ImageFileWithIsImport` to a top-level function `ImageFileWithIsImport`.
- Changes `protosource.InputFile.FileDescriptor` to `FileDescriptorProto`.

This is a cleanup and simplification of the `ImageFile` interface in preparation for our refactor of `bufmodule` and `bufimage`. `ImageFile` had both `*descriptorpb.FileDescriptorProto` and `protodescriptor.FileDescriptor` as properties on it, which was an attempt to get out of the `FileDescriptorProto` struct business entirely. This attempt failed. We still need `protodescriptor.FileDescriptor` in some places, as it is the common interface of `buf.alpha.image.v1.ImageFile` and `google.protobuf.FileDescriptorProto`, and it also is preferable if it can solely be used as it tries to show read-only by convention (even though it isn't read-only, many of the fields returned are structs themselves). However, with `ImageFile`, there's no need for a second interface.