### PR TITLE
Remove checking not_contains containing prefix/suffix/contains in buf lint for protovalidate

### DIFF
--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -666,7 +666,6 @@ func TestRunProtovalidateRules(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "string.proto", 122, 5, 122, 47, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "string.proto", 130, 5, 130, 46, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "string.proto", 133, 5, 133, 45, "PROTOVALIDATE"),
-		bufanalysistesting.NewFileAnnotation(t, "string.proto", 142, 5, 142, 47, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "timestamp.proto", 57, 5, 60, 6, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "timestamp.proto", 61, 5, 64, 6, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "timestamp.proto", 68, 5, 71, 6, "PROTOVALIDATE"),

--- a/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/field.go
@@ -517,19 +517,6 @@ func checkStringRules(adder *adder, stringRules *validate.StringRules) error {
 				*stringRules.NotContains,
 			)
 		}
-		if stringRules.NotContains != nil && strings.Contains(*stringRules.NotContains, substring) {
-			adder.addForPathf(
-				[]int32{stringRulesFieldNumber, substringFieldNumber},
-				"Field %q has a %s (%q) containing its %s (%q). It is impossible for a string to contain %q without containing %q.",
-				adder.fieldName(),
-				adder.getFieldRuleName(stringRulesFieldNumber, notContainsFieldNumberInStringRules),
-				*stringRules.NotContains,
-				substringField.name,
-				substring,
-				substring,
-				*stringRules.NotContains,
-			)
-		}
 	}
 	if stringRules.Pattern != nil {
 		if _, err := regexp.Compile(*stringRules.Pattern); err != nil {

--- a/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/string.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/string.proto
@@ -137,6 +137,7 @@ message StringTest {
     (buf.validate.field).string.prefix = "foo",
     (buf.validate.field).string.not_contains = "bar"
   ];
+  // this is valid: for example, "foo_" contains "foo" without containing "bar_foo".
   string not_contains_conatins_prefix = 31 [
     (buf.validate.field).string.not_contains = "bar_foo",
     (buf.validate.field).string.prefix = "foo"


### PR DESCRIPTION
This PR updates `PROTOVALIDATE` rule to stop checking whether `not_contains` contains `prefix`/`suffix`/`contains`, which does not imply invalid rules.

For example, `not_contains: "foo_bar", contains: "foo"` is valid because string `foo_` passes this check.