### PR TITLE
Add `v2` generate configs and modules to `generate` integration tests

### DIFF
--- a/private/buf/cmd/buf/command/generate/testdata/v2/duplicate_plugins/a.proto
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/duplicate_plugins/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package a.v1;
+
+message Foo {}

--- a/private/buf/cmd/buf/command/generate/testdata/v2/duplicate_plugins/buf.gen.yaml
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/duplicate_plugins/buf.gen.yaml
@@ -1,0 +1,10 @@
+# The same plugin can be executed more than once, as long as they are written
+# to different output directories.
+version: v2
+plugins:
+  - protoc_builtin: java
+    out: foo
+  - protoc_builtin: java
+    out: bar
+managed:
+  enabled: false

--- a/private/buf/cmd/buf/command/generate/testdata/v2/simple/a/v1/a.proto
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/simple/a/v1/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package a.v1;
+
+message Foo {}

--- a/private/buf/cmd/buf/command/generate/testdata/v2/simple/buf.gen.yaml
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/simple/buf.gen.yaml
@@ -1,0 +1,6 @@
+version: v2
+plugins:
+  - protoc_builtin: java
+    out: java
+managed:
+  enabled: false

--- a/private/buf/cmd/buf/command/generate/testdata/v2/simple/buf.yaml
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/simple/buf.yaml
@@ -1,0 +1,6 @@
+version: v2
+modules:
+  - directory: .
+    lint:
+      except:
+        - PACKAGE_NO_IMPORT_CYCLE


### PR DESCRIPTION
This adds `v2` generate configs and modules to our
`buf generate` integration tests.