### PR TITLE
Fix formatter issue with message literals with any syntax

### DIFF
--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -707,6 +707,10 @@ func (f *formatter) writeMessageFieldPrefix(messageFieldNode *ast.MessageFieldNo
 	fieldReferenceNode := messageFieldNode.Name
 	if fieldReferenceNode.Open != nil {
 		f.writeStart(fieldReferenceNode.Open)
+		if fieldReferenceNode.URLPrefix != nil {
+			f.writeInline(fieldReferenceNode.URLPrefix)
+			f.writeInline(fieldReferenceNode.Slash)
+		}
 		f.writeInline(fieldReferenceNode.Name)
 	} else {
 		f.writeStart(fieldReferenceNode.Name)

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.golden.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 package foo.bar;
 
+import "google/protobuf/any.proto";
 import "google/protobuf/descriptor.proto";
 
 message Simple {
@@ -25,6 +26,17 @@ message Test {
   extensions 100 to 200;
 
   extensions 249, 300 to 350, 500 to 550, 20000 to max [(label) = "jazz"];
+
+  option (any) = {
+    [type.googleapis.com/foo.bar.Test]: {
+      foo: "abc"
+      array: [
+        1,
+        2,
+        3
+      ]
+    }
+  };
 
   message Nested {
     extend google.protobuf.MessageOptions {
@@ -70,4 +82,5 @@ message Test {
 extend google.protobuf.MessageOptions {
   repeated Test rept = 20002;
   optional Test.Nested._NestedNested.EEE eee = 20010;
+  optional google.protobuf.Any any = 20300;
 }

--- a/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.proto
+++ b/private/buf/bufformat/testdata/proto2/option/v1/option_message_field.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 package foo.bar;
 
+import "google/protobuf/any.proto";
 import "google/protobuf/descriptor.proto";
 
 message Simple {
@@ -27,6 +28,12 @@ message Test {
 	extensions 100 to 200;
 
 	extensions 249, 300 to 350, 500 to 550, 20000 to max [(label) = "jazz"];
+
+	option (any) = {
+		[ type . googleapis . com/ foo.bar.Test	]: {
+			foo: "abc" array: [1,2,3]
+		}
+	};
 
 	message Nested {
 		extend google.protobuf.MessageOptions {
@@ -69,4 +76,5 @@ message Test {
 extend google.protobuf.MessageOptions {
 	repeated Test rept = 20002;
 	optional Test.Nested._NestedNested.EEE eee = 20010;
+	optional google.protobuf.Any any = 20300;
 }


### PR DESCRIPTION
This was recently pointed out to me by @jacobbuf. The formatter simply didn't handle the special Any syntax in message literals.