### PR TITLE
Modify protoc-gen-top-level-type-names-yaml to output per-proto-file yaml files

### DIFF
--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -154,7 +154,7 @@ func TestGenerateV2LocalPluginBasic(t *testing.T) {
 
 	expected, err := storagemem.NewReadBucket(
 		map[string][]byte{
-			filepath.Join("gen", "types.yaml"): []byte(`messages:
+			filepath.Join("gen", "a", "v1", "a.top-level-type-names.yaml"): []byte(`messages:
     - a.v1.Bar
     - a.v1.Foo
 `),


### PR DESCRIPTION
This modifies `protoc-gen-top-level-type-names-yaml` to output yaml files for each `.proto` file, instead of a single `types.yaml` file. This makes the plugin more inline with other common `protoc` plugins, and allows us to test `strategy: directory` properly.

The file `a/v1/a.proto` will result in `${OUT}/a/v1/a.top-level-type-names.yaml`.