### PR TITLE
Call detrand.Disable once and for all

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -224,6 +224,11 @@ issues:
       path: private/pkg/osext/osext.go
       text: "os.Chdir"
     - linters:
+        - gochecknoinits
+      # protoencoding calls detrand.Disable via go:linkname and and init function. See the comments
+      # in the file for more details.
+      path: private/pkg/protoencoding/detrand.go
+    - linters:
         - errcheck
       # headers.go has casts with values from contexts that should fail if there
       # is no error, but it would be very unidiomatic to return an error from

--- a/private/pkg/protoencoding/detrand.go
+++ b/private/pkg/protoencoding/detrand.go
@@ -1,0 +1,34 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoencoding
+
+import _ "unsafe"
+
+//go:linkname detrandDisable google.golang.org/protobuf/internal/detrand.Disable
+func detrandDisable()
+
+func init() {
+	// Disable detrand so that it does not mess with json or text serialization.
+	//
+	// https://github.com/golang/protobuf/issues/1121
+	// https://go-review.googlesource.com/c/protobuf/+/151340
+	// https://developers.google.com/protocol-buffers/docs/reference/go/faq#unstable-json
+	//
+	// Google is doing this in their own libraries at this point https://github.com/google/starlark-go/blob/ee8ed142361c69d52fe8e9fb5e311d2a0a7c02de/lib/proto/proto.go#L774
+	//
+	// See the above issues - detrand.Disable should fundamentally be allowed to be called by external
+	// libraries, this has been an issue for years.
+	detrandDisable()
+}

--- a/private/pkg/protoencoding/detrand_test.go
+++ b/private/pkg/protoencoding/detrand_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoencoding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// If our call to detrand.Disable ever stops working, these tests will result in
+// the data having random extra whitespaces on some test build.
+
+func TestJSONStable(t *testing.T) {
+	t.Parallel()
+
+	fileDescriptorProto := &descriptorpb.FileDescriptorProto{Name: proto.String("a.proto")}
+	data, err := NewJSONMarshaler(nil, JSONMarshalerWithIndent()).Marshal(fileDescriptorProto)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"{\n  \"name\": \"a.proto\"\n}",
+		string(data),
+	)
+}
+
+func TestTxtpbStable(t *testing.T) {
+	t.Parallel()
+
+	fileDescriptorProto := &descriptorpb.FileDescriptorProto{Name: proto.String("a.proto")}
+	data, err := NewTxtpbMarshaler(nil).Marshal(fileDescriptorProto)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"name: \"a.proto\"\n",
+		string(data),
+	)
+}

--- a/private/pkg/protoencoding/json_marshaler.go
+++ b/private/pkg/protoencoding/json_marshaler.go
@@ -15,9 +15,6 @@
 package protoencoding
 
 import (
-	"bytes"
-	"encoding/json"
-
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -49,28 +46,7 @@ func (m *jsonMarshaler) Marshal(message proto.Message) ([]byte, error) {
 		UseProtoNames:   m.useProtoNames,
 		UseEnumNumbers:  m.useEnumNumbers,
 		EmitUnpopulated: m.emitUnpopulated,
+		Indent:          m.indent,
 	}
-	data, err := options.Marshal(message)
-	if err != nil {
-		return nil, err
-	}
-	// This is needed due to the instability of protojson output.
-	//
-	// https://github.com/golang/protobuf/issues/1121
-	// https://go-review.googlesource.com/c/protobuf/+/151340
-	// https://developers.google.com/protocol-buffers/docs/reference/go/faq#unstable-json
-	//
-	// We may need to do a full encoding/json encode/decode in the future if protojson
-	// produces non-deterministic output.
-	buffer := bytes.NewBuffer(nil)
-	if m.indent != "" {
-		if err := json.Indent(buffer, data, "", m.indent); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := json.Compact(buffer, data); err != nil {
-			return nil, err
-		}
-	}
-	return buffer.Bytes(), nil
+	return options.Marshal(message)
 }

--- a/private/pkg/protoencoding/txtpb_marshaler.go
+++ b/private/pkg/protoencoding/txtpb_marshaler.go
@@ -32,9 +32,7 @@ func newTxtpbMarshaler(resolver Resolver) Marshaler {
 func (m *txtpbMarshaler) Marshal(message proto.Message) ([]byte, error) {
 	options := prototext.MarshalOptions{
 		Resolver: m.resolver,
-		// TODO: make this an option
-		Multiline: true,
-		Indent:    "  ",
+		Indent:   "  ",
 	}
 	return options.Marshal(message)
 }

--- a/private/pkg/protoencoding/yaml_marshaler.go
+++ b/private/pkg/protoencoding/yaml_marshaler.go
@@ -48,9 +48,5 @@ func (m *yamlMarshaler) Marshal(message proto.Message) ([]byte, error) {
 		UseEnumNumbers:  m.useEnumNumbers,
 		EmitUnpopulated: m.emitUnpopulated,
 	}
-	data, err := options.Marshal(message)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return options.Marshal(message)
 }


### PR DESCRIPTION
I've officially had it. The final straw was that prototext was borked and there's no `json.Compact` equivalent for prototext. Making `detrand.Disable` an internal-only function was always a bad idea, and now even Google is working around it in major libraries: https://github.com/google/starlark-go/blob/ee8ed142361c69d52fe8e9fb5e311d2a0a7c02de/lib/proto/proto.go#L774

I'm not linking to the issue on protobuf-go as to not link this issue in, but ask internally if you want to know the issue here.

If `detrand.Disable` is renamed, we will get a build-time error:

```
github.com/bufbuild/buf/private/pkg/protoencoding.init.0: relocation target google.golang.org/protobuf/internal/detrand.DisableMisspelled not defined
```

And if they rename it, it will break Google's own code. I think this is relatively safe long-term, and the worst-case is we blow up at build-time (unless Google maliciously changes the function behavior, but of course they could do this for any function in an OSS library, so I think that is not in-bounds).