### PR TITLE
Extract all `bufsync.*Func`s into a `bufsync.Handler`

### DIFF
--- a/private/buf/bufsync/bufsync.go
+++ b/private/buf/bufsync/bufsync.go
@@ -176,10 +176,10 @@ type Handler interface {
 		commitHashes map[string]struct{},
 	) (map[string]struct{}, error)
 
-	// GetModuleDefaultBranch is invoked before syncing, to gather default branch names for all the
+	// GetModuleReleaseBranch is invoked before syncing, to gather release branch names for all the
 	// modules that are about to be synced. If the BSR module does not exist, the implementation should
 	// return `ModuleDoesNotExistErr` error.
-	GetModuleDefaultBranch(
+	GetModuleReleaseBranch(
 		ctx context.Context,
 		module bufmoduleref.ModuleIdentity,
 	) (string, error)
@@ -235,10 +235,10 @@ func NewSyncer(
 // SyncerOption configures the creation of a new Syncer.
 type SyncerOption func(*syncer) error
 
-// SyncerWithRemote configures a Syncer with a resumption using a SyncPointResolver.
-func SyncerWithRemote(remoteName string) SyncerOption {
+// SyncerWithGitRemote configures a Syncer to sync commits from particular Git remote.
+func SyncerWithGitRemote(gitRemoteName string) SyncerOption {
 	return func(s *syncer) error {
-		s.remote = remoteName
+		s.gitRemoteName = gitRemoteName
 		return nil
 	}
 }

--- a/private/buf/bufsync/bufsync.go
+++ b/private/buf/bufsync/bufsync.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/git"
@@ -149,27 +150,84 @@ type ErrorHandler interface {
 	) error
 }
 
-// Syncer syncs a modules in a git.Repository.
+// Handler is a handler for Syncer. It controls the way in which Syncer handles errors, provides
+// any information the Syncer needs to Sync commits, and recieves ModuleCommits that should be
+// synced.
+type Handler interface {
+	ErrorHandler
+
+	// SyncModuleCommit is invoked to process a sync point. If an error is returned, sync will abort.
+	SyncModuleCommit(ctx context.Context, commit ModuleCommit) error
+
+	// ResolveSyncPoint is invoked to resolve a syncpoint for a particular module at a particular branch.
+	// If no syncpoint is found, this function returns nil. If an error is returned, sync will abort.
+	ResolveSyncPoint(
+		ctx context.Context,
+		module bufmoduleref.ModuleIdentity,
+		branch string,
+	) (git.Hash, error)
+
+	// CheckSyncedGitCommits is invoked when syncing branches to know which commits hashes from a set
+	// are already synced inthe BSR. It expects to receive the commit hashes that are synced already. If
+	// an error is returned, sync will abort.
+	CheckSyncedGitCommits(
+		ctx context.Context,
+		module bufmoduleref.ModuleIdentity,
+		commitHashes map[string]struct{},
+	) (map[string]struct{}, error)
+
+	// GetModuleDefaultBranch is invoked before syncing, to gather default branch names for all the
+	// modules that are about to be synced. If the BSR module does not exist, the implementation should
+	// return `ModuleDoesNotExistErr` error.
+	GetModuleDefaultBranch(
+		ctx context.Context,
+		module bufmoduleref.ModuleIdentity,
+	) (string, error)
+
+	// BackfillTags is invoked when a commit with valid modules is found within a lookback threshold
+	// past the start sync point for such module. The Syncer assumes that the "old" commit is already
+	// synced, so it will attempt to backfill existing tags using that git hash, in case they were
+	// recently created or moved there.
+	//
+	// A common scenario is SemVer releases: a commit is pushed to the default Git branch, the sync
+	// process triggers and completes, and some minutes later that commit is tagged "v1.2.3". The next
+	// time the sync command runs, this backfiller would pick such tag and backfill it to the correct
+	// BSR commit.
+	//
+	// It's expected to return the BSR commit name to which the tags were backfilled.
+	BackfillTags(
+		ctx context.Context,
+		module bufmoduleref.ModuleIdentity,
+		alreadySyncedHash git.Hash,
+		author git.Ident,
+		committer git.Ident,
+		tags []string,
+	) (string, error)
+}
+
+// Syncer syncs modules in a git.Repository.
 type Syncer interface {
-	// Sync syncs the repository using the provided SyncFunc. It processes commits in reverse
-	// topological order, loads any configured named modules, extracts any Git metadata for that
-	// commit, and invokes SyncFunc with a ModuleCommit.
-	Sync(context.Context, SyncFunc) error
+	// Sync syncs the repository. It processes commits in reverse topological order, loads any
+	// configured named modules, extracts any Git metadata for that commit, and invokes
+	// Handler#SyncModuleCommit with a ModuleCommit.
+	Sync(context.Context) error
 }
 
 // NewSyncer creates a new Syncer.
 func NewSyncer(
 	logger *zap.Logger,
+	clock Clock,
 	repo git.Repository,
 	storageGitProvider storagegit.Provider,
-	errorHandler ErrorHandler,
+	handler Handler,
 	options ...SyncerOption,
 ) (Syncer, error) {
 	return newSyncer(
 		logger,
+		clock,
 		repo,
 		storageGitProvider,
-		errorHandler,
+		handler,
 		options...,
 	)
 }
@@ -208,43 +266,6 @@ func SyncerWithModule(moduleDir string, identityOverride bufmoduleref.ModuleIden
 	}
 }
 
-// SyncerWithResumption configures a Syncer with a resumption using a SyncPointResolver.
-func SyncerWithResumption(resolver SyncPointResolver) SyncerOption {
-	return func(s *syncer) error {
-		s.syncPointResolver = resolver
-		return nil
-	}
-}
-
-// SyncerWithGitCommitChecker configures a git commit checker, to know if a module has a given git
-// hash alrady synced in a BSR instance.
-func SyncerWithGitCommitChecker(checker SyncedGitCommitChecker) SyncerOption {
-	return func(s *syncer) error {
-		s.syncedGitCommitChecker = checker
-		return nil
-	}
-}
-
-// SyncerWithModuleDefaultBranchGetter configures a getter for modules' default branch, to protect
-// those branches syncs in cases like a Git history rewrite. If this option is not passed, the
-// syncer treats the BSR default branch as any other branch.
-func SyncerWithModuleDefaultBranchGetter(getter ModuleDefaultBranchGetter) SyncerOption {
-	return func(s *syncer) error {
-		s.moduleDefaultBranchGetter = getter
-		return nil
-	}
-}
-
-// SyncerWithTagsBackfiller configures a tags backfiller for older, already synced commits. If this
-// option is not passed, the syncer won't try to sync older tags past each module's start sync
-// points on all branches.
-func SyncerWithTagsBackfiller(backfiller TagsBackfiller) SyncerOption {
-	return func(s *syncer) error {
-		s.tagsBackfiller = backfiller
-		return nil
-	}
-}
-
 // SyncerWithAllBranches sets the syncer to sync all branches. Be default the syncer only processes
 // commits in the current checked out branch.
 func SyncerWithAllBranches() SyncerOption {
@@ -253,56 +274,6 @@ func SyncerWithAllBranches() SyncerOption {
 		return nil
 	}
 }
-
-// SyncFunc is invoked by Syncer to process a sync point. If an error is returned,
-// sync will abort.
-type SyncFunc func(ctx context.Context, commit ModuleCommit) error
-
-// SyncPointResolver is invoked by Syncer to resolve a syncpoint for a particular module
-// at a particular branch. If no syncpoint is found, this function returns nil. If an error
-// is returned, sync will abort.
-type SyncPointResolver func(
-	ctx context.Context,
-	module bufmoduleref.ModuleIdentity,
-	branch string,
-) (git.Hash, error)
-
-// SyncedGitCommitChecker is invoked when syncing branches to know which commits hashes from a set
-// are already synced inthe BSR. It expects to receive the commit hashes that are synced already. If
-// an error is returned, sync will abort.
-type SyncedGitCommitChecker func(
-	ctx context.Context,
-	module bufmoduleref.ModuleIdentity,
-	commitHashes map[string]struct{},
-) (map[string]struct{}, error)
-
-// ModuleDefaultBranchGetter is invoked before syncing, to gather default branch names for all the
-// modules that are about to be synced. If the BSR module does not exist, the implementation should
-// return `ModuleDoesNotExistErr` error.
-type ModuleDefaultBranchGetter func(
-	ctx context.Context,
-	module bufmoduleref.ModuleIdentity,
-) (string, error)
-
-// TagsBackfiller is invoked when a commit with valid modules is found within a lookback threshold
-// past the start sync point for such module. The Syncer assumes that the "old" commit is already
-// synced, so it will attempt to backfill existing tags using that git hash, in case they were
-// recently created or moved there.
-//
-// A common scenario is SemVer releases: a commit is pushed to the default Git branch, the sync
-// process triggers and completes, and some minutes later that commit is tagged "v1.2.3". The next
-// time the sync command runs, this backfiller would pick such tag and backfill it to the correct
-// BSR commit.
-//
-// It's expected to return the BSR commit name to which the tags were backfilled.
-type TagsBackfiller func(
-	ctx context.Context,
-	module bufmoduleref.ModuleIdentity,
-	alreadySyncedHash git.Hash,
-	author git.Ident,
-	committer git.Ident,
-	tags []string,
-) (string, error)
 
 // ModuleCommit is a module at a particular commit.
 type ModuleCommit interface {
@@ -319,4 +290,15 @@ type ModuleCommit interface {
 	Identity() bufmoduleref.ModuleIdentity
 	// Bucket is the bucket for the module.
 	Bucket() storage.ReadBucket
+}
+
+// Clock provides the current time.
+type Clock interface {
+	// Now provides the current time.
+	Now() time.Time
+}
+
+// NewRealClock returns a Clock that returns the current time using time#Now().
+func NewRealClock() Clock {
+	return newClock()
 }

--- a/private/buf/bufsync/bufsync.go
+++ b/private/buf/bufsync/bufsync.go
@@ -151,7 +151,7 @@ type ErrorHandler interface {
 }
 
 // Handler is a handler for Syncer. It controls the way in which Syncer handles errors, provides
-// any information the Syncer needs to Sync commits, and recieves ModuleCommits that should be
+// any information the Syncer needs to Sync commits, and receives ModuleCommits that should be
 // synced.
 type Handler interface {
 	ErrorHandler

--- a/private/buf/bufsync/clock.go
+++ b/private/buf/bufsync/clock.go
@@ -1,0 +1,13 @@
+package bufsync
+
+import "time"
+
+type clock struct{}
+
+func newClock() *clock {
+	return &clock{}
+}
+
+func (*clock) Now() time.Time {
+	return time.Now()
+}

--- a/private/buf/bufsync/clock.go
+++ b/private/buf/bufsync/clock.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bufsync
 
 import "time"

--- a/private/buf/bufsync/commits_to_sync_test.go
+++ b/private/buf/bufsync/commits_to_sync_test.go
@@ -87,7 +87,7 @@ func TestCommitsToSyncWithNoPreviousSyncPoints(t *testing.T) {
 					)
 					require.NoError(t, err)
 					require.NoError(t, syncer.Sync(context.Background()))
-					syncedCommits := handler.commitsPerBranch[tc.branch]
+					syncedCommits := handler.commitsByBranch[tc.branch]
 					require.Len(t, syncedCommits, tc.expectedCommits)
 				})
 			}(tc)

--- a/private/buf/bufsync/prepare_sync_test.go
+++ b/private/buf/bufsync/prepare_sync_test.go
@@ -90,12 +90,12 @@ func TestPrepareSyncDuplicateIdentities(t *testing.T) {
 					opts...,
 				)
 				require.NoError(t, err)
-				prepareErr := syncer.Sync(context.Background())
-				require.Error(t, prepareErr)
-				assert.Contains(t, prepareErr.Error(), repeatedIdentity.IdentityString())
-				assert.Contains(t, prepareErr.Error(), defaultBranchName)
+				err = syncer.Sync(context.Background())
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), repeatedIdentity.IdentityString())
+				assert.Contains(t, err.Error(), defaultBranchName)
 				for _, moduleDir := range moduleDirs {
-					assert.Contains(t, prepareErr.Error(), moduleDir)
+					assert.Contains(t, err.Error(), moduleDir)
 				}
 			})
 		}(tc)

--- a/private/buf/bufsync/prepare_sync_test.go
+++ b/private/buf/bufsync/prepare_sync_test.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bufsync
+package bufsync_test
 
 import (
 	"context"
 	"fmt"
 	"testing"
 
+	"github.com/bufbuild/buf/private/buf/bufsync"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
 	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/storage/storagegit"
@@ -76,19 +77,20 @@ func TestPrepareSyncDuplicateIdentities(t *testing.T) {
 				for moduleDir := range tc.modulesIdentitiesInHEAD {
 					moduleDirs = append(moduleDirs, moduleDir)
 				}
-				testSyncer := syncer{
-					repo:                                  repo,
-					storageGitProvider:                    storagegit.NewProvider(repo.Objects()),
-					logger:                                zaptest.NewLogger(t),
-					sortedModulesDirsForSync:              moduleDirs,
-					modulesDirsToIdentityOverrideForSync:  tc.modulesOverrides,
-					commitsToTags:                         make(map[string][]string),
-					modulesDirsToBranchesToIdentities:     make(map[string]map[string]bufmoduleref.ModuleIdentity),
-					modulesToBranchesExpectedSyncPoints:   make(map[string]map[string]string),
-					modulesIdentitiesToCommitsSyncedCache: make(map[string]map[string]struct{}),
-					errorHandler:                          &mockErrorHandler{},
+				var opts []bufsync.SyncerOption
+				for moduleDir, identityOverride := range tc.modulesOverrides {
+					opts = append(opts, bufsync.SyncerWithModule(moduleDir, identityOverride))
 				}
-				prepareErr := testSyncer.prepareSync(context.Background())
+				syncer, err := bufsync.NewSyncer(
+					zaptest.NewLogger(t),
+					bufsync.NewRealClock(),
+					repo,
+					storagegit.NewProvider(repo.Objects()),
+					newMockSyncHandler(),
+					opts...,
+				)
+				require.NoError(t, err)
+				prepareErr := syncer.Sync(context.Background())
 				require.Error(t, prepareErr)
 				assert.Contains(t, prepareErr.Error(), repeatedIdentity.IdentityString())
 				assert.Contains(t, prepareErr.Error(), defaultBranchName)

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -184,7 +184,10 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 		branchesToSync = stringutil.MapToSlice(allBranches)
 	} else {
 		// sync current branch, make sure it's present
-		currentBranch := s.repo.CurrentBranch()
+		currentBranch, err := s.repo.CurrentBranch(ctx)
+		if err != nil {
+			return fmt.Errorf("determine checked out branch")
+		}
 		if _, currentBranchPresent := allBranches[currentBranch]; !currentBranchPresent {
 			return fmt.Errorf("current branch %s is not present %s", currentBranch, remoteErrMsg)
 		}

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
@@ -186,7 +186,7 @@ func sync(
 		return fmt.Errorf("create connect client %w", err)
 	}
 	syncerOptions := []bufsync.SyncerOption{
-		bufsync.SyncerWithRemote(remoteName),
+		bufsync.SyncerWithGitRemote(remoteName),
 	}
 	if allBranches {
 		syncerOptions = append(syncerOptions, bufsync.SyncerWithAllBranches())

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/reposync.go
@@ -20,28 +20,19 @@ import (
 	"fmt"
 	"strings"
 
-	"connectrpc.com/connect"
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufsync"
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
-	"github.com/bufbuild/buf/private/bufpkg/bufcas"
-	"github.com/bufbuild/buf/private/bufpkg/bufcas/bufcasalpha"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
-	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
-	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appflag"
 	"github.com/bufbuild/buf/private/pkg/command"
-	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/buf/private/pkg/git"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
-	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagegit"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -196,10 +187,6 @@ func sync(
 	}
 	syncerOptions := []bufsync.SyncerOption{
 		bufsync.SyncerWithRemote(remoteName),
-		bufsync.SyncerWithResumption(syncPointResolver(clientConfig)),
-		bufsync.SyncerWithGitCommitChecker(syncGitCommitChecker(clientConfig)),
-		bufsync.SyncerWithModuleDefaultBranchGetter(defaultBranchGetter(clientConfig)),
-		bufsync.SyncerWithTagsBackfiller(tagsBackfiller(clientConfig)),
 	}
 	if allBranches {
 		syncerOptions = append(syncerOptions, bufsync.SyncerWithAllBranches())
@@ -230,346 +217,21 @@ func sync(
 	}
 	syncer, err := bufsync.NewSyncer(
 		container.Logger(),
+		bufsync.NewRealClock(),
 		repo,
 		storageProvider,
-		newErrorHandler(container.Logger(), modulesDirsWithOverrides),
+		newSyncHandler(
+			container.Logger(),
+			clientConfig,
+			container,
+			repo,
+			createWithVisibility,
+			modulesDirsWithOverrides,
+		),
 		syncerOptions...,
 	)
 	if err != nil {
 		return fmt.Errorf("new syncer: %w", err)
 	}
-	return syncer.Sync(ctx, func(ctx context.Context, moduleCommit bufsync.ModuleCommit) error {
-		syncPoint, err := pushOrCreate(
-			ctx,
-			clientConfig,
-			repo,
-			moduleCommit.Commit(),
-			moduleCommit.Branch(),
-			moduleCommit.Tags(),
-			moduleCommit.Identity(),
-			moduleCommit.Bucket(),
-			createWithVisibility,
-		)
-		if err != nil {
-			// We failed to push. We fail hard on this because the error may be recoverable
-			// (i.e., the BSR may be down) and we should re-attempt this commit.
-			return fmt.Errorf(
-				"failed to push or create %s at %s: %w",
-				moduleCommit.Identity().IdentityString(),
-				moduleCommit.Commit().Hash(),
-				err,
-			)
-		}
-		_, err = container.Stderr().Write([]byte(
-			// from local                                        -> to remote
-			// <module-directory>:<git-branch>:<git-commit-hash> -> <module-identity>:<bsr-commit-name>
-			fmt.Sprintf(
-				"%s:%s:%s -> %s:%s\n",
-				moduleCommit.Directory(), moduleCommit.Branch(), moduleCommit.Commit().Hash().Hex(),
-				moduleCommit.Identity().IdentityString(), syncPoint.BsrCommitName,
-			)),
-		)
-		return err
-	})
-}
-
-func syncPointResolver(clientConfig *connectclient.Config) bufsync.SyncPointResolver {
-	return func(ctx context.Context, module bufmoduleref.ModuleIdentity, branch string) (git.Hash, error) {
-		service := connectclient.Make(clientConfig, module.Remote(), registryv1alpha1connect.NewSyncServiceClient)
-		syncPoint, err := service.GetGitSyncPoint(ctx, connect.NewRequest(&registryv1alpha1.GetGitSyncPointRequest{
-			Owner:      module.Owner(),
-			Repository: module.Repository(),
-			Branch:     branch,
-		}))
-		if err != nil {
-			if connect.CodeOf(err) == connect.CodeNotFound {
-				// No syncpoint
-				return nil, nil
-			}
-			return nil, fmt.Errorf("get git sync point: %w", err)
-		}
-		hash, err := git.NewHashFromHex(syncPoint.Msg.GetSyncPoint().GitCommitHash)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid sync point from BSR %q: %w",
-				syncPoint.Msg.GetSyncPoint().GetGitCommitHash(),
-				err,
-			)
-		}
-		return hash, nil
-	}
-}
-
-func syncGitCommitChecker(clientConfig *connectclient.Config) bufsync.SyncedGitCommitChecker {
-	return func(ctx context.Context, module bufmoduleref.ModuleIdentity, commitHashes map[string]struct{}) (map[string]struct{}, error) {
-		service := connectclient.Make(clientConfig, module.Remote(), registryv1alpha1connect.NewLabelServiceClient)
-		res, err := service.GetLabelsInNamespace(ctx, connect.NewRequest(&registryv1alpha1.GetLabelsInNamespaceRequest{
-			RepositoryOwner: module.Owner(),
-			RepositoryName:  module.Repository(),
-			LabelNamespace:  registryv1alpha1.LabelNamespace_LABEL_NAMESPACE_GIT_COMMIT,
-			LabelNames:      stringutil.MapToSlice(commitHashes),
-		}))
-		if err != nil {
-			if connect.CodeOf(err) == connect.CodeNotFound {
-				// Repo is not created
-				return nil, nil
-			}
-			return nil, fmt.Errorf("get labels in namespace: %w", err)
-		}
-		syncedHashes := make(map[string]struct{})
-		for _, label := range res.Msg.Labels {
-			syncedHash := label.LabelName.Name
-			if _, expected := commitHashes[syncedHash]; !expected {
-				return nil, fmt.Errorf("received unexpected synced hash %q, expected %v", syncedHash, commitHashes)
-			}
-			syncedHashes[syncedHash] = struct{}{}
-		}
-		return syncedHashes, nil
-	}
-}
-
-func defaultBranchGetter(clientConfig *connectclient.Config) bufsync.ModuleDefaultBranchGetter {
-	return func(ctx context.Context, module bufmoduleref.ModuleIdentity) (string, error) {
-		service := connectclient.Make(clientConfig, module.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
-		res, err := service.GetRepositoryByFullName(ctx, connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
-			FullName: module.Owner() + "/" + module.Repository(),
-		}))
-		if err != nil {
-			if connect.CodeOf(err) == connect.CodeNotFound {
-				// Repo is not created
-				return "", bufsync.ErrModuleDoesNotExist
-			}
-			return "", fmt.Errorf("get repository by full name %q: %w", module.IdentityString(), err)
-		}
-		return res.Msg.Repository.DefaultBranch, nil
-	}
-}
-
-func tagsBackfiller(clientConfig *connectclient.Config) bufsync.TagsBackfiller {
-	return func(
-		ctx context.Context,
-		module bufmoduleref.ModuleIdentity,
-		alreadySyncedHash git.Hash,
-		author git.Ident,
-		committer git.Ident,
-		tags []string,
-	) (string, error) {
-		service := connectclient.Make(clientConfig, module.Remote(), registryv1alpha1connect.NewSyncServiceClient)
-		res, err := service.AttachGitTags(ctx, connect.NewRequest(&registryv1alpha1.AttachGitTagsRequest{
-			Owner:      module.Owner(),
-			Repository: module.Repository(),
-			Hash:       alreadySyncedHash.Hex(),
-			Author: &registryv1alpha1.GitIdentity{
-				Name:  author.Name(),
-				Email: author.Email(),
-				Time:  timestamppb.New(author.Timestamp()),
-			},
-			Committer: &registryv1alpha1.GitIdentity{
-				Name:  committer.Name(),
-				Email: committer.Email(),
-				Time:  timestamppb.New(committer.Timestamp()),
-			},
-			Tags: tags,
-		}))
-		if err != nil {
-			if connect.CodeOf(err) == connect.CodeNotFound {
-				// Repo is not created
-				return "", bufsync.ErrModuleDoesNotExist
-			}
-			return "", fmt.Errorf("attach git tags to module %q: %w", module.IdentityString(), err)
-		}
-		return res.Msg.GetBsrCommitName(), nil
-	}
-}
-
-type syncErrorHandler struct {
-	logger                          *zap.Logger
-	modulesDirsWithIdentityOverride map[string]struct{}
-}
-
-func newErrorHandler(
-	logger *zap.Logger,
-	modulesDirsWithIdentityOverride map[string]struct{},
-) bufsync.ErrorHandler {
-	return &syncErrorHandler{
-		logger:                          logger,
-		modulesDirsWithIdentityOverride: modulesDirsWithIdentityOverride,
-	}
-}
-
-func (h *syncErrorHandler) HandleReadModuleError(err *bufsync.ReadModuleError) bufsync.LookbackDecisionCode {
-	switch err.Code() {
-	case bufsync.ReadModuleErrorCodeModuleNotFound,
-		bufsync.ReadModuleErrorCodeInvalidModuleConfig,
-		bufsync.ReadModuleErrorCodeBuildModule:
-		// if the module cannot be found, has an invalid config, or cannot build, we can just skip the
-		// commit.
-		return bufsync.LookbackDecisionCodeSkip
-	case bufsync.ReadModuleErrorCodeUnnamedModule,
-		bufsync.ReadModuleErrorCodeUnexpectedName:
-		// if the module has an unexpected or no name, we should override the module identity only if it
-		// was passed explicitly as an identity override, otherwise skip the commit.
-		if _, hasExplicitOverride := h.modulesDirsWithIdentityOverride[err.ModuleDir()]; hasExplicitOverride {
-			return bufsync.LookbackDecisionCodeOverride
-		}
-		return bufsync.LookbackDecisionCodeSkip
-	}
-	// any unhandled scenarios? just fail the sync
-	return bufsync.LookbackDecisionCodeFail
-}
-
-func (h *syncErrorHandler) InvalidBSRSyncPoint(
-	module bufmoduleref.ModuleIdentity,
-	branch string,
-	syncPoint git.Hash,
-	isGitDefaultBranch bool,
-	err error,
-) error {
-	// The most likely culprit for an invalid sync point is a rebase, where the last known commit has
-	// been garbage collected. In this case, let's present a better error message.
-	//
-	// This is not trivial scenario if the branch that's been rebased is a long-lived branch (like
-	// main) whose artifacts are consumed by other branches, as we may fail to sync those commits if
-	// we continue.
-	//
-	// For now we simply error if this happens in the default branch, and WARN+skip for the other
-	// branches. We may want to provide a flag in the future for forcing sync to continue despite
-	// this.
-	if errors.Is(err, git.ErrObjectNotFound) {
-		if isGitDefaultBranch {
-			return fmt.Errorf(
-				"last synced git commit %q for default branch %q in module %q is not found in the git repo, did you rebase or reset your default branch?",
-				syncPoint.Hex(), branch, module.IdentityString(),
-			)
-		}
-		h.logger.Warn(
-			"last synced git commit not found in the git repo for a non-default branch",
-			zap.String("module", module.IdentityString()),
-			zap.String("branch", branch),
-			zap.String("last synced git commit", syncPoint.Hex()),
-		)
-		return nil
-	}
-	// Other error, let's abort sync.
-	return fmt.Errorf(
-		"invalid sync point %q for branch %q in module %q: %w",
-		syncPoint.Hex(), branch, module.IdentityString(), err,
-	)
-}
-
-func pushOrCreate(
-	ctx context.Context,
-	clientConfig *connectclient.Config,
-	repo git.Repository,
-	commit git.Commit,
-	branch string,
-	tags []string,
-	moduleIdentity bufmoduleref.ModuleIdentity,
-	moduleBucket storage.ReadBucket,
-	createWithVisibility string,
-) (*registryv1alpha1.GitSyncPoint, error) {
-	modulePin, err := push(
-		ctx,
-		clientConfig,
-		repo,
-		commit,
-		branch,
-		tags,
-		moduleIdentity,
-		moduleBucket,
-	)
-	if err != nil {
-		// We rely on Push* returning a NotFound error to denote the repository is not created.
-		// This technically could be a NotFound error for some other entity than the repository
-		// in question, however if it is, then this Create call will just fail as the repository
-		// is already created, and there is no side effect. The 99% case is that a NotFound
-		// error is because the repository does not exist, and we want to avoid having to do
-		// a GetRepository RPC call for every call to push --create.
-		if createWithVisibility != "" && connect.CodeOf(err) == connect.CodeNotFound {
-			if err := create(ctx, clientConfig, moduleIdentity, createWithVisibility); err != nil {
-				return nil, fmt.Errorf("create repo: %w", err)
-			}
-			return push(
-				ctx,
-				clientConfig,
-				repo,
-				commit,
-				branch,
-				tags,
-				moduleIdentity,
-				moduleBucket,
-			)
-		}
-		return nil, fmt.Errorf("push: %w", err)
-	}
-	return modulePin, nil
-}
-
-func push(
-	ctx context.Context,
-	clientConfig *connectclient.Config,
-	repo git.Repository,
-	commit git.Commit,
-	branch string,
-	tags []string,
-	moduleIdentity bufmoduleref.ModuleIdentity,
-	moduleBucket storage.ReadBucket,
-) (*registryv1alpha1.GitSyncPoint, error) {
-	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewSyncServiceClient)
-	fileSet, err := bufcas.NewFileSetForBucket(ctx, moduleBucket)
-	if err != nil {
-		return nil, err
-	}
-	protoManifestBlob, protoBlobs, err := bufcas.FileSetToProtoManifestBlobAndBlobs(fileSet)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := service.SyncGitCommit(ctx, connect.NewRequest(&registryv1alpha1.SyncGitCommitRequest{
-		Owner:      moduleIdentity.Owner(),
-		Repository: moduleIdentity.Repository(),
-		Manifest:   bufcasalpha.BlobToAlpha(protoManifestBlob),
-		Blobs:      bufcasalpha.BlobsToAlpha(protoBlobs),
-		Hash:       commit.Hash().Hex(),
-		Branch:     branch,
-		Tags:       tags,
-		Author: &registryv1alpha1.GitIdentity{
-			Name:  commit.Author().Name(),
-			Email: commit.Author().Email(),
-			Time:  timestamppb.New(commit.Author().Timestamp()),
-		},
-		Committer: &registryv1alpha1.GitIdentity{
-			Name:  commit.Committer().Name(),
-			Email: commit.Committer().Email(),
-			Time:  timestamppb.New(commit.Committer().Timestamp()),
-		},
-	}))
-	if err != nil {
-		return nil, err
-	}
-	return resp.Msg.SyncPoint, nil
-}
-
-func create(
-	ctx context.Context,
-	clientConfig *connectclient.Config,
-	moduleIdentity bufmoduleref.ModuleIdentity,
-	visibility string,
-) error {
-	service := connectclient.Make(clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
-	visiblity, err := bufcli.VisibilityFlagToVisibility(visibility)
-	if err != nil {
-		return err
-	}
-	fullName := moduleIdentity.Owner() + "/" + moduleIdentity.Repository()
-	_, err = service.CreateRepositoryByFullName(
-		ctx,
-		connect.NewRequest(&registryv1alpha1.CreateRepositoryByFullNameRequest{
-			FullName:   fullName,
-			Visibility: visiblity,
-		}),
-	)
-	if err != nil && connect.CodeOf(err) == connect.CodeAlreadyExists {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("expected repository %s to be missing but found the repository to already exist", fullName))
-	}
-	return err
+	return syncer.Sync(ctx)
 }

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/sync_handler.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/sync_handler.go
@@ -114,7 +114,7 @@ func (h *syncHandler) CheckSyncedGitCommits(ctx context.Context, module bufmodul
 	return syncedHashes, nil
 }
 
-func (h *syncHandler) GetModuleDefaultBranch(ctx context.Context, module bufmoduleref.ModuleIdentity) (string, error) {
+func (h *syncHandler) GetModuleReleaseBranch(ctx context.Context, module bufmoduleref.ModuleIdentity) (string, error) {
 	service := connectclient.Make(h.clientConfig, module.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
 	res, err := service.GetRepositoryByFullName(ctx, connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
 		FullName: module.Owner() + "/" + module.Repository(),

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/sync_handler.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/sync_handler.go
@@ -1,0 +1,348 @@
+package reposync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/buf/bufsync"
+	"github.com/bufbuild/buf/private/bufpkg/bufcas"
+	"github.com/bufbuild/buf/private/bufpkg/bufcas/bufcasalpha"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduleref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/app/appflag"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
+	"github.com/bufbuild/buf/private/pkg/git"
+	"github.com/bufbuild/buf/private/pkg/storage"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type syncHandler struct {
+	logger                          *zap.Logger
+	clientConfig                    *connectclient.Config
+	container                       appflag.Container
+	repo                            git.Repository
+	createWithVisibility            string
+	modulesDirsWithIdentityOverride map[string]struct{}
+}
+
+func newSyncHandler(
+	logger *zap.Logger,
+	clientConfig *connectclient.Config,
+	container appflag.Container,
+	repo git.Repository,
+	createWithVisibility string,
+	modulesDirsWithIdentityOverride map[string]struct{},
+) bufsync.Handler {
+	return &syncHandler{
+		logger:                          logger,
+		clientConfig:                    clientConfig,
+		container:                       container,
+		repo:                            repo,
+		createWithVisibility:            createWithVisibility,
+		modulesDirsWithIdentityOverride: modulesDirsWithIdentityOverride,
+	}
+}
+
+func (h *syncHandler) ResolveSyncPoint(ctx context.Context, module bufmoduleref.ModuleIdentity, branch string) (git.Hash, error) {
+	service := connectclient.Make(h.clientConfig, module.Remote(), registryv1alpha1connect.NewSyncServiceClient)
+	syncPoint, err := service.GetGitSyncPoint(ctx, connect.NewRequest(&registryv1alpha1.GetGitSyncPointRequest{
+		Owner:      module.Owner(),
+		Repository: module.Repository(),
+		Branch:     branch,
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			// No syncpoint
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get git sync point: %w", err)
+	}
+	hash, err := git.NewHashFromHex(syncPoint.Msg.GetSyncPoint().GitCommitHash)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid sync point from BSR %q: %w",
+			syncPoint.Msg.GetSyncPoint().GetGitCommitHash(),
+			err,
+		)
+	}
+	return hash, nil
+}
+
+func (h *syncHandler) CheckSyncedGitCommits(ctx context.Context, module bufmoduleref.ModuleIdentity, commitHashes map[string]struct{}) (map[string]struct{}, error) {
+	service := connectclient.Make(h.clientConfig, module.Remote(), registryv1alpha1connect.NewLabelServiceClient)
+	res, err := service.GetLabelsInNamespace(ctx, connect.NewRequest(&registryv1alpha1.GetLabelsInNamespaceRequest{
+		RepositoryOwner: module.Owner(),
+		RepositoryName:  module.Repository(),
+		LabelNamespace:  registryv1alpha1.LabelNamespace_LABEL_NAMESPACE_GIT_COMMIT,
+		LabelNames:      stringutil.MapToSlice(commitHashes),
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			// Repo is not created
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get labels in namespace: %w", err)
+	}
+	syncedHashes := make(map[string]struct{})
+	for _, label := range res.Msg.Labels {
+		syncedHash := label.LabelName.Name
+		if _, expected := commitHashes[syncedHash]; !expected {
+			return nil, fmt.Errorf("received unexpected synced hash %q, expected %v", syncedHash, commitHashes)
+		}
+		syncedHashes[syncedHash] = struct{}{}
+	}
+	return syncedHashes, nil
+}
+
+func (h *syncHandler) GetModuleDefaultBranch(ctx context.Context, module bufmoduleref.ModuleIdentity) (string, error) {
+	service := connectclient.Make(h.clientConfig, module.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	res, err := service.GetRepositoryByFullName(ctx, connect.NewRequest(&registryv1alpha1.GetRepositoryByFullNameRequest{
+		FullName: module.Owner() + "/" + module.Repository(),
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			// Repo is not created
+			return "", bufsync.ErrModuleDoesNotExist
+		}
+		return "", fmt.Errorf("get repository by full name %q: %w", module.IdentityString(), err)
+	}
+	return res.Msg.Repository.DefaultBranch, nil
+}
+
+func (h *syncHandler) BackfillTags(
+	ctx context.Context,
+	module bufmoduleref.ModuleIdentity,
+	alreadySyncedHash git.Hash,
+	author git.Ident,
+	committer git.Ident,
+	tags []string,
+) (string, error) {
+	service := connectclient.Make(h.clientConfig, module.Remote(), registryv1alpha1connect.NewSyncServiceClient)
+	res, err := service.AttachGitTags(ctx, connect.NewRequest(&registryv1alpha1.AttachGitTagsRequest{
+		Owner:      module.Owner(),
+		Repository: module.Repository(),
+		Hash:       alreadySyncedHash.Hex(),
+		Author: &registryv1alpha1.GitIdentity{
+			Name:  author.Name(),
+			Email: author.Email(),
+			Time:  timestamppb.New(author.Timestamp()),
+		},
+		Committer: &registryv1alpha1.GitIdentity{
+			Name:  committer.Name(),
+			Email: committer.Email(),
+			Time:  timestamppb.New(committer.Timestamp()),
+		},
+		Tags: tags,
+	}))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			// Repo is not created
+			return "", bufsync.ErrModuleDoesNotExist
+		}
+		return "", fmt.Errorf("attach git tags to module %q: %w", module.IdentityString(), err)
+	}
+	return res.Msg.GetBsrCommitName(), nil
+}
+
+func (h *syncHandler) SyncModuleCommit(ctx context.Context, moduleCommit bufsync.ModuleCommit) error {
+	syncPoint, err := h.pushOrCreate(
+		ctx,
+		moduleCommit.Commit(),
+		moduleCommit.Branch(),
+		moduleCommit.Tags(),
+		moduleCommit.Identity(),
+		moduleCommit.Bucket(),
+	)
+	if err != nil {
+		// We failed to push. We fail hard on this because the error may be recoverable
+		// (i.e., the BSR may be down) and we should re-attempt this commit.
+		return fmt.Errorf(
+			"failed to push or create %s at %s: %w",
+			moduleCommit.Identity().IdentityString(),
+			moduleCommit.Commit().Hash(),
+			err,
+		)
+	}
+	_, err = h.container.Stderr().Write([]byte(
+		// from local                                        -> to remote
+		// <module-directory>:<git-branch>:<git-commit-hash> -> <module-identity>:<bsr-commit-name>
+		fmt.Sprintf(
+			"%s:%s:%s -> %s:%s\n",
+			moduleCommit.Directory(), moduleCommit.Branch(), moduleCommit.Commit().Hash().Hex(),
+			moduleCommit.Identity().IdentityString(), syncPoint.BsrCommitName,
+		)),
+	)
+	return err
+}
+
+func (h *syncHandler) HandleReadModuleError(err *bufsync.ReadModuleError) bufsync.LookbackDecisionCode {
+	switch err.Code() {
+	case bufsync.ReadModuleErrorCodeModuleNotFound,
+		bufsync.ReadModuleErrorCodeInvalidModuleConfig,
+		bufsync.ReadModuleErrorCodeBuildModule:
+		// if the module cannot be found, has an invalid config, or cannot build, we can just skip the
+		// commit.
+		return bufsync.LookbackDecisionCodeSkip
+	case bufsync.ReadModuleErrorCodeUnnamedModule,
+		bufsync.ReadModuleErrorCodeUnexpectedName:
+		// if the module has an unexpected or no name, we should override the module identity only if it
+		// was passed explicitly as an identity override, otherwise skip the commit.
+		if _, hasExplicitOverride := h.modulesDirsWithIdentityOverride[err.ModuleDir()]; hasExplicitOverride {
+			return bufsync.LookbackDecisionCodeOverride
+		}
+		return bufsync.LookbackDecisionCodeSkip
+	}
+	// any unhandled scenarios? just fail the sync
+	return bufsync.LookbackDecisionCodeFail
+}
+
+func (h *syncHandler) InvalidBSRSyncPoint(
+	module bufmoduleref.ModuleIdentity,
+	branch string,
+	syncPoint git.Hash,
+	isGitDefaultBranch bool,
+	err error,
+) error {
+	// The most likely culprit for an invalid sync point is a rebase, where the last known commit has
+	// been garbage collected. In this case, let's present a better error message.
+	//
+	// This is not trivial scenario if the branch that's been rebased is a long-lived branch (like
+	// main) whose artifacts are consumed by other branches, as we may fail to sync those commits if
+	// we continue.
+	//
+	// For now we simply error if this happens in the default branch, and WARN+skip for the other
+	// branches. We may want to provide a flag in the future for forcing sync to continue despite
+	// this.
+	if errors.Is(err, git.ErrObjectNotFound) {
+		if isGitDefaultBranch {
+			return fmt.Errorf(
+				"last synced git commit %q for default branch %q in module %q is not found in the git repo, did you rebase or reset your default branch?",
+				syncPoint.Hex(), branch, module.IdentityString(),
+			)
+		}
+		h.logger.Warn(
+			"last synced git commit not found in the git repo for a non-default branch",
+			zap.String("module", module.IdentityString()),
+			zap.String("branch", branch),
+			zap.String("last synced git commit", syncPoint.Hex()),
+		)
+		return nil
+	}
+	// Other error, let's abort sync.
+	return fmt.Errorf(
+		"invalid sync point %q for branch %q in module %q: %w",
+		syncPoint.Hex(), branch, module.IdentityString(), err,
+	)
+}
+
+func (h *syncHandler) pushOrCreate(
+	ctx context.Context,
+	commit git.Commit,
+	branch string,
+	tags []string,
+	moduleIdentity bufmoduleref.ModuleIdentity,
+	moduleBucket storage.ReadBucket,
+) (*registryv1alpha1.GitSyncPoint, error) {
+	modulePin, err := h.push(
+		ctx,
+		commit,
+		branch,
+		tags,
+		moduleIdentity,
+		moduleBucket,
+	)
+	if err != nil {
+		// We rely on Push* returning a NotFound error to denote the repository is not created.
+		// This technically could be a NotFound error for some other entity than the repository
+		// in question, however if it is, then this Create call will just fail as the repository
+		// is already created, and there is no side effect. The 99% case is that a NotFound
+		// error is because the repository does not exist, and we want to avoid having to do
+		// a GetRepository RPC call for every call to push --create.
+		if h.createWithVisibility != "" && connect.CodeOf(err) == connect.CodeNotFound {
+			if err := h.create(ctx, moduleIdentity); err != nil {
+				return nil, fmt.Errorf("create repo: %w", err)
+			}
+			return h.push(
+				ctx,
+				commit,
+				branch,
+				tags,
+				moduleIdentity,
+				moduleBucket,
+			)
+		}
+		return nil, fmt.Errorf("push: %w", err)
+	}
+	return modulePin, nil
+}
+
+func (h *syncHandler) push(
+	ctx context.Context,
+	commit git.Commit,
+	branch string,
+	tags []string,
+	moduleIdentity bufmoduleref.ModuleIdentity,
+	moduleBucket storage.ReadBucket,
+) (*registryv1alpha1.GitSyncPoint, error) {
+	service := connectclient.Make(h.clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewSyncServiceClient)
+	fileSet, err := bufcas.NewFileSetForBucket(ctx, moduleBucket)
+	if err != nil {
+		return nil, err
+	}
+	protoManifestBlob, protoBlobs, err := bufcas.FileSetToProtoManifestBlobAndBlobs(fileSet)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := service.SyncGitCommit(ctx, connect.NewRequest(&registryv1alpha1.SyncGitCommitRequest{
+		Owner:      moduleIdentity.Owner(),
+		Repository: moduleIdentity.Repository(),
+		Manifest:   bufcasalpha.BlobToAlpha(protoManifestBlob),
+		Blobs:      bufcasalpha.BlobsToAlpha(protoBlobs),
+		Hash:       commit.Hash().Hex(),
+		Branch:     branch,
+		Tags:       tags,
+		Author: &registryv1alpha1.GitIdentity{
+			Name:  commit.Author().Name(),
+			Email: commit.Author().Email(),
+			Time:  timestamppb.New(commit.Author().Timestamp()),
+		},
+		Committer: &registryv1alpha1.GitIdentity{
+			Name:  commit.Committer().Name(),
+			Email: commit.Committer().Email(),
+			Time:  timestamppb.New(commit.Committer().Timestamp()),
+		},
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.SyncPoint, nil
+}
+
+func (h *syncHandler) create(
+	ctx context.Context,
+	moduleIdentity bufmoduleref.ModuleIdentity,
+) error {
+	service := connectclient.Make(h.clientConfig, moduleIdentity.Remote(), registryv1alpha1connect.NewRepositoryServiceClient)
+	visiblity, err := bufcli.VisibilityFlagToVisibility(h.createWithVisibility)
+	if err != nil {
+		return err
+	}
+	fullName := moduleIdentity.Owner() + "/" + moduleIdentity.Repository()
+	_, err = service.CreateRepositoryByFullName(
+		ctx,
+		connect.NewRequest(&registryv1alpha1.CreateRepositoryByFullNameRequest{
+			FullName:   fullName,
+			Visibility: visiblity,
+		}),
+	)
+	if err != nil && connect.CodeOf(err) == connect.CodeAlreadyExists {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("expected repository %s to be missing but found the repository to already exist", fullName))
+	}
+	return err
+}

--- a/private/buf/cmd/buf/command/alpha/repo/reposync/sync_handler.go
+++ b/private/buf/cmd/buf/command/alpha/repo/reposync/sync_handler.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reposync
 
 import (

--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -272,7 +272,7 @@ type Repository interface {
 	// remote named `origin`). It can be customized via the `OpenRepositoryWithDefaultBranch` option.
 	DefaultBranch() string
 	// CurrentBranch is the current checked out branch.
-	CurrentBranch() string
+	CurrentBranch(ctx context.Context) (string, error)
 	// ForEachBranch ranges over branches in the repository in an undefined order.
 	ForEachBranch(f func(branch string, headHash Hash) error, options ...ForEachBranchOption) error
 	// ForEachCommit ranges over commits in reverse topological order, going backwards in time always

--- a/private/pkg/git/repository_test.go
+++ b/private/pkg/git/repository_test.go
@@ -15,6 +15,7 @@
 package git_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bufbuild/buf/private/pkg/git"
@@ -235,9 +236,11 @@ func TestForEachBranch(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				repo := gittest.ScaffoldGitRepository(t)
-				assert.Equal(t, gittest.DefaultBranch, repo.CurrentBranch())
+				currentBranch, err := repo.CurrentBranch(context.Background())
+				require.NoError(t, err)
+				assert.Equal(t, gittest.DefaultBranch, currentBranch)
 				branches := make(map[string]struct{})
-				err := repo.ForEachBranch(func(branch string, headHash git.Hash) error {
+				err = repo.ForEachBranch(func(branch string, headHash git.Hash) error {
 					require.NotEmpty(t, branch)
 					if _, alreadySeen := branches[branch]; alreadySeen {
 						assert.Fail(t, "duplicate branch", branch)


### PR DESCRIPTION
This also improves the testing to be blackbox; we invoke sync and assert on the end-state.