### PR TITLE
Clarify that storage.ReadBucket.Walk should work when a path is given as a prefix

### DIFF
--- a/private/pkg/storage/bucket.go
+++ b/private/pkg/storage/bucket.go
@@ -49,7 +49,7 @@ type ReadBucket interface {
 	// Note that a prefix can also be equal to a path in the bucket, in which
 	// case Walk will walk this single file. That is, if file a/b/c.txt is in
 	// the bucket, Walk(ctx, "a/b/c.txt", ...) will result in a single iteration,
-	// calling f on the file "a/b/c.txt").
+	// calling f on the file "a/b/c.txt".
 	//
 	// All paths given to f are normalized and validated.
 	// If f returns error, Walk will stop short and return this error.

--- a/private/pkg/storage/bucket.go
+++ b/private/pkg/storage/bucket.go
@@ -46,6 +46,11 @@ type ReadBucket interface {
 	// Note that foo/barbaz will not be called for foo/bar, but will
 	// be called for foo/bar/baz.
 	//
+	// Note that a prefix can also be equal to a path in the bucket, in which
+	// case Walk will walk this single file. That is, if file a/b/c.txt is in
+	// the bucket, Walk(ctx, "a/b/c.txt", ...) will result in a single iteration,
+	// calling f on the file "a/b/c.txt").
+	//
 	// All paths given to f are normalized and validated.
 	// If f returns error, Walk will stop short and return this error.
 	// Returns other error on system error.

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -1498,4 +1498,27 @@ func RunTestSuite(
 		)
 		assert.NoError(t, err)
 	})
+
+	t.Run("walk-on-file-path-that-is-not-pure-prefix", func(t *testing.T) {
+		t.Parallel()
+		readBucket, _ := newReadBucket(t, oneDirPath, defaultProvider)
+		AssertPathToContent(
+			t,
+			readBucket,
+			"root/a/b",
+			map[string]string{
+				"root/a/b/1.proto": testProtoContent,
+				"root/a/b/2.proto": testProtoContent,
+				"root/a/b/2.txt":   testTxtContent,
+			},
+		)
+		AssertPathToContent(
+			t,
+			readBucket,
+			"root/a/b/1.proto",
+			map[string]string{
+				"root/a/b/1.proto": testProtoContent,
+			},
+		)
+	})
 }


### PR DESCRIPTION
This also adds a test to the test suite to verify this property for all of our `storage.ReadBucket` implementations.