### PR TITLE
Prompt user to check for expired token in auth error message

### DIFF
--- a/private/buf/bufcli/errors.go
+++ b/private/buf/bufcli/errors.go
@@ -169,7 +169,7 @@ func wrapError(err error) error {
 			if authErr, ok := bufconnect.AsAuthError(err); ok && authErr.TokenEnvKey() != "" {
 				return fmt.Errorf(`Failure: the %[1]s environment variable is set, but is not valid. Set %[1]s to a valid Buf API key, or unset it. For details, visit https://docs.buf.build/bsr/authentication`, authErr.TokenEnvKey())
 			}
-			return errors.New(`Failure: you are not authenticated. Create a new entry in your netrc, using a Buf API Key as the password. For details, visit https://docs.buf.build/bsr/authentication`)
+			return errors.New(`Failure: you are not authenticated. Create a new entry in your netrc, using a Buf API Key as the password. If you already have an entry in your netrc, check to see that it is not expired. For details, visit https://docs.buf.build/bsr/authentication`)
 		case connectCode == connect.CodeUnavailable:
 			msg := `Failure: the server hosted at that remote is unavailable.`
 			// If the returned error is Unavailable, then determine if this is a DNS error.  If so, get the address used


### PR DESCRIPTION
A user in our public slack got confused when they suddenly started seeing this error message in the CLI:
> Failure: you are not authenticated. Create a new entry in your netrc, using a Buf API Key as the password. For details, visit https://docs.buf.build/bsr/authentication

The problem was that their token was expired and `buf registry logout` fixed it for them.

This change improves the error message so that users know to check to see if their token has expired.