### PR TITLE
Add 'commit' as an alias for 'tag' param in inputs that refer to git repos

### DIFF
--- a/private/buf/buffetch/internal/errors.go
+++ b/private/buf/buffetch/internal/errors.go
@@ -38,14 +38,14 @@ func NewFormatCannotBeDeterminedError(value string) error {
 	return fmt.Errorf("format cannot be determined from %q", value)
 }
 
-// NewCannotSpecifyGitBranchAndTagError is a fetch error.
-func NewCannotSpecifyGitBranchAndTagError() error {
-	return errors.New(`must specify only one of "branch", "tag"`)
+// NewCannotSpecifyGitBranchAndCommitOrTagError is a fetch error.
+func NewCannotSpecifyGitBranchAndCommitOrTagError() error {
+	return errors.New(`must specify only one of "branch", "commit", or "tag"`)
 }
 
-// NewCannotSpecifyTagWithRefError is a fetch error.
-func NewCannotSpecifyTagWithRefError() error {
-	return errors.New(`cannot specify "tag" with "ref"`)
+// NewCannotSpecifyCommitOrTagWithRefError is a fetch error.
+func NewCannotSpecifyCommitOrTagWithRefError() error {
+	return errors.New(`cannot specify "commit" or "tag" with "ref"`)
 }
 
 // NewDepthParseError is a fetch error.

--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -522,35 +522,41 @@ func NewProtoFileWriter(
 // The Path will be the only value set when the RawRefProcessor is invoked, and is not normalized.
 // After the RawRefProcessor is called, options will be parsed.
 type RawRef struct {
-	// Will always be set
-	// Not normalized yet
+	// Will always be set.
+	// Not normalized yet.
 	Path string
-	// Will always be set
-	// Set via RawRefProcessor if not explicitly set
+	// Will always be set.
+	// Set via RawRefProcessor if not explicitly set.
 	Format string
-	// Only set for single, archive formats
-	// Cannot be set for zip archives
+	// Only set for single, archive formats.
+	// Cannot be set for zip archives.
 	CompressionType CompressionType
-	// Only set for archive, git formats
+	// Only set for archive, git formats.
 	SubDirPath string
-	// Only set for git formats
-	// Only one of GitBranch and GitTag will be set
+	// Only set for git formats.
+	// Only one of GitBranch and GitCommitOrTag will be set.
 	GitBranch string
+	// Only set for git formats.
+	// Only one of GitBranch and GitCommitOrTag will be set.
+	// Should indicate a full commit hash or tag name.
+	// This is defined as anything that can be given to "git fetch".
+	GitCommitOrTag string
 	// Only set for git formats
-	// Only one of GitBranch and GitTag will be set
-	GitTag string
-	// Only set for git formats
-	// Specifies an exact git reference to use with git checkout.
-	// Can be used on its own or with GitBranch. Not allowed with GitTag.
-	// This is defined as anything that can be given to git checkout.
+	// Specifies a git reference to use with "git checkout".
+	// Can be used on its own or with GitBranch. Not allowed with GitCommitOrTag.
+	// This is defined as anything that can be given to "git checkout".
+	// Differs from GitCommitOrTag in that it can be a short hash, or even a
+	// relative commit, such as "HEAD^2".
 	GitRef string
-	// Only set for git formats
+	// Only set for git formats.
 	GitRecurseSubmodules bool
 	// Only set for git formats.
 	// The depth to use when cloning a repository. Only allowed when GitRef
-	// is set. Defaults to 50 if unset.
+	// is set. Defaults to 50 if unset. It must be deep enough that the
+	// requested GitRef will be included when cloning the requested branch
+	// (or the repo's default branch if GitBranch is empty).
 	GitDepth uint32
-	// Only set for archive formats
+	// Only set for archive formats.
 	ArchiveStripComponents uint32
 	// Only set for proto file ref format.
 	// Sets whether or not to include the files in the rest of the package

--- a/private/buf/buffetch/ref_parser_test.go
+++ b/private/buf/buffetch/ref_parser_test.go
@@ -1260,17 +1260,17 @@ func TestGetParsedRefError(t *testing.T) {
 	)
 	testGetParsedRefError(
 		t,
-		internal.NewCannotSpecifyGitBranchAndTagError(),
+		internal.NewCannotSpecifyGitBranchAndCommitOrTagError(),
 		"path/to/foo#format=git,branch=foo,tag=bar",
 	)
 	testGetParsedRefError(
 		t,
-		internal.NewCannotSpecifyGitBranchAndTagError(),
+		internal.NewCannotSpecifyGitBranchAndCommitOrTagError(),
 		"path/to/foo#format=git,branch=foo,tag=bar,ref=baz",
 	)
 	testGetParsedRefError(
 		t,
-		internal.NewCannotSpecifyTagWithRefError(),
+		internal.NewCannotSpecifyCommitOrTagWithRefError(),
 		"path/to/foo#format=git,tag=foo,ref=bar",
 	)
 	testGetParsedRefError(

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -570,6 +570,7 @@ type externalInputConfigV2 struct {
 	StripComponents     *uint32 `json:"strip_components,omitempty" yaml:"strip_components,omitempty"`
 	Subdir              *string `json:"subdir,omitempty" yaml:"subdir,omitempty"`
 	Branch              *string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	Commit              *string `json:"commit,omitempty" yaml:"tag,omitempty"`
 	Tag                 *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 	Ref                 *string `json:"ref,omitempty" yaml:"ref,omitempty"`
 	Depth               *uint32 `json:"depth,omitempty" yaml:"depth,omitempty"`

--- a/private/bufpkg/bufconfig/input_config.go
+++ b/private/bufpkg/bufconfig/input_config.go
@@ -144,7 +144,7 @@ type InputConfig interface {
 	SubDir() string
 	// Branch returns the git branch to checkout out, not empty only if format is git.
 	Branch() string
-	// CommitOrTag returns the git tag to checkout, not empty only if format is git.
+	// CommitOrTag returns the full commit hash or tag to checkout, not empty only if format is git.
 	CommitOrTag() string
 	// Ref returns the git ref to checkout, not empty only if format is git.
 	Ref() string
@@ -171,7 +171,7 @@ func NewGitRepoInputConfig(
 	location string,
 	subDir string,
 	branch string,
-	tag string,
+	commitOrTag string,
 	ref string,
 	depth *uint32,
 	recurseSubModules bool,
@@ -184,7 +184,7 @@ func NewGitRepoInputConfig(
 		location:          location,
 		subDir:            subDir,
 		branch:            branch,
-		commitOrTag:       tag,
+		commitOrTag:       commitOrTag,
 		ref:               ref,
 		depth:             depth,
 		recurseSubmodules: recurseSubModules,


### PR DESCRIPTION
This is intended to fix an issue that is commonly encountered when users try to pin an input to a particular commit of a git repo. The most intuitive parameter to use is `ref`, with a full commit hash. But the way that actually works is to clone the given `branch` (or repo's default branch if no `branch` param specified), only up to 50 commits deep (can be overridden/increased with `depth` param). This is a problem because, as more commits are added to the repo, the `ref` eventually falls out of the 50-commit depth of the branch's history.

It turns out, that one can use a full commit hash with the `tag` param instead. This pins to a commit perfectly. But `tag` is not an intuitive name for a parameter that accepts a commit hash.

So this PR simply allows users to use `commit` as a parameter, and it means the same thing as `tag`. Unlike `ref`, it **must** be a full hash (no short hashes allowed).

After this is merged and released, I will update the documentation to add `commit` and describe it as for use with full commit hashes or tag names (and to also mention that `tag` is an alias for this parameter, for clarity when using tag names as well as for backwards compatibility).