### PR TITLE
Remove references to the "main" branch

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
+++ b/private/buf/cmd/buf/command/beta/registry/commit/commitlist/commitlist.go
@@ -116,19 +116,13 @@ func run(
 		registryv1alpha1connect.NewRepositoryCommitServiceClient,
 	)
 
-	reference := moduleRef.Ref()
-	if reference == "" {
-		// This will go away when we call the new API.
-		reference = "main"
-	}
-
 	resp, err := service.ListRepositoryCommitsByReference(
 		ctx,
 		connect.NewRequest(
 			&registryv1alpha1.ListRepositoryCommitsByReferenceRequest{
 				RepositoryOwner: moduleRef.ModuleFullName().Owner(),
 				RepositoryName:  moduleRef.ModuleFullName().Name(),
-				Reference:       reference,
+				Reference:       moduleRef.Ref(),
 				PageSize:        flags.PageSize,
 				PageToken:       flags.PageToken,
 				Reverse:         flags.Reverse,

--- a/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
+++ b/private/buf/cmd/buf/command/beta/registry/draft/draftdelete/draftdelete.go
@@ -78,9 +78,6 @@ func run(
 	if err != nil {
 		return appcmd.NewInvalidArgumentError(err.Error())
 	}
-	if moduleRef.Ref() == "main" {
-		return appcmd.NewInvalidArgumentErrorf("%q is not a valid draft name", "main")
-	}
 	if moduleRef.Ref() == "" {
 		return appcmd.NewInvalidArgumentError("a valid draft name need to be specified")
 	}


### PR DESCRIPTION
Update the CLI to remove references to the "main" branch. The BSR is updated to allow empty references in ListRepositoryCommitsByReference to indicate the default branch. The DeleteRepositoryDraftCommit API already performs server-side validation to prevent deletion of the default branch.