### PR TITLE
Add make bufbinarysize and buf-binary-size GitHub Actions job

### DIFF
--- a/.github/workflows/buf-binary-size.yaml
+++ b/.github/workflows/buf-binary-size.yaml
@@ -1,0 +1,31 @@
+name: previous
+on: push
+# Prevent writing to the repository using the CI token.
+# Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
+permissions: read-all
+env:
+  MAKEFLAGS: "-j 2"
+jobs:
+  buf-binary-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+      - name: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/buf/${{ runner.os }}/x86_64/bin
+            ~/.cache/buf/${{ runner.os }}/x86_64/go/pkg/mod
+            ~/.cache/buf/${{ runner.os }}/x86_64/gocache
+            ~/.cache/buf/${{ runner.os }}/x86_64/include
+            ~/.cache/buf/${{ runner.os }}/x86_64/versions
+          key: ${{ runner.os }}-buf-${{ hashFiles('**/go.sum', 'make/**') }}
+          restore-keys: |
+            ${{ runner.os }}-buf-
+      - name: make-bufbinarysize
+        run: make bufbinarysize

--- a/.github/workflows/buf-binary-size.yaml
+++ b/.github/workflows/buf-binary-size.yaml
@@ -1,4 +1,4 @@
-name: previous
+name: binary-size
 on: push
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -132,6 +132,10 @@ bufgeneratesteps:: \
 bufrelease: $(MINISIGN)
 	DOCKER_IMAGE=golang:1.21-bullseye bash make/buf/scripts/release.bash
 
+.PHONY: bufbinarysize
+bufbinarysize:
+	@bash make/buf/scripts/binarysize.bash ./cmd/buf
+
 .PHONY: updateversion
 updateversion:
 ifndef VERSION

--- a/make/buf/scripts/binarysize.bash
+++ b/make/buf/scripts/binarysize.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
+cd "${DIR}"
+
+TMP="$(mktemp -d )"
+trap 'rm -rf "${TMP}"' EXIT
+
+fail() {
+  echo "error: $@" >&2
+  exit 1
+}
+
+size_bytes() {
+  case "$(uname -s)" in
+    Darwin) stat -f%z "${1}" ;;
+    Linux) stat -c%s "${1}" ;;
+    *) fail "must be run on darwin or linux" ;;
+  esac
+}
+
+# Build in the same manner as we do in release.bash.
+CGO_ENABLED=0 \
+  GOOS=darwin \
+  GOARCH=arm64 \
+  go build -a -ldflags "-s -w" -trimpath -buildvcs=false \
+  -o "${TMP}/bin" \
+  "${1}"
+
+echo "$(awk "BEGIN { printf(\"%.2f\", $(size_bytes "${TMP}/bin") / 1048576.0) }") MB"


### PR DESCRIPTION
I constantly want access to the binary size for each commit. This is quick and dirty - a better option would be to print out the binary size for the latest commit on `main` as well, the latest release, and give more information (os/arch).