### PR TITLE
Fix panic on `buf.yaml` or `buf.lock` unset

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_content.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_content.go
@@ -46,12 +46,22 @@ func newUniversalProtoContentForV1(v1ProtoContent *modulev1.DownloadResponse_Con
 }
 
 func newUniversalProtoContentForV1Beta1(v1beta1ProtoContent *modulev1beta1.DownloadResponse_Content) *universalProtoContent {
+	var (
+		v1BufYAMLFile *universalProtoFile
+		v1BufLockFile *universalProtoFile
+	)
+	if v1beta1ProtoContent.V1BufYamlFile != nil {
+		v1BufYAMLFile = newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufYamlFile)
+	}
+	if v1beta1ProtoContent.V1BufLockFile != nil {
+		v1BufLockFile = newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufLockFile)
+	}
 	return &universalProtoContent{
 		CommitID:      v1beta1ProtoContent.Commit.Id,
 		ModuleID:      v1beta1ProtoContent.Commit.ModuleId,
 		Files:         slicesext.Map(v1beta1ProtoContent.Files, newUniversalProtoFileForV1Beta1),
-		V1BufYAMLFile: newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufYamlFile),
-		V1BufLockFile: newUniversalProtoFileForV1Beta1(v1beta1ProtoContent.V1BufLockFile),
+		V1BufYAMLFile: v1BufYAMLFile,
+		V1BufLockFile: v1BufLockFile,
 	}
 }
 

--- a/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_file.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_file.go
@@ -36,6 +36,9 @@ func newUniversalProtoFileForV1(v1File *modulev1.File) *universalProtoFile {
 }
 
 func newUniversalProtoFileForV1Beta1(v1beta1File *modulev1beta1.File) *universalProtoFile {
+	if v1beta1File == nil {
+		return nil
+	}
 	return &universalProtoFile{
 		Path:    v1beta1File.Path,
 		Content: v1beta1File.Content,

--- a/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_file.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/universal_proto_file.go
@@ -36,9 +36,6 @@ func newUniversalProtoFileForV1(v1File *modulev1.File) *universalProtoFile {
 }
 
 func newUniversalProtoFileForV1Beta1(v1beta1File *modulev1beta1.File) *universalProtoFile {
-	if v1beta1File == nil {
-		return nil
-	}
 	return &universalProtoFile{
 		Path:    v1beta1File.Path,
 		Content: v1beta1File.Content,


### PR DESCRIPTION
For v1beta1/v1 modules, the registry _may_ return these files if it has them. The CLI should only use them to calculate digests if they are present.