### PR TITLE
Re-introduce managed mode enabled warning

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -96,6 +96,11 @@ func (g *generator) Generate(
 	for _, option := range options {
 		option(generateOptions)
 	}
+	if !config.GenerateManagedConfig().Enabled() {
+		if len(config.GenerateManagedConfig().Overrides()) != 0 || len(config.GenerateManagedConfig().Disables()) != 0 {
+			g.logger.Sugar().Warn("managed mode configs are set but are not enabled")
+		}
+	}
 	for _, image := range images {
 		if err := bufimagemodify.Modify(image, config.GenerateManagedConfig()); err != nil {
 			return err


### PR DESCRIPTION
We had a warning message where if the user has
managed mode options set but `enabled: false`: #1552.
This warning was originally implemented when reading
the config, which required the config reader to have access
to a logger.

Instead of passing around a logger to the config reader, we can
instead print this message when the `Generate` is called, since
the `generator` has access to a logger.