### PR TITLE
Fix buf lint mistaking proto3 optional fields for oneof fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   be consulted to resolve an element. This can be useful when the result of an RPC
   contains extensions or values in `google.protobuf.Any` messages that are not defined
   in the same schema that defines the RPC service.
+- Fix issue where `buf lint` incorrectly reports error when `(buf.validate.field).required`
+  is set for an optional field in proto3.
 
 ## [v1.28.0] - 2023-11-10
 

--- a/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/field.go
@@ -178,7 +178,9 @@ func checkConstraintsForField(
 	if fieldDescriptor.IsExtension() {
 		checkConstraintsForExtension(adder, fieldConstraints)
 	}
-	if fieldDescriptor.ContainingOneof() != nil && fieldConstraints.GetRequired() {
+	if fieldDescriptor.ContainingOneof() != nil &&
+		!protodesc.ToFieldDescriptorProto(fieldDescriptor).GetProto3Optional() &&
+		fieldConstraints.GetRequired() {
 		adder.addForPathf(
 			[]int32{requiredFieldNumber},
 			"Field %q has %s but is in a oneof (%s). Oneof fields must not have %s.",

--- a/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/oneof.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/oneof.proto
@@ -22,4 +22,7 @@ message OneofTest {
   }
   // required is OK for non-oneof fields
   string f4 = 4 [(buf.validate.field).required = true];
+  // optional in proto3 is a synthetic oneof, we should not report error.
+  optional string f5 = 5 [(buf.validate.field).required = true];
+  optional google.protobuf.Duration f6 = 6 [(buf.validate.field).required = true];
 }


### PR DESCRIPTION
Fixes https://github.com/bufbuild/buf/issues/2589.

This PR fixes the bug where `buf lint` incorrectly report error on proto3 optional fields.