### PR TITLE
Fix InvalidRemoteErr panic

### DIFF
--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -93,9 +93,13 @@ func run(
 	}
 	var dependencyModulePins []bufmoduleref.ModulePin
 	if len(requestReferences) > 0 {
-		var remote string
+		var (
+			remote         string
+			moduleIdentity string
+		)
 		if config.ModuleIdentity != nil && config.ModuleIdentity.Remote() != "" {
 			remote = config.ModuleIdentity.Remote()
+			moduleIdentity = config.ModuleIdentity.IdentityString()
 		} else {
 			// At this point we know there's at least one dependency. If it's an unnamed module, select
 			// the right remote from the list of dependencies.
@@ -104,10 +108,11 @@ func run(
 				return fmt.Errorf(`File %q has invalid "deps" references`, existingConfigFilePath)
 			}
 			remote = selectedRef.Remote()
+			moduleIdentity = selectedRef.IdentityString()
 			container.Logger().Debug(fmt.Sprintf(
 				`File %q does not specify the "name" field. Based on the dependency %q, it appears that you are using a BSR instance at %q. Did you mean to specify "name: %s/..." within %q?`,
 				existingConfigFilePath,
-				selectedRef.IdentityString(),
+				moduleIdentity,
 				remote,
 				remote,
 				existingConfigFilePath,
@@ -126,7 +131,7 @@ func run(
 		)
 		if err != nil {
 			if remote != bufconnect.DefaultRemote {
-				return bufcli.NewInvalidRemoteError(err, remote, config.ModuleIdentity.IdentityString())
+				return bufcli.NewInvalidRemoteError(err, remote, moduleIdentity)
 			}
 			return err
 		}

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -94,12 +94,12 @@ func run(
 	var dependencyModulePins []bufmoduleref.ModulePin
 	if len(requestReferences) > 0 {
 		var (
-			remote         string
-			moduleIdentity string
+			remote               string
+			moduleIdentityString string
 		)
 		if config.ModuleIdentity != nil && config.ModuleIdentity.Remote() != "" {
 			remote = config.ModuleIdentity.Remote()
-			moduleIdentity = config.ModuleIdentity.IdentityString()
+			moduleIdentityString = config.ModuleIdentity.IdentityString()
 		} else {
 			// At this point we know there's at least one dependency. If it's an unnamed module, select
 			// the right remote from the list of dependencies.
@@ -108,11 +108,11 @@ func run(
 				return fmt.Errorf(`File %q has invalid "deps" references`, existingConfigFilePath)
 			}
 			remote = selectedRef.Remote()
-			moduleIdentity = selectedRef.IdentityString()
+			moduleIdentityString = selectedRef.IdentityString()
 			container.Logger().Debug(fmt.Sprintf(
 				`File %q does not specify the "name" field. Based on the dependency %q, it appears that you are using a BSR instance at %q. Did you mean to specify "name: %s/..." within %q?`,
 				existingConfigFilePath,
-				moduleIdentity,
+				moduleIdentityString,
 				remote,
 				remote,
 				existingConfigFilePath,
@@ -131,7 +131,7 @@ func run(
 		)
 		if err != nil {
 			if !connect.IsWireError(err) && remote != bufconnect.DefaultRemote {
-				return bufcli.NewInvalidRemoteError(err, remote, moduleIdentity)
+				return bufcli.NewInvalidRemoteError(err, remote, moduleIdentityString)
 			}
 			return err
 		}

--- a/private/buf/cmd/buf/command/mod/modprune/modprune.go
+++ b/private/buf/cmd/buf/command/mod/modprune/modprune.go
@@ -130,7 +130,7 @@ func run(
 			}),
 		)
 		if err != nil {
-			if remote != bufconnect.DefaultRemote {
+			if !connect.IsWireError(err) && remote != bufconnect.DefaultRemote {
 				return bufcli.NewInvalidRemoteError(err, remote, moduleIdentity)
 			}
 			return err

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -216,12 +216,12 @@ func getDependencies(
 		return nil, nil
 	}
 	var (
-		remote         string
-		moduleIdentity string
+		remote               string
+		moduleIdentityString string
 	)
 	if moduleConfig.ModuleIdentity != nil && moduleConfig.ModuleIdentity.Remote() != "" {
 		remote = moduleConfig.ModuleIdentity.Remote()
-		moduleIdentity = moduleConfig.ModuleIdentity.IdentityString()
+		moduleIdentityString = moduleConfig.ModuleIdentity.IdentityString()
 	} else {
 		// At this point we know there's at least one dependency. If it's an unnamed module, select
 		// the right remote from the list of dependencies.
@@ -230,11 +230,11 @@ func getDependencies(
 			return nil, fmt.Errorf(`File %q has invalid "deps" references`, existingConfigFilePath)
 		}
 		remote = selectedRef.Remote()
-		moduleIdentity = selectedRef.IdentityString()
+		moduleIdentityString = selectedRef.IdentityString()
 		container.Logger().Debug(fmt.Sprintf(
 			`File %q does not specify the "name" field. Based on the dependency %q, it appears that you are using a BSR instance at %q. Did you mean to specify "name: %s/..." within %q?`,
 			existingConfigFilePath,
-			moduleIdentity,
+			moduleIdentityString,
 			remote,
 			remote,
 			existingConfigFilePath,
@@ -274,7 +274,7 @@ func getDependencies(
 	)
 	if err != nil {
 		if !connect.IsWireError(err) && remote != bufconnect.DefaultRemote {
-			return nil, bufcli.NewInvalidRemoteError(err, remote, moduleIdentity)
+			return nil, bufcli.NewInvalidRemoteError(err, remote, moduleIdentityString)
 		}
 		return nil, err
 	}

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -273,7 +273,7 @@ func getDependencies(
 		}),
 	)
 	if err != nil {
-		if remote != bufconnect.DefaultRemote {
+		if !connect.IsWireError(err) && remote != bufconnect.DefaultRemote {
 			return nil, bufcli.NewInvalidRemoteError(err, remote, moduleIdentity)
 		}
 		return nil, err

--- a/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
+++ b/private/buf/cmd/buf/command/mod/modupdate/modupdate.go
@@ -215,9 +215,13 @@ func getDependencies(
 	if len(moduleConfig.Build.DependencyModuleReferences) == 0 {
 		return nil, nil
 	}
-	var remote string
+	var (
+		remote         string
+		moduleIdentity string
+	)
 	if moduleConfig.ModuleIdentity != nil && moduleConfig.ModuleIdentity.Remote() != "" {
 		remote = moduleConfig.ModuleIdentity.Remote()
+		moduleIdentity = moduleConfig.ModuleIdentity.IdentityString()
 	} else {
 		// At this point we know there's at least one dependency. If it's an unnamed module, select
 		// the right remote from the list of dependencies.
@@ -226,10 +230,11 @@ func getDependencies(
 			return nil, fmt.Errorf(`File %q has invalid "deps" references`, existingConfigFilePath)
 		}
 		remote = selectedRef.Remote()
+		moduleIdentity = selectedRef.IdentityString()
 		container.Logger().Debug(fmt.Sprintf(
 			`File %q does not specify the "name" field. Based on the dependency %q, it appears that you are using a BSR instance at %q. Did you mean to specify "name: %s/..." within %q?`,
 			existingConfigFilePath,
-			selectedRef.IdentityString(),
+			moduleIdentity,
 			remote,
 			remote,
 			existingConfigFilePath,
@@ -269,7 +274,7 @@ func getDependencies(
 	)
 	if err != nil {
 		if remote != bufconnect.DefaultRemote {
-			return nil, bufcli.NewInvalidRemoteError(err, remote, moduleConfig.ModuleIdentity.IdentityString())
+			return nil, bufcli.NewInvalidRemoteError(err, remote, moduleIdentity)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
On an unknown remote ModuleIdentity may be nil. Use the fallback logic to select the correct dependency and derive the related module identity. Fixes #2725

A dial error for an invalid host will now correctly return the error formatted with a prompt to check the registry:
```
Failure: dial tcp: lookup private.registry: no such host. Are you sure "private.registry" (derived from module name "private.registry/org/dependency") is a Buf Schema Registry?
```