### PR TITLE
Add functionality to private/pkg

### DIFF
--- a/private/pkg/cache/cache.go
+++ b/private/pkg/cache/cache.go
@@ -1,0 +1,74 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+)
+
+// Cache is a cache from K to V.
+//
+// It uses double-locking to get values.
+type Cache[K comparable, V any] struct {
+	store map[K]*result[V]
+	lock  sync.RWMutex
+}
+
+// GetOrAdd gets the value for the key, or calls getUncached to get a new value,
+// and then caches the value.
+//
+// If getUncached calls another Cache, the order of GetOrAdd calls between caches
+// must be preserved for lock ordering.
+func (c *Cache[K, V]) GetOrAdd(key K, getUncached func() (V, error)) (V, error) {
+	c.lock.RLock()
+	var result *result[V]
+	var ok bool
+	if c.store != nil {
+		result, ok = c.store[key]
+	}
+	c.lock.RUnlock()
+	if ok {
+		return result.value, result.err
+	}
+	c.lock.Lock()
+	value, err := c.getOrAddInsideWriteLock(key, getUncached)
+	c.lock.Unlock()
+	return value, err
+}
+
+func (c *Cache[K, V]) getOrAddInsideWriteLock(key K, getUncached func() (V, error)) (V, error) {
+	if c.store == nil {
+		c.store = make(map[K]*result[V])
+	}
+	result, ok := c.store[key]
+	if ok {
+		return result.value, result.err
+	}
+	value, err := getUncached()
+	c.store[key] = newResult(value, err)
+	return value, err
+}
+
+type result[V any] struct {
+	value V
+	err   error
+}
+
+func newResult[V any](value V, err error) *result[V] {
+	return &result[V]{
+		value: value,
+		err:   err,
+	}
+}

--- a/private/pkg/cache/usage.gen.go
+++ b/private/pkg/cache/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package cache
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/pkg/dag/dagtest/dagtest.go
+++ b/private/pkg/dag/dagtest/dagtest.go
@@ -1,0 +1,97 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dagtest
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/bufbuild/buf/private/pkg/dag"
+	"github.com/bufbuild/buf/private/pkg/slicesextended"
+	"github.com/stretchr/testify/require"
+)
+
+// Ordered matches cmp.Ordered until we only support Go versions >= 1.21.
+//
+// TODO: remove and replace with cmp.Ordered when we only support Go versions >= 1.21.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 |
+		~string
+}
+
+type ExpectedNode[Key Ordered] struct {
+	Key      Key
+	Outbound []Key
+}
+
+// RequireGraphEqual requires that the graph equals the given ExpectedNodes.
+//
+// The order of the input ExpectedNodes does not matter, and the order of
+// the outbound Keys does not matter.
+func RequireGraphEqual[Key Ordered](
+	t *testing.T,
+	expected []ExpectedNode[Key],
+	graph *dag.Graph[Key],
+) {
+	actual := make([]ExpectedNode[Key], 0, len(expected))
+	err := graph.WalkNodes(
+		func(key Key, _ []Key, outbound []Key) error {
+			actual = append(
+				actual,
+				ExpectedNode[Key]{
+					Key:      key,
+					Outbound: outbound,
+				},
+			)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, normalizeExpectedNodes(expected), normalizeExpectedNodes(actual))
+}
+
+func normalizeExpectedNodes[Key Ordered](expectedNodes []ExpectedNode[Key]) []ExpectedNode[Key] {
+	if expectedNodes == nil {
+		return []ExpectedNode[Key]{}
+	}
+	c := slicesextended.Copy(expectedNodes)
+	sort.Slice(
+		c,
+		func(i int, j int) bool {
+			return c[i].Key < c[j].Key
+		},
+	)
+	for i, e := range c {
+		e.Outbound = normalizeKeys(e.Outbound)
+		c[i] = e
+	}
+	return c
+}
+
+func normalizeKeys[Key Ordered](keys []Key) []Key {
+	if keys == nil {
+		return []Key{}
+	}
+	keys = slicesextended.Copy(keys)
+	sort.Slice(
+		keys,
+		func(i int, j int) bool {
+			return keys[i] < keys[j]
+		},
+	)
+	return keys
+}

--- a/private/pkg/dag/dagtest/usage.gen.go
+++ b/private/pkg/dag/dagtest/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package dagtest
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/pkg/slicesextended/slicesextended.go
+++ b/private/pkg/slicesextended/slicesextended.go
@@ -131,6 +131,13 @@ func CountError[T any](s []T, f func(T) (bool, error)) (int, error) {
 	return count, nil
 }
 
+// Copy returns a copy of the slice.
+func Copy[T any](s []T) []T {
+	sc := make([]T, len(s))
+	copy(sc, s)
+	return sc
+}
+
 // ToMap converts the slice to a map.
 func ToMap[T comparable](s []T) map[T]struct{} {
 	m := make(map[T]struct{}, len(s))

--- a/private/pkg/storage/bucket.go
+++ b/private/pkg/storage/bucket.go
@@ -131,6 +131,9 @@ func NopReadWriteBucketCloser(readWriteBucket ReadWriteBucket) ReadWriteBucketCl
 }
 
 // ObjectInfo contains object info.
+//
+// An ObjectInfo will always be the same for a given path within a given Bucket,
+// that is an ObjectInfo is cacheable for a given Bucket.
 type ObjectInfo interface {
 	// Path is the path of the object.
 	//


### PR DESCRIPTION
- Add `slicesextended.Copy` to easily copy slices.
- Add `private/pkg/cache` that implements a simple cache that utilizes double-locking.
- Add `private/pkg/dag/dagtest` which has function `RequireGraphEqual` to test graphs.
- Add comment about `storage.ObjectInfo` stating that it is cachable.