### PR TITLE
Update exclude-dirs-use-default setting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  exclude-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -90,6 +88,7 @@ linters:
     - whitespace
   disable-all: true
 issues:
+  exclude-dirs-use-default: false
   exclude-rules:
     # We didn't turn on exhaustruct historically, but we really want to make sure it is turned on
     # for this file, as we do conversion between v1beta1 and v1 registry-proto types.


### PR DESCRIPTION
A previous commit in makego had this defined in the wrong place - it needs to be created under 'issues', not 'run'.