### PR TITLE
Parse lint and breaking ignore paths in buf.yaml v2

### DIFF
--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -538,8 +538,9 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 			},
 		)
 		for _, moduleConfig := range bufYAMLFile.ModuleConfigs() {
+			moduleDirPath := moduleConfig.DirPath()
 			externalModule := externalBufYAMLFileModuleV2{
-				Directory: moduleConfig.DirPath(),
+				Directory: moduleDirPath,
 			}
 			if moduleFullName := moduleConfig.ModuleFullName(); moduleFullName != nil {
 				externalModule.Name = moduleFullName.String()
@@ -558,7 +559,7 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 			externalModule.Lint.Use = lintConfig.UseIDsAndCategories()
 			externalModule.Lint.Except = lintConfig.ExceptIDsAndCategories()
 			joinDirPath := func(importPath string) string {
-				return filepath.Join(moduleConfig.DirPath(), importPath)
+				return filepath.Join(moduleDirPath, importPath)
 			}
 			externalModule.Lint.Ignore = slicesext.Map(lintConfig.IgnorePaths(), joinDirPath)
 			externalModule.Lint.IgnoreOnly = make(map[string][]string, len(lintConfig.IgnoreIDOrCategoryToPaths()))

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -306,20 +306,30 @@ func readBufYAMLFile(reader io.Reader, allowJSON bool) (BufYAMLFile, error) {
 		if err != nil {
 			return nil, err
 		}
+		// TODO: we do no validation of paths now
+		lintConfig, err := getLintConfigForExternalLint(
+			fileVersion,
+			externalBufYAMLFile.Lint,
+			normalpath.NormalizeAndValidate,
+		)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: we do no validation of paths now
+		breakingConfig, err := getBreakingConfigForExternalBreaking(
+			fileVersion,
+			externalBufYAMLFile.Breaking,
+			normalpath.NormalizeAndValidate,
+		)
+		if err != nil {
+			return nil, err
+		}
 		moduleConfig, err := newModuleConfig(
 			"",
 			moduleFullName,
 			rootToExcludes,
-			// TODO: we do no validation of paths now
-			getLintConfigForExternalLint(
-				fileVersion,
-				externalBufYAMLFile.Lint,
-			),
-			// TODO: we do no validation of paths now
-			getBreakingConfigForExternalBreaking(
-				fileVersion,
-				externalBufYAMLFile.Breaking,
-			),
+			lintConfig,
+			breakingConfig,
 		)
 		if err != nil {
 			return nil, err
@@ -389,20 +399,41 @@ func readBufYAMLFile(reader io.Reader, allowJSON bool) (BufYAMLFile, error) {
 			if err != nil {
 				return nil, err
 			}
+			validateAndTransformPath := func(pathInWorkspace string) (string, error) {
+				pathInWorkspace, err := normalpath.NormalizeAndValidate(pathInWorkspace)
+				if err != nil {
+					// user error
+					return "", fmt.Errorf("invalid path: %w", err)
+				}
+				if !normalpath.EqualsOrContainsPath(dirPath, pathInWorkspace, normalpath.Relative) {
+					return "", fmt.Errorf("%q does not reside within module directory %q", pathInWorkspace, dirPath)
+				}
+				return filepath.Rel(dirPath, pathInWorkspace)
+			}
+			// TODO: we do no validation of paths now
+			lintConfig, err := getLintConfigForExternalLint(
+				fileVersion,
+				externalModule.Lint,
+				validateAndTransformPath,
+			)
+			if err != nil {
+				return nil, err
+			}
+			// TODO: we do no validation of paths now
+			breakingConfig, err := getBreakingConfigForExternalBreaking(
+				fileVersion,
+				externalModule.Breaking,
+				validateAndTransformPath,
+			)
+			if err != nil {
+				return nil, err
+			}
 			moduleConfig, err := newModuleConfig(
 				dirPath,
 				moduleFullName,
 				rootToExcludes,
-				// TODO: we do no validation of paths now
-				getLintConfigForExternalLint(
-					fileVersion,
-					externalModule.Lint,
-				),
-				// TODO: we do no validation of paths now
-				getBreakingConfigForExternalBreaking(
-					fileVersion,
-					externalModule.Breaking,
-				),
+				lintConfig,
+				breakingConfig,
 			)
 			if err != nil {
 				return nil, err
@@ -526,8 +557,14 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 			lintConfig := moduleConfig.LintConfig()
 			externalModule.Lint.Use = lintConfig.UseIDsAndCategories()
 			externalModule.Lint.Except = lintConfig.ExceptIDsAndCategories()
-			externalModule.Lint.Ignore = lintConfig.IgnorePaths()
-			externalModule.Lint.IgnoreOnly = lintConfig.IgnoreIDOrCategoryToPaths()
+			joinDirPath := func(importPath string) string {
+				return filepath.Join(moduleConfig.DirPath(), importPath)
+			}
+			externalModule.Lint.Ignore = slicesext.Map(lintConfig.IgnorePaths(), joinDirPath)
+			externalModule.Lint.IgnoreOnly = make(map[string][]string, len(lintConfig.IgnoreIDOrCategoryToPaths()))
+			for idOrCategory, importPaths := range lintConfig.IgnoreIDOrCategoryToPaths() {
+				externalModule.Lint.IgnoreOnly[idOrCategory] = slicesext.Map(importPaths, joinDirPath)
+			}
 			externalModule.Lint.EnumZeroValueSuffix = lintConfig.EnumZeroValueSuffix()
 			externalModule.Lint.RPCAllowSameRequestResponse = lintConfig.RPCAllowSameRequestResponse()
 			externalModule.Lint.RPCAllowGoogleProtobufEmptyRequests = lintConfig.RPCAllowGoogleProtobufEmptyRequests()
@@ -537,8 +574,11 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 			breakingConfig := moduleConfig.BreakingConfig()
 			externalModule.Breaking.Use = breakingConfig.UseIDsAndCategories()
 			externalModule.Breaking.Except = breakingConfig.ExceptIDsAndCategories()
-			externalModule.Breaking.Ignore = breakingConfig.IgnorePaths()
-			externalModule.Breaking.IgnoreOnly = breakingConfig.IgnoreIDOrCategoryToPaths()
+			externalModule.Breaking.Ignore = slicesext.Map(breakingConfig.IgnorePaths(), joinDirPath)
+			externalModule.Breaking.IgnoreOnly = make(map[string][]string, len(breakingConfig.IgnoreIDOrCategoryToPaths()))
+			for idOrCategory, importPaths := range breakingConfig.IgnoreIDOrCategoryToPaths() {
+				externalModule.Breaking.IgnoreOnly[idOrCategory] = slicesext.Map(importPaths, joinDirPath)
+			}
 			externalModule.Breaking.IgnoreUnstablePackages = breakingConfig.IgnoreUnstablePackages()
 			externalBufYAMLFile.Modules = append(externalBufYAMLFile.Modules, externalModule)
 		}
@@ -642,14 +682,33 @@ func getConfiguredDepModuleRefsForExternalDeps(
 func getLintConfigForExternalLint(
 	fileVersion FileVersion,
 	externalLint externalBufYAMLFileLintV1Beta1V1V2,
-) LintConfig {
+	pathTransformFunc func(string) (string, error),
+) (LintConfig, error) {
+	ignore, err := slicesext.MapError(
+		externalLint.Ignore,
+		pathTransformFunc,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ignoreOnly := make(map[string][]string)
+	for idOrCategory, specifiedPaths := range externalLint.IgnoreOnly {
+		transformedPaths, err := slicesext.MapError(
+			specifiedPaths,
+			pathTransformFunc,
+		)
+		if err != nil {
+			return nil, err
+		}
+		ignoreOnly[idOrCategory] = transformedPaths
+	}
 	return newLintConfig(
 		newCheckConfig(
 			fileVersion,
 			externalLint.Use,
 			externalLint.Except,
-			externalLint.Ignore,
-			externalLint.IgnoreOnly,
+			ignore,
+			ignoreOnly,
 		),
 		externalLint.EnumZeroValueSuffix,
 		externalLint.RPCAllowSameRequestResponse,
@@ -657,23 +716,42 @@ func getLintConfigForExternalLint(
 		externalLint.RPCAllowGoogleProtobufEmptyResponses,
 		externalLint.ServiceSuffix,
 		externalLint.AllowCommentIgnores,
-	)
+	), nil
 }
 
 func getBreakingConfigForExternalBreaking(
 	fileVersion FileVersion,
 	externalBreaking externalBufYAMLFileBreakingV1Beta1V1V2,
-) BreakingConfig {
+	pathTransformFunc func(string) (string, error),
+) (BreakingConfig, error) {
+	ignore, err := slicesext.MapError(
+		externalBreaking.Ignore,
+		pathTransformFunc,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ignoreOnly := make(map[string][]string)
+	for idOrCategory, specifiedPaths := range externalBreaking.IgnoreOnly {
+		transformedPaths, err := slicesext.MapError(
+			specifiedPaths,
+			pathTransformFunc,
+		)
+		if err != nil {
+			return nil, err
+		}
+		ignoreOnly[idOrCategory] = transformedPaths
+	}
 	return newBreakingConfig(
 		newCheckConfig(
 			fileVersion,
 			externalBreaking.Use,
 			externalBreaking.Except,
-			externalBreaking.Ignore,
-			externalBreaking.IgnoreOnly,
+			ignore,
+			ignoreOnly,
 		),
 		externalBreaking.IgnoreUnstablePackages,
-	)
+	), nil
 }
 
 // externalBufYAMLFileV1Beta1V1 represents the v1 or v1beta1 buf.yaml file, which have

--- a/private/bufpkg/bufconfig/check_config.go
+++ b/private/bufpkg/bufconfig/check_config.go
@@ -61,11 +61,9 @@ type CheckConfig interface {
 	// Paths are specific to the Module.
 	// Paths are relative to roots.
 	// Sorted
-	// TODO: should we make these now relative to root of workspace in v2?
 	IgnorePaths() []string
 	// Paths are specific to the Module.
 	// Paths are relative to roots.
-	// TODO: should we make these now relative to root of workspace in v2?
 	// Paths sorted.
 	IgnoreIDOrCategoryToPaths() map[string][]string
 


### PR DESCRIPTION
In buf.yaml v2, we want paths for `ignore` and `ignore_only` in `lint` and `breaking` to be relative to the workspace root, but paths in a `CheckConfig` should be relative to module roots, i.e. they are import paths. This PR adds this transformation for read and write.