### PR TITLE
Create a script to collect all bufmod TODOs

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -176,3 +176,7 @@ endif
 	$(SED_I) "s/golang:1\.[0-9][0-9]*\.[0-9][0-9]*/golang:$(GOVERSION)/g" $(shell git-ls-files-unstaged | grep Dockerfile)
 	$(SED_I) "s/golang:1\.[0-9][0-9]*\.[0-9][0-9]*/golang:$(GOVERSION)/g" $(shell git-ls-files-unstaged | grep \.mk$)
 	$(SED_I) "s/go-version: 1\.[0-9][0-9]*\.[0-9][0-9]*/go-version: $(GOVERSION)/g" $(shell git-ls-files-unstaged | grep \.github\/workflows | grep -v previous.yaml)
+
+.PHONY: newtodos
+newtodos:
+	bash make/buf/scripts/newtodos.bash

--- a/make/buf/scripts/bufmodtodos.bash
+++ b/make/buf/scripts/bufmodtodos.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
+cd "${DIR}"
+
+BUFMOD_TODOS="$(git diff main bufmod | awk '
+  /^diff / {f="?"; next}
+  f=="?" {if (/^\+\+\+ /) f=substr($0, 7)"\n"; next}
+  /^@@/ {n=$3; sub(/,.*/,"",n); n=0+$3; next}
+  /^\+.*TODO/ {print f n ":" substr($0,2); f=""}
+  substr($0,1,1)~/[ +]/ {n++}')"
+
+FILENAME=""
+while read -r line; do
+  if [[ "${line}" =~ [a-z,0-9]+.go ]]; then
+    FILENAME="${line}"
+  elif [[ "${line}" =~ PACKAGES.md ]]; then
+    # ignore the contents of PACKAGES.md
+    FILENAME="no print"
+  else
+    if [[ "${FILENAME}" != "no print" ]]; then
+      LINENUMBER="${line%%:*}"
+      TODO="${line#*:}"
+      echo "${FILENAME}": "${LINENUMBER}" "${TODO#"${TODO%%[![:space:]]*}"}"
+    fi
+  fi
+done <<< "${BUFMOD_TODOS}"

--- a/make/buf/scripts/newtodos.bash
+++ b/make/buf/scripts/newtodos.bash
@@ -18,13 +18,12 @@ TODOS="$(git diff "${BASE_BRANCH}" | awk '
 
 FILENAME=""
 while read -r line; do
-  if [[ "${line}" =~ [a-z,0-9]+.go ]]; then
+  if [[ "${line}" =~ [a-z,A-Z,0-9]+\.[a-z]{2,3}$ ]]; then
     FILENAME="${line}"
-  elif [[ "${line}" =~ PACKAGES.md ]]; then
-    # ignore the contents of PACKAGES.md
+  elif [[ "${line}" == *"make/buf/scripts/newtodos.bash"* ]]; then
     FILENAME="no print"
   else
-    if [[ "${FILENAME}" != "no print" ]]; then
+    if [[ "${FILENAME}" != "no print" ]]; then 
       LINENUMBER="${line%%:*}"
       TODO="${line#*:}"
       echo "${FILENAME}":"${LINENUMBER}":"${TODO#"${TODO%%[![:space:]]*}"}"

--- a/make/buf/scripts/newtodos.bash
+++ b/make/buf/scripts/newtodos.bash
@@ -27,7 +27,7 @@ while read -r line; do
     if [[ "${FILENAME}" != "no print" ]]; then
       LINENUMBER="${line%%:*}"
       TODO="${line#*:}"
-      echo "${FILENAME}": "${LINENUMBER}" "${TODO#"${TODO%%[![:space:]]*}"}"
+      echo "${FILENAME}":"${LINENUMBER}":"${TODO#"${TODO%%[![:space:]]*}"}"
     fi
   fi
 done <<< "${TODOS}"

--- a/make/buf/scripts/newtodos.bash
+++ b/make/buf/scripts/newtodos.bash
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
 cd "${DIR}"
 
-BUFMOD_TODOS="$(git diff main bufmod | awk '
+if [ -z "${BASE_BRANCH}" ]; then
+  BASE_BRANCH="main"
+fi
+
+TODOS="$(git diff "${BASE_BRANCH}" | awk '
   /^diff / {f="?"; next}
   f=="?" {if (/^\+\+\+ /) f=substr($0, 7)"\n"; next}
   /^@@/ {n=$3; sub(/,.*/,"",n); n=0+$3; next}
@@ -26,4 +30,4 @@ while read -r line; do
       echo "${FILENAME}": "${LINENUMBER}" "${TODO#"${TODO%%[![:space:]]*}"}"
     fi
   fi
-done <<< "${BUFMOD_TODOS}"
+done <<< "${TODOS}"


### PR DESCRIPTION
This is a script for collecting all `TODO`s on `bufmod` that are
not on `main`. Sample output:

```
private/bufpkg/bufmodule/remote_dep.go: 44 // TODO: This needs a LOT of testing.
private/pkg/connectclient/connectclient.go: 21 // TODO: eliminate config, just make the below MakeOptions, add httpClient as a parameter to Make
private/pkg/dag/graph.go: 45 // TODO: It really stinks that we have to use the constructor. We have what amounts
private/pkg/slicesext/slicesext.go: 146 // TODO: Delete this in favor of slices.Clone.
private/pkg/slicesext/slicesext.go: 166 // TODO: Make ToStructMap use this logic, remove ToStructMapOmitEmpty, to match other functions.
private/pkg/slicesext/slicesext.go: 315 // TODO: Replace with slices.Sort when we only support Go versions >= 1.21.
private/pkg/syncext/syncext.go: 25 // TODO: This is directly copied from 1.21 source, remove when no longer need <1.20.
private/pkg/syncext/syncext.go: 57 // TODO: This is directly copied from 1.21 source, remove when no longer need <1.20.
```