### PR TITLE
Check for duplicate files on Build

### DIFF
--- a/private/bufpkg/bufmodule/errors.go
+++ b/private/bufpkg/bufmodule/errors.go
@@ -155,6 +155,23 @@ func (m *ModuleCycleError) Error() string {
 	return builder.String()
 }
 
+// DuplicatePathError is the error returned if a path is duplicated in a module.
+//
+// This is returned by Build on a [ModuleSetBuilder].
+type DuplicatePathError struct {
+	Path    string
+	Module1 ModuleFullName
+	Module2 ModuleFullName
+}
+
+// Error implements the error interface.
+func (d *DuplicatePathError) Error() string {
+	if d == nil {
+		return ""
+	}
+	return fmt.Sprintf("duplicate path %q in module %q and module %q", d.Path, d.Module1, d.Module2)
+}
+
 // *** PRIVATE ***
 
 func newErrNoProtoFiles(moduleID string) error {


### PR DESCRIPTION
Build on a ModuleSetBuilder will now fail with a duplicate error if a module contains the same file path for a proto file as another module. A new error type `DuplicatePathError` will be returned.