### PR TITLE
Enable govet nilness check and fix infractions (#2729)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,9 @@ linters-settings:
       - '^log\.'
       - '^print$'
       - '^println$'
+  govet:
+    enable:
+      - nilness
   importas:
     alias:
       - pkg: github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -130,9 +130,6 @@ func run(
 	if err != nil {
 		return err
 	}
-	if err != nil {
-		return err
-	}
 	var allFileAnnotations []bufanalysis.FileAnnotation
 	for _, imageWithConfig := range imageWithConfigs {
 		if err := buflint.NewHandler(

--- a/private/pkg/protosource/file.go
+++ b/private/pkg/protosource/file.go
@@ -638,9 +638,6 @@ func (f *file) populateMessage(
 			getMessageExtensionPackedPath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
 			getMessageExtensionExtendeePath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
 		)
-		if err != nil {
-			return nil, err
-		}
 		message.addExtension(field)
 		if oneof != nil {
 			oneof.addField(field)


### PR DESCRIPTION
Merges latest `main` into `bufmod` and enforces the checks introduced in #2729 on this branch.