### PR TITLE
Pin bufbuild/registry dependency to prior commit

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -1,5 +1,9 @@
 GO_ALL_REPO_PKGS := ./cmd/... ./private/...
-#GO_GET_PKGS := $(GO_GET_PKGS)
+# Keep bufbuild/registry pinned at version prior to landing the refactor branch.
+# This allows main to continue to build until it is ready to incorporate changes from the refactor branch.
+BUFBUILD_REGISTRY_VERSION := 20231205222057-ac336d436f46
+GO_GET_PKGS := $(GO_GET_PKGS) \
+	buf.build/gen/go/bufbuild/registry/protocolbuffers/go@v1.32.0-$(BUFBUILD_REGISTRY_VERSION).1
 GO_BINS := $(GO_BINS) \
 	cmd/buf \
 	cmd/protoc-gen-buf-breaking \


### PR DESCRIPTION
Update the bufbuild/registry dependency to pin it to the commit prior to landing the refactor branch. This will allow main to continue to upgrade dependencies until the changes to incorporate the refactor branch are landed.