### PR TITLE
Make MapToSlice accept maps with generic values, not just struct{}

### DIFF
--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -171,7 +171,7 @@ func (s *syncer) prepareSync(ctx context.Context) error {
 	var branchesToSync []string
 	if s.syncAllBranches {
 		// sync all branches
-		branchesToSync = slicesextended.MapToSlice(allBranches)
+		branchesToSync = slicesextended.MapKeysToSlice(allBranches)
 	} else {
 		// sync current branch, make sure it's present
 		currentBranch, err := s.repo.CheckedOutBranch()

--- a/private/buf/bufwork/config.go
+++ b/private/buf/bufwork/config.go
@@ -49,7 +49,7 @@ func newConfigV1(externalConfig ExternalConfigV1, workspaceID string) (*Config, 
 	}
 	// It's very important that we sort the directories here so that the
 	// constructed modules and/or images are in a deterministic order.
-	directories := slicesextended.MapToSlice(directorySet)
+	directories := slicesextended.MapKeysToSlice(directorySet)
 	sort.Slice(directories, func(i int, j int) bool {
 		return directories[i] < directories[j]
 	})

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -305,5 +305,5 @@ func getExternalPathsForImages(imageConfigs []bufwire.ImageConfig, excludeImport
 			externalPaths[imageFile.ExternalPath()] = struct{}{}
 		}
 	}
-	return slicesextended.MapToSlice(externalPaths), nil
+	return slicesextended.MapKeysToSlice(externalPaths), nil
 }

--- a/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintcheck/buflintcheck.go
@@ -117,13 +117,13 @@ func checkDirectorySamePackage(add addFunc, dirPath string, files []protosource.
 		if _, ok := pkgMap[""]; ok {
 			delete(pkgMap, "")
 			if len(pkgMap) > 1 {
-				messagePrefix = fmt.Sprintf("Multiple packages %q and file with no package", strings.Join(slicesextended.MapToSortedSlice(pkgMap), ","))
+				messagePrefix = fmt.Sprintf("Multiple packages %q and file with no package", strings.Join(slicesextended.MapKeysToSortedSlice(pkgMap), ","))
 			} else {
 				// Join works with only one element as well by adding no comma
-				messagePrefix = fmt.Sprintf("Package %q and file with no package", strings.Join(slicesextended.MapToSortedSlice(pkgMap), ","))
+				messagePrefix = fmt.Sprintf("Package %q and file with no package", strings.Join(slicesextended.MapKeysToSortedSlice(pkgMap), ","))
 			}
 		} else {
-			messagePrefix = fmt.Sprintf("Multiple packages %q", strings.Join(slicesextended.MapToSortedSlice(pkgMap), ","))
+			messagePrefix = fmt.Sprintf("Multiple packages %q", strings.Join(slicesextended.MapKeysToSortedSlice(pkgMap), ","))
 		}
 		for _, file := range files {
 			add(file, file.PackageLocation(), nil, "%s detected within directory %q.", messagePrefix, dirPath)
@@ -526,7 +526,7 @@ func checkPackageSameDirectory(add addFunc, pkg string, files []protosource.File
 		dirMap[normalpath.Dir(file.Path())] = struct{}{}
 	}
 	if len(dirMap) > 1 {
-		dirs := slicesextended.MapToSortedSlice(dirMap)
+		dirs := slicesextended.MapKeysToSortedSlice(dirMap)
 		for _, file := range files {
 			add(file, file.PackageLocation(), nil, "Multiple directories %q contain files with package %q.", strings.Join(dirs, ","), pkg)
 		}
@@ -603,7 +603,7 @@ func checkPackageSameOptionValue(
 	if len(optionValueMap) > 1 {
 		_, noOptionValue := optionValueMap[""]
 		delete(optionValueMap, "")
-		optionValues := slicesextended.MapToSortedSlice(optionValueMap)
+		optionValues := slicesextended.MapKeysToSortedSlice(optionValueMap)
 		for _, file := range files {
 			if noOptionValue {
 				add(file, getOptionLocation(file), nil, "Files in package %q have both values %q and no value for option %q and all values must be equal.", pkg, strings.Join(optionValues, ","), name)

--- a/private/bufpkg/bufcheck/internal/version_spec.go
+++ b/private/bufpkg/bufcheck/internal/version_spec.go
@@ -39,7 +39,7 @@ func AllCategoriesForVersionSpec(versionSpec *VersionSpec) []string {
 			categoriesMap[category] = struct{}{}
 		}
 	}
-	categories := slicesextended.MapToSlice(categoriesMap)
+	categories := slicesextended.MapKeysToSlice(categoriesMap)
 	sort.Slice(
 		categories,
 		func(i int, j int) bool {
@@ -57,7 +57,7 @@ func AllIDsForVersionSpec(versionSpec *VersionSpec) []string {
 	for id := range versionSpec.IDToCategories {
 		m[id] = struct{}{}
 	}
-	return slicesextended.MapToSortedSlice(m)
+	return slicesextended.MapKeysToSortedSlice(m)
 }
 
 // AllCategoriesAndIDsForVersionSpec returns all categories and rules for the VersionSpec.
@@ -71,5 +71,5 @@ func AllCategoriesAndIDsForVersionSpec(versionSpec *VersionSpec) []string {
 			m[category] = struct{}{}
 		}
 	}
-	return slicesextended.MapToSortedSlice(m)
+	return slicesextended.MapKeysToSortedSlice(m)
 }

--- a/private/pkg/normalpath/normalpath.go
+++ b/private/pkg/normalpath/normalpath.go
@@ -297,7 +297,7 @@ func MapAllEqualOrContainingPaths(m map[string]struct{}, path string, pathType P
 	if len(m) == 0 {
 		return nil
 	}
-	return slicesextended.MapToSortedSlice(MapAllEqualOrContainingPathMap(m, path, pathType))
+	return slicesextended.MapKeysToSortedSlice(MapAllEqualOrContainingPathMap(m, path, pathType))
 }
 
 // StripComponents strips the specified number of components.

--- a/private/pkg/slicesextended/slicesextended.go
+++ b/private/pkg/slicesextended/slicesextended.go
@@ -147,9 +147,9 @@ func ToMap[T comparable](s []T) map[T]struct{} {
 	return m
 }
 
-// MapToSortedSlice converts the map's keys to a sorted slice.
-func MapToSortedSlice[M ~map[K]V, K Ordered, V any](m M) []K {
-	s := MapToSlice(m)
+// MapKeysToSortedSlice converts the map's keys to a sorted slice.
+func MapKeysToSortedSlice[M ~map[K]V, K Ordered, V any](m M) []K {
+	s := MapKeysToSlice(m)
 	// TODO: Replace with slices.Sort when we only support Go versions >= 1.21.
 	sort.Slice(
 		s,
@@ -160,8 +160,8 @@ func MapToSortedSlice[M ~map[K]V, K Ordered, V any](m M) []K {
 	return s
 }
 
-// MapToSlice converts the map's keys to a slice.
-func MapToSlice[K comparable, V any](m map[K]V) []K {
+// MapKeysToSlice converts the map's keys to a slice.
+func MapKeysToSlice[K comparable, V any](m map[K]V) []K {
 	s := make([]K, 0, len(m))
 	for e := range m {
 		s = append(s, e)
@@ -171,7 +171,7 @@ func MapToSlice[K comparable, V any](m map[K]V) []K {
 
 // ToUniqueSorted returns a sorted copy of s with no duplicates.
 func ToUniqueSorted[S ~[]T, T Ordered](s S) S {
-	return MapToSortedSlice(ToMap(s))
+	return MapKeysToSortedSlice(ToMap(s))
 }
 
 // ToChunks splits s into chunks of the given chunk size.

--- a/private/pkg/slicesextended/slicesextended.go
+++ b/private/pkg/slicesextended/slicesextended.go
@@ -147,8 +147,8 @@ func ToMap[T comparable](s []T) map[T]struct{} {
 	return m
 }
 
-// MapToSortedSlice converts the map to a sorted slice.
-func MapToSortedSlice[M ~map[T]struct{}, T Ordered](m M) []T {
+// MapToSortedSlice converts the map's keys to a sorted slice.
+func MapToSortedSlice[M ~map[K]V, K Ordered, V any](m M) []K {
 	s := MapToSlice(m)
 	// TODO: Replace with slices.Sort when we only support Go versions >= 1.21.
 	sort.Slice(
@@ -160,9 +160,9 @@ func MapToSortedSlice[M ~map[T]struct{}, T Ordered](m M) []T {
 	return s
 }
 
-// MapToSlice converts the map to a slice.
-func MapToSlice[T comparable](m map[T]struct{}) []T {
-	s := make([]T, 0, len(m))
+// MapToSlice converts the map's keys to a slice.
+func MapToSlice[K comparable, V any](m map[K]V) []K {
+	s := make([]K, 0, len(m))
 	for e := range m {
 		s = append(s, e)
 	}

--- a/private/pkg/stringutil/stringutil.go
+++ b/private/pkg/stringutil/stringutil.go
@@ -60,14 +60,14 @@ func SplitTrimLinesNoEmpty(output string) []string {
 //
 // Deprecated: Use slicesextended.MapToSortedSlice instead.
 func MapToSortedSlice(m map[string]struct{}) []string {
-	return slicesextended.MapToSortedSlice(m)
+	return slicesextended.MapKeysToSortedSlice(m)
 }
 
 // MapToSlice transforms m to a slice.
 //
 // Deprecated: Use slicesextended.MapToSlice instead.
 func MapToSlice(m map[string]struct{}) []string {
-	return slicesextended.MapToSlice(m)
+	return slicesextended.MapKeysToSlice(m)
 }
 
 // SliceToMap transforms s to a map.
@@ -94,7 +94,7 @@ func SliceToUniqueSortedSliceFilterEmptyStrings(s []string) []string {
 			delete(m, key)
 		}
 	}
-	return slicesextended.MapToSortedSlice(m)
+	return slicesextended.MapKeysToSortedSlice(m)
 }
 
 // SliceToChunks splits s into chunks of the given chunk size.


### PR DESCRIPTION
This unlocks more cases where `MapToSlice` is useful. This change is compatible with all existing usage of this function.

Should I rename it to something like `MapToSortedKeySlice`?