### PR TITLE
Make logger and repository service client optional in api module reader

### DIFF
--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -543,6 +543,10 @@ func newModuleReaderAndCreateCacheDirs(
 	}
 	delegateReader := bufapimodule.NewModuleReader(
 		bufapimodule.NewDownloadServiceClientFactory(clientConfig),
+		bufapimodule.ModuleReaderWithDeprecationWarning(
+			container.Logger(),
+			bufapimodule.NewRepositoryServiceClientFactory(clientConfig),
+		),
 	)
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	var moduleReader bufmodule.ModuleReader

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -542,9 +542,7 @@ func newModuleReaderAndCreateCacheDirs(
 		return nil, err
 	}
 	delegateReader := bufapimodule.NewModuleReader(
-		container.Logger(),
 		bufapimodule.NewDownloadServiceClientFactory(clientConfig),
-		bufapimodule.NewRepositoryServiceClientFactory(clientConfig),
 	)
 	storageosProvider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 	var moduleReader bufmodule.ModuleReader

--- a/private/buf/bufcli/bufcli.go
+++ b/private/buf/bufcli/bufcli.go
@@ -542,9 +542,9 @@ func newModuleReaderAndCreateCacheDirs(
 		return nil, err
 	}
 	delegateReader := bufapimodule.NewModuleReader(
+		container.Logger(),
 		bufapimodule.NewDownloadServiceClientFactory(clientConfig),
 		bufapimodule.ModuleReaderWithDeprecationWarning(
-			container.Logger(),
 			bufapimodule.NewRepositoryServiceClientFactory(clientConfig),
 		),
 	)

--- a/private/bufpkg/bufapimodule/bufapimodule.go
+++ b/private/bufpkg/bufapimodule/bufapimodule.go
@@ -58,7 +58,12 @@ func NewModuleReader(
 // ModuleReaderOption allows configuration of a module reader.
 type ModuleReaderOption func(reader *moduleReader)
 
-func ModuleReaderWithDeprecationWarning(logger *zap.Logger, repositoryClientFactory RepositoryServiceClientFactory) ModuleReaderOption {
+// ModuleReaderWithDeprecationWarning makes the module reader print a warning
+// when reading a deprecated module.
+func ModuleReaderWithDeprecationWarning(
+	logger *zap.Logger,
+	repositoryClientFactory RepositoryServiceClientFactory,
+) ModuleReaderOption {
 	return func(reader *moduleReader) {
 		reader.logger = logger
 		reader.repositoryClientFactory = repositoryClientFactory

--- a/private/bufpkg/bufapimodule/bufapimodule.go
+++ b/private/bufpkg/bufapimodule/bufapimodule.go
@@ -46,10 +46,12 @@ func NewRepositoryServiceClientFactory(clientConfig *connectclient.Config) Repos
 
 // NewModuleReader returns a new ModuleReader backed by the download service.
 func NewModuleReader(
+	logger *zap.Logger,
 	downloadClientFactory DownloadServiceClientFactory,
 	opts ...ModuleReaderOption,
 ) bufmodule.ModuleReader {
 	return newModuleReader(
+		logger,
 		downloadClientFactory,
 		opts...,
 	)
@@ -61,11 +63,9 @@ type ModuleReaderOption func(reader *moduleReader)
 // ModuleReaderWithDeprecationWarning makes the module reader print a warning
 // when reading a deprecated module.
 func ModuleReaderWithDeprecationWarning(
-	logger *zap.Logger,
 	repositoryClientFactory RepositoryServiceClientFactory,
 ) ModuleReaderOption {
 	return func(reader *moduleReader) {
-		reader.logger = logger
 		reader.repositoryClientFactory = repositoryClientFactory
 	}
 }

--- a/private/bufpkg/bufapimodule/bufapimodule.go
+++ b/private/bufpkg/bufapimodule/bufapimodule.go
@@ -46,21 +46,24 @@ func NewRepositoryServiceClientFactory(clientConfig *connectclient.Config) Repos
 
 // NewModuleReader returns a new ModuleReader backed by the download service.
 func NewModuleReader(
-	logger *zap.Logger,
 	downloadClientFactory DownloadServiceClientFactory,
-	repositoryClientFactory RepositoryServiceClientFactory,
 	opts ...ModuleReaderOption,
 ) bufmodule.ModuleReader {
 	return newModuleReader(
-		logger,
 		downloadClientFactory,
-		repositoryClientFactory,
 		opts...,
 	)
 }
 
 // ModuleReaderOption allows configuration of a module reader.
 type ModuleReaderOption func(reader *moduleReader)
+
+func ModuleReaderWithDeprecationWarning(logger *zap.Logger, repositoryClientFactory RepositoryServiceClientFactory) ModuleReaderOption {
+	return func(reader *moduleReader) {
+		reader.logger = logger
+		reader.repositoryClientFactory = repositoryClientFactory
+	}
+}
 
 // NewModuleResolver returns a new ModuleResolver backed by the resolve service.
 func NewModuleResolver(

--- a/private/bufpkg/bufapimodule/module_reader.go
+++ b/private/bufpkg/bufapimodule/module_reader.go
@@ -79,8 +79,8 @@ func (m *moduleReader) GetModule(ctx context.Context, modulePin bufmoduleref.Mod
 	if err != nil {
 		return nil, err
 	}
-	if logger, repositoryClientFactory := m.logger, m.repositoryClientFactory; logger != nil && repositoryClientFactory != nil {
-		if err := warnIfDeprecated(ctx, repositoryClientFactory, modulePin, logger); err != nil {
+	if m.repositoryClientFactory != nil {
+		if err := warnIfDeprecated(ctx, m.repositoryClientFactory, modulePin, m.logger); err != nil {
 			return nil, err
 		}
 	}

--- a/private/bufpkg/bufapimodule/module_reader.go
+++ b/private/bufpkg/bufapimodule/module_reader.go
@@ -30,7 +30,6 @@ import (
 )
 
 type moduleReader struct {
-	// logger may be nil
 	logger                *zap.Logger
 	downloadClientFactory DownloadServiceClientFactory
 	// repositoryClientFactory may be nil
@@ -38,10 +37,12 @@ type moduleReader struct {
 }
 
 func newModuleReader(
+	logger *zap.Logger,
 	downloadClientFactory DownloadServiceClientFactory,
 	opts ...ModuleReaderOption,
 ) *moduleReader {
 	reader := &moduleReader{
+		logger:                logger,
 		downloadClientFactory: downloadClientFactory,
 	}
 	for _, opt := range opts {

--- a/private/bufpkg/bufapimodule/module_reader.go
+++ b/private/bufpkg/bufapimodule/module_reader.go
@@ -79,7 +79,7 @@ func (m *moduleReader) GetModule(ctx context.Context, modulePin bufmoduleref.Mod
 		return nil, err
 	}
 	if logger, repositoryClientFactory := m.logger, m.repositoryClientFactory; logger != nil && repositoryClientFactory != nil {
-		if err := warnIfDeprecated(ctx, m.repositoryClientFactory, modulePin, m.logger); err != nil {
+		if err := warnIfDeprecated(ctx, repositoryClientFactory, modulePin, logger); err != nil {
 			return nil, err
 		}
 	}

--- a/private/bufpkg/bufapimodule/module_reader_test.go
+++ b/private/bufpkg/bufapimodule/module_reader_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestDownload(t *testing.T) {
@@ -118,6 +119,7 @@ func testDownload(
 		t.Parallel()
 		var moduleReaderOpts []ModuleReaderOption
 		moduleReader := newModuleReader(
+			zap.NewNop(),
 			mock.factory,
 			moduleReaderOpts...,
 		)

--- a/private/bufpkg/bufapimodule/module_reader_test.go
+++ b/private/bufpkg/bufapimodule/module_reader_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestDownload(t *testing.T) {
@@ -119,11 +118,7 @@ func testDownload(
 		t.Parallel()
 		var moduleReaderOpts []ModuleReaderOption
 		moduleReader := newModuleReader(
-			zap.NewNop(),
 			mock.factory,
-			func(string) registryv1alpha1connect.RepositoryServiceClient {
-				return &nopRepositoryServiceClient{}
-			},
 			moduleReaderOpts...,
 		)
 		ctx := context.Background()


### PR DESCRIPTION
`bufmoduleapi.ModuleReader` is also used in the elsewhere, where this reader does not need to print warning when a module is deprecated (the CLI is the only place where we print a warning). This also means other repos can keep calling `NewModuleReader(someDownloadClientFactory)`.