### PR TITLE
Fix permission issue from checkout action

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -1,5 +1,8 @@
 name: Create Release PR
 on:
+  push:
+    branches:
+      - osun/fix-git-permission
   workflow_dispatch:
     inputs:
       version:
@@ -26,6 +29,6 @@ jobs:
       - name: Create release PR
         run: bash ./make/buf/scripts/createreleasepr.bash
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           VERSION: ${{ github.event.inputs.version }}
           WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }}

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -1,9 +1,5 @@
 name: Create Release PR
 on:
-  # todo: remove push
-  push:
-    branches:
-      - osun/fix-git-permission
   workflow_dispatch:
     inputs:
       version:
@@ -32,7 +28,6 @@ jobs:
       - name: Create release PR
         run: bash ./make/buf/scripts/createreleasepr.bash
         env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
-          # VERSION: ${{ github.event.inputs.version }}
-          VERSION: 1.28.0-test
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          VERSION: ${{ github.event.inputs.version }}
           WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }}

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -10,6 +10,8 @@ on:
         description: The released version without 'v'. For example, 1.0.0.
 env:
   APP_ID: 251311
+  # todo: remove
+  VERSION: 1.28.0
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -1,5 +1,6 @@
 name: Create Release PR
 on:
+  # todo: remove push
   push:
     branches:
       - osun/fix-git-permission
@@ -26,12 +27,12 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
       - name: Set up Git name and email
         run: |
-          git config --global user.email "251311+buf-release-bot[bot]@users.noreply.github.com"
-          git config --global user.name "buf-release-bot[bot]"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
       - name: Create release PR
         run: bash ./make/buf/scripts/createreleasepr.bash
         env:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           # VERSION: ${{ github.event.inputs.version }}
-          VERSION: 1.28.0
+          VERSION: 1.28.0-test
           WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }}

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -10,8 +10,6 @@ on:
         description: The released version without 'v'. For example, 1.0.0.
 env:
   APP_ID: 251311
-  # todo: remove
-  VERSION: 1.28.0
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -32,5 +30,6 @@ jobs:
         run: bash ./make/buf/scripts/createreleasepr.bash
         env:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
-          VERSION: ${{ github.event.inputs.version }}
+          # VERSION: ${{ github.event.inputs.version }}
+          VERSION: 1.28.0
           WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }}

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -14,14 +14,16 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository code
-        uses: actions/checkout@v4
       - name: Get GitHub app token
         uses: actions/create-github-app-token@v1
         id: app_token
         with:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ secrets.TOKEN_EXCHANGE_GH_APP_PRIVATE_KEY }}
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app_token.outputs.token }}
       - name: Set up Git name and email
         run: |
           git config --global user.email "251311+buf-release-bot[bot]@users.noreply.github.com"

--- a/make/buf/scripts/createreleasepr.bash
+++ b/make/buf/scripts/createreleasepr.bash
@@ -8,7 +8,7 @@ cd "${DIR}"
 # We already have set -u, but want to fail early if a required variable is not set.
 : ${WEBHOOK_URL}
 # However, if you are already logged in for GitHub CLI locally, you can remove this line when running it locally.
-: ${GH_TOKEN}
+# : ${GH_TOKEN}
 
 if [[ "${VERSION}" == v* ]]; then
   echo "error: VERSION ${VERSION} must not start with 'v'" >&2

--- a/make/buf/scripts/createreleasepr.bash
+++ b/make/buf/scripts/createreleasepr.bash
@@ -8,7 +8,7 @@ cd "${DIR}"
 # We already have set -u, but want to fail early if a required variable is not set.
 : ${WEBHOOK_URL}
 # However, if you are already logged in for GitHub CLI locally, you can remove this line when running it locally.
-# : ${GH_TOKEN}
+: ${GH_TOKEN}
 
 if [[ "${VERSION}" == v* ]]; then
   echo "error: VERSION ${VERSION} must not start with 'v'" >&2


### PR DESCRIPTION
The checkout action needs a token for `git push` to work.

Also reverts the `git config` change.