### PR TITLE
Print count of unrecognized bytes in "buf curl"

### DIFF
--- a/private/pkg/protoencoding/json_unmarshaler.go
+++ b/private/pkg/protoencoding/json_unmarshaler.go
@@ -20,20 +20,24 @@ import (
 )
 
 type jsonUnmarshaler struct {
-	resolver Resolver
+	resolver        Resolver
+	disallowUnknown bool
 }
 
-func newJSONUnmarshaler(resolver Resolver) Unmarshaler {
-	return &jsonUnmarshaler{
+func newJSONUnmarshaler(resolver Resolver, options ...JSONUnmarshalerOption) Unmarshaler {
+	jsonUnmarshaler := &jsonUnmarshaler{
 		resolver: resolver,
 	}
+	for _, option := range options {
+		option(jsonUnmarshaler)
+	}
+	return jsonUnmarshaler
 }
 
 func (m *jsonUnmarshaler) Unmarshal(data []byte, message proto.Message) error {
 	options := protojson.UnmarshalOptions{
-		Resolver: m.resolver,
-		// TODO: make this an option
-		DiscardUnknown: true,
+		Resolver:       m.resolver,
+		DiscardUnknown: !m.disallowUnknown,
 	}
 	return options.Unmarshal(data, message)
 }

--- a/private/pkg/protoencoding/protoencoding.go
+++ b/private/pkg/protoencoding/protoencoding.go
@@ -117,8 +117,18 @@ func NewWireUnmarshaler(resolver Resolver) Unmarshaler {
 // NewJSONUnmarshaler returns a new Unmarshaler for json.
 //
 // resolver can be nil if unknown and are only needed for extensions.
-func NewJSONUnmarshaler(resolver Resolver) Unmarshaler {
-	return newJSONUnmarshaler(resolver)
+func NewJSONUnmarshaler(resolver Resolver, options ...JSONUnmarshalerOption) Unmarshaler {
+	return newJSONUnmarshaler(resolver, options...)
+}
+
+// JSONUnmarshalerOption is an option for a new JSONUnmarshaler.
+type JSONUnmarshalerOption func(*jsonUnmarshaler)
+
+// JSONUnmarshalerWithDisallowUnknown says to disallow unrecognized fields.
+func JSONUnmarshalerWithDisallowUnknown() JSONUnmarshalerOption {
+	return func(jsonUnmarshaler *jsonUnmarshaler) {
+		jsonUnmarshaler.disallowUnknown = true
+	}
 }
 
 // NewTxtpbUnmarshaler returns a new Unmarshaler for txtpb.


### PR DESCRIPTION
Currently, `buf curl` transcodes the response from the binary format to JSON. However, if the response includes any unrecognized fields, they are just discarded since JSON does not emit unrecognized field data.

So this provides a cue to user's that such data might be in the response and getting dropped (which suggests an incomplete or out-of-date schema) by logging the presence of unrecognized bytes when the `-v` flag is used.

While in here, I noticed that this was allowing unrecognized fields in the JSON request provided to `buf curl`, which seems wrong since a likely issue with formulating a request will be a typo in a field name, which would just be ignored instead of validated. I was tempted to fix this by simply using `protojson` directly. I don't really understand the value of `protoencoding` having to reproduce the same functionality with a different API. But I suspected you would object to that, so I instead addressed a TODO in here.

But it does beg the question in mind: why have these `protoencoding` wrappers? Why not directly use `proto` and `protojson` for serialization?