### PR TITLE
Fix wkt-go-data for new bufmod API

### DIFF
--- a/private/bufpkg/bufwkt/cmd/wkt-go-data/main.go
+++ b/private/bufpkg/bufwkt/cmd/wkt-go-data/main.go
@@ -148,16 +148,18 @@ func getProtosourceFiles(
 	container appflag.Container,
 	bucket storage.ReadBucket,
 ) ([]protosource.File, error) {
-	// TODO: why is this not working? this is the path that should be used, not NewModuleForBucket
-	//module, err := bufmodulebuild.NewModuleBucketBuilder(container.Logger()).BuildForBucket(
-	//ctx,
-	//bucket,
-	//&bufmoduleconfig.Config{},
-	//)
-	module, err := bufmodule.NewModuleForBucket(ctx, bucket)
+	moduleSet, err := bufmodule.NewModuleSetBuilder(
+		ctx,
+		bufmodule.NopModuleDataProvider,
+	).AddLocalModule(
+		bucket,
+		".",
+		true,
+	).Build()
 	if err != nil {
 		return nil, err
 	}
+	module := bufmodule.ModuleSetToModuleReadBucketWithOnlyProtoFiles(moduleSet)
 	image, fileAnnotations, err := bufimage.BuildImage(
 		ctx,
 		module,


### PR DESCRIPTION
This allows much more of `make generate` to function. It is now possible to run _most_ of the functionality with `make generate BUF_BIN=$(which buf)` after this is merged.