### PR TITLE
Improve description of Buf in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,8 @@
 [![Homebrew](https://img.shields.io/homebrew/v/buf)][badges_homebrew]
 [![Slack](https://img.shields.io/badge/slack-buf-%23e01563)][badges_slack]
 
-The [`buf`][buf] CLI is a tool for working with [Protocol Buffers][protobuf].
+The [`buf`][buf] CLI is the best tool for working with [Protocol Buffers][protobuf]. It provides:
 
-<a id="features"></a>
-
-- The ability to manage Protobuf assets on the [Buf Schema Registry][bsr] (BSR).
 - A [linter][lint_usage] that enforces good API design choices and structure.
 - A [breaking change detector][breaking_usage] that enforces compatibility at the source code or wire level.
 - A [generator][generate_usage] that invokes your plugins based on configurable [templates][templates].


### PR DESCRIPTION
This makes a few small changes to the README
* Adjust the one sentence description of the CLI to better match the repository tagline.
* Add a transition phrase to make the list of features read more naturally.
* Remove first bullet point, which appears to be a duplicate of the last bullet point in the list.
* Remove the features anchor. Both because it is unnecessary, and also because it might be interfering with the description Google is choosing when rendering search results.
    ![Screenshot 2023-12-18 at 10 32 41 AM](https://github.com/bufbuild/buf/assets/754768/a15a953f-41bb-483d-a6e1-2f59cbc6b781)
    See also: https://github.com/bufbuild/buf/pull/2672
  
