### PR TITLE
Use enable value from managed generate config

### DIFF
--- a/private/bufpkg/bufconfig/generate_managed_config.go
+++ b/private/bufpkg/bufconfig/generate_managed_config.go
@@ -817,7 +817,7 @@ func newExternalManagedConfigV2FromGenerateManagedConfig(
 		)
 	}
 	return externalGenerateManagedConfigV2{
-		Enabled:  true,
+		Enabled:  managedConfig.Enabled(),
 		Disable:  externalDisables,
 		Override: externalOverrides,
 	}


### PR DESCRIPTION
When I was using `buf migrate`, I found that it always set managed
mode to `enabled: true`, regardless of the config I was migrating from.
This is because `newExternalManagedConfigV2FromGenerateManagedConfig`
was not respecting the original value of `enabled` from the managed config.