### PR TITLE
Fix plugins field validation for out

### DIFF
--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -509,7 +509,7 @@ type externalGeneratePluginConfigV2 struct {
 	Opt            interface{} `json:"opt,omitempty" yaml:"opt,omitempty"`
 	IncludeImports bool        `json:"include_imports,omitempty" yaml:"include_imports,omitempty"`
 	IncludeWKT     bool        `json:"include_wkt,omitempty" yaml:"include_wkt,omitempty"`
-	// Strategy is only valid with ProtoBuiltin and Binary.
+	// Strategy is only valid with ProtoBuiltin and Local.
 	Strategy *string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }
 

--- a/private/bufpkg/bufconfig/generate_plugin_config.go
+++ b/private/bufpkg/bufconfig/generate_plugin_config.go
@@ -400,6 +400,9 @@ func newPluginConfigFromExternalV2(
 	if pluginTypeCount > 1 {
 		return nil, errors.New("only one of remote, local or protoc_builtin")
 	}
+	if externalConfig.Out == "" {
+		return nil, errors.New("must specify out")
+	}
 	var strategy string
 	if externalConfig.Strategy != nil {
 		strategy = *externalConfig.Strategy


### PR DESCRIPTION
For `buf.gen.yaml` v2 enforce plugins `out` as a required field with a non default empty string.