### PR TITLE
Update exclude-dirs-use-default setting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  exclude-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -85,6 +83,7 @@ linters:
     - whitespace
   disable-all: true
 issues:
+  exclude-dirs-use-default: false
   exclude-rules:
     - linters:
         - forbidigo


### PR DESCRIPTION
A previous commit in makego had this defined in the wrong place - it needs to be created under 'issues', not 'run'.