### PR TITLE
Omit build roots in v1 buf.yaml serialization

### DIFF
--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -496,7 +496,7 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 		externalBufYAMLFile := externalBufYAMLFileV1Beta1V1{
 			Version: fileVersion.String(),
 		}
-		// Alredy sorted.
+		// Already sorted.
 		externalBufYAMLFile.Deps = slicesext.Map(
 			bufYAMLFile.ConfiguredDepModuleRefs(),
 			func(moduleRef bufmodule.ModuleRef) string {
@@ -512,10 +512,13 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 		if len(rootToExcludes) != 1 || !(ok && len(excludes) == 0) {
 			roots := slicesext.MapKeysToSortedSlice(rootToExcludes)
 			for _, root := range roots {
-				externalBufYAMLFile.Build.Roots = append(
-					externalBufYAMLFile.Build.Roots,
-					root,
-				)
+				// Roots only valid for v1beta1
+				if fileVersion == FileVersionV1Beta1 {
+					externalBufYAMLFile.Build.Roots = append(
+						externalBufYAMLFile.Build.Roots,
+						root,
+					)
+				}
 				for _, exclude := range rootToExcludes[root] {
 					// Excludes are defined to be sorted.
 					externalBufYAMLFile.Build.Excludes = append(

--- a/private/bufpkg/bufconfig/buf_yaml_file_test.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file_test.go
@@ -56,6 +56,22 @@ lint:
 
 	testReadWriteBufYAMLFileRoundTrip(
 		t,
+		//input
+		`version: v1
+build:
+  excludes:
+    - tests
+`,
+		// expected output
+		`version: v1
+build:
+  excludes:
+    - tests
+`,
+	)
+
+	testReadWriteBufYAMLFileRoundTrip(
+		t,
 		// input
 		`version: v2
 lint:


### PR DESCRIPTION
Update buf.yaml serialization to omit the 'build' -> 'roots' section of for v1. This is only valid for v1beta1 config files.

Add a test case to verify the fix (previous failed to round trip v1 config files with excludes).