### PR TITLE
Provide mechanism to start implementing and testing editions-specific functionality

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -277,3 +277,8 @@ issues:
       # This greatly simplifies creation of descriptors, and it's safe enough since
       # it's just test code.
       path: private/bufpkg/bufimage/source_retention_options_test\.go
+    - linters:
+        - gochecknoinits
+      # Only safe way to opt-in to protocompile editions support. Temporary and
+      # will be removed once opt-in is not necessary.
+      path: private/bufpkg/bufimage/build_image.go

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.33.0-20240401180337-569d290ee4cc.1
 	connectrpc.com/connect v1.16.0
 	connectrpc.com/otelconnect v0.7.0
-	github.com/bufbuild/protocompile v0.9.1-0.20240308135515-fa654189ac66
+	github.com/bufbuild/protocompile v0.10.0
 	github.com/bufbuild/protoplugin v0.0.0-20240318153824-eeb4e72439df
 	github.com/bufbuild/protovalidate-go v0.6.0
 	github.com/bufbuild/protoyaml-go v0.1.8
@@ -42,7 +42,7 @@ require (
 	golang.org/x/sync v0.6.0
 	golang.org/x/term v0.18.0
 	golang.org/x/tools v0.19.0
-	google.golang.org/protobuf v1.33.0
+	google.golang.org/protobuf v1.33.1-0.20240319125436-3039476726e4
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/bufbuild/protocompile v0.9.1-0.20240308135515-fa654189ac66 h1:loZ5KuOGAbdWg6Nw1B4ciG6JoPajiTp4kfgysDrigAQ=
-github.com/bufbuild/protocompile v0.9.1-0.20240308135515-fa654189ac66/go.mod h1:s89m1O8CqSYpyE/YaSGtg1r1YFMF5nLTwh4vlj6O444=
+github.com/bufbuild/protocompile v0.10.0 h1:+jW/wnLMLxaCEG8AX9lD0bQ5v9h1RUiMKOBOT5ll9dM=
+github.com/bufbuild/protocompile v0.10.0/go.mod h1:G9qQIQo0xZ6Uyj6CMNz0saGmx2so+KONo8/KrELABiY=
 github.com/bufbuild/protoplugin v0.0.0-20240318153824-eeb4e72439df h1:NKWBNfCyh69MyW1qrL2cdY5AlTwXC8fN0vqwjC39yKw=
 github.com/bufbuild/protoplugin v0.0.0-20240318153824-eeb4e72439df/go.mod h1:x9aJ5IuWuJIKJKSyEa7WS7knVx2s2rv0MzcvYEyDRtM=
 github.com/bufbuild/protovalidate-go v0.6.0 h1:Jgs1kFuZ2LHvvdj8SpCLA1W/+pXS8QSM3F/E2l3InPY=
@@ -237,8 +237,9 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.62.1 h1:B4n+nfKzOICUXMgyrNd19h/I9oH0L1pizfk1d4zSgTk=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.33.1-0.20240319125436-3039476726e4 h1:fea3X9JPnW4oM9z1ctAuAN7kAnM/YbdI7QHCZXKLVMk=
+google.golang.org/protobuf v1.33.1-0.20240319125436-3039476726e4/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/a.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/a.proto
@@ -9,7 +9,7 @@ message Foo {
 	option (message_foo).foo = "str";
 	option (message_baz) = "str";
 
-	optional string foo = 1 [
+	optional uint64 foo = 1 [
 		(field_foo).foo = "str",
 		(field_baz) = "str",
 		jstype = JS_STRING

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/all-exclude-options.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/all-exclude-options.txtar
@@ -4,7 +4,7 @@ package pkg;
 message Empty {
 }
 message Foo {
-  optional string foo = 1 [jstype = JS_STRING];
+  optional uint64 foo = 1 [jstype = JS_STRING];
   oneof testOneof {
     string bar = 2;
     bytes baz = 3;

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/all-with-Files.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/all-with-Files.txtar
@@ -9,7 +9,7 @@ message Empty {
 message Foo {
   option (message_baz) = "str";
   option (message_foo) = { foo: "str" };
-  optional string foo = 1 [
+  optional uint64 foo = 1 [
     jstype = JS_STRING,
     (field_baz) = "str",
     (field_foo) = { foo: "str" }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/all.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/all.txtar
@@ -9,7 +9,7 @@ message Empty {
 message Foo {
   option (message_baz) = "str";
   option (message_foo) = { foo: "str" };
-  optional string foo = 1 [
+  optional uint64 foo = 1 [
     jstype = JS_STRING,
     (field_baz) = "str",
     (field_foo) = { foo: "str" }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.Foo.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.Foo.txtar
@@ -7,7 +7,7 @@ option (UsedOption.file_foo) = { foo: "str" };
 message Foo {
   option (message_baz) = "str";
   option (message_foo) = { foo: "str" };
-  optional string foo = 1 [
+  optional uint64 foo = 1 [
     jstype = JS_STRING,
     (field_baz) = "str",
     (field_foo) = { foo: "str" }

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	_ "unsafe" // to support go:linkname below
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
@@ -27,6 +26,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/thread"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/bufbuild/protocompile"
+	"github.com/bufbuild/protocompile/editionstesting"
 	"github.com/bufbuild/protocompile/linker"
 	"github.com/bufbuild/protocompile/parser"
 	"github.com/bufbuild/protocompile/protoutil"
@@ -34,13 +34,13 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// This enables editions support in protocompile. Buf doesn't yet support editions, but rejecting
-// such files happens elsewhere (in github.com/bufbuilder/buf/private/pkg/protodescriptor). We
-// need the compiler's support enabled so that we can start implementing and testing editions
-// support in the CLI, before we enable that support for users.
-//
-//go:linkname allowEditionsInCompiler github.com/bufbuild/protocompile/internal.AllowEditions
-var allowEditionsInCompiler = true
+func init() {
+	// This enables editions support in protocompile. Buf doesn't yet support editions, but rejecting
+	// such files happens elsewhere (in github.com/bufbuilder/buf/private/pkg/protodescriptor). We
+	// need the compiler's support enabled so that we can start implementing and testing editions
+	// support in the CLI, before we enable that support for users.
+	editionstesting.AllowEditions()
+}
 
 func buildImage(
 	ctx context.Context,

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	_ "unsafe" // to support go:linkname below
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
@@ -32,6 +33,14 @@ import (
 	"github.com/bufbuild/protocompile/reporter"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
+
+// This enables editions support in protocompile. Buf doesn't yet support editions, but rejecting
+// such files happens elsewhere (in github.com/bufbuilder/buf/private/pkg/protodescriptor). We
+// need the compiler's support enabled so that we can start implementing and testing editions
+// support in the CLI, before we enable that support for users.
+//
+//go:linkname allowEditionsInCompiler github.com/bufbuild/protocompile/internal.AllowEditions
+var allowEditionsInCompiler = true
 
 func buildImage(
 	ctx context.Context,


### PR DESCRIPTION
This allows us to start implementing and testing logic for editions (which is mostly confined to protosource and bufbreaking), before actually having the CLI provide editions support to users. The idea is that users won't be able to use editions with the CLI until everything is updated to work correctly, but we need a way to enable the support until then, for testing any in-progress editions-specific work.

We have to use "shenanigans" with `go:linkname` because support isn't yet complete and enabled in protocompile, but it's complete "enough" for what we need to do in the CLI (or at least it will be after https://github.com/bufbuild/protocompile/pull/264 lands, and a new release is cut). Unfortunately, protocompile won't be "done-done" with editions support until we can get protobuf-go's `descriptorpb` package updated with the [latest editions-related changes](https://github.com/protocolbuffers/protobuf/commit/b09b3e46fe2a111d412251f6d043649334e9cbee#diff-ccd6d1c124956da1d1ef88a291957bd98abf1b0e7472f7e5153f7b70ef20efb2), and that's not likely to happen until we get a release candidate for v27.0 of protoc 😞.

Happy to hold off until cutting that next release of protocompile, but I wanted to open this up for discussion as I suspect the technique here (which some might call "crimes") may be controversial 😂.