### PR TITLE
Prevent pushing with empty Label/Tag names

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -360,7 +360,7 @@ func validateCreateFlags(flags *flags) error {
 	if flags.Create {
 		if flags.CreateVisibility == "" {
 			return appcmd.NewInvalidArgumentErrorf(
-				"--%s is required if --%s is set.",
+				"--%s is required if --%s is set",
 				createVisibilityFlagName,
 				createFlagName,
 			)
@@ -371,7 +371,7 @@ func validateCreateFlags(flags *flags) error {
 	} else {
 		if flags.CreateVisibility != "" {
 			return appcmd.NewInvalidArgumentErrorf(
-				"Cannot set --%s without --%s.",
+				"Cannot set --%s without --%s",
 				createVisibilityFlagName,
 				createFlagName,
 			)
@@ -395,9 +395,7 @@ func validateLabelFlags(flags *flags) error {
 }
 
 func combineLabelLikeFlags(flags *flags) []string {
-	labels := make([]string, 0, len(flags.Labels)+len(flags.Tags))
-	labels = append(labels, flags.Labels...)
-	labels = append(labels, flags.Tags...)
+	labels := append(slicesext.Copy(flags.Labels), flags.Tags...)
 	if flags.Draft != "" {
 		labels = append(labels, flags.Draft)
 	}

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -368,7 +368,7 @@ func validateLabelFlags(flags *flags) error {
 	for _, tag := range flags.Tags {
 		if tag == "" {
 			return appcmd.NewInvalidArgumentErrorf(
-				"%s|--%s requires a non-empty string.",
+				"-%s|--%s requires a non-empty string.",
 				tagFlagShortName,
 				tagFlagName,
 			)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -356,26 +356,6 @@ func validateFlags(flags *flags) error {
 	return nil
 }
 
-func validateLabelFlags(flags *flags) error {
-	for _, label := range flags.Labels {
-		if label == "" {
-			return appcmd.NewInvalidArgumentErrorf(
-				"--%s requires a non-empty string.",
-				labelFlagName,
-			)
-		}
-	}
-	for _, tag := range flags.Tags {
-		if tag == "" {
-			return appcmd.NewInvalidArgumentErrorf(
-				"--%s requires a non-empty string.",
-				tagFlagName,
-			)
-		}
-	}
-	return nil
-}
-
 func validateCreateFlags(flags *flags) error {
 	if flags.Create {
 		if flags.CreateVisibility == "" {
@@ -394,6 +374,26 @@ func validateCreateFlags(flags *flags) error {
 				"Cannot set --%s without --%s.",
 				createVisibilityFlagName,
 				createFlagName,
+			)
+		}
+	}
+	return nil
+}
+
+func validateLabelFlags(flags *flags) error {
+	for _, label := range flags.Labels {
+		if label == "" {
+			return appcmd.NewInvalidArgumentErrorf(
+				"--%s requires a non-empty string.",
+				labelFlagName,
+			)
+		}
+	}
+	for _, tag := range flags.Tags {
+		if tag == "" {
+			return appcmd.NewInvalidArgumentErrorf(
+				"--%s requires a non-empty string.",
+				tagFlagName,
 			)
 		}
 	}

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -383,12 +383,12 @@ func validateCreateFlags(flags *flags) error {
 func validateLabelFlags(flags *flags) error {
 	for _, label := range flags.Labels {
 		if label == "" {
-			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string.", labelFlagName)
+			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", labelFlagName)
 		}
 	}
 	for _, tag := range flags.Tags {
 		if tag == "" {
-			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string.", tagFlagName)
+			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", tagFlagName)
 		}
 	}
 	return nil

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -368,8 +368,7 @@ func validateLabelFlags(flags *flags) error {
 	for _, tag := range flags.Tags {
 		if tag == "" {
 			return appcmd.NewInvalidArgumentErrorf(
-				"-%s|--%s requires a non-empty string.",
-				tagFlagShortName,
+				"--%s requires a non-empty string.",
 				tagFlagName,
 			)
 		}

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -383,18 +383,12 @@ func validateCreateFlags(flags *flags) error {
 func validateLabelFlags(flags *flags) error {
 	for _, label := range flags.Labels {
 		if label == "" {
-			return appcmd.NewInvalidArgumentErrorf(
-				"--%s requires a non-empty string.",
-				labelFlagName,
-			)
+			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string.", labelFlagName)
 		}
 	}
 	for _, tag := range flags.Tags {
 		if tag == "" {
-			return appcmd.NewInvalidArgumentErrorf(
-				"--%s requires a non-empty string.",
-				tagFlagName,
-			)
+			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string.", tagFlagName)
 		}
 	}
 	return nil


### PR DESCRIPTION
`flags.Draft` and `flags.Branch` may be empty string, and they were being added to the labels name. Instead, I conditionally add them.

I also chose to detect empty strings in `flags.Labels` and `flags.Tags`, via `--label ''` or `--tag ''`.