### PR TITLE
Update bufimagemodify exports

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -97,7 +97,7 @@ func (g *generator) Generate(
 		option(generateOptions)
 	}
 	for _, image := range images {
-		if err := bufimagemodify.Modify(ctx, image, config.GenerateManagedConfig()); err != nil {
+		if err := bufimagemodify.Modify(image, config.GenerateManagedConfig()); err != nil {
 			return err
 		}
 		if err := g.generateCode(

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -15,8 +15,6 @@
 package bufimagemodify
 
 import (
-	"context"
-
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage/bufimagemodify/internal"
@@ -24,42 +22,215 @@ import (
 )
 
 // Modify modifies the image according to the managed config.
+//
+// The CLI should use this function instead of ModifyXYZ.
 func Modify(
-	ctx context.Context,
 	image bufimage.Image,
 	config bufconfig.GenerateManagedConfig,
 	options ...ModifyOption,
 ) error {
-	if !config.Enabled() {
-		return nil
-	}
-	sweeper := internal.NewMarkSweeper(image)
-	for _, imageFile := range image.Files() {
-		if datawkt.Exists(imageFile.Path()) {
-			continue
-		}
-		modifyFuncs := []func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig, ...ModifyOption) error{
-			ModifyCcEnableArenas,
-			ModifyCsharpNamespace,
-			ModifyGoPackage,
-			ModifyJavaMultipleFiles,
-			ModifyJavaOuterClass,
-			ModifyJavaPackage,
-			ModifyJavaStringCheckUtf8,
-			ModifyObjcClassPrefix,
-			ModifyOptmizeFor,
-			ModifyPhpMetadataNamespace,
-			ModifyPhpNamespace,
-			ModifyRubyPackage,
-			ModifyJsType,
-		}
-		for _, modifyFunc := range modifyFuncs {
-			if err := modifyFunc(sweeper, imageFile, config, options...); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return modifyImage(
+		image,
+		config,
+		[]func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig, ...ModifyOption) error{
+			modifyCcEnableArenas,
+			modifyCsharpNamespace,
+			modifyGoPackage,
+			modifyJavaMultipleFiles,
+			modifyJavaOuterClass,
+			modifyJavaPackage,
+			modifyJavaStringCheckUtf8,
+			modifyObjcClassPrefix,
+			modifyOptmizeFor,
+			modifyPhpMetadataNamespace,
+			modifyPhpNamespace,
+			modifyRubyPackage,
+			modifyJsType,
+		},
+		options...,
+	)
+}
+
+// ModifyJavaOuterClass modifies the java_outer_class file option.
+func ModifyJavaOuterClass(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyJavaOuterClass,
+		options...,
+	)
+}
+
+// ModifyJavaPackage modifies the java_package file option.
+func ModifyJavaPackage(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyJavaPackage,
+		options...,
+	)
+}
+
+// ModifyGoPackage modifies the go_package file option.
+func ModifyGoPackage(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyGoPackage,
+		options...,
+	)
+}
+
+// ModifyObjcClassPrefix modifies the objc_class_prefix file option.
+func ModifyObjcClassPrefix(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyObjcClassPrefix,
+		options...,
+	)
+}
+
+// ModifyCsharpNamespace modifies the csharp_namespace file option.
+func ModifyCsharpNamespace(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyCsharpNamespace,
+		options...,
+	)
+}
+
+// ModifyPhpNamespace modifies the php_namespace file option.
+func ModifyPhpNamespace(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyPhpNamespace,
+		options...,
+	)
+}
+
+// ModifyPhpMetadataNamespace modifies the php_metadata_namespace file option.
+func ModifyPhpMetadataNamespace(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyPhpMetadataNamespace,
+		options...,
+	)
+}
+
+// ModifyRubyPackage modifies the ruby_package file option.
+func ModifyRubyPackage(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyRubyPackage,
+		options...,
+	)
+}
+
+// ModifyCcEnableArenas modifies the cc_enable_arenas file option.
+func ModifyCcEnableArenas(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyCcEnableArenas,
+		options...,
+	)
+}
+
+// ModifyJavaMultipleFiles modifies the java_multiple_files file option.
+func ModifyJavaMultipleFiles(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyJavaMultipleFiles,
+		options...,
+	)
+}
+
+// ModifyJavaStringCheckUtf8 modifies the java_string_check_utf8 file option.
+func ModifyJavaStringCheckUtf8(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyJavaStringCheckUtf8,
+		options...,
+	)
+}
+
+// ModifyOptmizeFor modifies the optimize_for file option.
+func ModifyOptmizeFor(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyOptmizeFor,
+		options...,
+	)
+}
+
+// ModifyJsType modifies the js_type field option.
+func ModifyJsType(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
+) error {
+	return modifyImageForSingleOption(
+		image,
+		config,
+		modifyJsType,
+		options...,
+	)
 }
 
 // ModifyOption is an option for Modify.
@@ -82,4 +253,41 @@ type modifyOptions struct {
 
 func newModifyOptions() *modifyOptions {
 	return &modifyOptions{}
+}
+
+func modifyImage(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	modifyFuncs []func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig, ...ModifyOption) error,
+	options ...ModifyOption,
+) error {
+	if !config.Enabled() {
+		return nil
+	}
+	sweeper := internal.NewMarkSweeper(image)
+	for _, imageFile := range image.Files() {
+		if datawkt.Exists(imageFile.Path()) {
+			continue
+		}
+		for _, modifyFunc := range modifyFuncs {
+			if err := modifyFunc(sweeper, imageFile, config, options...); err != nil {
+				return err
+			}
+		}
+	}
+	return sweeper.Sweep()
+}
+
+func modifyImageForSingleOption(
+	image bufimage.Image,
+	config bufconfig.GenerateManagedConfig,
+	modifyFunc func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig, ...ModifyOption) error,
+	options ...ModifyOption,
+) error {
+	return modifyImage(
+		image,
+		config,
+		[]func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig, ...ModifyOption) error{modifyFunc},
+		options...,
+	)
 }

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -185,7 +185,7 @@ func TestModifyImageFile(
 		description                           string
 		dirPathToModuleFullName               map[string]string
 		config                                bufconfig.GenerateManagedConfig
-		modifyFunc                            func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig) error
+		modifyFunc                            func(internal.MarkSweeper, bufimage.ImageFile, bufconfig.GenerateManagedConfig, ...ModifyOption) error
 		filePathToExpectedOptions             map[string]*descriptorpb.FileOptions
 		filePathToExpectedMarkedLocationPaths map[string][][]int32
 	}{
@@ -202,7 +202,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "buf.build/acme/bar", bufconfig.FileOptionCcEnableArenas, false),
 				},
 			),
-			modifyFunc: modifyCcEnableArenas,
+			modifyFunc: ModifyCcEnableArenas,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"foo_empty/without_package.proto": nil,
 				"bar_empty/without_package.proto": {
@@ -231,7 +231,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "foo_empty", "buf.build/acme/foo", bufconfig.FileOptionCsharpNamespacePrefix, "FooPrefix"),
 				},
 			),
-			modifyFunc: modifyCsharpNamespace,
+			modifyFunc: ModifyCsharpNamespace,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"bar_empty/with_package.proto": {
 					CsharpNamespace: proto.String("BarPrefix.Bar.Empty"),
@@ -268,7 +268,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "foo_empty", "buf.build/acme/foo", bufconfig.FileOptionGoPackagePrefix, "fooprefix"),
 				},
 			),
-			modifyFunc: modifyGoPackage,
+			modifyFunc: ModifyGoPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"bar_empty/with_package.proto": {
 					GoPackage: proto.String("barprefix/bar_empty"),
@@ -306,7 +306,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "buf.build/acme/foo", bufconfig.FileOptionJavaPackageSuffix, "foosuffix"),
 				},
 			),
-			modifyFunc: modifyJavaPackage,
+			modifyFunc: ModifyJavaPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"foo_empty/with_package.proto": {
 					// default prefix and override suffix
@@ -402,7 +402,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "", bufconfig.FileOptionJavaPackageSuffix, "suffix"),
 				},
 			),
-			modifyFunc: modifyJavaPackage,
+			modifyFunc: ModifyJavaPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"foo_empty/with_package.proto": {
 					// only suffix matches, but apply both prefix and suffix
@@ -458,7 +458,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "buf.build/acme/foo", bufconfig.FileOptionJavaPackage, "foo.value"),
 				},
 			),
-			modifyFunc: modifyJavaPackage,
+			modifyFunc: ModifyJavaPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				// bar_empty disabled
 				"bar_empty/with_package.proto":    nil,
@@ -513,7 +513,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "foo_all", "buf.build/acme/foo", bufconfig.FileOptionObjcClassPrefix, "FOOALL"),
 				},
 			),
-			modifyFunc: modifyObjcClassPrefix,
+			modifyFunc: ModifyObjcClassPrefix,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"bar_empty/with_package.proto": {
 					ObjcClassPrefix: proto.String("BAR"),

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -158,7 +158,6 @@ func TestModifyImage(t *testing.T) {
 				t.Parallel()
 				image := testGetImageFromDirs(t, testcase.dirPathToModuleFullName, includeSourceInfo)
 				err := Modify(
-					context.Background(),
 					image,
 					testcase.config,
 				)
@@ -202,7 +201,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "buf.build/acme/bar", bufconfig.FileOptionCcEnableArenas, false),
 				},
 			),
-			modifyFunc: ModifyCcEnableArenas,
+			modifyFunc: modifyCcEnableArenas,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"foo_empty/without_package.proto": nil,
 				"bar_empty/without_package.proto": {
@@ -231,7 +230,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "foo_empty", "buf.build/acme/foo", bufconfig.FileOptionCsharpNamespacePrefix, "FooPrefix"),
 				},
 			),
-			modifyFunc: ModifyCsharpNamespace,
+			modifyFunc: modifyCsharpNamespace,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"bar_empty/with_package.proto": {
 					CsharpNamespace: proto.String("BarPrefix.Bar.Empty"),
@@ -268,7 +267,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "foo_empty", "buf.build/acme/foo", bufconfig.FileOptionGoPackagePrefix, "fooprefix"),
 				},
 			),
-			modifyFunc: ModifyGoPackage,
+			modifyFunc: modifyGoPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"bar_empty/with_package.proto": {
 					GoPackage: proto.String("barprefix/bar_empty"),
@@ -306,7 +305,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "buf.build/acme/foo", bufconfig.FileOptionJavaPackageSuffix, "foosuffix"),
 				},
 			),
-			modifyFunc: ModifyJavaPackage,
+			modifyFunc: modifyJavaPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"foo_empty/with_package.proto": {
 					// default prefix and override suffix
@@ -402,7 +401,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "", bufconfig.FileOptionJavaPackageSuffix, "suffix"),
 				},
 			),
-			modifyFunc: ModifyJavaPackage,
+			modifyFunc: modifyJavaPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"foo_empty/with_package.proto": {
 					// only suffix matches, but apply both prefix and suffix
@@ -458,7 +457,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "", "buf.build/acme/foo", bufconfig.FileOptionJavaPackage, "foo.value"),
 				},
 			),
-			modifyFunc: ModifyJavaPackage,
+			modifyFunc: modifyJavaPackage,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				// bar_empty disabled
 				"bar_empty/with_package.proto":    nil,
@@ -513,7 +512,7 @@ func TestModifyImageFile(
 					newTestFileOptionOverrideRule(t, "foo_all", "buf.build/acme/foo", bufconfig.FileOptionObjcClassPrefix, "FOOALL"),
 				},
 			),
-			modifyFunc: ModifyObjcClassPrefix,
+			modifyFunc: modifyObjcClassPrefix,
 			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
 				"bar_empty/with_package.proto": {
 					ObjcClassPrefix: proto.String("BAR"),

--- a/private/bufpkg/bufimage/bufimagemodify/field_option.go
+++ b/private/bufpkg/bufimage/bufimagemodify/field_option.go
@@ -33,8 +33,7 @@ import (
 // https://github.com/protocolbuffers/protobuf/blob/61689226c0e3ec88287eaed66164614d9c4f2bf7/src/google/protobuf/descriptor.proto#L567
 var jsTypeSubPath = []int32{8, 6}
 
-// ModifyJsType modifies the js_type field option.
-func ModifyJsType(
+func modifyJsType(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,

--- a/private/bufpkg/bufimage/bufimagemodify/file_option.go
+++ b/private/bufpkg/bufimage/bufimagemodify/file_option.go
@@ -62,15 +62,22 @@ var (
 	rubyPackagePath = []int32{8, 45}
 )
 
-func modifyJavaOuterClass(
+// ModifyJavaOuterClass modifies the java_outer_class file option.
+func ModifyJavaOuterClass(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionJavaOuterClassname,
 		bufconfig.FileOptionUnspecified,
 		bufconfig.FileOptionUnspecified,
@@ -86,19 +93,29 @@ func modifyJavaOuterClass(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.JavaOuterClassname = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.JavaOuterClassname != nil
+		},
 		javaOuterClassnamePath,
 	)
 }
 
-func modifyJavaPackage(
+// ModifyJavaPackage modifies the java_package file option.
+func ModifyJavaPackage(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionJavaPackage,
 		bufconfig.FileOptionJavaPackagePrefix,
 		bufconfig.FileOptionJavaPackageSuffix,
@@ -112,19 +129,29 @@ func modifyJavaPackage(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.JavaPackage = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.JavaPackage != nil
+		},
 		javaPackagePath,
 	)
 }
 
-func modifyGoPackage(
+// ModifyGoPackage modifies the go_package file option.
+func ModifyGoPackage(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionGoPackage,
 		bufconfig.FileOptionGoPackagePrefix,
 		bufconfig.FileOptionUnspecified,
@@ -143,19 +170,29 @@ func modifyGoPackage(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.GoPackage = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.GoPackage != nil
+		},
 		goPackagePath,
 	)
 }
 
-func modifyObjcClassPrefix(
+// ModifyObjcClassPrefix modifies the objc_class_prefix file option.
+func ModifyObjcClassPrefix(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionObjcClassPrefix,
 		bufconfig.FileOptionUnspecified,
 		bufconfig.FileOptionUnspecified,
@@ -171,19 +208,29 @@ func modifyObjcClassPrefix(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.ObjcClassPrefix = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.ObjcClassPrefix != nil
+		},
 		objcClassPrefixPath,
 	)
 }
 
-func modifyCsharpNamespace(
+// ModifyCsharpNamespace modifies the csharp_namespace file option.
+func ModifyCsharpNamespace(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionCsharpNamespace,
 		bufconfig.FileOptionCsharpNamespacePrefix,
 		bufconfig.FileOptionUnspecified,
@@ -199,19 +246,29 @@ func modifyCsharpNamespace(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.CsharpNamespace = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.CsharpNamespace != nil
+		},
 		csharpNamespacePath,
 	)
 }
 
-func modifyPhpNamespace(
+// ModifyPhpNamespace modifies the php_namespace file option.
+func ModifyPhpNamespace(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionPhpNamespace,
 		bufconfig.FileOptionUnspecified,
 		bufconfig.FileOptionUnspecified,
@@ -227,19 +284,29 @@ func modifyPhpNamespace(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.PhpNamespace = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.PhpNamespace != nil
+		},
 		phpNamespacePath,
 	)
 }
 
-func modifyPhpMetadataNamespace(
+// ModifyPhpMetadataNamespace modifies the php_metadata_namespace file option.
+func ModifyPhpMetadataNamespace(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionPhpMetadataNamespace,
 		bufconfig.FileOptionUnspecified,
 		bufconfig.FileOptionPhpMetadataNamespaceSuffix,
@@ -255,19 +322,29 @@ func modifyPhpMetadataNamespace(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.PhpMetadataNamespace = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.PhpMetadataNamespace != nil
+		},
 		phpMetadataNamespacePath,
 	)
 }
 
-func modifyRubyPackage(
+// ModifyRubyPackage modifies the ruby_package file option.
+func ModifyRubyPackage(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
 	return modifyStringOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionRubyPackage,
 		bufconfig.FileOptionUnspecified,
 		bufconfig.FileOptionRubyPackageSuffix,
@@ -283,19 +360,29 @@ func modifyRubyPackage(
 		func(options *descriptorpb.FileOptions, value string) {
 			options.RubyPackage = proto.String(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.RubyPackage != nil
+		},
 		rubyPackagePath,
 	)
 }
 
-func modifyCcEnableArenas(
+// ModifyCcEnableArenas modifies the cc_enable_arenas file option.
+func ModifyCcEnableArenas(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
-	return modifyFileOption[bool](
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
+	return modifyFileOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionCcEnableArenas,
 		true,
 		func(options *descriptorpb.FileOptions) bool {
@@ -304,19 +391,29 @@ func modifyCcEnableArenas(
 		func(options *descriptorpb.FileOptions, value bool) {
 			options.CcEnableArenas = proto.Bool(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.CcEnableArenas != nil
+		},
 		ccEnableArenasPath,
 	)
 }
 
-func modifyJavaMultipleFiles(
+// ModifyJavaMultipleFiles modifies the java_multiple_files file option.
+func ModifyJavaMultipleFiles(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
-	return modifyFileOption[bool](
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
+	return modifyFileOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionJavaMultipleFiles,
 		true,
 		func(options *descriptorpb.FileOptions) bool {
@@ -325,19 +422,29 @@ func modifyJavaMultipleFiles(
 		func(options *descriptorpb.FileOptions, value bool) {
 			options.JavaMultipleFiles = proto.Bool(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.JavaMultipleFiles != nil
+		},
 		javaMultipleFilesPath,
 	)
 }
 
-func modifyJavaStringCheckUtf8(
+// ModifyJavaStringCheckUtf8 modifies the java_string_check_utf8 file option.
+func ModifyJavaStringCheckUtf8(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
-	return modifyFileOption[bool](
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
+	return modifyFileOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionJavaStringCheckUtf8,
 		false,
 		func(options *descriptorpb.FileOptions) bool {
@@ -346,19 +453,29 @@ func modifyJavaStringCheckUtf8(
 		func(options *descriptorpb.FileOptions, value bool) {
 			options.JavaStringCheckUtf8 = proto.Bool(value)
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.JavaStringCheckUtf8 != nil
+		},
 		javaStringCheckUtf8Path,
 	)
 }
 
-func modifyOptmizeFor(
+// ModifyOptmizeFor modifies the optimize_for file option.
+func ModifyOptmizeFor(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	options ...ModifyOption,
 ) error {
-	return modifyFileOption[descriptorpb.FileOptions_OptimizeMode](
+	modifyOptions := newModifyOptions()
+	for _, option := range options {
+		option(modifyOptions)
+	}
+	return modifyFileOption(
 		sweeper,
 		imageFile,
 		config,
+		modifyOptions.preserveExisting,
 		bufconfig.FileOptionOptimizeFor,
 		descriptorpb.FileOptions_SPEED,
 		func(options *descriptorpb.FileOptions) descriptorpb.FileOptions_OptimizeMode {
@@ -367,21 +484,32 @@ func modifyOptmizeFor(
 		func(options *descriptorpb.FileOptions, value descriptorpb.FileOptions_OptimizeMode) {
 			options.OptimizeFor = value.Enum()
 		},
+		func(options *descriptorpb.FileOptions) bool {
+			return options != nil && options.OptimizeFor != nil
+		},
 		optimizeForPath,
 	)
 }
+
+// *** PRIVATE ***
 
 func modifyFileOption[T bool | descriptorpb.FileOptions_OptimizeMode](
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	preserveExisting bool,
 	fileOption bufconfig.FileOption,
 	// You can set this value to the same as protobuf default, in order to not modify a value by default.
 	defaultValue T,
 	getOptionFunc func(*descriptorpb.FileOptions) T,
 	setOptionFunc func(*descriptorpb.FileOptions, T),
+	checkOptionSetFunc func(*descriptorpb.FileOptions) bool,
 	sourceLocationPath []int32,
 ) error {
+	descriptor := imageFile.FileDescriptorProto()
+	if preserveExisting && checkOptionSetFunc(descriptor.Options) {
+		return nil
+	}
 	value := defaultValue
 	if isFileOptionDisabledForFile(
 		imageFile,
@@ -401,7 +529,6 @@ func modifyFileOption[T bool | descriptorpb.FileOptions_OptimizeMode](
 	if override != nil {
 		value = *override
 	}
-	descriptor := imageFile.FileDescriptorProto()
 	if getOptionFunc(descriptor.Options) == value {
 		// The option is already set to the same value, don't modify or mark it.
 		return nil
@@ -418,6 +545,7 @@ func modifyStringOption(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
+	preserveExisting bool,
 	valueOption bufconfig.FileOption,
 	prefixOption bufconfig.FileOption,
 	suffixOption bufconfig.FileOption,
@@ -425,8 +553,13 @@ func modifyStringOption(
 	valueFunc func(bufimage.ImageFile, stringOverrideOptions) string,
 	getOptionFunc func(*descriptorpb.FileOptions) string,
 	setOptionFunc func(*descriptorpb.FileOptions, string),
+	checkOptionSetFunc func(*descriptorpb.FileOptions) bool,
 	sourceLocationPath []int32,
 ) error {
+	descriptor := imageFile.FileDescriptorProto()
+	if preserveExisting && checkOptionSetFunc(descriptor.Options) {
+		return nil
+	}
 	overrideOptions, err := stringOverrideFromConfig(
 		imageFile,
 		config,
@@ -452,7 +585,6 @@ func modifyStringOption(
 	if value == "" {
 		return nil
 	}
-	descriptor := imageFile.FileDescriptorProto()
 	if getOptionFunc(descriptor.Options) == value {
 		// The option is already set to the same value, don't modify or mark it.
 		return nil

--- a/private/bufpkg/bufimage/bufimagemodify/file_option.go
+++ b/private/bufpkg/bufimage/bufimagemodify/file_option.go
@@ -62,8 +62,7 @@ var (
 	rubyPackagePath = []int32{8, 45}
 )
 
-// ModifyJavaOuterClass modifies the java_outer_class file option.
-func ModifyJavaOuterClass(
+func modifyJavaOuterClass(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -100,8 +99,7 @@ func ModifyJavaOuterClass(
 	)
 }
 
-// ModifyJavaPackage modifies the java_package file option.
-func ModifyJavaPackage(
+func modifyJavaPackage(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -136,8 +134,7 @@ func ModifyJavaPackage(
 	)
 }
 
-// ModifyGoPackage modifies the go_package file option.
-func ModifyGoPackage(
+func modifyGoPackage(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -177,8 +174,7 @@ func ModifyGoPackage(
 	)
 }
 
-// ModifyObjcClassPrefix modifies the objc_class_prefix file option.
-func ModifyObjcClassPrefix(
+func modifyObjcClassPrefix(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -215,8 +211,7 @@ func ModifyObjcClassPrefix(
 	)
 }
 
-// ModifyCsharpNamespace modifies the csharp_namespace file option.
-func ModifyCsharpNamespace(
+func modifyCsharpNamespace(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -253,8 +248,7 @@ func ModifyCsharpNamespace(
 	)
 }
 
-// ModifyPhpNamespace modifies the php_namespace file option.
-func ModifyPhpNamespace(
+func modifyPhpNamespace(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -291,8 +285,7 @@ func ModifyPhpNamespace(
 	)
 }
 
-// ModifyPhpMetadataNamespace modifies the php_metadata_namespace file option.
-func ModifyPhpMetadataNamespace(
+func modifyPhpMetadataNamespace(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -329,8 +322,7 @@ func ModifyPhpMetadataNamespace(
 	)
 }
 
-// ModifyRubyPackage modifies the ruby_package file option.
-func ModifyRubyPackage(
+func modifyRubyPackage(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -367,8 +359,7 @@ func ModifyRubyPackage(
 	)
 }
 
-// ModifyCcEnableArenas modifies the cc_enable_arenas file option.
-func ModifyCcEnableArenas(
+func modifyCcEnableArenas(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -398,8 +389,7 @@ func ModifyCcEnableArenas(
 	)
 }
 
-// ModifyJavaMultipleFiles modifies the java_multiple_files file option.
-func ModifyJavaMultipleFiles(
+func modifyJavaMultipleFiles(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -429,8 +419,7 @@ func ModifyJavaMultipleFiles(
 	)
 }
 
-// ModifyJavaStringCheckUtf8 modifies the java_string_check_utf8 file option.
-func ModifyJavaStringCheckUtf8(
+func modifyJavaStringCheckUtf8(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,
@@ -460,8 +449,7 @@ func ModifyJavaStringCheckUtf8(
 	)
 }
 
-// ModifyOptmizeFor modifies the optimize_for file option.
-func ModifyOptmizeFor(
+func modifyOptmizeFor(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,


### PR DESCRIPTION
This PR makes two changes that unblocks other repos that depend on `bufimagemodify`:
* Add `ModifyXYZ` to `bufimagemodify` to allow modifying only some options.
  - Technically this can be done by exposing some `GetDisablesForOtherOptions` and the caller can call `GetDisablesForOtherOptions(fileOpionA, fileOpionB)` to modify only A and B, but this operates on the assumption that no new file options will be added to the list of file options in managed mode.
* Add option `ModifyPreserveExisting` (this was a flag in v1, but not used by the CLI), which tells Modify[XYZ] not to modify an option if it's already set in the proto file.

TODO: Testing in this package needs to be revamped, especially after these functions are added.
