### PR TITLE
Pass in default branch name for `gittest` scaffold

### DIFF
--- a/private/pkg/git/gittest/gittest.go
+++ b/private/pkg/git/gittest/gittest.go
@@ -99,6 +99,7 @@ func scaffoldGitRepository(t *testing.T, runner command.Runner, defaultBranch st
 	writeFiles(t, localDir, map[string]string{"README.md": "This is a scaffold repository.\n"})
 	runInDir(t, runner, localDir, "git", "add", ".")
 	runInDir(t, runner, localDir, "git", "commit", "-m", "initial commit")
+	runInDir(t, runner, localDir, "git", "branch", "-m", defaultBranch) // this ensures a consistent defaultBranch name for all versions of Git
 	runInDir(t, runner, localDir, "git", "push", "-u", "-f", "origin", defaultBranch)
 
 	return localDir


### PR DESCRIPTION
Depending on the version of local Git, repositories may be initialised with a different
default branch name for Git. This ensures that we are consistently using the `defaultBranch`
name passed in for the test.