### PR TITLE
Improvements to Docker tagging set up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,25 +94,23 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: set-tags
-        # See the following links for setting job outputs
-        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs
-        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
-        id: tags
-        run: |
-          {
-            echo "tags<<EOF"
-            echo "bufbuild/buf:unstable"
-            if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-              echo "bufbuild/buf:latest"
-              echo "bufbuild/buf:${GITHUB_REF#refs/tags/v}"
-            fi
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
+      - name: docker-meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            bufbuild/buf
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+          flavor: |
+            latest=auto
       - name: docker-build-push
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.buf
           platforms: ${{ steps.qemu.outputs.platforms }}
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,7 @@ jobs:
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{version}}
           flavor: |
             latest=auto
       - name: docker-build-push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,23 +94,25 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      - name: set-tag
+      - name: set-tags
         # See the following links for setting job outputs
         # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
-        id: tag
+        id: tags
         run: |
-          if echo "${GITHUB_REF}" | grep ^refs/heads/main$ >/dev/null; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          elif echo "${GITHUB_REF}" | grep ^refs/tags/v >/dev/null; then
-            echo "tag=${GITHUB_REF}" | sed "s|refs/tags/v||" >> $GITHUB_OUTPUT
-          fi
+          {
+            echo "tags<<EOF"
+            echo "bufbuild/buf:unstable"
+            if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+              echo "bufbuild/buf:latest"
+              echo "bufbuild/buf:${GITHUB_REF#refs/tags/v}"
+            fi
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
       - name: docker-build-push
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.buf
           platforms: ${{ steps.qemu.outputs.platforms }}
           push: true
-          tags: |
-            bufbuild/buf:latest
-            bufbuild/buf:${{ steps.tag.outputs.tag }}
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
Uses the official Docker action for generating tag names based on GitHub metadata. This should do the following:

- `latest` tag: Now should only be updated when there is a release tag. This is handled by the `flavor` argument.
- Added `edge` tag that matches the latest commit on main, similar to official Docker images.
- Added semver tags. A tag of v1.2.3 should result in pushes to `1`, `1.2` and `1.2.3` allowing users to track the latest v1 or latest patch release of a minor release.

~~I'm not sure how to actually test this, right now. I may need to set up a separate Docker repo on my fork.~~ Done, works.

P.S.: Merging into `main` first because we want to probably stop updating the `latest` tag ASAP.

P.P.S.: Just so it is clear, the way that Docker handles it indeed expects the semver version to look like `v1.2.3` and then pushes something like `1.2.3`. I checked this with [the docs](https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver) and also [with my own test repo](https://github.com/jchadwick-buf/buf/actions/runs/7728812242/job/21070560056#step:5:104).