### PR TITLE
Clean up protoc-gen plugin error message

### DIFF
--- a/private/buf/bufpluginexec/bufpluginexec.go
+++ b/private/buf/bufpluginexec/bufpluginexec.go
@@ -149,7 +149,7 @@ func NewHandler(
 		}
 	}
 	return nil, fmt.Errorf(
-		"could not find protoc plugin for name %s - please make sure protoc-gen-%s is installed and present on your $PATH",
+		"could not find protoc plugin for name %s - please make sure %s is installed and present on your $PATH",
 		pluginName,
 		pluginName,
 	)


### PR DESCRIPTION
With `v2` `buf.gen.yaml` the plugin name is already parsed with
`protoc-gen-<plugin name>` when this error is returned, so we no
longer need to prefix the plugin name with `protoc-gen` in the
error message.