### PR TITLE
Update to latest protocompile release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.31.0-20231124180711-402ed9081590.2
 	connectrpc.com/connect v1.12.0
 	connectrpc.com/otelconnect v0.6.0
-	github.com/bufbuild/protocompile v0.6.1-0.20231108163138-146b831231f7
+	github.com/bufbuild/protocompile v0.7.0
 	github.com/bufbuild/protovalidate-go v0.4.2
 	github.com/bufbuild/protoyaml-go v0.1.7
 	github.com/docker/docker v24.0.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/bufbuild/protocompile v0.6.1-0.20231108163138-146b831231f7 h1:1pUks8VaLdprN9wrxAgshb06b08IzdYp0B7JgoDeUfw=
-github.com/bufbuild/protocompile v0.6.1-0.20231108163138-146b831231f7/go.mod h1:9N39DyRmxAF5+5AjqXQKV6hyWDI0EeoX4TRMix2ZnPE=
+github.com/bufbuild/protocompile v0.7.0 h1:ZfJAqcMG5okLzemO016O1BByzTJx2k32hBAby5nYE8k=
+github.com/bufbuild/protocompile v0.7.0/go.mod h1:+Etjg4guZoAqzVk2czwEQP12yaxLJ8DxuqCJ9qHdH94=
 github.com/bufbuild/protovalidate-go v0.4.2 h1:rh34FFVIJ2pQ/vPnkiQK+Y5pMQ6W4POmHkqHFZLfPWA=
 github.com/bufbuild/protovalidate-go v0.4.2/go.mod h1:+p5FXfOjSEgLz5WBDTOMPMdQPXqALEERbJZU7huDCtA=
 github.com/bufbuild/protoyaml-go v0.1.7 h1:3uKIoNb/l5zrZ93u+Xzsg6cdAO06lveZE/K7UUbUQLw=


### PR DESCRIPTION
This release includes a fix to a [panic bug](https://github.com/bufbuild/protocompile/issues/196). This would mainly impact `buf format`, which directly uses the `parser` sub-package. Most other usages, which go through the `protocompile.Compiler` type, wouldn't actually panic, but would return an ugly error describing the panic.