### PR TITLE
Fix wrong v1/v1beta proto file in `newUniversalProtoContentForV1Beta1 `

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_content.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_content.go
@@ -51,7 +51,7 @@ func newUniversalProtoContentForV1Beta1(v1beta1ProtoContent *modulev1beta1.Downl
 		ModuleID:      v1beta1ProtoContent.Commit.ModuleId,
 		Files:         slicesext.Map(v1beta1ProtoContent.Files, newUniversalProtoFileForV1Beta1),
 		V1BufYAMLFile: newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufYamlFile),
-		V1BufLockFile: newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufYamlFile),
+		V1BufLockFile: newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufLockFile),
 	}
 }
 


### PR DESCRIPTION
We were using the `buf.yaml` file instead of the `buf.lock` file, resulting in duplicate file errors when calculating the B4 digest.