### PR TITLE
Rename plugin.binary to plugin.local for v2 buf.gen.yaml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ private/buf/bufwkt/cmd/wkt-go-data/wkt-go-data
 private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver/protoc-gen-insertion-point-receiver
 private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer/protoc-gen-insertion-point-writer
 private/buf/cmd/buf/command/alpha/protoc/test.txt
+private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/protoc-gen-top-level-type-names-yaml
 private/bufpkg/bufmodule/bufmoduleapi/cmd/buf-legacyfederation-go-data/buf-legacyfederation-go-data
 private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-commit-id-from-dashless/buf-commit-id-from-dashless
 private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-commit-id-to-dashless/buf-commit-id-to-dashless

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver/protoc-gen-insertion-point-receiver
 /private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer/protoc-gen-insertion-point-writer
 /private/buf/cmd/buf/command/alpha/protoc/test.txt
+/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/protoc-gen-top-level-type-names-yaml
 /private/bufpkg/bufmodule/bufmoduleapi/cmd/buf-legacyfederation-go-data/buf-legacyfederation-go-data
 /private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-commit-id-from-dashless/buf-commit-id-from-dashless
 /private/bufpkg/bufmodule/bufmoduletesting/cmd/buf-commit-id-to-dashless/buf-commit-id-to-dashless

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -19,7 +19,8 @@ GO_BINS := $(GO_BINS) \
 	private/pkg/spdx/cmd/spdx-go-data
 GO_TEST_BINS := $(GO_TEST_BINS) \
 	private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver \
-	private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer
+	private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer \
+	private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml
 GO_MOD_VERSION := 1.20
 DOCKER_BINS := $(DOCKER_BINS) buf
 FILE_IGNORES := $(FILE_IGNORES) \

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -184,6 +184,9 @@ func (g *generator) execPlugins(
 	for i, pluginConfig := range pluginConfigs {
 		index := i
 		currentPluginConfig := pluginConfig
+		// We're using this as a proxy for Type() == PluginConfigTypeRemote.
+		//
+		// We should be using the enum here.
 		remote := currentPluginConfig.RemoteHost()
 		if remote != "" {
 			remotePluginConfigTable[remote] = append(

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -136,6 +136,39 @@ func TestCompareInsertionPointOutput(t *testing.T) {
 	)
 }
 
+func TestGenerateV2LocalPluginBasic(t *testing.T) {
+	t.Parallel()
+
+	tempDirPath := t.TempDir()
+	input := filepath.Join("testdata", "v2", "local_plugin")
+	template := filepath.Join("testdata", "v2", "local_plugin", "buf.basic.gen.yaml")
+
+	testRunSuccess(
+		t,
+		"--output",
+		tempDirPath,
+		"--template",
+		template,
+		input,
+	)
+
+	expected, err := storagemem.NewReadBucket(
+		map[string][]byte{
+			filepath.Join("gen", "types.yaml"): []byte(`messages:
+    - a.v1.Bar
+    - a.v1.Foo
+`),
+		},
+	)
+	require.NoError(t, err)
+	actual, err := storageos.NewProvider().NewReadWriteBucket(tempDirPath)
+	require.NoError(t, err)
+
+	diff, err := storage.DiffBytes(context.Background(), command.NewRunner(), expected, actual)
+	require.NoError(t, err)
+	require.Empty(t, string(diff))
+}
+
 func TestOutputFlag(t *testing.T) {
 	t.Parallel()
 	for _, paths := range []struct {

--- a/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/main.go
+++ b/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/main.go
@@ -1,0 +1,69 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"sort"
+
+	"github.com/bufbuild/protoplugin"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	protoplugin.Main(protoplugin.HandlerFunc(handle))
+}
+
+func handle(
+	_ context.Context,
+	_ protoplugin.PluginEnv,
+	responseWriter protoplugin.ResponseWriter,
+	request protoplugin.Request,
+) error {
+	fileDescriptors, err := request.FileDescriptorsToGenerate()
+	if err != nil {
+		return err
+	}
+	externalFile := &externalFile{}
+	for _, fileDescriptor := range fileDescriptors {
+		enumDescriptors := fileDescriptor.Enums()
+		for i := 0; i < enumDescriptors.Len(); i++ {
+			externalFile.Enums = append(externalFile.Enums, string(enumDescriptors.Get(i).FullName()))
+		}
+		messageDescriptors := fileDescriptor.Messages()
+		for i := 0; i < messageDescriptors.Len(); i++ {
+			externalFile.Messages = append(externalFile.Messages, string(messageDescriptors.Get(i).FullName()))
+		}
+		serviceDescriptors := fileDescriptor.Services()
+		for i := 0; i < serviceDescriptors.Len(); i++ {
+			externalFile.Services = append(externalFile.Services, string(serviceDescriptors.Get(i).FullName()))
+		}
+	}
+	sort.Strings(externalFile.Enums)
+	sort.Strings(externalFile.Messages)
+	sort.Strings(externalFile.Services)
+	data, err := yaml.Marshal(externalFile)
+	if err != nil {
+		return err
+	}
+	responseWriter.AddFile("types.yaml", string(data))
+	return nil
+}
+
+type externalFile struct {
+	Enums    []string `json:"enums,omitempty" yaml:"enums,omitempty"`
+	Messages []string `json:"messages,omitempty" yaml:"messages,omitempty"`
+	Services []string `json:"services,omitempty" yaml:"services,omitempty"`
+}

--- a/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/usage.gen.go
+++ b/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package main
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/generate/testdata/v2/local_plugin/a/v1/a.proto
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/local_plugin/a/v1/a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package a.v1;
+
+message Foo {}
+
+message Bar {}

--- a/private/buf/cmd/buf/command/generate/testdata/v2/local_plugin/buf.basic.gen.yaml
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/local_plugin/buf.basic.gen.yaml
@@ -1,0 +1,4 @@
+version: v2
+plugins:
+  - local: protoc-gen-top-level-type-names-yaml
+    out: gen

--- a/private/buf/cmd/buf/command/generate/testdata/v2/local_plugin/buf.yaml
+++ b/private/buf/cmd/buf/command/generate/testdata/v2/local_plugin/buf.yaml
@@ -1,0 +1,1 @@
+version: v2

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -495,8 +495,10 @@ type externalGeneratePluginConfigV2 struct {
 	Remote *string `json:"remote,omitempty" yaml:"remote,omitempty"`
 	// Revision is only valid with Remote set.
 	Revision *int `json:"revision,omitempty" yaml:"revision,omitempty"`
-	// Binary is the binary path, which can be one string or multiple strings.
-	Binary interface{} `json:"binary,omitempty" yaml:"binary,omitempty"`
+	// Local is the local path (either relative or absolute) to a binary or other runnable program which
+	// implements the protoc plugin interface. This can be one string (the program) or multiple (remaining
+	// strings are arguments to the program).
+	Local interface{} `json:"local,omitempty" yaml:"local,omitempty"`
 	// ProtocBuiltin is the protoc built-in plugin name, in the form of 'java' instead of 'protoc-gen-java'.
 	ProtocBuiltin *string `json:"protoc_builtin,omitempty" yaml:"protoc_builtin,omitempty"`
 	// ProtocPath is only valid with ProtocBuiltin

--- a/private/bufpkg/bufconfig/generate_config_test.go
+++ b/private/bufpkg/bufconfig/generate_config_test.go
@@ -47,7 +47,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 				managedConfig: &generateManagedConfig{enabled: false},
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "java",
 						out:              "java/out",
 						// one string because it's one string in the config
@@ -74,7 +74,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 				managedConfig: &generateManagedConfig{enabled: false},
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "java",
 						out:              "java/out",
 						opts:             []string{"a"},
@@ -101,7 +101,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 				managedConfig: &generateManagedConfig{enabled: false},
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeBinary,
+						pluginConfigType: PluginConfigTypeLocal,
 						name:             "go",
 						out:              "go/out",
 						path:             []string{"go", "run", "goplugin"},
@@ -129,7 +129,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 				managedConfig: &generateManagedConfig{enabled: false},
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeBinary,
+						pluginConfigType: PluginConfigTypeLocal,
 						name:             "go",
 						out:              "go/out",
 						path:             []string{"go", "run", "goplugin"},
@@ -155,7 +155,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 				managedConfig: &generateManagedConfig{enabled: false},
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeBinary,
+						pluginConfigType: PluginConfigTypeLocal,
 						name:             "go2",
 						out:              "go2/out",
 						path:             []string{"protoc-gen-go"},
@@ -179,7 +179,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 				managedConfig: &generateManagedConfig{enabled: false},
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeBinary,
+						pluginConfigType: PluginConfigTypeLocal,
 						name:             "go2",
 						out:              "go2/out",
 						path:             []string{"protoc-gen-go"},
@@ -302,7 +302,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},
@@ -341,7 +341,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},
@@ -420,7 +420,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},
@@ -476,7 +476,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},
@@ -527,7 +527,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},
@@ -577,7 +577,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},
@@ -633,7 +633,7 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 			expectedConfig: &generateConfig{
 				pluginConfigs: []GeneratePluginConfig{
 					&pluginConfig{
-						pluginConfigType: PluginConfigTypeLocal,
+						pluginConfigType: PluginConfigTypeLocalOrProtocBuiltin,
 						name:             "go",
 						out:              "go/out",
 					},

--- a/windows/test.bash
+++ b/windows/test.bash
@@ -31,5 +31,6 @@ go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
 go install connectrpc.com/connect/cmd/protoc-gen-connect-go@${CONNECT_VERSION}
 go install ./cmd/buf \
   ./private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-writer \
-  ./private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver
+  ./private/buf/cmd/buf/command/alpha/protoc/internal/protoc-gen-insertion-point-receiver \
+  ./private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml
 go test ./...


### PR DESCRIPTION
This renames the `plugins.binary` key to `plugins.local` for `v2` `buf.gen.yamls`.

This also adds some test helpers to help test `buf generate`. A new test plugin `protoc-gen-top-level-type-names-yaml` is added that will list all the enums, message, and services at the top-level of the input in a `types.yaml` file. For example, if the `out` is `gen`, `gen/types.yaml` would contain (for an input with these types):

```yaml
enums:
    - foo.v1.EnumOne
    - foo.v1.EnumTwo
messages:
    - foo.v1.MessageOne
services:
    - foo.v1.ServiceOne
```

A test is added like this:

```go
func TestGenerateV2LocalPluginBasic(t *testing.T) {
       t.Parallel()

       tempDirPath := t.TempDir()
       input := filepath.Join("testdata", "v2", "local_plugin")
       template := filepath.Join("testdata", "v2", "local_plugin", "buf.basic.gen.yaml")

       testRunSuccess(
               t,
               "--output",
               tempDirPath,
               "--template",
               template,
               input,
       )

       expected, err := storagemem.NewReadBucket(
               map[string][]byte{
                       filepath.Join("gen", "types.yaml"): []byte(`messages:
    - a.v1.Bar
    - a.v1.Foo
`),
               },
       )
       require.NoError(t, err)
       actual, err := storageos.NewProvider().NewReadWriteBucket(tempDirPath)
       require.NoError(t, err)

       diff, err := storage.DiffBytes(context.Background(), command.NewRunner(), expected, actual)
       require.NoError(t, err)
       require.Empty(t, string(diff))
}
```

This testing pattern can be used for other `buf generate` tests.