### PR TITLE
Enable govet nilness check and fix infractions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,9 @@ linters-settings:
       - '^log\.'
       - '^print$'
       - '^println$'
+  govet:
+    enable:
+      - nilness
   importas:
     alias:
       - pkg: github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1

--- a/private/buf/bufsync/syncer.go
+++ b/private/buf/bufsync/syncer.go
@@ -641,9 +641,6 @@ func (s *syncer) protectSyncedModuleBranch(
 	if err != nil {
 		return fmt.Errorf("resolve sync point for module %s: %w", moduleIdentity.IdentityString(), err)
 	}
-	if err != nil {
-		return err
-	}
 	if syncPoint == nil {
 		// Branch has never been synced, there is nothing to protected against.
 		return nil

--- a/private/buf/cmd/buf/command/beta/graph/graph.go
+++ b/private/buf/cmd/buf/command/beta/graph/graph.go
@@ -129,9 +129,6 @@ func run(
 		bufcli.NewFetchReader(container.Logger(), storageosProvider, runner, moduleResolver, moduleReader),
 		bufmodulebuild.NewModuleBucketBuilder(),
 	)
-	if err != nil {
-		return err
-	}
 	graphBuilder := bufgraph.NewBuilder(
 		container.Logger(),
 		moduleResolver,

--- a/private/bufpkg/bufimage/bufimagemodify/java_multiple_files.go
+++ b/private/bufpkg/bufimage/bufimagemodify/java_multiple_files.go
@@ -87,7 +87,7 @@ func javaMultipleFilesForFile(
 			// The option is already set to the same value, don't do anything.
 			return nil
 		}
-	case options == nil && descriptorpb.Default_FileOptions_JavaMultipleFiles == value:
+	case descriptorpb.Default_FileOptions_JavaMultipleFiles == value:
 		// The option is not set, but the value we want to set is the
 		// same as the default, don't do anything.
 		return nil

--- a/private/pkg/protosource/file.go
+++ b/private/pkg/protosource/file.go
@@ -638,9 +638,6 @@ func (f *file) populateMessage(
 			getMessageExtensionPackedPath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
 			getMessageExtensionExtendeePath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
 		)
-		if err != nil {
-			return nil, err
-		}
 		message.addExtension(field)
 		if oneof != nil {
 			oneof.addField(field)


### PR DESCRIPTION
Seems like a reasonable check; removes some unnecessary extra code.

Some of these codepaths don't exist in `bufmod`, but happy to port over this check and fixes there as well.