### PR TITLE
Improve CI performance for Windows

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -21,9 +21,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: setup-go
-        uses: actions/setup-go@v4 # this contains a fix for Windows file extraction
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21.x'
+          # This runs very slowly and inconsistently on Windows for undetermined reasons.
+          # We manually cache in the GitHub Actions _temp directory instead.
           cache: false
       - name: windows-cache
         uses: actions/cache@v3

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,10 +7,11 @@ jobs:
   test:
     env:
       DOWNLOAD_CACHE: 'd:\downloadcache'
-      # Improve performance by using GHA _temp directory.
-      # %USERPROFILE% seems to be really slow, especially for cache restores.
-      GOCACHE: 'd:\a\_temp\go\cache'
-      GOMODCACHE: 'd:\a\_temp\go\modcache'
+      # Improve performance by using D: drive.
+      # C: seems to be really slow, especially for cache restores.
+      GOPATH: 'd:\go\path'
+      GOCACHE: 'd:\go\cache'
+      GOMODCACHE: 'd:\go\modcache'
     runs-on: windows-latest
     steps:
       - name: checkout

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,26 +7,19 @@ jobs:
   test:
     env:
       DOWNLOAD_CACHE: 'd:\downloadcache'
-      GOPATH: 'd:\a\_temp\go\work'
+      # Improve performance by using GHA _temp directory.
+      # %USERPROFILE% seems to be really slow, especially for cache restores.
       GOCACHE: 'd:\a\_temp\go\cache'
+      GOMODCACHE: 'd:\a\_temp\go\modcache'
     runs-on: windows-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: go-cache
-        uses: actions/cache@v3
-        with:
-          path: D:/a/_temp/go
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-v2
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: setup-go
         uses: actions/setup-go@v4
         with:
           go-version: '1.21.x'
-          # This runs very slowly and inconsistently on Windows for undetermined reasons.
-          # We manually cache in the GitHub Actions _temp directory instead.
-          cache: false
+          cache: true
       - name: windows-cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -9,15 +9,17 @@ jobs:
       DOWNLOAD_CACHE: 'd:\downloadcache'
     runs-on: windows-latest
     steps:
+      - shell: pwsh
+        run: |
+          echo "GOPATH=D:/a/_temp/go/work" >> $env:GITHUB_ENV
+          echo "GOCACHE=D:/a/_temp/go/cache" >> $env:GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v4
       - name: go-cache
         uses: actions/cache@v3
         with:
-          path: |
-            ~\AppData\Local\go-build
-            ~\go\pkg\mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          path: D:/a/_temp/go
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-v2
           restore-keys: |
             ${{ runner.os }}-go-
       - name: setup-go

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,12 +7,10 @@ jobs:
   test:
     env:
       DOWNLOAD_CACHE: 'd:\downloadcache'
+      GOPATH: 'd:\a\_temp\go\work'
+      GOCACHE: 'd:\a\_temp\go\cache'
     runs-on: windows-latest
     steps:
-      - shell: pwsh
-        run: |
-          echo "GOPATH=D:/a/_temp/go/work" >> $env:GITHUB_ENV
-          echo "GOCACHE=D:/a/_temp/go/cache" >> $env:GITHUB_ENV
       - name: checkout
         uses: actions/checkout@v4
       - name: go-cache


### PR DESCRIPTION
Sometimes the existing workflow [runs quickly](https://github.com/bufbuild/buf/actions/runs/6896243827/job/18761936996) - sometimes it runs [incredibly slowly](https://github.com/bufbuild/buf/actions/runs/6905941659/job/18789829770).

This seems to come down to a disk I/O issue. The cache tarball will get downloaded very quickly, but then it will take minutes to untar. It's unclear why. I suspect there is something in particular wrong with the home directory in the Windows runner. In addition, `go test` itself seems to have unreliable performance characteristics.

Merely just moving the Go cache and path into the GitHub Actions `_temp` dir seems to vastly improve consistency. I ran the workflow multiple times to collect some runs:

- [**Attempt #1**](https://github.com/bufbuild/buf/actions/runs/6906720017/job/18792364497): 3m 2s, _no cache_
- [**Attempt #2**](https://github.com/bufbuild/buf/actions/runs/6906720017/job/18792644471): 3m 1s, cached
- [**Attempt #3**](https://github.com/bufbuild/buf/actions/runs/6906720017/job/18792750339): 2m 45s, cached
- [**Attempt #4**](https://github.com/bufbuild/buf/actions/runs/6906720017/job/18792871341): 4m 1s, cached
- [**Attempt #5**](https://github.com/bufbuild/buf/actions/runs/6906720017/job/18793063059): 2m 44s, cached
- [**Attempt #6**](https://github.com/bufbuild/buf/actions/runs/6906720017/job/18793181885): 2m 45s, cached

The cache restore times are reliably counted in seconds. There is still some run-to-run variance, but pathological behavior seems to have disappeared, both for `go test` and cache restore. While this doesn't bring performance quite up to par with the other workflows, it does seem to help quite a bit.

I'm really hoping I didn't miss anything here. Any reason why I may have tricked myself into thinking I solved the problem? :)