### PR TITLE
Add standard opencontainers labels to images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,3 +115,4 @@ jobs:
           platforms: ${{ steps.qemu.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Update the Docker build to specify standard opencontainers labels on images using hte docker/metadata-action.