### PR TITLE
Return early if map type mismatch in buf lint protovalidate

### DIFF
--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -614,6 +614,7 @@ func TestRunProtovalidateRules(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "map.proto", 44, 5, 44, 47, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "map.proto", 46, 5, 46, 47, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "map.proto", 50, 5, 50, 57, "PROTOVALIDATE"),
+		bufanalysistesting.NewFileAnnotation(t, "map.proto", 53, 5, 53, 50, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "message.proto", 20, 3, 20, 49, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "message.proto", 27, 5, 27, 51, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "number.proto", 20, 5, 20, 42, "PROTOVALIDATE"),

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -641,6 +641,7 @@ func TestRunProtovalidateRules(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "repeated.proto", 45, 5, 45, 48, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "repeated.proto", 49, 28, 49, 71, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "repeated.proto", 51, 38, 51, 92, "PROTOVALIDATE"),
+		bufanalysistesting.NewFileAnnotation(t, "repeated.proto", 53, 26, 53, 74, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "string.proto", 31, 5, 31, 46, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "string.proto", 36, 5, 36, 44, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "string.proto", 41, 5, 41, 44, "PROTOVALIDATE"),

--- a/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/field.go
@@ -378,6 +378,7 @@ func checkMapRules(
 			baseAdder.fieldName(),
 			baseAdder.getFieldRuleName(mapRulesFieldNumber),
 		)
+		return nil
 	}
 	if mapRules.MinPairs != nil && mapRules.MaxPairs != nil && *mapRules.MinPairs > *mapRules.MaxPairs {
 		baseAdder.addForPathf(

--- a/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/map.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/map.proto
@@ -49,4 +49,8 @@ message MapTest {
     (buf.validate.field).map.min_pairs = 1,
     (buf.validate.field).map.values.string.pattern = "["
   ];
+  int32 not_a_map = 14 [
+    (buf.validate.field).map.values.int32.lt = 10,
+    (buf.validate.field).map.values.int32.gt = 1
+  ];
 }

--- a/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/repeated.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/protovalidate_rules/repeated.proto
@@ -49,4 +49,6 @@ message RepeatedTest {
   int32 not_repeated = 15 [(buf.validate.field).repeated.unique = true];
   // map value is also not repeated
   map<int32, string> map_field = 16 [(buf.validate.field).map.values.repeated.unique = true];
+  // int64 does not match int32
+  int32 wrong_type = 17 [(buf.validate.field).repeated.items.int64.lt = 1];
 }


### PR DESCRIPTION
This PR fixes an issue where `buf lint` crashes when map rules are defined on a non-map field:

```
  int32 not_a_map = 14 [
    (buf.validate.field).map.values.int32.lt = 10,
    (buf.validate.field).map.values.int32.gt = 1
  ];
```

The fix is to return early if type mismatches.