### PR TITLE
Change include_paths option to paths

### DIFF
--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -417,7 +417,7 @@ func getInputImages(
 	inputSpecified string,
 	bufGenYAMLFile bufconfig.BufGenYAMLFile,
 	moduleConfigOverride string,
-	includePathsOverride []string,
+	targetPathsOverride []string,
 	excludePathsOverride []string,
 	includeTypesOverride []string,
 ) ([]bufimage.Image, error) {
@@ -440,7 +440,7 @@ func getInputImages(
 			ctx,
 			input,
 			bufctl.WithConfigOverride(moduleConfigOverride),
-			bufctl.WithTargetPaths(includePathsOverride, excludePathsOverride),
+			bufctl.WithTargetPaths(targetPathsOverride, excludePathsOverride),
 			bufctl.WithImageTypes(includeTypes),
 		)
 		if err != nil {
@@ -449,9 +449,9 @@ func getInputImages(
 		inputImages = []bufimage.Image{inputImage}
 	} else {
 		for _, inputConfig := range bufGenYAMLFile.InputConfigs() {
-			includePaths := inputConfig.IncludePaths()
-			if len(includePathsOverride) > 0 {
-				includePaths = includePathsOverride
+			targetPaths := inputConfig.TargetPaths()
+			if len(targetPathsOverride) > 0 {
+				targetPaths = targetPathsOverride
 			}
 			excludePaths := inputConfig.ExcludePaths()
 			if len(excludePathsOverride) > 0 {
@@ -459,7 +459,6 @@ func getInputImages(
 			}
 			// In V2 we do not need to look at generateTypeConfig.IncludeTypes()
 			// because it is always nil.
-			// TODO: document the above in godoc
 			includeTypes := inputConfig.IncludeTypes()
 			if len(includeTypesOverride) > 0 {
 				includeTypes = includeTypesOverride
@@ -468,7 +467,7 @@ func getInputImages(
 				ctx,
 				inputConfig,
 				bufctl.WithConfigOverride(moduleConfigOverride),
-				bufctl.WithTargetPaths(includePaths, excludePaths),
+				bufctl.WithTargetPaths(targetPaths, excludePaths),
 				bufctl.WithImageTypes(includeTypes),
 			)
 			if err != nil {

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -527,9 +527,9 @@ type externalInputConfigV2 struct {
 	JSONImage   *string `json:"json_image,omitempty" yaml:"json_image,omitempty"`
 	TextImage   *string `json:"text_image,omitempty" yaml:"text_image,omitempty"`
 	GitRepo     *string `json:"git_repo,omitempty" yaml:"git_repo,omitempty"`
-	// Types, IncludePaths and ExcludePaths are available for all formats.
+	// Types, TargetPaths and ExcludePaths are available for all formats.
 	Types        []string `json:"types,omitempty" yaml:"types,omitempty"`
-	IncludePaths []string `json:"include_paths,omitempty" yaml:"include_paths,omitempty"`
+	TargetPaths  []string `json:"paths,omitempty" yaml:"paths,omitempty"`
 	ExcludePaths []string `json:"exclude_paths,omitempty" yaml:"exclude_paths,omitempty"`
 	// The following options are available depending on input format.
 	Compression         *string `json:"compression,omitempty" yaml:"compression,omitempty"`

--- a/private/bufpkg/bufconfig/input_config.go
+++ b/private/bufpkg/bufconfig/input_config.go
@@ -149,12 +149,11 @@ type InputConfig interface {
 	// IncludePackageFiles returns other files in the same package as the proto file,
 	// not empty only if format is proto file.
 	IncludePackageFiles() bool
-	// TargetPaths returns paths to generate for. Empty value means to generate for all paths.
+	// TargetPaths returns paths to generate for. An empty slice means to generate for all paths.
 	TargetPaths() []string
 	// ExcludePaths returns paths not to generate for.
 	ExcludePaths() []string
-	// IncludeTypes returns the types to generate. If GenerateConfig.GenerateTypeConfig()
-	// returns a non-empty list of types.
+	// IncludeTypes returns the types to generate. An empty slice means to generate for all types.
 	IncludeTypes() []string
 
 	isInputConfig()

--- a/private/bufpkg/bufconfig/input_config.go
+++ b/private/bufpkg/bufconfig/input_config.go
@@ -149,8 +149,8 @@ type InputConfig interface {
 	// IncludePackageFiles returns other files in the same package as the proto file,
 	// not empty only if format is proto file.
 	IncludePackageFiles() bool
-	// IncludePaths returns paths to generate for.
-	IncludePaths() []string
+	// TargetPaths returns paths to generate for. Empty value means to generate for all paths.
+	TargetPaths() []string
 	// ExcludePaths returns paths not to generate for.
 	ExcludePaths() []string
 	// IncludeTypes returns the types to generate. If GenerateConfig.GenerateTypeConfig()
@@ -307,32 +307,6 @@ func NewTextImageInputConfig(
 	}, nil
 }
 
-// NewInputConfigWithTargets returns an input config the same as the passed config,
-// but with include paths, exclude paths and include types overriden.
-func NewInputConfigWithTargets(
-	config InputConfig,
-	includePaths []string,
-	excludePaths []string,
-	includeTypes []string,
-) (InputConfig, error) {
-	originalConfig, ok := config.(*inputConfig)
-	if !ok {
-		return nil, syserror.Newf("unknown implementation of InputConfig: %T", config)
-	}
-	// targetConfig is a copy of the original config.
-	targetConfig := *originalConfig
-	if len(includePaths) > 0 {
-		targetConfig.includePaths = includePaths
-	}
-	if len(excludePaths) > 0 {
-		targetConfig.excludePaths = excludePaths
-	}
-	if len(includeTypes) > 0 {
-		targetConfig.includeTypes = includeTypes
-	}
-	return &targetConfig, nil
-}
-
 // *** PRIVATE ***
 
 type inputConfig struct {
@@ -348,8 +322,8 @@ type inputConfig struct {
 	recurseSubmodules   bool
 	includePackageFiles bool
 	includeTypes        []string
+	targetPaths         []string
 	excludePaths        []string
-	includePaths        []string
 }
 
 func newInputConfigFromExternalV2(externalConfig externalInputConfigV2) (InputConfig, error) {
@@ -495,8 +469,8 @@ func (i *inputConfig) ExcludePaths() []string {
 	return i.excludePaths
 }
 
-func (i *inputConfig) IncludePaths() []string {
-	return i.includePaths
+func (i *inputConfig) TargetPaths() []string {
+	return i.targetPaths
 }
 
 func (i *inputConfig) IncludeTypes() []string {
@@ -556,7 +530,7 @@ func newExternalInputConfigV2FromInputConfig(
 	if inputConfig.IncludePackageFiles() {
 		externalInputConfigV2.IncludePackageFiles = toPointer(inputConfig.IncludePackageFiles())
 	}
-	externalInputConfigV2.IncludePaths = inputConfig.IncludePaths()
+	externalInputConfigV2.TargetPaths = inputConfig.TargetPaths()
 	externalInputConfigV2.ExcludePaths = inputConfig.ExcludePaths()
 	externalInputConfigV2.Types = inputConfig.IncludeTypes()
 	return externalInputConfigV2, nil


### PR DESCRIPTION
Externally, `include_paths` key in `inputs` in buf.gen.yaml v2 is changed to `paths`.

Internally (in Go code), we now refer to it as `targetPaths` whenever possible, instead of `includePaths`.