### PR TITLE
Improve err message for different commit on image builder

### DIFF
--- a/private/bufpkg/bufimage/image.go
+++ b/private/bufpkg/bufimage/image.go
@@ -35,7 +35,7 @@ func newImage(files []ImageFile, reorder bool) (*image, error) {
 		commit   string
 		filepath string
 	}
-	identityStringToCommit := make(map[string]commitAndFilepath)
+	identityStringToCommitAndFilepath := make(map[string]commitAndFilepath)
 	for _, file := range files {
 		path := file.Path()
 		if _, ok := pathToImageFile[path]; ok {
@@ -44,7 +44,7 @@ func newImage(files []ImageFile, reorder bool) (*image, error) {
 		pathToImageFile[path] = file
 		if moduleIdentity := file.ModuleIdentity(); moduleIdentity != nil {
 			identityString := moduleIdentity.IdentityString()
-			existing, ok := identityStringToCommit[identityString]
+			existing, ok := identityStringToCommitAndFilepath[identityString]
 			if ok {
 				if existing.commit != file.Commit() {
 					return nil, fmt.Errorf(
@@ -53,7 +53,7 @@ func newImage(files []ImageFile, reorder bool) (*image, error) {
 					)
 				}
 			} else {
-				identityStringToCommit[identityString] = commitAndFilepath{
+				identityStringToCommitAndFilepath[identityString] = commitAndFilepath{
 					commit:   file.Commit(),
 					filepath: path,
 				}

--- a/private/bufpkg/bufimage/image.go
+++ b/private/bufpkg/bufimage/image.go
@@ -31,22 +31,32 @@ func newImage(files []ImageFile, reorder bool) (*image, error) {
 		return nil, errors.New("image contains no files")
 	}
 	pathToImageFile := make(map[string]ImageFile, len(files))
-	identityStringToCommit := make(map[string]string)
+	type commitAndFilepath struct {
+		commit   string
+		filepath string
+	}
+	identityStringToCommit := make(map[string]commitAndFilepath)
 	for _, file := range files {
 		path := file.Path()
 		if _, ok := pathToImageFile[path]; ok {
-			return nil, fmt.Errorf("duplicate file: %s", path)
+			return nil, fmt.Errorf("duplicate file path: %s", path)
 		}
 		pathToImageFile[path] = file
 		if moduleIdentity := file.ModuleIdentity(); moduleIdentity != nil {
 			identityString := moduleIdentity.IdentityString()
-			existingCommit, ok := identityStringToCommit[identityString]
+			existing, ok := identityStringToCommit[identityString]
 			if ok {
-				if existingCommit != file.Commit() {
-					return nil, fmt.Errorf("image had two different commits for the same module: %q and %q", existingCommit, file.Commit())
+				if existing.commit != file.Commit() {
+					return nil, fmt.Errorf(
+						"files with different commits for the same module %s: %s:%s and %s:%s",
+						identityString, existing.filepath, existing.commit, path, file.Commit(),
+					)
 				}
 			} else {
-				identityStringToCommit[identityString] = file.Commit()
+				identityStringToCommit[identityString] = commitAndFilepath{
+					commit:   file.Commit(),
+					filepath: path,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Have the module identity and the file paths in the error message.