### PR TITLE
Update protocompile to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.32.0-20231115204500-e097f827e652.1
 	connectrpc.com/connect v1.14.0
 	connectrpc.com/otelconnect v0.7.0
-	github.com/bufbuild/protocompile v0.7.1
+	github.com/bufbuild/protocompile v0.8.0
 	github.com/bufbuild/protovalidate-go v0.5.0
 	github.com/bufbuild/protoyaml-go v0.1.7
 	github.com/docker/docker v24.0.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/bufbuild/protocompile v0.7.1 h1:Kd8fb6EshOHXNNRtYAmLAwy/PotlyFoN0iMbuwGNh0M=
-github.com/bufbuild/protocompile v0.7.1/go.mod h1:+Etjg4guZoAqzVk2czwEQP12yaxLJ8DxuqCJ9qHdH94=
+github.com/bufbuild/protocompile v0.8.0 h1:9Kp1q6OkS9L4nM3FYbr8vlJnEwtbpDPQlQOVXfR+78s=
+github.com/bufbuild/protocompile v0.8.0/go.mod h1:+Etjg4guZoAqzVk2czwEQP12yaxLJ8DxuqCJ9qHdH94=
 github.com/bufbuild/protovalidate-go v0.5.0 h1:xFery2RlLh07FQTvB7hlasKqPrDK2ug+uw6DUiuadjo=
 github.com/bufbuild/protovalidate-go v0.5.0/go.mod h1:3XAwFeJ2x9sXyPLgkxufH9sts1tQRk8fdt1AW93NiUU=
 github.com/bufbuild/protoyaml-go v0.1.7 h1:3uKIoNb/l5zrZ93u+Xzsg6cdAO06lveZE/K7UUbUQLw=

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -1273,8 +1273,6 @@ func (f *formatter) writeCompositeValueForArrayLiteral(
 	switch node := compositeNode.(type) {
 	case *ast.CompoundStringLiteralNode:
 		f.writeCompoundStringLiteralForArray(node, lastElement)
-	case *ast.PositiveUintLiteralNode:
-		f.writePositiveUintLiteralForArray(node, lastElement)
 	case *ast.NegativeIntLiteralNode:
 		f.writeNegativeIntLiteralForArray(node, lastElement)
 	case *ast.SignedFloatLiteralNode:
@@ -1569,29 +1567,6 @@ func (f *formatter) writeNegativeIntLiteralForArray(
 	f.writeInline(negativeIntLiteralNode.Uint)
 }
 
-// writePositiveUintLiteral writes a positive uint literal (e.g. '+42').
-func (f *formatter) writePositiveUintLiteral(positiveIntLiteralNode *ast.PositiveUintLiteralNode) {
-	f.writeInline(positiveIntLiteralNode.Plus)
-	f.writeInline(positiveIntLiteralNode.Uint)
-}
-
-// writePositiveUintLiteralForArray writes a positive uint literal value, but writes
-// its comments suitable for an element in an array literal.
-//
-// The lastElement boolean is used to signal whether or not the value should
-// be written as the last element (i.e. it doesn't have a trailing comma).
-func (f *formatter) writePositiveUintLiteralForArray(
-	positiveIntLiteralNode *ast.PositiveUintLiteralNode,
-	lastElement bool,
-) {
-	f.writeStart(positiveIntLiteralNode.Plus)
-	if lastElement {
-		f.writeLineEnd(positiveIntLiteralNode.Uint)
-		return
-	}
-	f.writeInline(positiveIntLiteralNode.Uint)
-}
-
 // writeIdent writes an identifier (e.g. 'foo').
 func (f *formatter) writeIdent(identNode *ast.IdentNode) {
 	f.WriteString(identNode.Val)
@@ -1670,8 +1645,6 @@ func (f *formatter) writeNode(node ast.Node) {
 		f.writeOptionName(element)
 	case *ast.PackageNode:
 		f.writePackage(element)
-	case *ast.PositiveUintLiteralNode:
-		f.writePositiveUintLiteral(element)
 	case *ast.RangeNode:
 		f.writeRange(element)
 	case *ast.ReservedNode:


### PR DESCRIPTION
This removes an AST node type that is no longer used (and was never actually allowed in the language... a mistake in protocompile). See https://github.com/bufbuild/protocompile/pull/229 for more details.