### PR TITLE
Resolve TODOs for Windows duplicated path separator tests

### DIFF
--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -751,8 +751,11 @@ func getReadBucketCloserForOSProtoFile(
 				return nil, err
 			}
 			pwd = normalpath.Normalize(pwd)
-			// Removing the root so we can make mapPath relative.
-			protoTerminateFileDirPath, err = normalpath.Rel(pwd[1:], mapPath)
+			protoTerminateFileDirPath, err = normalpath.Rel(
+				// Deleting leading os.PathSeparator so we can make mapPath relative.
+				normalpath.Normalize(normalpath.Join(normalpath.Components(pwd)[1:]...)),
+				mapPath,
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -750,7 +750,6 @@ func getReadBucketCloserForOSProtoFile(
 			if err != nil {
 				return nil, err
 			}
-			pwd = normalpath.Normalize(pwd)
 			protoTerminateFileDirPath, err = normalpath.Rel(
 				// Deleting leading os.PathSeparator so we can make mapPath relative.
 				normalpath.Normalize(normalpath.Join(normalpath.Components(pwd)[1:]...)),

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -585,11 +585,17 @@ func getReadWriteBucketForOS(
 	if err != nil {
 		return nil, err
 	}
+	var inputSubDirPath string
+	if len(absInputDirPathComponents) > 1 {
+		// The first component is the FS root, so we check this is safe and join
+		// the rest of the components for the relative input subdir path.
+		inputSubDirPath = normalpath.Join(absInputDirPathComponents[1:]...)
+	}
 	mapPath, subDirPath, _, err := getMapPathAndSubDirPath(
 		ctx,
 		logger,
 		osRootBucket,
-		normalpath.Join(absInputDirPathComponents[1:]...), // relative path to the FS root
+		inputSubDirPath,
 		terminateFunc,
 	)
 	if err != nil {
@@ -616,11 +622,17 @@ func getReadWriteBucketForOS(
 		if err != nil {
 			return nil, err
 		}
-		bucketPath, err = normalpath.Rel(
-			// Deleting leading os.PathSeparator so we can make mapPath relative.
-			normalpath.Normalize(normalpath.Join(normalpath.Components(pwd)[1:]...)),
-			mapPath,
-		)
+		// Removing the root so we can make mapPath relative.
+		// We are using normalpath.Components to split the path and remove the root (first component).
+		// The length of the root may vary depending on the OS and file path type (e.g. Windows paths),
+		// but normalpath.Components takes care of that.
+		pwdComponents := normalpath.Components(pwd)
+		if len(pwdComponents) > 1 {
+			pwd = normalpath.Normalize(normalpath.Join(pwdComponents[1:]...))
+		} else {
+			pwd = ""
+		}
+		bucketPath, err = normalpath.Rel(pwd, mapPath)
 		if err != nil {
 			return nil, err
 		}
@@ -690,13 +702,19 @@ func getReadBucketCloserForOSProtoFile(
 	if err != nil {
 		return nil, err
 	}
+	var inputSubDirPath string
+	if len(absProtoFileDirPathComponents) > 1 {
+		// The first component is the FS root, so we check this is safe and join
+		// the rest of the components for the relative input subdir path.
+		inputSubDirPath = normalpath.Join(absProtoFileDirPathComponents[1:]...)
+	}
 	// mapPath is the path to the bucket that contains a buf.yaml.
 	// subDirPath is the relative path from mapPath to the protoFileDirPath, but we don't use it.
 	mapPath, _, terminate, err := getMapPathAndSubDirPath(
 		ctx,
 		logger,
 		osRootBucket,
-		normalpath.Join(absProtoFileDirPathComponents[1:]...), // relative path to the FS root
+		inputSubDirPath,
 		protoFileTerminateFunc,
 	)
 	if err != nil {
@@ -750,11 +768,17 @@ func getReadBucketCloserForOSProtoFile(
 			if err != nil {
 				return nil, err
 			}
-			protoTerminateFileDirPath, err = normalpath.Rel(
-				// Deleting leading os.PathSeparator so we can make mapPath relative.
-				normalpath.Normalize(normalpath.Join(normalpath.Components(pwd)[1:]...)),
-				mapPath,
-			)
+			// Removing the root so we can make mapPath relative.
+			// We are using normalpath.Components to split the path and remove the root (first component).
+			// The length of the root may vary depending on the OS and file path type (e.g. Windows paths),
+			// but normalpath.Components takes care of that.
+			pwdComponents := normalpath.Components(pwd)
+			if len(pwdComponents) > 1 {
+				pwd = normalpath.Normalize(normalpath.Join(pwdComponents[1:]...))
+			} else {
+				pwd = ""
+			}
+			protoTerminateFileDirPath, err = normalpath.Rel(pwd, mapPath)
 			if err != nil {
 				return nil, err
 			}

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -616,9 +616,11 @@ func getReadWriteBucketForOS(
 		if err != nil {
 			return nil, err
 		}
-		pwd = normalpath.Normalize(pwd)
-		// Deleting leading os.PathSeparator so we can make mapPath relative.
-		bucketPath, err = normalpath.Rel(pwd[1:], mapPath)
+		bucketPath, err = normalpath.Rel(
+			// Deleting leading os.PathSeparator so we can make mapPath relative.
+			normalpath.Normalize(normalpath.Join(normalpath.Components(pwd)[1:]...)),
+			mapPath,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -749,7 +751,7 @@ func getReadBucketCloserForOSProtoFile(
 				return nil, err
 			}
 			pwd = normalpath.Normalize(pwd)
-			// Deleting leading os.PathSeparator so we can make mapPath relative.
+			// Removing the root so we can make mapPath relative.
 			protoTerminateFileDirPath, err = normalpath.Rel(pwd[1:], mapPath)
 			if err != nil {
 				return nil, err

--- a/private/buf/bufworkspace/option.go
+++ b/private/buf/bufworkspace/option.go
@@ -221,7 +221,7 @@ func newWorkspaceBucketConfig(options []WorkspaceBucketOption) (*workspaceBucket
 					// We clean and unnormalize the target paths to show in the error message
 					unnormalizedTargetExcludePath := filepath.Clean(normalpath.Unnormalize(targetExcludePath))
 					unnormalizedTargetPath := filepath.Clean(normalpath.Unnormalize(targetPath))
-					return nil, fmt.Errorf("excluded path %q contains targeted path %q, which means all paths in %q will be excluded", unnormalizedTargetExcludePath, unnormalizedTargetPath, unnormalizedTargetPath)
+					return nil, fmt.Errorf(`excluded path "%s" contains targeted path "%s", which means all paths in "%s" will be excluded`, unnormalizedTargetExcludePath, unnormalizedTargetPath, unnormalizedTargetPath)
 				}
 			}
 		}

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -1479,9 +1478,6 @@ func TestExportProtoFileRefWithPathFlag(t *testing.T) {
 }
 
 func TestBuildWithPaths(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO: fix on windows, handling duplicated path separator")
-	}
 	t.Parallel()
 	testRunStdout(t, nil, 0, ``, "build", filepath.Join("testdata", "paths"), "--path", filepath.Join("testdata", "paths", "a", "v3"), "--exclude-path", filepath.Join("testdata", "paths", "a", "v3", "foo"))
 	testRunStdoutStderrNoWarn(
@@ -1502,9 +1498,6 @@ func TestBuildWithPaths(t *testing.T) {
 }
 
 func TestLintWithPaths(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO: fix on windows, handling duplicated path separator")
-	}
 	t.Parallel()
 	testRunStdoutStderrNoWarn(
 		t,
@@ -1537,9 +1530,6 @@ func TestLintWithPaths(t *testing.T) {
 }
 
 func TestBreakingWithPaths(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO: fix on windows, handling duplicated path separator")
-	}
 	t.Parallel()
 	tempDir := t.TempDir()
 	testRunStdout(t, nil, 0, ``, "build", filepath.Join("command", "generate", "testdata", "paths"), "-o", filepath.Join(tempDir, "previous.binpb"))

--- a/private/buf/cmd/buf/command/generate/generate_windows_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_windows_test.go
@@ -83,8 +83,7 @@ func TestOutputWithPathWithinExclude(t *testing.T) {
 		``,
 		// This is new post-refactor. Before, we gave precedence to --path. While a change,
 		// doing --path foo/bar --exclude-path foo seems like a bug rather than expected behavior to maintain.
-		// TODO: figure out why duplicated path separators are not cleaned by filepath.Clean
-		`Failure: excluded path "testdata\\paths\\a" contains targeted path "testdata\\paths\\a\\v1\\a.proto", which means all paths in "testdata\\paths\\a\\v1\\a.proto" will be excluded`,
+		`Failure: excluded path "testdata\paths\a" contains targeted path "testdata\paths\a\v1\a.proto", which means all paths in "testdata\paths\a\v1\a.proto" will be excluded`,
 		"--output",
 		tempDirPath,
 		"--template",
@@ -128,8 +127,7 @@ func TestOutputWithNestedExcludeAndTargetPaths(t *testing.T) {
 		``,
 		// This is new post-refactor. Before, we gave precedence to --path. While a change,
 		// doing --path foo/bar --exclude-path foo seems like a bug rather than expected behavior to maintain.
-		// TODO: figure out why duplicated path separators are not cleaned by filepath.Clean
-		`Failure: excluded path "a\\v3" contains targeted path "a\\v3\\foo", which means all paths in "a\\v3\\foo" will be excluded`,
+		`Failure: excluded path "a\v3" contains targeted path "a\v3\foo", which means all paths in "a\v3\foo" will be excluded`,
 		"--output",
 		tempDirPath,
 		"--template",
@@ -153,8 +151,7 @@ func TestWorkspaceGenerateWithExcludeAndTargetPaths(t *testing.T) {
 		``,
 		// This is new post-refactor. Before, we gave precedence to --path. While a change,
 		// doing --path foo/bar --exclude-path foo seems like a bug rather than expected behavior to maintain.
-		// TODO: figure out why duplicated path separators are not cleaned by filepath.Clean
-		`Failure: excluded path "testdata\\workspace\\a\\v3" contains targeted path "testdata\\workspace\\a\\v3\\foo", which means all paths in "testdata\\workspace\\a\\v3\\foo" will be excluded`,
+		`Failure: excluded path "testdata\workspace\a\v3" contains targeted path "testdata\workspace\a\v3\foo", which means all paths in "testdata\workspace\a\v3\foo" will be excluded`,
 		"--output",
 		tempDirPath,
 		"--template",


### PR DESCRIPTION
Overall, this PR resolves the TODOs that were set for duplicated path
separators in errors returned from Windows by addressing the following:
- `%q` when setting the error for excluded paths escaped the Windows file paths, which uses a separator that is already escaped, so this created "duplicated" backslashes
- found a buf in `buffetch` where we are not handling the root path component correctly