### PR TITLE
Fix memory read bucket mapping when no controlling workspace is found

### DIFF
--- a/private/buf/buffetch/internal/read_bucket_closer.go
+++ b/private/buf/buffetch/internal/read_bucket_closer.go
@@ -33,7 +33,6 @@ type readBucketCloser struct {
 
 func newReadBucketCloser(
 	storageReadBucketCloser storage.ReadBucketCloser,
-	bucketPath string,
 	bucketTargeting buftarget.BucketTargeting,
 ) *readBucketCloser {
 	normalizedSubDirPath := normalpath.Normalize(bucketTargeting.SubDirPath())

--- a/private/buf/buffetch/internal/reader_test.go
+++ b/private/buf/buffetch/internal/reader_test.go
@@ -41,14 +41,11 @@ func TestGetReadBucketCloserForBucketNoTerminateFileName(t *testing.T) {
 		"three/four/five",
 		nil, // no target paths
 		nil, // no target exclude paths
-		nil,
+		nil, // no terminate func, which should result in never finding a controlling workspace
 	)
 	require.NoError(t, err)
 	require.Nil(t, bucketTargeting.ControllingWorkspace())
 	require.Equal(t, "three/four/five", readBucketCloser.SubDirPath())
-	_, err = readBucketCloser.Stat(ctx, "buf.yaml")
-	require.NoError(t, err)
-	require.NoError(t, readBucketCloser.Close())
 }
 
 func TestGetReadBucketCloserTerminateFileName(t *testing.T) {

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -2355,6 +2355,25 @@ func TestProtoFileNoWorkspaceOrModule(t *testing.T) {
 	)
 }
 
+func TestModuleArchiveDir(t *testing.T) {
+	// Archive that defines module at input path
+	t.Parallel()
+	zipDir := createZipFromDir(
+		t,
+		filepath.Join("testdata", "failarchive"),
+		"archive.zip",
+	)
+	testRunStdout(
+		t,
+		nil,
+		bufctl.ExitCodeFileAnnotation,
+		filepath.FromSlash(`fail/buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
+fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "one_two".`),
+		"lint",
+		filepath.Join(zipDir, "archive.zip#subdir=fail"),
+	)
+}
+
 // testBuildLsFilesFormatImport does effectively an ls-files, but via doing a build of an Image, and then
 // listing the files from the image as if --format=import was set.
 func testBuildLsFilesFormatImport(t *testing.T, expectedExitCode int, expectedFiles []string, buildArgs ...string) {

--- a/private/buf/cmd/buf/testdata/failarchive/fail/buf.yaml
+++ b/private/buf/cmd/buf/testdata/failarchive/fail/buf.yaml
@@ -1,0 +1,4 @@
+version: v1
+lint:
+  use:
+    - BASIC

--- a/private/buf/cmd/buf/testdata/failarchive/fail/buf/buf.proto
+++ b/private/buf/cmd/buf/testdata/failarchive/fail/buf/buf.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package other;
+
+message Foo {
+  int64 oneTwo = 1;
+}


### PR DESCRIPTION
In order to treat archive and git refs the same way we treat dir
and proto file refs, we are handling `inputSubDirPath` already
in workspace targeting. This means that we should not actually
be remapping archive and git memory buckets if no controlling
workspace is found.

This was found in our bug bash when testing against an archive
with a `v1` module rooted at the input sub dir path. Added a test
case for this.