### PR TITLE
Clean up storage.PutOptions

### DIFF
--- a/private/pkg/storage/bucket.go
+++ b/private/pkg/storage/bucket.go
@@ -104,11 +104,15 @@ type PutOption func(*putOptions)
 // Some implementations of Put allow multi-part upload, and allow customizing the
 // chunk size of each part upload, or even disabling multi-part upload.
 //
-// # Setting a suggestedChunkSize of 0 says to suggest disable chunking
+// Setting a suggestedChunkSize of 0 says to suggest disable chunking
+// Negative values will be ignored.
 //
 // This is a suggestion, implementations may choose to ignore this option.
 func PutWithSuggestedChunkSize(suggestedChunkSize int) PutOption {
 	return func(putOptions *putOptions) {
+		if suggestedChunkSize < 0 {
+			return
+		}
 		putOptions.suggestedChunkSize = &suggestedChunkSize
 	}
 }

--- a/private/pkg/storage/bucket.go
+++ b/private/pkg/storage/bucket.go
@@ -81,6 +81,8 @@ type PutOptions interface {
 	//
 	// This is a suggestion, implementations may choose to ignore this option.
 	SuggestedChunkSize() int
+
+	isPutOptions()
 }
 
 // NewPutOptions returns a new PutOptions.
@@ -102,9 +104,9 @@ type PutOption func(*putOptions)
 // Some implementations of Put allow multi-part upload, and allow customizing the
 // chunk size of each part upload, or even disabling multi-part upload.
 //
-// This is a suggestion, implementations may choose to ignore this option.
+// # Setting a suggestedChunkSize of 0 says to suggest disable chunking
 //
-// Setting a suggestedChunkSize of 0 says to suggest disable chunking
+// This is a suggestion, implementations may choose to ignore this option.
 func PutWithSuggestedChunkSize(suggestedChunkSize int) PutOption {
 	return func(putOptions *putOptions) {
 		putOptions.suggestedChunkSize = &suggestedChunkSize
@@ -312,3 +314,5 @@ func (p *putOptions) SuggestedChunkSize() int {
 	}
 	return *p.suggestedChunkSize
 }
+
+func (*putOptions) isPutOptions() {}

--- a/private/pkg/storage/storageos/bucket.go
+++ b/private/pkg/storage/storageos/bucket.go
@@ -164,11 +164,7 @@ func (b *bucket) Walk(
 	return nil
 }
 
-func (b *bucket) Put(ctx context.Context, path string, opts ...storage.PutOption) (storage.WriteObjectCloser, error) {
-	var putOptions storage.PutOptions
-	for _, opt := range opts {
-		opt(&putOptions)
-	}
+func (b *bucket) Put(ctx context.Context, path string, options ...storage.PutOption) (storage.WriteObjectCloser, error) {
 	externalPath, err := b.getExternalPath(path)
 	if err != nil {
 		return nil, err
@@ -193,7 +189,7 @@ func (b *bucket) Put(ctx context.Context, path string, opts ...storage.PutOption
 	}
 	var file *os.File
 	var finalPath string
-	if putOptions.Atomic {
+	if storage.NewPutOptions(options).Atomic() {
 		file, err = os.CreateTemp(externalDir, ".tmp"+filepath.Base(externalPath)+"*")
 		finalPath = externalPath
 	} else {


### PR DESCRIPTION
Use an interface so these can only be built by the `storage` package, clean up docs, clean up meaning of 0.