### PR TITLE
Simplify uuidutil.ToDashless to not return an error

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -208,19 +208,16 @@ func run(
 			},
 		)
 	} else {
-		lines, err = slicesext.MapError(
-			commits,
-			// Printing dashless for historical reasons.
-			func(commit bufmodule.Commit) (string, error) {
-				return uuidutil.ToDashless(commit.ModuleKey().CommitID())
-			},
-		)
-		if err != nil {
-			return err
-		}
 		if len(commits) > 1 {
 			linesErr = syserror.Newf("Received multiple commits back for a v1 module. We should only ever have created a single commit for a v1 module.")
 		}
+		lines = slicesext.Map(
+			commits,
+			// Printing dashless for historical reasons.
+			func(commit bufmodule.Commit) string {
+				return uuidutil.ToDashless(commit.ModuleKey().CommitID())
+			},
+		)
 	}
 	if _, err := container.Stdout().Write([]byte(strings.Join(lines, "\n") + "\n")); err != nil {
 		return err

--- a/private/bufpkg/bufconfig/buf_lock_file.go
+++ b/private/bufpkg/bufconfig/buf_lock_file.go
@@ -374,10 +374,7 @@ func writeBufLockFile(
 			if err != nil {
 				return err
 			}
-			externalCommitID, err := uuidutil.ToDashless(depModuleKey.CommitID())
-			if err != nil {
-				return err
-			}
+			externalCommitID := uuidutil.ToDashless(depModuleKey.CommitID())
 			externalBufLockFile.Deps[i] = externalBufLockFileDepV1Beta1V1{
 				Remote:     depModuleKey.ModuleFullName().Registry(),
 				Owner:      depModuleKey.ModuleFullName().Owner(),

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -301,10 +301,7 @@ func imageFilesToFileDescriptorProtos(imageFiles []ImageFile) []*descriptorpb.Fi
 
 func imageFileToProtoImageFile(imageFile ImageFile) (*imagev1.ImageFile, error) {
 	// Need to use dashless for historical reasons.
-	protoCommitID, err := uuidutil.ToDashless(imageFile.CommitID())
-	if err != nil {
-		return nil, err
-	}
+	protoCommitID := uuidutil.ToDashless(imageFile.CommitID())
 	return fileDescriptorProtoToProtoImageFile(
 		imageFile.FileDescriptorProto(),
 		imageFile.IsImport(),

--- a/private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-commit-id-to-dashless/commitidtodashless.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-commit-id-to-dashless/commitidtodashless.go
@@ -71,10 +71,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	commitIDString, err := uuidutil.ToDashless(commitID)
-	if err != nil {
-		return err
-	}
+	commitIDString := uuidutil.ToDashless(commitID)
 	_, err = container.Stdout().Write([]byte(commitIDString + "\n"))
 	return err
 }

--- a/private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-new-commit-id/newcommitid.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-new-commit-id/newcommitid.go
@@ -85,10 +85,7 @@ func run(
 	var commitIDString string
 	switch flags.Type {
 	case "v1":
-		commitIDString, err = uuidutil.ToDashless(commitID)
-		if err != nil {
-			return err
-		}
+		commitIDString = uuidutil.ToDashless(commitID)
 	case "v2":
 		commitIDString = commitID.String()
 	default:

--- a/private/pkg/uuidutil/uuidutil.go
+++ b/private/pkg/uuidutil/uuidutil.go
@@ -30,21 +30,9 @@ func New() (uuid.UUID, error) {
 }
 
 // ToDashless returns the uuid without dashes.
-func ToDashless(id uuid.UUID) (string, error) {
+func ToDashless(id uuid.UUID) string {
 	s := id.String()
-	if s[8] != '-' {
-		return "", fmt.Errorf("expected - at char 9: %q", s)
-	}
-	if s[13] != '-' {
-		return "", fmt.Errorf("expected - at char 14: %q", s)
-	}
-	if s[18] != '-' {
-		return "", fmt.Errorf("expected - at char 19: %q", s)
-	}
-	if s[23] != '-' {
-		return "", fmt.Errorf("expected - at char 24: %q", s)
-	}
-	return s[0:8] + s[9:13] + s[14:18] + s[19:23] + s[24:], nil
+	return s[0:8] + s[9:13] + s[14:18] + s[19:23] + s[24:]
 }
 
 // FromString returns the uuid from the string.

--- a/private/pkg/uuidutil/uuidutil_test.go
+++ b/private/pkg/uuidutil/uuidutil_test.go
@@ -25,8 +25,7 @@ func TestRoundTrip(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		id, err := New()
 		require.NoError(t, err)
-		dashless, err := ToDashless(id)
-		require.NoError(t, err)
+		dashless := ToDashless(id)
 		roundTripID, err := FromDashless(dashless)
 		require.NoError(t, err)
 		require.Equal(t, id, roundTripID)
@@ -37,8 +36,7 @@ func TestFromStringFailsWithDashless(t *testing.T) {
 	t.Parallel()
 	id, err := New()
 	require.NoError(t, err)
-	dashless, err := ToDashless(id)
-	require.NoError(t, err)
+	dashless := ToDashless(id)
 	_, err = FromString(dashless)
 	require.Error(t, err)
 }
@@ -55,8 +53,7 @@ func TestValidateFailsWithDashless(t *testing.T) {
 	t.Parallel()
 	id, err := New()
 	require.NoError(t, err)
-	dashless, err := ToDashless(id)
-	require.NoError(t, err)
+	dashless := ToDashless(id)
 	err = Validate(dashless)
 	require.Error(t, err)
 }
@@ -75,11 +72,7 @@ func TestFromStringSliceFailsWithDashless(t *testing.T) {
 	require.NoError(t, err)
 	id2, err := New()
 	require.NoError(t, err)
-	dashless1, err := ToDashless(id1)
-	require.NoError(t, err)
-	dashless2, err := ToDashless(id2)
-	require.NoError(t, err)
-	dashless := []string{dashless1, dashless2}
+	dashless := []string{ToDashless(id1), ToDashless(id2)}
 	_, err = FromStringSlice(dashless)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Update the ToDashless function to not return an error, simplifying call sites. The error checking will only fail if there is a major issue in the uuid module and would be caught by existing unit tests in uuidutil_test.go.