### PR TITLE
Fix error message for invalid buf.work.yaml versions

### DIFF
--- a/private/bufpkg/bufconfig/buf_work_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_work_yaml_file.go
@@ -181,8 +181,7 @@ func readBufWorkYAMLFile(
 		return nil, err
 	}
 	if fileVersion != FileVersionV1 {
-		// This is effectively a system error.
-		return nil, syserror.Wrap(newUnsupportedFileVersionError("", fileVersion))
+		return nil, newUnsupportedFileVersionError(objectData.Name(), fileVersion)
 	}
 	var externalBufWorkYAMLFile externalBufWorkYAMLFileV1
 	if err := getUnmarshalStrict(allowJSON)(data, &externalBufWorkYAMLFile); err != nil {


### PR DESCRIPTION
An invalid `buf.work.yaml` version will raise a system error on read:

`Failure: it looks like you have found a bug in buf. Please file an issue at https://github.com/bufbuild/buf/issues and provide the command you ran, as well as the following message: v2 is not supported`

Downgrade the error to report a decode issue:

`Failure: decode buf.work.yaml: v2 is not supported for buf.work.yaml files`

Other system errors for version are all on write, keep current system error behaviour.