### PR TITLE
Ignore private/buf/buftesting/cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 cmd/buf/buf
 cmd/protoc-gen-buf-breaking/protoc-gen-buf-breaking
 cmd/protoc-gen-buf-lint/protoc-gen-buf-lint
+private/buf/buftesting/cache/
 private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver/protoc-gen-insertion-point-receiver
 private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer/protoc-gen-insertion-point-writer
 private/buf/cmd/buf/command/alpha/protoc/test.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /cmd/buf/buf
 /cmd/protoc-gen-buf-breaking/protoc-gen-buf-breaking
 /cmd/protoc-gen-buf-lint/protoc-gen-buf-lint
+/private/buf/buftesting/cache/
 /private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver/protoc-gen-insertion-point-receiver
 /private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer/protoc-gen-insertion-point-writer
 /private/buf/cmd/buf/command/alpha/protoc/test.txt

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -24,6 +24,7 @@ FILE_IGNORES := $(FILE_IGNORES) \
 	private/buf/cmd/buf/command/alpha/protoc/test.txt \
 	private/buf/cmd/buf/workspacetests/other/proto/workspacetest/cache/ \
 	private/bufpkg/buftesting/cache/ \
+	private/buf/buftesting/cache/ \
 	private/pkg/storage/storageos/tmp/
 LICENSE_HEADER_LICENSE_TYPE := apache
 LICENSE_HEADER_COPYRIGHT_HOLDER := Buf Technologies, Inc.


### PR DESCRIPTION
Switching back and forth between `main` and `bufmod` makes this a constant annoyance. Just doing this for now so there's no issues.