### PR TITLE
Allow disabling lint or breaking for an entire module via a configuration ignore

### DIFF
--- a/private/buf/bufmigrate/migrate_builder.go
+++ b/private/buf/bufmigrate/migrate_builder.go
@@ -183,7 +183,7 @@ func (m *migrateBuilder) addModule(ctx context.Context, moduleDirPath string) (r
 				".": {},
 			},
 			bufconfig.NewLintConfig(
-				bufconfig.NewCheckConfigForUseIDsAndCategories(
+				bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 					bufconfig.FileVersionV2,
 					nil,
 				),
@@ -195,7 +195,7 @@ func (m *migrateBuilder) addModule(ctx context.Context, moduleDirPath string) (r
 				false,
 			),
 			bufconfig.NewBreakingConfig(
-				bufconfig.NewCheckConfigForUseIDsAndCategories(
+				bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 					bufconfig.FileVersionV2,
 					nil,
 				),

--- a/private/buf/bufmigrate/migrator.go
+++ b/private/buf/bufmigrate/migrator.go
@@ -711,7 +711,7 @@ func equivalentCheckConfigInV2(
 	)
 	// First create a check config with the exact same UseIDsAndCategories. This
 	// is a simple translation. It may or may not be equivalent to the given check config.
-	simplyTranslatedCheckConfig, err := bufconfig.NewCheckConfig(
+	simplyTranslatedCheckConfig, err := bufconfig.NewEnabledCheckConfig(
 		bufconfig.FileVersionV2,
 		filterFileSamePhpGenericServices(checkConfig.UseIDsAndCategories()),
 		filterFileSamePhpGenericServices(checkConfig.ExceptIDsAndCategories()),
@@ -754,7 +754,7 @@ func equivalentCheckConfigInV2(
 			return !ok
 		},
 	)
-	return bufconfig.NewCheckConfig(
+	return bufconfig.NewEnabledCheckConfig(
 		bufconfig.FileVersionV2,
 		append(checkConfig.UseIDsAndCategories(), missingIDs...),
 		append(checkConfig.ExceptIDsAndCategories(), extraIDs...),

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -2374,6 +2374,18 @@ fail/buf/buf.proto:6:9:Field name "oneTwo" should be lower_snake_case, such as "
 	)
 }
 
+func TestLintDisabledForModuleInWorkspace(t *testing.T) {
+	t.Parallel()
+	testRunStdout(
+		t,
+		nil,
+		bufctl.ExitCodeFileAnnotation,
+		filepath.FromSlash(`testdata/lint_ignore_disabled/proto/a.proto:3:9:Message name "foo" should be PascalCase, such as "Foo".`),
+		"lint",
+		filepath.Join("testdata", "lint_ignore_disabled"),
+	)
+}
+
 // testBuildLsFilesFormatImport does effectively an ls-files, but via doing a build of an Image, and then
 // listing the files from the image as if --format=import was set.
 func testBuildLsFilesFormatImport(t *testing.T, expectedExitCode int, expectedFiles []string, buildArgs ...string) {

--- a/private/buf/cmd/buf/command/config/configinit/configinit.go
+++ b/private/buf/cmd/buf/command/config/configinit/configinit.go
@@ -139,7 +139,7 @@ func run(
 			".": {},
 		},
 		bufconfig.NewLintConfig(
-			bufconfig.NewCheckConfigForUseIDsAndCategories(
+			bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 				fileVersion,
 				[]string{"DEFAULT"},
 			),
@@ -152,7 +152,7 @@ func run(
 			true,
 		),
 		bufconfig.NewBreakingConfig(
-			bufconfig.NewCheckConfigForUseIDsAndCategories(
+			bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 				fileVersion,
 				[]string{"FILE"},
 			),

--- a/private/buf/cmd/buf/testdata/lint_ignore_disabled/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lint_ignore_disabled/buf.yaml
@@ -1,0 +1,9 @@
+version: v2
+modules:
+  - path: proto
+  - path: vendor
+lint:
+  use:
+    - MESSAGE_PASCAL_CASE
+  ignore:
+    - vendor

--- a/private/buf/cmd/buf/testdata/lint_ignore_disabled/proto/a.proto
+++ b/private/buf/cmd/buf/testdata/lint_ignore_disabled/proto/a.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message foo {}

--- a/private/buf/cmd/buf/testdata/lint_ignore_disabled/vendor/b.proto
+++ b/private/buf/cmd/buf/testdata/lint_ignore_disabled/vendor/b.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+message bar {}

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
@@ -156,7 +156,7 @@ func rulesForInternalRules(rules []*internal.Rule) []bufcheck.Rule {
 
 func newBreakingConfigForVersionSpec(versionSpec *internal.VersionSpec) bufconfig.BreakingConfig {
 	return bufconfig.NewBreakingConfig(
-		bufconfig.NewCheckConfigForUseIDsAndCategories(
+		bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 			versionSpec.FileVersion,
 			internal.AllIDsForVersionSpec(versionSpec),
 		),

--- a/private/bufpkg/bufcheck/bufbreaking/handler.go
+++ b/private/bufpkg/bufcheck/bufbreaking/handler.go
@@ -50,6 +50,9 @@ func (h *handler) Check(
 	previousImage bufimage.Image,
 	image bufimage.Image,
 ) error {
+	if config.Disabled() {
+		return nil
+	}
 	previousFiles, err := bufprotosource.NewFiles(ctx, previousImage)
 	if err != nil {
 		return err

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -226,7 +226,7 @@ func rulesForInternalRules(rules []*internal.Rule) []bufcheck.Rule {
 
 func newLintConfigForVersionSpec(versionSpec *internal.VersionSpec) bufconfig.LintConfig {
 	return bufconfig.NewLintConfig(
-		bufconfig.NewCheckConfigForUseIDsAndCategories(
+		bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 			versionSpec.FileVersion,
 			internal.AllIDsForVersionSpec(versionSpec),
 		),

--- a/private/bufpkg/bufcheck/buflint/handler.go
+++ b/private/bufpkg/bufcheck/buflint/handler.go
@@ -53,6 +53,9 @@ func (h *handler) Check(
 	config bufconfig.LintConfig,
 	image bufimage.Image,
 ) error {
+	if config.Disabled() {
+		return nil
+	}
 	files, err := bufprotosource.NewFiles(ctx, image)
 	if err != nil {
 		return err

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -724,29 +724,38 @@ func getLintConfigForExternalLintV1Beta1V1(
 	moduleDirPath string,
 	requirePathsToBeContainedWithinModuleDirPath bool,
 ) (LintConfig, error) {
-	ignore, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore", externalLint.Ignore, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+	var checkConfig CheckConfig
+	disabled, err := isLintOrBreakingDisabledBasedOnIgnores("lint.ignore", externalLint.Ignore, moduleDirPath)
 	if err != nil {
 		return nil, err
 	}
-	ignoreOnly := make(map[string][]string)
-	for idOrCategory, paths := range externalLint.IgnoreOnly {
-		relPaths, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore_only", paths, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+	if disabled {
+		checkConfig = newDisabledCheckConfig(fileVersion)
+	} else {
+		ignore, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore", externalLint.Ignore, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
 		if err != nil {
 			return nil, err
 		}
-		if len(relPaths) > 0 {
-			ignoreOnly[idOrCategory] = relPaths
+		ignoreOnly := make(map[string][]string)
+		for idOrCategory, paths := range externalLint.IgnoreOnly {
+			relPaths, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore_only", paths, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+			if err != nil {
+				return nil, err
+			}
+			if len(relPaths) > 0 {
+				ignoreOnly[idOrCategory] = relPaths
+			}
 		}
-	}
-	checkConfig, err := newCheckConfig(
-		fileVersion,
-		externalLint.Use,
-		externalLint.Except,
-		ignore,
-		ignoreOnly,
-	)
-	if err != nil {
-		return nil, err
+		checkConfig, err = newEnabledCheckConfig(
+			fileVersion,
+			externalLint.Use,
+			externalLint.Except,
+			ignore,
+			ignoreOnly,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return newLintConfig(
 		checkConfig,
@@ -765,29 +774,38 @@ func getLintConfigForExternalLintV2(
 	moduleDirPath string,
 	requirePathsToBeContainedWithinModuleDirPath bool,
 ) (LintConfig, error) {
-	ignore, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore", externalLint.Ignore, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+	var checkConfig CheckConfig
+	disabled, err := isLintOrBreakingDisabledBasedOnIgnores("lint.ignore", externalLint.Ignore, moduleDirPath)
 	if err != nil {
 		return nil, err
 	}
-	ignoreOnly := make(map[string][]string)
-	for idOrCategory, paths := range externalLint.IgnoreOnly {
-		relPaths, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore_only", paths, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+	if disabled {
+		checkConfig = newDisabledCheckConfig(fileVersion)
+	} else {
+		ignore, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore", externalLint.Ignore, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
 		if err != nil {
 			return nil, err
 		}
-		if len(relPaths) > 0 {
-			ignoreOnly[idOrCategory] = relPaths
+		ignoreOnly := make(map[string][]string)
+		for idOrCategory, paths := range externalLint.IgnoreOnly {
+			relPaths, err := getRelPathsForLintOrBreakingExternalPaths("lint.ignore_only", paths, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+			if err != nil {
+				return nil, err
+			}
+			if len(relPaths) > 0 {
+				ignoreOnly[idOrCategory] = relPaths
+			}
 		}
-	}
-	checkConfig, err := newCheckConfig(
-		fileVersion,
-		externalLint.Use,
-		externalLint.Except,
-		ignore,
-		ignoreOnly,
-	)
-	if err != nil {
-		return nil, err
+		checkConfig, err = newEnabledCheckConfig(
+			fileVersion,
+			externalLint.Use,
+			externalLint.Except,
+			ignore,
+			ignoreOnly,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return newLintConfig(
 		checkConfig,
@@ -806,34 +824,65 @@ func getBreakingConfigForExternalBreaking(
 	moduleDirPath string,
 	requirePathsToBeContainedWithinModuleDirPath bool,
 ) (BreakingConfig, error) {
-	ignore, err := getRelPathsForLintOrBreakingExternalPaths("breaking.ignore", externalBreaking.Ignore, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+	var checkConfig CheckConfig
+	disabled, err := isLintOrBreakingDisabledBasedOnIgnores("breaking.ignore", externalBreaking.Ignore, moduleDirPath)
 	if err != nil {
 		return nil, err
 	}
-	ignoreOnly := make(map[string][]string)
-	for idOrCategory, paths := range externalBreaking.IgnoreOnly {
-		relPaths, err := getRelPathsForLintOrBreakingExternalPaths("breaking.ignore_only", paths, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+	if disabled {
+		checkConfig = newDisabledCheckConfig(fileVersion)
+	} else {
+		ignore, err := getRelPathsForLintOrBreakingExternalPaths("breaking.ignore", externalBreaking.Ignore, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
 		if err != nil {
 			return nil, err
 		}
-		if len(relPaths) > 0 {
-			ignoreOnly[idOrCategory] = relPaths
+		ignoreOnly := make(map[string][]string)
+		for idOrCategory, paths := range externalBreaking.IgnoreOnly {
+			relPaths, err := getRelPathsForLintOrBreakingExternalPaths("breaking.ignore_only", paths, moduleDirPath, requirePathsToBeContainedWithinModuleDirPath)
+			if err != nil {
+				return nil, err
+			}
+			if len(relPaths) > 0 {
+				ignoreOnly[idOrCategory] = relPaths
+			}
 		}
-	}
-	checkConfig, err := newCheckConfig(
-		fileVersion,
-		externalBreaking.Use,
-		externalBreaking.Except,
-		ignore,
-		ignoreOnly,
-	)
-	if err != nil {
-		return nil, err
+		checkConfig, err = newEnabledCheckConfig(
+			fileVersion,
+			externalBreaking.Use,
+			externalBreaking.Except,
+			ignore,
+			ignoreOnly,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return newBreakingConfig(
 		checkConfig,
 		externalBreaking.IgnoreUnstablePackages,
 	), nil
+}
+
+// isLintOrBreakingDisabledBasedOnIgnores returns true if lint or breaking should be entirely disabled
+// based on an ignore path equaling moduleDirPath.
+//
+// See comments on CheckConfig.Disabled() for why this is a scenario we want to support.
+func isLintOrBreakingDisabledBasedOnIgnores(
+	fieldName string,
+	ignores []string,
+	moduleDirPath string,
+) (bool, error) {
+	for _, ignore := range ignores {
+		ignore, err := normalpath.NormalizeAndValidate(ignore)
+		if err != nil {
+			// user error
+			return false, fmt.Errorf("%s: invalid path: %w", fieldName, err)
+		}
+		if ignore == moduleDirPath {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // getRelPathsForLintOrBreakingExternalPaths performs the following operation for either
@@ -846,6 +895,8 @@ func getBreakingConfigForExternalBreaking(
 //     are transforming a path from the default workspace-wide lint or breaking config. We want to skip these paths.
 //     If requirePathsToBeContainedWithinModuleDirPath is true, return error.
 //   - Otherwise, adds the path relative to the given module directory path to the returned slice.
+//
+// isLintOrBreakingDisabledBasedOnIgnores should be called before this function.
 func getRelPathsForLintOrBreakingExternalPaths(
 	fieldName string,
 	paths []string,
@@ -858,10 +909,6 @@ func getRelPathsForLintOrBreakingExternalPaths(
 		if err != nil {
 			// user error
 			return nil, fmt.Errorf("%s: invalid path: %w", fieldName, err)
-		}
-		if path == moduleDirPath {
-			// user error
-			return nil, fmt.Errorf("%s: path %q is equal to module directory %q", fieldName, path, moduleDirPath)
 		}
 		if !normalpath.EqualsOrContainsPath(moduleDirPath, path, normalpath.Relative) {
 			if !requirePathsToBeContainedWithinModuleDirPath {

--- a/private/bufpkg/bufconfig/check_config.go
+++ b/private/bufpkg/bufconfig/check_config.go
@@ -76,7 +76,7 @@ type CheckConfig interface {
 	//     ignore:
 	//       - .
 	//
-	// We could make it so that ignore == moduleDirPath is only allowed for v1, however
+	// We could make it so that ignore == moduleDirPath is only allowed for v2, however
 	// this feels like overkill, so we're just going to keep this consistent for v1
 	// and v2.
 	Disabled() bool

--- a/private/bufpkg/bufconfig/check_config.go
+++ b/private/bufpkg/bufconfig/check_config.go
@@ -19,14 +19,14 @@ import (
 )
 
 var (
-	defaultCheckConfigV1 = newCheckConfigNoValidate(
+	defaultCheckConfigV1 = newEnabledCheckConfigNoValidate(
 		FileVersionV1,
 		nil,
 		nil,
 		nil,
 		nil,
 	)
-	defaultCheckConfigV2 = newCheckConfigNoValidate(
+	defaultCheckConfigV2 = newEnabledCheckConfigNoValidate(
 		FileVersionV2,
 		nil,
 		nil,
@@ -45,6 +45,41 @@ type CheckConfig interface {
 	// of the IDs and categories.
 	FileVersion() FileVersion
 
+	// Disabled says whether or not the given check should be entirely disabled.
+	//
+	// This happens if an ignore path matches a module directory, which is valid
+	// in cases such as:
+	//
+	//   version: v2
+	//   modules:
+	//     - path: proto
+	//     - path: vendor
+	//   lint:
+	//     ignore:
+	//       - vendor
+	//
+	// Or:
+	//
+	//   version: v2
+	//   modules:
+	//     - path: proto
+	//     - path: vendor
+	//       lint:
+	//         ignore:
+	//           - vendor
+	//
+	// We no longer produce an error in this case. Instead, we set Disabled(), and
+	// do not run checks. This means that the following is no longer an error:
+	//
+	//   version: v1
+	//   lint:
+	//     ignore:
+	//       - .
+	//
+	// We could make it so that ignore == moduleDirPath is only allowed for v1, however
+	// this feels like overkill, so we're just going to keep this consistent for v1
+	// and v2.
+	Disabled() bool
 	// Sorted.
 	UseIDsAndCategories() []string
 	// Sorted
@@ -61,15 +96,15 @@ type CheckConfig interface {
 	isCheckConfig()
 }
 
-// NewCheckConfig returns a new CheckConfig.
-func NewCheckConfig(
+// NewEnabledCheckConfig returns a new enabled CheckConfig.
+func NewEnabledCheckConfig(
 	fileVersion FileVersion,
 	use []string,
 	except []string,
 	ignore []string,
 	ignoreOnly map[string][]string,
 ) (CheckConfig, error) {
-	return newCheckConfig(
+	return newEnabledCheckConfig(
 		fileVersion,
 		use,
 		except,
@@ -78,12 +113,12 @@ func NewCheckConfig(
 	)
 }
 
-// NewCheckConfig returns a new CheckConfig for only the use IDs and categories.
-func NewCheckConfigForUseIDsAndCategories(
+// NewEnabledCheckConfig returns a new enabled CheckConfig for only the use IDs and categories.
+func NewEnabledCheckConfigForUseIDsAndCategories(
 	fileVersion FileVersion,
 	use []string,
 ) CheckConfig {
-	return newCheckConfigNoValidate(
+	return newEnabledCheckConfigNoValidate(
 		fileVersion,
 		slicesext.ToUniqueSorted(use),
 		nil,
@@ -96,13 +131,14 @@ func NewCheckConfigForUseIDsAndCategories(
 
 type checkConfig struct {
 	fileVersion FileVersion
+	disabled    bool
 	use         []string
 	except      []string
 	ignore      []string
 	ignoreOnly  map[string][]string
 }
 
-func newCheckConfig(
+func newEnabledCheckConfig(
 	fileVersion FileVersion,
 	use []string,
 	except []string,
@@ -127,10 +163,10 @@ func newCheckConfig(
 	}
 	ignoreOnly = newIgnoreOnly
 
-	return newCheckConfigNoValidate(fileVersion, use, except, ignore, ignoreOnly), nil
+	return newEnabledCheckConfigNoValidate(fileVersion, use, except, ignore, ignoreOnly), nil
 }
 
-func newCheckConfigNoValidate(
+func newEnabledCheckConfigNoValidate(
 	fileVersion FileVersion,
 	use []string,
 	except []string,
@@ -139,11 +175,23 @@ func newCheckConfigNoValidate(
 ) *checkConfig {
 	return &checkConfig{
 		fileVersion: fileVersion,
+		disabled:    false,
 		use:         use,
 		except:      except,
 		ignore:      ignore,
 		ignoreOnly:  ignoreOnly,
 	}
+}
+
+func newDisabledCheckConfig(fileVersion FileVersion) *checkConfig {
+	return &checkConfig{
+		fileVersion: fileVersion,
+		disabled:    true,
+	}
+}
+
+func (c *checkConfig) Disabled() bool {
+	return c.disabled
 }
 
 func (c *checkConfig) FileVersion() FileVersion {


### PR DESCRIPTION
Up until now, we have made it an error to do the following in your `buf.yaml` configuration:

```yaml
# buf.yaml
version: v1
lint:
  ignore:
    - .
```

This being an error made sense - this is saying that you'd like to ignore lint for all paths in the module. If you didn't want to lint the module, then...don't lint it.

However, this did not take into account workspaces. We have never provided a way for someone to ignore a module within a workspace for linting. Even pre-v2-configuration, this might be something you'd want to do:

```yaml
# buf.work.yaml
version: v1
directories:
- proto/module1
- proto/module2
- vendor
```

You may commonly want to not lint `vendor` while still being able to run `buf lint` for the entire workspace.

In v2, this really comes into the fore. We should provide a way for people to ignore a single module. Instinctively, I would do this:

```yaml
# buf.yaml
version: v2
modules:
  - path: module1
  - path: module2
  - path: vendor
lint:
  ignore:
    - vendor
```

Or I might do this:

```yaml
# buf.yaml
version: v2
modules:
  - path: module1
  - path: module2
  - path: vendor
    lint:
      ignore:
        - vendor
```

However, before this PR, this would result in the following error:

```
Failure: decode buf.yaml: lint.ignore: path "vendor" is equal to module directory "vendor"
```

This PR makes this a valid configuration. If you specify an ignore that is also a module directory, lint (or breaking) checks will be disabled for this entire module.

`ignore` seems like the most logical place to do this. We did consider adding a special `disabled` key, however this feels like it just clutters the configuration. If we want to do this in the future, we can easily add it in in a backwards-compatible manner.

The actual code here isn't the prettiest, but it gets it in. Tests have been added to verify the behavior now matches what we expect.