### PR TITLE
Fix `GetGraphForModuleKeys` requiring unique Registries

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleapi/registry.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/registry.go
@@ -48,7 +48,7 @@ func getPrimarySecondaryRegistry[T hasModuleFullName](s []T) (string, string, er
 	if len(s) == 0 {
 		return "", "", syserror.New("must have at least one value in getPrimarySecondaryRegistry")
 	}
-	registryMap, err := slicesext.ToUniqueValuesMapError(
+	registryMap, err := slicesext.ToValuesMapError(
 		s,
 		func(e T) (string, error) {
 			moduleFullName := e.ModuleFullName()


### PR DESCRIPTION
`GetGraphForModuleKeys` was attempting to determine a primary and secondary registry, but it was doing so by requiring that the Registry is unique across all deps. Instead, it should simply extract the unique registries.