### PR TITLE
Revert "Add support for #validate=true to message refs (#2633)"

### DIFF
--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -41,7 +41,6 @@ const (
 
 	useProtoNamesKey  = "use_proto_names"
 	useEnumNumbersKey = "use_enum_numbers"
-	validateKey       = "validate"
 )
 
 var (
@@ -111,16 +110,10 @@ type MessageRef interface {
 	//
 	// May be used for items such as YAML unmarshaling errors.
 	Path() string
-	// UseProtoNames indicates if the message should use proto names when encoding.
-	//
-	// Only applies for MessageEncodingYAML at this time.
+	// UseProtoNames only applies for MessageEncodingYAML at this time.
 	UseProtoNames() bool
-	// UseEnumNumbers indicates if the message should use enum numbers when encoding.
-	//
-	// Only applies for MessageEncodingYAML at this time.
+	// UseEnumNumbers only applies for MessageEncodingYAML at this time.
 	UseEnumNumbers() bool
-	// Validate indicates if the message should be validated when decoding.
-	Validate() bool
 	IsNull() bool
 	internalSingleRef() internal.SingleRef
 }

--- a/private/buf/buffetch/message_ref.go
+++ b/private/buf/buffetch/message_ref.go
@@ -25,7 +25,6 @@ type messageRef struct {
 	singleRef       internal.SingleRef
 	useProtoNames   bool
 	useEnumNumbers  bool
-	validate        bool
 	messageEncoding MessageEncoding
 }
 
@@ -41,15 +40,10 @@ func newMessageRef(
 	if err != nil {
 		return nil, err
 	}
-	validate, err := getTrueOrFalseForSingleRef(singleRef, validateKey)
-	if err != nil {
-		return nil, err
-	}
 	return &messageRef{
 		singleRef:       singleRef,
 		useProtoNames:   useProtoNames,
 		useEnumNumbers:  useEnumNumbers,
-		validate:        validate,
 		messageEncoding: messageEncoding,
 	}, nil
 }
@@ -72,10 +66,6 @@ func (r *messageRef) UseProtoNames() bool {
 
 func (r *messageRef) UseEnumNumbers() bool {
 	return r.useEnumNumbers
-}
-
-func (r *messageRef) Validate() bool {
-	return r.validate
 }
 
 func (r *messageRef) IsNull() bool {

--- a/private/buf/buffetch/ref_parser.go
+++ b/private/buf/buffetch/ref_parser.go
@@ -49,29 +49,18 @@ func newRefParser(logger *zap.Logger) *refParser {
 		fetchRefParser: internal.NewRefParser(
 			logger,
 			internal.WithRawRefProcessor(processRawRef),
-			internal.WithSingleFormat(
-				formatBin,
-				internal.WithSingleCustomOptionKey(validateKey),
-			),
-			internal.WithSingleFormat(
-				formatBinpb,
-				internal.WithSingleCustomOptionKey(validateKey),
-			),
+			internal.WithSingleFormat(formatBin),
+			internal.WithSingleFormat(formatBinpb),
 			internal.WithSingleFormat(
 				formatJSON,
 				internal.WithSingleCustomOptionKey(useProtoNamesKey),
 				internal.WithSingleCustomOptionKey(useEnumNumbersKey),
-				internal.WithSingleCustomOptionKey(validateKey),
 			),
-			internal.WithSingleFormat(
-				formatTxtpb,
-				internal.WithSingleCustomOptionKey(validateKey),
-			),
+			internal.WithSingleFormat(formatTxtpb),
 			internal.WithSingleFormat(
 				formatYAML,
 				internal.WithSingleCustomOptionKey(useProtoNamesKey),
 				internal.WithSingleCustomOptionKey(useEnumNumbersKey),
-				internal.WithSingleCustomOptionKey(validateKey),
 			),
 			internal.WithSingleFormat(
 				formatBingz,
@@ -118,28 +107,18 @@ func newMessageRefParser(logger *zap.Logger, options ...MessageRefParserOption) 
 		fetchRefParser: internal.NewRefParser(
 			logger,
 			internal.WithRawRefProcessor(newProcessRawRefMessage(messageRefParserOptions.defaultMessageEncoding)),
-			internal.WithSingleFormat(
-				formatBin,
-				internal.WithSingleCustomOptionKey(validateKey),
-			),
-			internal.WithSingleFormat(
-				formatBinpb,
-				internal.WithSingleCustomOptionKey(validateKey),
-			),
+			internal.WithSingleFormat(formatBin),
+			internal.WithSingleFormat(formatBinpb),
 			internal.WithSingleFormat(
 				formatJSON,
 				internal.WithSingleCustomOptionKey(useProtoNamesKey),
 				internal.WithSingleCustomOptionKey(useEnumNumbersKey),
-				internal.WithSingleCustomOptionKey(validateKey),
 			),
-			internal.WithSingleFormat(formatTxtpb,
-				internal.WithSingleCustomOptionKey(validateKey),
-			),
+			internal.WithSingleFormat(formatTxtpb),
 			internal.WithSingleFormat(
 				formatYAML,
 				internal.WithSingleCustomOptionKey(useProtoNamesKey),
 				internal.WithSingleCustomOptionKey(useEnumNumbersKey),
-				internal.WithSingleCustomOptionKey(validateKey),
 			),
 			internal.WithSingleFormat(
 				formatBingz,

--- a/private/buf/bufwire/proto_encoding_reader.go
+++ b/private/buf/bufwire/proto_encoding_reader.go
@@ -25,8 +25,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufreflect"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
-	"github.com/bufbuild/protovalidate-go"
-	"github.com/bufbuild/protoyaml-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.uber.org/multierr"
@@ -73,14 +71,6 @@ func (p *protoEncodingReader) GetMessage(
 	if err != nil {
 		return nil, err
 	}
-	var validator protoyaml.Validator
-	if messageRef.Validate() {
-		var err error
-		validator, err = protovalidate.New()
-		if err != nil {
-			return nil, err
-		}
-	}
 	var unmarshaler protoencoding.Unmarshaler
 	switch messageRef.MessageEncoding() {
 	case buffetch.MessageEncodingBinpb:
@@ -93,9 +83,7 @@ func (p *protoEncodingReader) GetMessage(
 		unmarshaler = protoencoding.NewYAMLUnmarshaler(
 			resolver,
 			protoencoding.YAMLUnmarshalerWithPath(messageRef.Path()),
-			protoencoding.YAMLUnmarshalerWithValidator(validator),
 		)
-		validator = nil // Validation errors are handled by the unmarshaler.
 	default:
 		return nil, errors.New("unknown message encoding type")
 	}
@@ -119,11 +107,6 @@ func (p *protoEncodingReader) GetMessage(
 	}
 	if err := unmarshaler.Unmarshal(data, message); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal the message: %v", err)
-	}
-	if validator != nil {
-		if err := validator.Validate(message); err != nil {
-			return nil, err
-		}
 	}
 	return message, nil
 }

--- a/private/buf/cmd/buf/command/convert/convert.go
+++ b/private/buf/cmd/buf/command/convert/convert.go
@@ -195,10 +195,12 @@ func run(
 	}
 	fromMessageRef, err := buffetch.NewMessageRefParser(
 		container.Logger(),
-		buffetch.MessageRefParserWithDefaultMessageEncoding(buffetch.MessageEncodingBinpb),
+		buffetch.MessageRefParserWithDefaultMessageEncoding(
+			buffetch.MessageEncodingBinpb,
+		),
 	).GetMessageRef(ctx, flags.From)
 	if err != nil {
-		return fmt.Errorf("--%s: %v", fromFlagName, err)
+		return fmt.Errorf("--%s: %v", outputFlagName, err)
 	}
 	storageosProvider := bufcli.NewStorageosProvider(flags.DisableSymlinks)
 	runner := command.NewRunner()


### PR DESCRIPTION
Reverts https://github.com/bufbuild/buf/pull/2633. We want to limit this to just `buf convert --from` - there's no usecase otherwise (no need to validate `--to`, and `Images` do not use protovalidate).