### PR TITLE
Add public constructors for generation related configs.

### DIFF
--- a/private/bufpkg/bufconfig/generate_managed_config.go
+++ b/private/bufpkg/bufconfig/generate_managed_config.go
@@ -125,7 +125,7 @@ type ManagedOverrideRule interface {
 	isManagedOverrideRule()
 }
 
-// NewFieldOptionOverrideRule returns a new ManagedOverrideRule for a field option.
+// NewFieldOptionOverrideRule returns a new ManagedOverrideRule for a file option.
 func NewManagedOverrideRuleForFileOption(
 	path string,
 	moduleFullName string,

--- a/private/bufpkg/bufconfig/generate_managed_config.go
+++ b/private/bufpkg/bufconfig/generate_managed_config.go
@@ -80,8 +80,8 @@ type ManagedDisableRule interface {
 	isManagedDisableRule()
 }
 
-// NewDisableRule returns a new ManagedDisableRule
-func NewDisableRule(
+// NewManagedDisableRule returns a new ManagedDisableRule.
+func NewManagedDisableRule(
 	path string,
 	moduleFullName string,
 	fieldName string,
@@ -125,8 +125,8 @@ type ManagedOverrideRule interface {
 	isManagedOverrideRule()
 }
 
-// NewFieldOptionOverrideRule returns an OverrideRule for a field option.
-func NewFileOptionOverrideRule(
+// NewFieldOptionOverrideRule returns a new ManagedOverrideRule for a field option.
+func NewManagedOverrideRuleForFileOption(
 	path string,
 	moduleFullName string,
 	fileOption FileOption,
@@ -140,8 +140,8 @@ func NewFileOptionOverrideRule(
 	)
 }
 
-// NewFieldOptionOverrideRule returns an OverrideRule for a field option.
-func NewFieldOptionOverrideRule(
+// NewManagedOverrideRuleForFieldOption returns a new ManagedOverrideRule for a field option.
+func NewManagedOverrideRuleForFieldOption(
 	path string,
 	moduleFullName string,
 	fieldName string,
@@ -173,7 +173,7 @@ func newManagedConfigFromExternalV1Beta1(
 		overrides []ManagedOverrideRule
 	)
 	if externalCCEnableArenas := externalConfig.CcEnableArenas; externalCCEnableArenas != nil {
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionCcEnableArenas,
@@ -185,7 +185,7 @@ func newManagedConfigFromExternalV1Beta1(
 		overrides = append(overrides, override)
 	}
 	if externalJavaMultipleFiles := externalConfig.JavaMultipleFiles; externalJavaMultipleFiles != nil {
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionJavaMultipleFiles,
@@ -197,7 +197,7 @@ func newManagedConfigFromExternalV1Beta1(
 		overrides = append(overrides, override)
 	}
 	if externalOptimizeFor := externalConfig.OptimizeFor; externalOptimizeFor != "" {
-		defaultOverride, err := NewFileOptionOverrideRule(
+		defaultOverride, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionOptimizeFor,
@@ -222,7 +222,7 @@ func newManagedConfigFromExternalV1(
 		overrides []ManagedOverrideRule
 	)
 	if externalCCEnableArenas := externalConfig.CcEnableArenas; externalCCEnableArenas != nil {
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionCcEnableArenas,
@@ -234,7 +234,7 @@ func newManagedConfigFromExternalV1(
 		overrides = append(overrides, override)
 	}
 	if externalJavaMultipleFiles := externalConfig.JavaMultipleFiles; externalJavaMultipleFiles != nil {
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionJavaMultipleFiles,
@@ -246,7 +246,7 @@ func newManagedConfigFromExternalV1(
 		overrides = append(overrides, override)
 	}
 	if externalJavaStringCheckUtf8 := externalConfig.JavaStringCheckUtf8; externalJavaStringCheckUtf8 != nil {
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionJavaStringCheckUtf8,
@@ -261,7 +261,7 @@ func newManagedConfigFromExternalV1(
 		if externalJavaPackagePrefix.Default == "" {
 			return nil, errors.New("java_package_prefix requires a default value")
 		}
-		defaultOverride, err := NewFileOptionOverrideRule(
+		defaultOverride, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionJavaPackagePrefix,
@@ -300,7 +300,7 @@ func newManagedConfigFromExternalV1(
 		if externalOptimizeFor.Default == "" {
 			return nil, errors.New("optimize_for requires a default value")
 		}
-		defaultOverride, err := NewFileOptionOverrideRule(
+		defaultOverride, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionOptimizeFor,
@@ -326,7 +326,7 @@ func newManagedConfigFromExternalV1(
 		if externalGoPackagePrefix.Default == "" {
 			return nil, errors.New("go_package_prefix requires a default value")
 		}
-		defaultOverride, err := NewFileOptionOverrideRule(
+		defaultOverride, err := NewManagedOverrideRuleForFileOption(
 			"",
 			"",
 			FileOptionGoPackagePrefix,
@@ -351,7 +351,7 @@ func newManagedConfigFromExternalV1(
 	if externalObjcClassPrefix := externalConfig.ObjcClassPrefix; !externalObjcClassPrefix.isEmpty() {
 		if externalObjcClassPrefix.Default != "" {
 			// objc class prefix allows empty default
-			defaultOverride, err := NewFileOptionOverrideRule(
+			defaultOverride, err := NewManagedOverrideRuleForFileOption(
 				"",
 				"",
 				FileOptionObjcClassPrefix,
@@ -449,7 +449,7 @@ func newManagedConfigFromExternalV2(
 			if err != nil {
 				return nil, err
 			}
-			override, err := NewFieldOptionOverrideRule(
+			override, err := NewManagedOverrideRuleForFieldOption(
 				externalOverrideConfig.Path,
 				externalOverrideConfig.Module,
 				externalOverrideConfig.Field,
@@ -466,7 +466,7 @@ func newManagedConfigFromExternalV2(
 		if err != nil {
 			return nil, err
 		}
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			externalOverrideConfig.Path,
 			externalOverrideConfig.Module,
 			fileOption,
@@ -712,7 +712,7 @@ func disablesAndOverridesFromExceptAndOverrideV1(
 		if _, ok := seenExceptModuleFullNames[overrideModuleFullName]; ok {
 			return nil, nil, fmt.Errorf("override %q is already defined as an except", overrideModuleFullName)
 		}
-		override, err := NewFileOptionOverrideRule(
+		override, err := NewManagedOverrideRuleForFileOption(
 			"",
 			overrideModuleFullName,
 			overrideFileOption,
@@ -752,7 +752,7 @@ func overrideRulesForPerFileOverridesV1(
 					return nil, fmt.Errorf("")
 				}
 			}
-			overrideRule, err := NewFileOptionOverrideRule(
+			overrideRule, err := NewManagedOverrideRuleForFileOption(
 				filePath,
 				"",
 				fileOption,

--- a/private/bufpkg/bufconfig/generate_plugin_config.go
+++ b/private/bufpkg/bufconfig/generate_plugin_config.go
@@ -106,6 +106,87 @@ type GeneratePluginConfig interface {
 	isGeneratePluginConfig()
 }
 
+// NewRemotePluginConfig returns a new GeneratePluginConfig for a remote plugin.
+func NewRemotePluginConfig(
+	name string,
+	out string,
+	opt []string,
+	includeImports bool,
+	includeWKT bool,
+	revision int,
+) (GeneratePluginConfig, error) {
+	return newRemotePluginConfig(
+		name,
+		out,
+		opt,
+		includeImports,
+		includeWKT,
+		revision,
+	)
+}
+
+// NewLocalPluginConfig returns a new GeneratePluginConfig for a local plugin.
+func NewLocalPluginConfig(
+	name string,
+	out string,
+	opt []string,
+	includeImports bool,
+	includeWKT bool,
+	strategy *GenerateStrategy,
+) (GeneratePluginConfig, error) {
+	return newLocalPluginConfig(
+		name,
+		out,
+		opt,
+		includeImports,
+		includeWKT,
+		strategy,
+	)
+}
+
+// NewBinaryPluginConfig returns a new GeneratePluginConfig for a binary plugin.
+func NewBinaryPluginConfig(
+	name string,
+	out string,
+	opt []string,
+	includeImports bool,
+	includeWKT bool,
+	strategy *GenerateStrategy,
+	path []string,
+) (GeneratePluginConfig, error) {
+	return newBinaryPluginConfig(
+		name,
+		out,
+		opt,
+		includeImports,
+		includeWKT,
+		strategy,
+		path,
+	)
+}
+
+// NewProtocBuiltinPluginConfig returns a new GeneratePluginConfig for a protoc
+// builtin plugin.
+func NewProtocBuiltinPluginConfig(
+	name string,
+	out string,
+	opt []string,
+	includeImports bool,
+	includeWKT bool,
+	strategy *GenerateStrategy,
+	protocPath string,
+) (GeneratePluginConfig, error) {
+	return newProtocBuiltinPluginConfig(
+		name,
+		out,
+		opt,
+		includeImports,
+		includeWKT,
+		strategy,
+		protocPath,
+	)
+}
+
 // NewGeneratePluginWithIncludeImportsAndWKT returns a GeneratePluginConfig the
 // same as the input, with include imports and include wkt overriden.
 func NewGeneratePluginWithIncludeImportsAndWKT(

--- a/private/bufpkg/bufconfig/generate_type_config.go
+++ b/private/bufpkg/bufconfig/generate_type_config.go
@@ -23,6 +23,11 @@ type GenerateTypeConfig interface {
 	isGenerateTypeConfig()
 }
 
+// NewGenerateTypeConfig returns a new GenerateTypeConfig.
+func NewGenerateTypeConfig(includeTypes []string) GenerateTypeConfig {
+	return newGenerateTypeConfig(includeTypes)
+}
+
 // *** PRIVATE ***
 
 type generateTypeConfig struct {

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -833,7 +833,7 @@ func newTestManagedDisableRule(
 	fileOption bufconfig.FileOption,
 	fieldOption bufconfig.FieldOption,
 ) bufconfig.ManagedDisableRule {
-	disable, err := bufconfig.NewDisableRule(
+	disable, err := bufconfig.NewManagedDisableRule(
 		path,
 		moduleFullName,
 		fieldName,
@@ -851,7 +851,7 @@ func newTestFileOptionOverrideRule(
 	fileOption bufconfig.FileOption,
 	value interface{},
 ) bufconfig.ManagedOverrideRule {
-	fileOptionOverride, err := bufconfig.NewFileOptionOverrideRule(
+	fileOptionOverride, err := bufconfig.NewManagedOverrideRuleForFileOption(
 		path,
 		moduleFullName,
 		fileOption,
@@ -869,7 +869,7 @@ func newTestFieldOptionOverrideRule(
 	fieldOption bufconfig.FieldOption,
 	value interface{},
 ) bufconfig.ManagedOverrideRule {
-	fieldOptionOverrid, err := bufconfig.NewFieldOptionOverrideRule(
+	fieldOptionOverrid, err := bufconfig.NewManagedOverrideRuleForFieldOption(
 		path,
 		moduleFullName,
 		bufconfig.FileOptionPhpMetadataNamespace.String(),


### PR DESCRIPTION
This PR:
* adds public constructors for `GeneratePluginConfig` and `GenerateTypeConfig`, so that other repos can create generation configs.

* renames the following:
`NewDisableRule` --> `NewManagedDisableRule`
`NewFileOptionOverrideRule` --> `NewManagedOverrideRuleForFileOption`
`NewFieldOptionOverrideRule` --> `NewManagedOverrideRuleForFieldOption`

`make testbufnew` passes