### PR TITLE
Add --exclude-source-retention-options flag to 'buf build'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
   field of the `CodeGeneratorRequest` message. This provides the plugin with access to options
   that are configured to only be retained in source and not at runtime (via
   [field option](https://github.com/protocolbuffers/protobuf/blob/v24.0/src/google/protobuf/descriptor.proto#L693-L702)).
-  Descriptors in the `proto_file` field will not include any options configured this way.
+  Descriptors in the `proto_file` field will not include any options configured this way
+  for the files named in `file_to_generate` field.
+- Add `--exclude-source-retention-options` flag to `buf build`, which
+  causes options configured to only be retained in source to be stripped
+  from the output descriptors.
 
 ## [v1.29.0] - 2024-01-24
 

--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -31,17 +31,18 @@ import (
 )
 
 const (
-	asFileDescriptorSetFlagName = "as-file-descriptor-set"
-	errorFormatFlagName         = "error-format"
-	excludeImportsFlagName      = "exclude-imports"
-	excludeSourceInfoFlagName   = "exclude-source-info"
-	pathsFlagName               = "path"
-	outputFlagName              = "output"
-	outputFlagShortName         = "o"
-	configFlagName              = "config"
-	excludePathsFlagName        = "exclude-path"
-	disableSymlinksFlagName     = "disable-symlinks"
-	typeFlagName                = "type"
+	asFileDescriptorSetFlagName           = "as-file-descriptor-set"
+	errorFormatFlagName                   = "error-format"
+	excludeImportsFlagName                = "exclude-imports"
+	excludeSourceInfoFlagName             = "exclude-source-info"
+	excludeSourceRetentionOptionsFlagName = "exclude-source-retention-options"
+	pathsFlagName                         = "path"
+	outputFlagName                        = "output"
+	outputFlagShortName                   = "o"
+	configFlagName                        = "config"
+	excludePathsFlagName                  = "exclude-path"
+	disableSymlinksFlagName               = "disable-symlinks"
+	typeFlagName                          = "type"
 )
 
 // NewCommand returns a new Command.
@@ -66,16 +67,17 @@ func NewCommand(
 }
 
 type flags struct {
-	AsFileDescriptorSet bool
-	ErrorFormat         string
-	ExcludeImports      bool
-	ExcludeSourceInfo   bool
-	Paths               []string
-	Output              string
-	Config              string
-	ExcludePaths        []string
-	DisableSymlinks     bool
-	Types               []string
+	AsFileDescriptorSet           bool
+	ErrorFormat                   string
+	ExcludeImports                bool
+	ExcludeSourceInfo             bool
+	ExcludeSourceRetentionOptions bool
+	Paths                         []string
+	Output                        string
+	Config                        string
+	ExcludePaths                  []string
+	DisableSymlinks               bool
+	Types                         []string
 	// special
 	InputHashtag string
 }
@@ -92,6 +94,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 	bufcli.BindPaths(flagSet, &f.Paths, pathsFlagName)
 	bufcli.BindExcludePaths(flagSet, &f.ExcludePaths, excludePathsFlagName)
 	bufcli.BindDisableSymlinks(flagSet, &f.DisableSymlinks, disableSymlinksFlagName)
+	flagSet.BoolVar(
+		&f.ExcludeSourceRetentionOptions,
+		excludeSourceRetentionOptionsFlagName,
+		false,
+		"Exclude options whose retention is source",
+	)
 	flagSet.StringVar(
 		&f.ErrorFormat,
 		errorFormatFlagName,
@@ -161,6 +169,12 @@ func run(
 	}
 	if len(flags.Types) > 0 {
 		image, err = bufimageutil.ImageFilteredByTypes(image, flags.Types...)
+		if err != nil {
+			return err
+		}
+	}
+	if flags.ExcludeSourceRetentionOptions {
+		image, err = bufimageutil.StripSourceRetentionOptions(image)
 		if err != nil {
 			return err
 		}

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/protosource"
+	"github.com/bufbuild/protocompile/options"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -370,6 +371,21 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 		}
 	}
 	return bufimage.NewImage(includedFiles)
+}
+
+// StripSourceRetentionOptions strips any options with a retention of "source" from
+// the descriptors in the given image. The image is not mutated but instead a new
+// image is returned. The returned image may share state with the original.
+func StripSourceRetentionOptions(image bufimage.Image) (bufimage.Image, error) {
+	updatedFiles := make([]bufimage.ImageFile, len(image.Files()))
+	for i, inputFile := range image.Files() {
+		updatedFile, err := stripSourceRetentionOptionsFromFile(inputFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to strip source-retention options from file %q: %w", inputFile.Path(), err)
+		}
+		updatedFiles[i] = updatedFile
+	}
+	return bufimage.NewImage(updatedFiles)
 }
 
 // trimMessageDescriptors removes (nested) messages and nested enums from a slice
@@ -916,4 +932,20 @@ func newImageFilterOptions() *imageFilterOptions {
 		includeKnownExtensions: true,
 		allowImportedTypes:     false,
 	}
+}
+
+func stripSourceRetentionOptionsFromFile(imageFile bufimage.ImageFile) (bufimage.ImageFile, error) {
+	updatedFileDescriptor, err := options.StripSourceRetentionOptionsFromFile(imageFile.FileDescriptorProto())
+	if err != nil {
+		return nil, err
+	}
+	return bufimage.NewImageFile(
+		updatedFileDescriptor,
+		imageFile.ModuleIdentity(),
+		imageFile.Commit(),
+		imageFile.ExternalPath(),
+		imageFile.IsImport(),
+		imageFile.IsSyntaxUnspecified(),
+		imageFile.UnusedDependencyIndexes(),
+	)
 }


### PR DESCRIPTION
This adds a flag that controls whether source-retention options are included in the output image or descriptor set from `buf build`.

I compared the output to `protoc` and did notice one small discrepancy: the code I wrote in `protocompile` leaves an empty `options` field if it happens to remove all options (i.e. if they were all source-retention). But `protoc` clears that field if it ends up empty. I can go make a small PR to `protocompile`, but I don't think the difference really matters or is worth holding any of this up.

(Never mind the unrecognized field 8042: I didn't use `--as-file-descriptor-set` with `buf build` when creating these files. So the right-hand column is actually an image, so it has that extra `ImageFile` field which is interpreted as an unrecognized field of `FileDescriptorProto`.)
```
> diff -W 110 -y test-w-protoc-minimal.txt test-w-buf-minimal.txt
file {						       file {
  name: "test.proto"				         name: "test.proto"
  dependency: "google/protobuf/descriptor.proto"         dependency: "google/protobuf/descriptor.proto"
  message_type {				         message_type {
    name: "Foo"					           name: "Foo"
    extension_range {				           extension_range {
      start: 1					             start: 1
      end: 1001					             end: 1001
						     >       options {
						     >       }
    }						           }
  }						         }
  extension {					         extension {
    name: "foo"					           name: "foo"
    extendee: ".google.protobuf.FileOptions"	           extendee: ".google.protobuf.FileOptions"
    number: 10101				           number: 10101
    label: LABEL_OPTIONAL			           label: LABEL_OPTIONAL
    type: TYPE_STRING				           type: TYPE_STRING
    options {					           options {
      retention: RETENTION_SOURCE		             retention: RETENTION_SOURCE
    }						           }
    json_name: "foo"				           json_name: "foo"
						     >   }
						     >   options {
						     >   }
						     >   8042 {
						     >     1: 0
						     >     3: 0
  }						         }
}						       }
```

The file I was testing with included both standard options that are source-only (the extension range declaration stuff, which is why option retention was introduced in the first place) and a custom option with source-only retention:
```proto
syntax = "proto2";

import "google/protobuf/descriptor.proto";

extend google.protobuf.FileOptions {
  optional string foo = 10101 [retention = RETENTION_SOURCE];
}

message Foo {
  extensions 1 to 1000 [
    declaration = {
      number: 10,
      full_name: ".foo.bar.baz";
      type: "int32"
    },
    declaration = {
      number: 20,
      full_name: ".bob.lob.law",
      type: ".bob.lob.Lawdy"
      repeated: true
    },
    declaration = {
      number: 30
      reserved: true
    },
    verification = DECLARATION
  ];
}

option (foo) = "abcdefghijklmnopqrstuvwxz0123456789";
```