### PR TITLE
Inline badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Buf
 
-[![License](https://img.shields.io/github/license/bufbuild/buf?color=blue)][badges_license]
-[![Release](https://img.shields.io/github/v/release/bufbuild/buf?include_prereleases)][badges_release]
-[![CI](https://github.com/bufbuild/buf/workflows/ci/badge.svg)][badges_ci]
-[![Docker](https://img.shields.io/docker/pulls/bufbuild/buf)][badges_docker]
-[![Homebrew](https://img.shields.io/homebrew/v/buf)][badges_homebrew]
+[![License](https://img.shields.io/github/license/bufbuild/buf?color=blue)](https://github.com/bufbuild/buf/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/bufbuild/buf?include_prereleases)](https://github.com/bufbuild/buf/releases)
+[![CI](https://github.com/bufbuild/buf/workflows/ci/badge.svg)](https://github.com/bufbuild/buf/actions?workflow=ci)
+[![Docker](https://img.shields.io/docker/pulls/bufbuild/buf)](https://hub.docker.com/r/bufbuild/buf)
+[![Homebrew](https://img.shields.io/homebrew/v/buf)](https://github.com/bufbuild/homebrew-buf)
 [![Slack](https://img.shields.io/badge/slack-buf-%23e01563)][badges_slack]
 
 The [`buf`][buf] CLI is a tool for working with [Protocol Buffers][protobuf].
@@ -108,12 +108,6 @@ For updates on the Buf CLI, [follow this repo on GitHub][repo].
 
 For feature requests, bugs, or technical questions, email us at [dev@buf.build][email_dev]. For general inquiries or inclusion in our upcoming feature betas, email us at [info@buf.build][email_info].
 
-[badges_aur]: https://aur.archlinux.org/packages/buf
-[badges_ci]: https://github.com/bufbuild/buf/actions?workflow=ci
-[badges_docker]: https://hub.docker.com/r/bufbuild/buf
-[badges_homebrew]: https://github.com/bufbuild/homebrew-buf
-[badges_license]: https://github.com/bufbuild/buf/blob/main/LICENSE
-[badges_release]: https://github.com/bufbuild/buf/releases
 [badges_slack]: https://buf.build/links/slack
 [bash]: https://www.gnu.org/software/bash
 [binary]: https://docs.buf.build/installation#binary


### PR DESCRIPTION
This change attempts to improve the description text in Google search results.

Before this change, text from the badge links shows up in the description:
![Screenshot 2023-12-18 at 10 32 41 AM](https://github.com/bufbuild/buf/assets/754768/4718deb2-6412-4a5a-a2f6-a2ee41aa177f)

Other similar repositories do not have this problem:

[connect-es](https://github.com/connectrpc/connect-es)
![Screenshot 2023-12-18 at 10 35 48 AM](https://github.com/bufbuild/buf/assets/754768/ad268087-f313-4d42-b463-c09c2b45cb27)

[connect-go](https://github.com/connectrpc/connect-go)
![Screenshot 2023-12-18 at 10 36 32 AM](https://github.com/bufbuild/buf/assets/754768/27307f09-98cc-4630-b29b-2db105927678)

The above repos mostly don't use the short link syntax here so this PR tests the hypothesis that using short links contributes to the undesirable display.

[protovalidate](https://github.com/bufbuild/protovalidate) is a counter example where it does use short links but still renders correctly
![Screenshot 2023-12-18 at 10 41 33 AM](https://github.com/bufbuild/buf/assets/754768/2184f711-90bb-449e-9669-24ff5b1a4ccc)

It isn't clear whether this is the actual problem or not, but worth trying. If this doesn't help, we could revert this change, but I would also advocate for keeping it because I think it is good to only use markdown variables if a URL is actually used in more than one spot in the README (and all these that I am moving are only used once). Slack is referenced in 2 places, so I left that (similar to connect-go and that doesn't seem to cause an issue).

If this doesn't work, my next idea is to delete `<a id="features"></a>`. I am wondering if Google doesn't find the text `The Buf CLI is a tool for working with Protocol Buffers` descriptive enough and starts looking for more text preferring above than below because the link kind of "breaks" the flow of the text.

