### PR TITLE
Fix generate v2 disable rules exclusions

### DIFF
--- a/private/bufpkg/bufimage/bufimagemodify/override.go
+++ b/private/bufpkg/bufimage/bufimagemodify/override.go
@@ -235,6 +235,9 @@ func isFileOptionDisabledForFile(
 		if disableRule.FileOption() != bufconfig.FileOptionUnspecified && disableRule.FileOption() != fileOption {
 			continue
 		}
+		if disableRule.FieldOption() != bufconfig.FieldOptionUnspecified {
+			continue // FieldOption specified, not a matching FileOption
+		}
 		if !fileMatchConfig(imageFile, disableRule.Path(), disableRule.ModuleFullName()) {
 			continue
 		}

--- a/private/bufpkg/bufimage/bufimagemodify/override.go
+++ b/private/bufpkg/bufimage/bufimagemodify/override.go
@@ -236,7 +236,7 @@ func isFileOptionDisabledForFile(
 			continue
 		}
 		if disableRule.FieldOption() != bufconfig.FieldOptionUnspecified {
-			continue // FieldOption specified, not a matching FileOption
+			continue // FieldOption specified, not a matching rule.
 		}
 		if !fileMatchConfig(imageFile, disableRule.Path(), disableRule.ModuleFullName()) {
 			continue


### PR DESCRIPTION
Fix for a disable rule targeting a `field_option` being applied to a `file_option` and vice versa. For example the following `buf.gen.yaml` file:
```yaml
version: v2
managed:
  enabled: true
  disable:
    - module: buf.build/emcfarlane/foo
      field_option: jstype
  override:
    - file_option: go_package_prefix
      module: buf.build/emcfarlane/foo
      value: github.com/emcfarlane/foo
plugins:
  - local: protoc-gen-go
    out: gen
    opt: 
      - paths=source_relative
inputs:
  - module: buf.build/emcfarlane/foo
```
The disable rule should not affect the `file_option: go_package_prefix`.