### PR TITLE
Add concept of deprecated bufcheck Rules and make FILE_SAME_PHP_GENERIC_SERVICES the first deprecated Rule

### DIFF
--- a/private/buf/bufmigrate/migrator.go
+++ b/private/buf/bufmigrate/migrator.go
@@ -701,22 +701,21 @@ func equivalentCheckConfigInV2(
 		return nil, err
 	}
 
-	expectedIDs := filterFileSamePhpGenericServices(
-		slicesext.Map(
-			expectedRules,
-			func(rule bufcheck.Rule) string {
-				return rule.ID()
-			},
-		),
+	expectedIDs := slicesext.Map(
+		expectedRules,
+		func(rule bufcheck.Rule) string {
+			return rule.ID()
+		},
 	)
+
 	// First create a check config with the exact same UseIDsAndCategories. This
 	// is a simple translation. It may or may not be equivalent to the given check config.
 	simplyTranslatedCheckConfig, err := bufconfig.NewEnabledCheckConfig(
 		bufconfig.FileVersionV2,
-		filterFileSamePhpGenericServices(checkConfig.UseIDsAndCategories()),
-		filterFileSamePhpGenericServices(checkConfig.ExceptIDsAndCategories()),
+		checkConfig.UseIDsAndCategories(),
+		checkConfig.ExceptIDsAndCategories(),
 		checkConfig.IgnorePaths(),
-		filterFileSamePhpGenericServicesMap(checkConfig.IgnoreIDOrCategoryToPaths()),
+		checkConfig.IgnoreIDOrCategoryToPaths(),
 	)
 	if err != nil {
 		return nil, err
@@ -725,13 +724,11 @@ func equivalentCheckConfigInV2(
 	if err != nil {
 		return nil, err
 	}
-	simplyTranslatedIDs := filterFileSamePhpGenericServices(
-		slicesext.Map(
-			simplyTranslatedRules,
-			func(rule bufcheck.Rule) string {
-				return rule.ID()
-			},
-		),
+	simplyTranslatedIDs := slicesext.Map(
+		simplyTranslatedRules,
+		func(rule bufcheck.Rule) string {
+			return rule.ID()
+		},
 	)
 	if slicesext.ElementsEqual(expectedIDs, simplyTranslatedIDs) {
 		// If the simple translation is equivalent to before, use it.
@@ -761,24 +758,4 @@ func equivalentCheckConfigInV2(
 		checkConfig.IgnorePaths(),
 		checkConfig.IgnoreIDOrCategoryToPaths(),
 	)
-}
-
-func filterFileSamePhpGenericServices(ids []string) []string {
-	return slicesext.Filter(
-		ids,
-		func(id string) bool {
-			return id != "FILE_SAME_PHP_GENERIC_SERVICES"
-		},
-	)
-}
-
-func filterFileSamePhpGenericServicesMap(m map[string][]string) map[string][]string {
-	c := make(map[string][]string)
-	for k, v := range c {
-		if k == "FILE_SAME_PHP_GENERIC_SERVICES" {
-			continue
-		}
-		c[k] = v
-	}
-	return c
 }

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -812,61 +812,61 @@ func TestLsBreakingRulesDeprecated(t *testing.T) {
 
 	stdout := bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1beta1")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1beta1", "--include-deprecated")
-	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.Contains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1", "--include-deprecated")
-	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.Contains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1beta1")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1beta1", "--include-deprecated")
-	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.Contains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1", "--include-deprecated")
-	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.Contains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v2")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v2", "--include-deprecated")
-	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.Contains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	// Test the non-all version too. Should never have deprecated rules.
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--include-deprecated")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--configured-only")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 
 	stdout = bytes.NewBuffer(nil)
 	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--configured-only", "--include-deprecated")
-	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+	assert.NotContains(t, stdout.String(), "FILE_SAME_PHP_GENERIC_SERVICES")
 }
 
 func TestLsFiles(t *testing.T) {

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -807,6 +807,68 @@ FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED          WIRE_JSON, WIRE                 
 	)
 }
 
+func TestLsBreakingRulesDeprecated(t *testing.T) {
+	t.Parallel()
+
+	stdout := bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1beta1")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1beta1", "--include-deprecated")
+	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--version", "v1", "--include-deprecated")
+	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1beta1")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1beta1", "--include-deprecated")
+	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v1", "--include-deprecated")
+	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v2")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--version", "v2", "--include-deprecated")
+	assert.Contains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	// Test the non-all version too. Should never have deprecated rules.
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "mod", "ls-breaking-rules", "--include-deprecated")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--configured-only")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+
+	stdout = bytes.NewBuffer(nil)
+	testRun(t, 0, nil, stdout, "config", "ls-breaking-rules", "--configured-only", "--include-deprecated")
+	assert.NotContains(t, string(stdout.Bytes()), "FILE_SAME_PHP_GENERIC_SERVICES")
+}
+
 func TestLsFiles(t *testing.T) {
 	t.Parallel()
 	testRunStdout(

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -652,7 +652,6 @@ FILE_SAME_JAVA_STRING_CHECK_UTF8                FILE, PACKAGE                   
 FILE_SAME_OBJC_CLASS_PREFIX                     FILE, PACKAGE                   Checks that files have the same value for the objc_class_prefix option.
 FILE_SAME_OPTIMIZE_FOR                          FILE, PACKAGE                   Checks that files have the same value for the optimize_for option.
 FILE_SAME_PHP_CLASS_PREFIX                      FILE, PACKAGE                   Checks that files have the same value for the php_class_prefix option.
-FILE_SAME_PHP_GENERIC_SERVICES                  FILE, PACKAGE                   Checks that files have the same value for the php_generic_services option.
 FILE_SAME_PHP_METADATA_NAMESPACE                FILE, PACKAGE                   Checks that files have the same value for the php_metadata_namespace option.
 FILE_SAME_PHP_NAMESPACE                         FILE, PACKAGE                   Checks that files have the same value for the php_namespace option.
 FILE_SAME_PY_GENERIC_SERVICES                   FILE, PACKAGE                   Checks that files have the same value for the py_generic_services option.
@@ -763,7 +762,6 @@ FILE_SAME_JAVA_STRING_CHECK_UTF8                FILE, PACKAGE                   
 FILE_SAME_OBJC_CLASS_PREFIX                     FILE, PACKAGE                   Checks that files have the same value for the objc_class_prefix option.
 FILE_SAME_OPTIMIZE_FOR                          FILE, PACKAGE                   Checks that files have the same value for the optimize_for option.
 FILE_SAME_PHP_CLASS_PREFIX                      FILE, PACKAGE                   Checks that files have the same value for the php_class_prefix option.
-FILE_SAME_PHP_GENERIC_SERVICES                  FILE, PACKAGE                   Checks that files have the same value for the php_generic_services option.
 FILE_SAME_PHP_METADATA_NAMESPACE                FILE, PACKAGE                   Checks that files have the same value for the php_metadata_namespace option.
 FILE_SAME_PHP_NAMESPACE                         FILE, PACKAGE                   Checks that files have the same value for the php_namespace option.
 FILE_SAME_PY_GENERIC_SERVICES                   FILE, PACKAGE                   Checks that files have the same value for the py_generic_services option.

--- a/private/buf/cmd/buf/command/config/internal/internal.go
+++ b/private/buf/cmd/buf/command/config/internal/internal.go
@@ -107,7 +107,10 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.IncludeDeprecated,
 		includeDeprecatedFlagName,
 		false,
-		`Also print deprecated rules.`,
+		fmt.Sprintf(
+			`Also print deprecated rules. Has no effect if --%s is set.`,
+			configuredOnlyFlagName,
+		),
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/config/internal/internal.go
+++ b/private/buf/cmd/buf/command/config/internal/internal.go
@@ -33,11 +33,12 @@ import (
 )
 
 const (
-	configuredOnlyFlagName = "configured-only"
-	configFlagName         = "config"
-	formatFlagName         = "format"
-	versionFlagName        = "version"
-	modulePathFlagName     = "module-path"
+	configuredOnlyFlagName    = "configured-only"
+	configFlagName            = "config"
+	includeDeprecatedFlagName = "include-deprecated"
+	formatFlagName            = "format"
+	versionFlagName           = "version"
+	modulePathFlagName        = "module-path"
 )
 
 // NewLSCommand returns a new ls Command.
@@ -74,11 +75,12 @@ func NewLSCommand(
 }
 
 type flags struct {
-	ConfiguredOnly bool
-	Config         string
-	Format         string
-	Version        string
-	ModulePath     string
+	ConfiguredOnly    bool
+	Config            string
+	IncludeDeprecated bool
+	Format            string
+	Version           string
+	ModulePath        string
 }
 
 func newFlags() *flags {
@@ -100,6 +102,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			`The buf.yaml file or data to use for configuration. --%s must be set`,
 			configuredOnlyFlagName,
 		),
+	)
+	flagSet.BoolVar(
+		&f.IncludeDeprecated,
+		includeDeprecatedFlagName,
+		false,
+		`Also print deprecated rules.`,
 	)
 	flagSet.StringVar(
 		&f.Format,
@@ -242,6 +250,7 @@ func lsRun(
 		container.Stdout(),
 		rules,
 		flags.Format,
+		flags.IncludeDeprecated,
 	)
 }
 

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -105,7 +105,10 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.IncludeDeprecated,
 		includeDeprecatedFlagName,
 		false,
-		`Also print deprecated rules.`,
+		fmt.Sprintf(
+			`Also print deprecated rules. Has no effect if --%s is not set.`,
+			allFlagName,
+		),
 	)
 	flagSet.StringVar(
 		&f.Format,

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -32,10 +32,11 @@ import (
 )
 
 const (
-	allFlagName     = "all"
-	configFlagName  = "config"
-	formatFlagName  = "format"
-	versionFlagName = "version"
+	allFlagName               = "all"
+	configFlagName            = "config"
+	includeDeprecatedFlagName = "include-deprecated"
+	formatFlagName            = "format"
+	versionFlagName           = "version"
 )
 
 // NewLSCommand returns a new ls Command.
@@ -72,10 +73,11 @@ func NewLSCommand(
 }
 
 type flags struct {
-	All     bool
-	Config  string
-	Format  string
-	Version string
+	All               bool
+	Config            string
+	IncludeDeprecated bool
+	Format            string
+	Version           string
 }
 
 func newFlags() *flags {
@@ -98,6 +100,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			allFlagName,
 			versionFlagName,
 		),
+	)
+	flagSet.BoolVar(
+		&f.IncludeDeprecated,
+		includeDeprecatedFlagName,
+		false,
+		`Also print deprecated rules.`,
 	)
 	flagSet.StringVar(
 		&f.Format,
@@ -200,5 +208,6 @@ func lsRun(
 		container.Stdout(),
 		rules,
 		flags.Format,
+		flags.IncludeDeprecated,
 	)
 }

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -53,7 +53,7 @@ func NewLSCommand(
 		Use:        name,
 		Short:      fmt.Sprintf("List %s rules", ruleType),
 		Args:       appcmd.NoArgs,
-		Deprecated: fmt.Sprintf(`use "buf config %s" instead. However, "buf mod %s will continue to work."`, name, name),
+		Deprecated: fmt.Sprintf(`use "buf config %s" instead. However, "buf mod %s" will continue to work.`, name, name),
 		Hidden:     true,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appext.Container) error {

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
@@ -70,7 +70,11 @@ func RulesForConfig(config bufconfig.BreakingConfig) ([]bufcheck.Rule, error) {
 //
 // Should only be used for printing.
 func GetAllRulesV1Beta1() ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(newBreakingConfigForVersionSpec(bufbreakingv1beta1.VersionSpec))
+	breakingConfig, err := newBreakingConfigForVersionSpec(bufbreakingv1beta1.VersionSpec)
+	if err != nil {
+		return nil, err
+	}
+	internalConfig, err := internalConfigForConfig(breakingConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +85,11 @@ func GetAllRulesV1Beta1() ([]bufcheck.Rule, error) {
 //
 // Should only be used for printing.
 func GetAllRulesV1() ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(newBreakingConfigForVersionSpec(bufbreakingv1.VersionSpec))
+	breakingConfig, err := newBreakingConfigForVersionSpec(bufbreakingv1.VersionSpec)
+	if err != nil {
+		return nil, err
+	}
+	internalConfig, err := internalConfigForConfig(breakingConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -92,32 +100,15 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 //
 // Should only be used for printing.
 func GetAllRulesV2() ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(newBreakingConfigForVersionSpec(bufbreakingv2.VersionSpec))
+	breakingConfig, err := newBreakingConfigForVersionSpec(bufbreakingv2.VersionSpec)
+	if err != nil {
+		return nil, err
+	}
+	internalConfig, err := internalConfigForConfig(breakingConfig)
 	if err != nil {
 		return nil, err
 	}
 	return rulesForInternalRules(internalConfig.Rules), nil
-}
-
-// GetAllRulesAndCategoriesV1Beta1 returns all rules and categories for v1beta1 as a string slice.
-//
-// This is used for validation purposes only.
-func GetAllRulesAndCategoriesV1Beta1() []string {
-	return internal.AllCategoriesAndIDsForVersionSpec(bufbreakingv1beta1.VersionSpec)
-}
-
-// GetAllRulesAndCategoriesV1 returns all rules and categories for v1 as a string slice.
-//
-// This is used for validation purposes only.
-func GetAllRulesAndCategoriesV1() []string {
-	return internal.AllCategoriesAndIDsForVersionSpec(bufbreakingv1.VersionSpec)
-}
-
-// GetAllRulesAndCategoriesV2 returns all rules and categories for v2 as a string slice.
-//
-// This is used for validation purposes only.
-func GetAllRulesAndCategoriesV2() []string {
-	return internal.AllCategoriesAndIDsForVersionSpec(bufbreakingv2.VersionSpec)
 }
 
 func internalConfigForConfig(config bufconfig.BreakingConfig) (*internal.Config, error) {
@@ -154,12 +145,16 @@ func rulesForInternalRules(rules []*internal.Rule) []bufcheck.Rule {
 	return s
 }
 
-func newBreakingConfigForVersionSpec(versionSpec *internal.VersionSpec) bufconfig.BreakingConfig {
+func newBreakingConfigForVersionSpec(versionSpec *internal.VersionSpec) (bufconfig.BreakingConfig, error) {
+	undeprecatedIDs, err := internal.AllUndeprecatedIDsForVersionSpec(versionSpec)
+	if err != nil {
+		return nil, err
+	}
 	return bufconfig.NewBreakingConfig(
 		bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 			versionSpec.FileVersion,
-			internal.AllIDsForVersionSpec(versionSpec),
+			undeprecatedIDs,
 		),
 		false,
-	)
+	), nil
 }

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking.go
@@ -57,9 +57,11 @@ func NewHandler(logger *zap.Logger, tracer tracing.Tracer) Handler {
 
 // RulesForConfig returns the rules for a given config.
 //
+// Does NOT include deprecated rules.
+//
 // Should only be used for printing.
 func RulesForConfig(config bufconfig.BreakingConfig) ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(config, false)
+	internalConfig, err := internalConfigForConfig(config, true)
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufcheck/bufbreaking/handler.go
+++ b/private/bufpkg/bufcheck/bufbreaking/handler.go
@@ -61,7 +61,7 @@ func (h *handler) Check(
 	if err != nil {
 		return err
 	}
-	internalConfig, err := internalConfigForConfig(config)
+	internalConfig, err := internalConfigForConfig(config, true)
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingbuild/bufbreakingbuild.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingbuild/bufbreakingbuild.go
@@ -30,456 +30,342 @@ var (
 	EnumNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_NO_DELETE",
 		"enums are not deleted from a given file",
-		false,
-		nil,
 		bufbreakingcheck.CheckEnumNoDelete,
 	)
 	// EnumValueNoDeleteRuleBuilder is a rule builder.
 	EnumValueNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_NO_DELETE",
 		"enum values are not deleted from a given enum",
-		false,
-		nil,
 		bufbreakingcheck.CheckEnumValueNoDelete,
 	)
 	// EnumValueNoDeleteUnlessNameReservedRuleBuilder is a rule builder.
 	EnumValueNoDeleteUnlessNameReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED",
 		"enum values are not deleted from a given enum unless the name is reserved",
-		false,
-		nil,
 		bufbreakingcheck.CheckEnumValueNoDeleteUnlessNameReserved,
 	)
 	// EnumValueNoDeleteUnlessNumberReservedRuleBuilder is a rule builder.
 	EnumValueNoDeleteUnlessNumberReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED",
 		"enum values are not deleted from a given enum unless the number is reserved",
-		false,
-		nil,
 		bufbreakingcheck.CheckEnumValueNoDeleteUnlessNumberReserved,
 	)
 	// EnumValueSameNameRuleBuilder is a rule builder.
 	EnumValueSameNameRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_SAME_NAME",
 		"enum values have the same name",
-		false,
-		nil,
 		bufbreakingcheck.CheckEnumValueSameName,
 	)
 	// ExtensionMessageNoDeleteRuleBuilder is a rule builder.
 	ExtensionMessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"EXTENSION_MESSAGE_NO_DELETE",
 		"extension ranges are not deleted from a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckExtensionMessageNoDelete,
 	)
 	// FieldNoDeleteRuleBuilder is a rule builder.
 	FieldNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DELETE",
 		"fields are not deleted from a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldNoDelete,
 	)
 	// FieldNoDeleteUnlessNameReservedRuleBuilder is a rule builder.
 	FieldNoDeleteUnlessNameReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DELETE_UNLESS_NAME_RESERVED",
 		"fields are not deleted from a given message unless the name is reserved",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldNoDeleteUnlessNameReserved,
 	)
 	// FieldNoDeleteUnlessNumberReservedRuleBuilder is a rule builder.
 	FieldNoDeleteUnlessNumberReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED",
 		"fields are not deleted from a given message unless the number is reserved",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldNoDeleteUnlessNumberReserved,
 	)
 	// FieldSameCTypeRuleBuilder is a rule builder.
 	FieldSameCTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_CTYPE",
 		"fields have the same value for the ctype option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameCType,
 	)
 	// FieldSameJSONNameRuleBuilder is a rule builder.
 	FieldSameJSONNameRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_JSON_NAME",
 		"fields have the same value for the json_name option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameJSONName,
 	)
 	// FieldSameJSTypeRuleBuilder is a rule builder.
 	FieldSameJSTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_JSTYPE",
 		"fields have the same value for the jstype option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameJSType,
 	)
 	// FieldSameLabelRuleBuilder is a rule builder.
 	FieldSameLabelRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_LABEL",
 		"fields have the same labels in a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameLabel,
 	)
 	// FieldSameNameRuleBuilder is a rule builder.
 	FieldSameNameRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_NAME",
 		"fields have the same names in a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameName,
 	)
 	// FieldSameOneofRuleBuilder is a rule builder.
 	FieldSameOneofRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_ONEOF",
 		"fields have the same oneofs in a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameOneof,
 	)
 	// FieldSameTypeRuleBuilder is a rule builder.
 	FieldSameTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_TYPE",
 		"fields have the same types in a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldSameType,
 	)
 	// FieldWireCompatibleTypeRuleBuilder is a rule builder.
 	FieldWireCompatibleTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_WIRE_COMPATIBLE_TYPE",
 		"fields have wire-compatible types in a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldWireCompatibleType,
 	)
 	// FieldWireJSONCompatibleTypeRuleBuilder is a rule builder.
 	FieldWireJSONCompatibleTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_WIRE_JSON_COMPATIBLE_TYPE",
 		"fields have wire and JSON compatible types in a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckFieldWireJSONCompatibleType,
 	)
 	// FileNoDeleteRuleBuilder is a rule builder.
 	FileNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_NO_DELETE",
 		"files are not deleted",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileNoDelete,
 	)
 	// FileSameCsharpNamespaceRuleBuilder is a rule builder.
 	FileSameCsharpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_CSHARP_NAMESPACE",
 		"files have the same value for the csharp_namespace option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameCsharpNamespace,
 	)
 	// FileSameGoPackageRuleBuilder is a rule builder.
 	FileSameGoPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_GO_PACKAGE",
 		"files have the same value for the go_package option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameGoPackage,
 	)
 	// FileSameJavaMultipleFilesRuleBuilder is a rule builder.
 	FileSameJavaMultipleFilesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_MULTIPLE_FILES",
 		"files have the same value for the java_multiple_files option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameJavaMultipleFiles,
 	)
 	// FileSameJavaOuterClassnameRuleBuilder is a rule builder.
 	FileSameJavaOuterClassnameRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_OUTER_CLASSNAME",
 		"files have the same value for the java_outer_classname option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameJavaOuterClassname,
 	)
 	// FileSameJavaPackageRuleBuilder is a rule builder.
 	FileSameJavaPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_PACKAGE",
 		"files have the same value for the java_package option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameJavaPackage,
 	)
 	// FileSameJavaStringCheckUtf8RuleBuilder is a rule builder.
 	FileSameJavaStringCheckUtf8RuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_STRING_CHECK_UTF8",
 		"files have the same value for the java_string_check_utf8 option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameJavaStringCheckUtf8,
 	)
 	// FileSameObjcClassPrefixRuleBuilder is a rule builder.
 	FileSameObjcClassPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_OBJC_CLASS_PREFIX",
 		"files have the same value for the objc_class_prefix option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameObjcClassPrefix,
 	)
 	// FileSamePackageRuleBuilder is a rule builder.
 	FileSamePackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PACKAGE",
 		"files have the same package",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSamePackage,
 	)
 	// FileSamePhpClassPrefixRuleBuilder is a rule builder.
 	FileSamePhpClassPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_CLASS_PREFIX",
 		"files have the same value for the php_class_prefix option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSamePhpClassPrefix,
 	)
 	// FileSamePhpMetadataNamespaceRuleBuilder is a rule builder.
 	FileSamePhpMetadataNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_METADATA_NAMESPACE",
 		"files have the same value for the php_metadata_namespace option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSamePhpMetadataNamespace,
 	)
 	// FileSamePhpNamespaceRuleBuilder is a rule builder.
 	FileSamePhpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_NAMESPACE",
 		"files have the same value for the php_namespace option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSamePhpNamespace,
 	)
 	// FileSameRubyPackageRuleBuilder is a rule builder.
 	FileSameRubyPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_RUBY_PACKAGE",
 		"files have the same value for the ruby_package option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameRubyPackage,
 	)
 	// FileSameSwiftPrefixRuleBuilder is a rule builder.
 	FileSameSwiftPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_SWIFT_PREFIX",
 		"files have the same value for the swift_prefix option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameSwiftPrefix,
 	)
 	// FileSameOptimizeForRuleBuilder is a rule builder.
 	FileSameOptimizeForRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_OPTIMIZE_FOR",
 		"files have the same value for the optimize_for option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameOptimizeFor,
 	)
 	// FileSameCcGenericServicesRuleBuilder is a rule builder.
 	FileSameCcGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_CC_GENERIC_SERVICES",
 		"files have the same value for the cc_generic_services option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameCcGenericServices,
 	)
 	// FileSameJavaGenericServicesRuleBuilder is a rule builder.
 	FileSameJavaGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_GENERIC_SERVICES",
 		"files have the same value for the java_generic_services option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameJavaGenericServices,
 	)
 	// FileSamePyGenericServicesRuleBuilder is a rule builder.
 	FileSamePyGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PY_GENERIC_SERVICES",
 		"files have the same value for the py_generic_services option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSamePyGenericServices,
 	)
 	// FileSamePhpGenericServicesRuleBuilder is a rule builder.
-	FileSamePhpGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
+	FileSamePhpGenericServicesRuleBuilder = internal.NewDeprecatedRuleBuilder(
 		"FILE_SAME_PHP_GENERIC_SERVICES",
 		"files have the same value for the php_generic_services option",
-		false,
 		nil,
-		bufbreakingcheck.CheckFileSamePhpGenericServices,
 	)
 	// FileSameCcEnableArenasRuleBuilder is a rule builder.
 	FileSameCcEnableArenasRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_CC_ENABLE_ARENAS",
 		"files have the same value for the cc_enable_arenas option",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameCcEnableArenas,
 	)
 	// FileSameSyntaxRuleBuilder is a rule builder.
 	FileSameSyntaxRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_SYNTAX",
 		"files have the same syntax",
-		false,
-		nil,
 		bufbreakingcheck.CheckFileSameSyntax,
 	)
 	// MessageNoDeleteRuleBuilder is a rule builder.
 	MessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_NO_DELETE",
 		"messages are not deleted from a given file",
-		false,
-		nil,
 		bufbreakingcheck.CheckMessageNoDelete,
 	)
 	// MessageNoRemoveStandardDescriptorAccessorRuleBuilder is a rule builder.
 	MessageNoRemoveStandardDescriptorAccessorRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR",
 		"messages do not change the no_standard_descriptor_accessor option from false or unset to true",
-		false,
-		nil,
 		bufbreakingcheck.CheckMessageNoRemoveStandardDescriptorAccessor,
 	)
 	// MessageSameMessageSetWireFormatRuleBuilder is a rule builder.
 	MessageSameMessageSetWireFormatRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT",
 		"messages have the same value for the message_set_wire_format option",
-		false,
-		nil,
 		bufbreakingcheck.CheckMessageSameMessageSetWireFormat,
 	)
 	// MessageSameRequiredFieldsRuleBuilder is a rule builder.
 	MessageSameRequiredFieldsRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_SAME_REQUIRED_FIELDS",
 		"messages have no added or deleted required fields",
-		false,
-		nil,
 		bufbreakingcheck.CheckMessageSameRequiredFields,
 	)
 	// OneofNoDeleteRuleBuilder is a rule builder.
 	OneofNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"ONEOF_NO_DELETE",
 		"oneofs are not deleted from a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckOneofNoDelete,
 	)
 	// PackageEnumNoDeleteRuleBuilder is a rule builder.
 	PackageEnumNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_ENUM_NO_DELETE",
 		"enums are not deleted from a given package",
-		false,
-		nil,
 		bufbreakingcheck.CheckPackageEnumNoDelete,
 	)
 	// PackageMessageNoDeleteRuleBuilder is a rule builder.
 	PackageMessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_MESSAGE_NO_DELETE",
 		"messages are not deleted from a given package",
-		false,
-		nil,
 		bufbreakingcheck.CheckPackageMessageNoDelete,
 	)
 	// PackageNoDeleteRuleBuilder is a rule builder.
 	PackageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_NO_DELETE",
 		"packages are not deleted",
-		false,
-		nil,
 		bufbreakingcheck.CheckPackageNoDelete,
 	)
 	// PackageServiceNoDeleteRuleBuilder is a rule builder.
 	PackageServiceNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SERVICE_NO_DELETE",
 		"services are not deleted from a given package",
-		false,
-		nil,
 		bufbreakingcheck.CheckPackageServiceNoDelete,
 	)
 	// ReservedEnumNoDeleteRuleBuilder is a rule builder.
 	ReservedEnumNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"RESERVED_ENUM_NO_DELETE",
 		"reserved ranges and names are not deleted from a given enum",
-		false,
-		nil,
 		bufbreakingcheck.CheckReservedEnumNoDelete,
 	)
 	// ReservedMessageNoDeleteRuleBuilder is a rule builder.
 	ReservedMessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"RESERVED_MESSAGE_NO_DELETE",
 		"reserved ranges and names are not deleted from a given message",
-		false,
-		nil,
 		bufbreakingcheck.CheckReservedMessageNoDelete,
 	)
 	// RPCNoDeleteRuleBuilder is a rule builder.
 	RPCNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_NO_DELETE",
 		"rpcs are not deleted from a given service",
-		false,
-		nil,
 		bufbreakingcheck.CheckRPCNoDelete,
 	)
 	// RPCSameClientStreamingRuleBuilder is a rule builder.
 	RPCSameClientStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_CLIENT_STREAMING",
 		"rpcs have the same client streaming value",
-		false,
-		nil,
 		bufbreakingcheck.CheckRPCSameClientStreaming,
 	)
 	// RPCSameIdempotencyLevelRuleBuilder is a rule builder.
 	RPCSameIdempotencyLevelRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_IDEMPOTENCY_LEVEL",
 		"rpcs have the same value for the idempotency_level option",
-		false,
-		nil,
 		bufbreakingcheck.CheckRPCSameIdempotencyLevel,
 	)
 	// RPCSameRequestTypeRuleBuilder is a rule builder.
 	RPCSameRequestTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_REQUEST_TYPE",
 		"rpcs are have the same request type",
-		false,
-		nil,
 		bufbreakingcheck.CheckRPCSameRequestType,
 	)
 	// RPCSameResponseTypeRuleBuilder is a rule builder.
 	RPCSameResponseTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_RESPONSE_TYPE",
 		"rpcs are have the same response type",
-		false,
-		nil,
 		bufbreakingcheck.CheckRPCSameResponseType,
 	)
 	// RPCSameServerStreamingRuleBuilder is a rule builder.
 	RPCSameServerStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_SERVER_STREAMING",
 		"rpcs have the same server streaming value",
-		false,
-		nil,
 		bufbreakingcheck.CheckRPCSameServerStreaming,
 	)
 	// ServiceNoDeleteRuleBuilder is a rule builder.
 	ServiceNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"SERVICE_NO_DELETE",
 		"services are not deleted from a given file",
-		false,
-		nil,
 		bufbreakingcheck.CheckServiceNoDelete,
 	)
 )

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingbuild/bufbreakingbuild.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingbuild/bufbreakingbuild.go
@@ -30,342 +30,456 @@ var (
 	EnumNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_NO_DELETE",
 		"enums are not deleted from a given file",
+		false,
+		nil,
 		bufbreakingcheck.CheckEnumNoDelete,
 	)
 	// EnumValueNoDeleteRuleBuilder is a rule builder.
 	EnumValueNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_NO_DELETE",
 		"enum values are not deleted from a given enum",
+		false,
+		nil,
 		bufbreakingcheck.CheckEnumValueNoDelete,
 	)
 	// EnumValueNoDeleteUnlessNameReservedRuleBuilder is a rule builder.
 	EnumValueNoDeleteUnlessNameReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_NO_DELETE_UNLESS_NAME_RESERVED",
 		"enum values are not deleted from a given enum unless the name is reserved",
+		false,
+		nil,
 		bufbreakingcheck.CheckEnumValueNoDeleteUnlessNameReserved,
 	)
 	// EnumValueNoDeleteUnlessNumberReservedRuleBuilder is a rule builder.
 	EnumValueNoDeleteUnlessNumberReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_NO_DELETE_UNLESS_NUMBER_RESERVED",
 		"enum values are not deleted from a given enum unless the number is reserved",
+		false,
+		nil,
 		bufbreakingcheck.CheckEnumValueNoDeleteUnlessNumberReserved,
 	)
 	// EnumValueSameNameRuleBuilder is a rule builder.
 	EnumValueSameNameRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_SAME_NAME",
 		"enum values have the same name",
+		false,
+		nil,
 		bufbreakingcheck.CheckEnumValueSameName,
 	)
 	// ExtensionMessageNoDeleteRuleBuilder is a rule builder.
 	ExtensionMessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"EXTENSION_MESSAGE_NO_DELETE",
 		"extension ranges are not deleted from a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckExtensionMessageNoDelete,
 	)
 	// FieldNoDeleteRuleBuilder is a rule builder.
 	FieldNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DELETE",
 		"fields are not deleted from a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldNoDelete,
 	)
 	// FieldNoDeleteUnlessNameReservedRuleBuilder is a rule builder.
 	FieldNoDeleteUnlessNameReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DELETE_UNLESS_NAME_RESERVED",
 		"fields are not deleted from a given message unless the name is reserved",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldNoDeleteUnlessNameReserved,
 	)
 	// FieldNoDeleteUnlessNumberReservedRuleBuilder is a rule builder.
 	FieldNoDeleteUnlessNumberReservedRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DELETE_UNLESS_NUMBER_RESERVED",
 		"fields are not deleted from a given message unless the number is reserved",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldNoDeleteUnlessNumberReserved,
 	)
 	// FieldSameCTypeRuleBuilder is a rule builder.
 	FieldSameCTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_CTYPE",
 		"fields have the same value for the ctype option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameCType,
 	)
 	// FieldSameJSONNameRuleBuilder is a rule builder.
 	FieldSameJSONNameRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_JSON_NAME",
 		"fields have the same value for the json_name option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameJSONName,
 	)
 	// FieldSameJSTypeRuleBuilder is a rule builder.
 	FieldSameJSTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_JSTYPE",
 		"fields have the same value for the jstype option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameJSType,
 	)
 	// FieldSameLabelRuleBuilder is a rule builder.
 	FieldSameLabelRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_LABEL",
 		"fields have the same labels in a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameLabel,
 	)
 	// FieldSameNameRuleBuilder is a rule builder.
 	FieldSameNameRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_NAME",
 		"fields have the same names in a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameName,
 	)
 	// FieldSameOneofRuleBuilder is a rule builder.
 	FieldSameOneofRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_ONEOF",
 		"fields have the same oneofs in a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameOneof,
 	)
 	// FieldSameTypeRuleBuilder is a rule builder.
 	FieldSameTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_SAME_TYPE",
 		"fields have the same types in a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldSameType,
 	)
 	// FieldWireCompatibleTypeRuleBuilder is a rule builder.
 	FieldWireCompatibleTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_WIRE_COMPATIBLE_TYPE",
 		"fields have wire-compatible types in a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldWireCompatibleType,
 	)
 	// FieldWireJSONCompatibleTypeRuleBuilder is a rule builder.
 	FieldWireJSONCompatibleTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_WIRE_JSON_COMPATIBLE_TYPE",
 		"fields have wire and JSON compatible types in a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckFieldWireJSONCompatibleType,
 	)
 	// FileNoDeleteRuleBuilder is a rule builder.
 	FileNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_NO_DELETE",
 		"files are not deleted",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileNoDelete,
 	)
 	// FileSameCsharpNamespaceRuleBuilder is a rule builder.
 	FileSameCsharpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_CSHARP_NAMESPACE",
 		"files have the same value for the csharp_namespace option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameCsharpNamespace,
 	)
 	// FileSameGoPackageRuleBuilder is a rule builder.
 	FileSameGoPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_GO_PACKAGE",
 		"files have the same value for the go_package option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameGoPackage,
 	)
 	// FileSameJavaMultipleFilesRuleBuilder is a rule builder.
 	FileSameJavaMultipleFilesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_MULTIPLE_FILES",
 		"files have the same value for the java_multiple_files option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameJavaMultipleFiles,
 	)
 	// FileSameJavaOuterClassnameRuleBuilder is a rule builder.
 	FileSameJavaOuterClassnameRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_OUTER_CLASSNAME",
 		"files have the same value for the java_outer_classname option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameJavaOuterClassname,
 	)
 	// FileSameJavaPackageRuleBuilder is a rule builder.
 	FileSameJavaPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_PACKAGE",
 		"files have the same value for the java_package option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameJavaPackage,
 	)
 	// FileSameJavaStringCheckUtf8RuleBuilder is a rule builder.
 	FileSameJavaStringCheckUtf8RuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_STRING_CHECK_UTF8",
 		"files have the same value for the java_string_check_utf8 option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameJavaStringCheckUtf8,
 	)
 	// FileSameObjcClassPrefixRuleBuilder is a rule builder.
 	FileSameObjcClassPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_OBJC_CLASS_PREFIX",
 		"files have the same value for the objc_class_prefix option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameObjcClassPrefix,
 	)
 	// FileSamePackageRuleBuilder is a rule builder.
 	FileSamePackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PACKAGE",
 		"files have the same package",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSamePackage,
 	)
 	// FileSamePhpClassPrefixRuleBuilder is a rule builder.
 	FileSamePhpClassPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_CLASS_PREFIX",
 		"files have the same value for the php_class_prefix option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSamePhpClassPrefix,
 	)
 	// FileSamePhpMetadataNamespaceRuleBuilder is a rule builder.
 	FileSamePhpMetadataNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_METADATA_NAMESPACE",
 		"files have the same value for the php_metadata_namespace option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSamePhpMetadataNamespace,
 	)
 	// FileSamePhpNamespaceRuleBuilder is a rule builder.
 	FileSamePhpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_NAMESPACE",
 		"files have the same value for the php_namespace option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSamePhpNamespace,
 	)
 	// FileSameRubyPackageRuleBuilder is a rule builder.
 	FileSameRubyPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_RUBY_PACKAGE",
 		"files have the same value for the ruby_package option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameRubyPackage,
 	)
 	// FileSameSwiftPrefixRuleBuilder is a rule builder.
 	FileSameSwiftPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_SWIFT_PREFIX",
 		"files have the same value for the swift_prefix option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameSwiftPrefix,
 	)
 	// FileSameOptimizeForRuleBuilder is a rule builder.
 	FileSameOptimizeForRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_OPTIMIZE_FOR",
 		"files have the same value for the optimize_for option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameOptimizeFor,
 	)
 	// FileSameCcGenericServicesRuleBuilder is a rule builder.
 	FileSameCcGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_CC_GENERIC_SERVICES",
 		"files have the same value for the cc_generic_services option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameCcGenericServices,
 	)
 	// FileSameJavaGenericServicesRuleBuilder is a rule builder.
 	FileSameJavaGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_JAVA_GENERIC_SERVICES",
 		"files have the same value for the java_generic_services option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameJavaGenericServices,
 	)
 	// FileSamePyGenericServicesRuleBuilder is a rule builder.
 	FileSamePyGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PY_GENERIC_SERVICES",
 		"files have the same value for the py_generic_services option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSamePyGenericServices,
 	)
 	// FileSamePhpGenericServicesRuleBuilder is a rule builder.
 	FileSamePhpGenericServicesRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_PHP_GENERIC_SERVICES",
 		"files have the same value for the php_generic_services option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSamePhpGenericServices,
 	)
 	// FileSameCcEnableArenasRuleBuilder is a rule builder.
 	FileSameCcEnableArenasRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_CC_ENABLE_ARENAS",
 		"files have the same value for the cc_enable_arenas option",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameCcEnableArenas,
 	)
 	// FileSameSyntaxRuleBuilder is a rule builder.
 	FileSameSyntaxRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_SAME_SYNTAX",
 		"files have the same syntax",
+		false,
+		nil,
 		bufbreakingcheck.CheckFileSameSyntax,
 	)
 	// MessageNoDeleteRuleBuilder is a rule builder.
 	MessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_NO_DELETE",
 		"messages are not deleted from a given file",
+		false,
+		nil,
 		bufbreakingcheck.CheckMessageNoDelete,
 	)
 	// MessageNoRemoveStandardDescriptorAccessorRuleBuilder is a rule builder.
 	MessageNoRemoveStandardDescriptorAccessorRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_NO_REMOVE_STANDARD_DESCRIPTOR_ACCESSOR",
 		"messages do not change the no_standard_descriptor_accessor option from false or unset to true",
+		false,
+		nil,
 		bufbreakingcheck.CheckMessageNoRemoveStandardDescriptorAccessor,
 	)
 	// MessageSameMessageSetWireFormatRuleBuilder is a rule builder.
 	MessageSameMessageSetWireFormatRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_SAME_MESSAGE_SET_WIRE_FORMAT",
 		"messages have the same value for the message_set_wire_format option",
+		false,
+		nil,
 		bufbreakingcheck.CheckMessageSameMessageSetWireFormat,
 	)
 	// MessageSameRequiredFieldsRuleBuilder is a rule builder.
 	MessageSameRequiredFieldsRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_SAME_REQUIRED_FIELDS",
 		"messages have no added or deleted required fields",
+		false,
+		nil,
 		bufbreakingcheck.CheckMessageSameRequiredFields,
 	)
 	// OneofNoDeleteRuleBuilder is a rule builder.
 	OneofNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"ONEOF_NO_DELETE",
 		"oneofs are not deleted from a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckOneofNoDelete,
 	)
 	// PackageEnumNoDeleteRuleBuilder is a rule builder.
 	PackageEnumNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_ENUM_NO_DELETE",
 		"enums are not deleted from a given package",
+		false,
+		nil,
 		bufbreakingcheck.CheckPackageEnumNoDelete,
 	)
 	// PackageMessageNoDeleteRuleBuilder is a rule builder.
 	PackageMessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_MESSAGE_NO_DELETE",
 		"messages are not deleted from a given package",
+		false,
+		nil,
 		bufbreakingcheck.CheckPackageMessageNoDelete,
 	)
 	// PackageNoDeleteRuleBuilder is a rule builder.
 	PackageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_NO_DELETE",
 		"packages are not deleted",
+		false,
+		nil,
 		bufbreakingcheck.CheckPackageNoDelete,
 	)
 	// PackageServiceNoDeleteRuleBuilder is a rule builder.
 	PackageServiceNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SERVICE_NO_DELETE",
 		"services are not deleted from a given package",
+		false,
+		nil,
 		bufbreakingcheck.CheckPackageServiceNoDelete,
 	)
 	// ReservedEnumNoDeleteRuleBuilder is a rule builder.
 	ReservedEnumNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"RESERVED_ENUM_NO_DELETE",
 		"reserved ranges and names are not deleted from a given enum",
+		false,
+		nil,
 		bufbreakingcheck.CheckReservedEnumNoDelete,
 	)
 	// ReservedMessageNoDeleteRuleBuilder is a rule builder.
 	ReservedMessageNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"RESERVED_MESSAGE_NO_DELETE",
 		"reserved ranges and names are not deleted from a given message",
+		false,
+		nil,
 		bufbreakingcheck.CheckReservedMessageNoDelete,
 	)
 	// RPCNoDeleteRuleBuilder is a rule builder.
 	RPCNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_NO_DELETE",
 		"rpcs are not deleted from a given service",
+		false,
+		nil,
 		bufbreakingcheck.CheckRPCNoDelete,
 	)
 	// RPCSameClientStreamingRuleBuilder is a rule builder.
 	RPCSameClientStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_CLIENT_STREAMING",
 		"rpcs have the same client streaming value",
+		false,
+		nil,
 		bufbreakingcheck.CheckRPCSameClientStreaming,
 	)
 	// RPCSameIdempotencyLevelRuleBuilder is a rule builder.
 	RPCSameIdempotencyLevelRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_IDEMPOTENCY_LEVEL",
 		"rpcs have the same value for the idempotency_level option",
+		false,
+		nil,
 		bufbreakingcheck.CheckRPCSameIdempotencyLevel,
 	)
 	// RPCSameRequestTypeRuleBuilder is a rule builder.
 	RPCSameRequestTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_REQUEST_TYPE",
 		"rpcs are have the same request type",
+		false,
+		nil,
 		bufbreakingcheck.CheckRPCSameRequestType,
 	)
 	// RPCSameResponseTypeRuleBuilder is a rule builder.
 	RPCSameResponseTypeRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_RESPONSE_TYPE",
 		"rpcs are have the same response type",
+		false,
+		nil,
 		bufbreakingcheck.CheckRPCSameResponseType,
 	)
 	// RPCSameServerStreamingRuleBuilder is a rule builder.
 	RPCSameServerStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_SAME_SERVER_STREAMING",
 		"rpcs have the same server streaming value",
+		false,
+		nil,
 		bufbreakingcheck.CheckRPCSameServerStreaming,
 	)
 	// ServiceNoDeleteRuleBuilder is a rule builder.
 	ServiceNoDeleteRuleBuilder = internal.NewNopRuleBuilder(
 		"SERVICE_NO_DELETE",
 		"services are not deleted from a given file",
+		false,
+		nil,
 		bufbreakingcheck.CheckServiceNoDelete,
 	)
 )

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
@@ -658,13 +658,6 @@ func checkFileSamePyGenericServices(add addFunc, corpus *corpus, previousFile bu
 	return checkFileSameValue(add, strconv.FormatBool(previousFile.PyGenericServices()), strconv.FormatBool(file.PyGenericServices()), file, file.PyGenericServicesLocation(), `option "py_generic_services"`)
 }
 
-// CheckFileSamePhpGenericServices is a check function.
-var CheckFileSamePhpGenericServices = newFilePairCheckFunc(checkFileSamePhpGenericServices)
-
-func checkFileSamePhpGenericServices(add addFunc, corpus *corpus, previousFile bufprotosource.File, file bufprotosource.File) error {
-	return checkFileSameValue(add, strconv.FormatBool(previousFile.PhpGenericServices()), strconv.FormatBool(file.PhpGenericServices()), file, file.PhpGenericServicesLocation(), `option "php_generic_services"`)
-}
-
 // CheckFileSameCcEnableArenas is a check function.
 var CheckFileSameCcEnableArenas = newFilePairCheckFunc(checkFileSameCcEnableArenas)
 

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingv2/bufbreakingv2.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingv2/bufbreakingv2.go
@@ -15,8 +15,6 @@
 // Package bufbreakingv2 contains the VersionSpec for v2.
 //
 // It uses bufbreakingcheck and bufbreakingbuild.
-//
-// The only change from v1 was that the FILE_SAME_PHP_GENERIC_SERVICES rule was removed.
 package bufbreakingv2
 
 import (

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingv2/vars.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingv2/vars.go
@@ -234,6 +234,10 @@ var (
 			"FILE",
 			"PACKAGE",
 		},
+		"FILE_SAME_PHP_GENERIC_SERVICES": {
+			"FILE",
+			"PACKAGE",
+		},
 		"FILE_SAME_CC_ENABLE_ARENAS": {
 			"FILE",
 			"PACKAGE",

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingv2/vars.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingv2/vars.go
@@ -58,6 +58,7 @@ var (
 		bufbreakingbuild.FileSameCcGenericServicesRuleBuilder,
 		bufbreakingbuild.FileSameJavaGenericServicesRuleBuilder,
 		bufbreakingbuild.FileSamePyGenericServicesRuleBuilder,
+		bufbreakingbuild.FileSamePhpGenericServicesRuleBuilder,
 		bufbreakingbuild.FileSameCcEnableArenasRuleBuilder,
 		bufbreakingbuild.FileSameSyntaxRuleBuilder,
 		bufbreakingbuild.MessageNoDeleteRuleBuilder,

--- a/private/bufpkg/bufcheck/bufcheck.go
+++ b/private/bufpkg/bufcheck/bufcheck.go
@@ -53,12 +53,27 @@ type Rule interface {
 	//
 	// Full sentence.
 	Purpose() string
+
+	// Deprecated returns whether or not this rule is deprecated.
+	//
+	// If it is, it may be replaced by 0 or more rules. These will be denoted with Replacements.
+	Deprecated() bool
+	// ReplacementIDs returns the IDs of the Rules that replace this Rule.
+	//
+	// This means that the combination of the Rules specified by ReplacementIDs replace this Rule entirely,
+	// and this Rule is considered equivalent to the AND of the rules specified by ReplacementIDs.
+	//
+	// This will only be non-empty if Deprecated is true.
+	//
+	// Is it not valid for a Deprecated Rule to specify another Deprecated Rule as a replacement. We verify
+	// that this does not happen for any VersionSpec in testing. TODO
+	ReplacementIDs() []string
 }
 
 // PrintRules prints the rules to the writer.
 //
 // The empty string defaults to text.
-func PrintRules(writer io.Writer, rules []Rule, formatString string) (retErr error) {
+func PrintRules(writer io.Writer, rules []Rule, formatString string, includeDeprecated bool) (retErr error) {
 	if len(rules) == 0 {
 		return nil
 	}
@@ -82,6 +97,9 @@ func PrintRules(writer io.Writer, rules []Rule, formatString string) (retErr err
 		}
 	}
 	for _, rule := range rules {
+		if !includeDeprecated && rule.Deprecated() {
+			continue
+		}
 		if err := printRule(writer, rule, asJSON); err != nil {
 			return err
 		}

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -67,7 +67,7 @@ func NewHandler(logger *zap.Logger, tracer tracing.Tracer) Handler {
 //
 // Should only be used for printing.
 func RulesForConfig(config bufconfig.LintConfig) ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(config)
+	internalConfig, err := internalConfigForConfig(config, false)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func GetAllRulesV1Beta1() ([]bufcheck.Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	internalConfig, err := internalConfigForConfig(lintConfig)
+	internalConfig, err := internalConfigForConfig(lintConfig, false)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	internalConfig, err := internalConfigForConfig(lintConfig)
+	internalConfig, err := internalConfigForConfig(lintConfig, false)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func GetAllRulesV2() ([]bufcheck.Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	internalConfig, err := internalConfigForConfig(lintConfig)
+	internalConfig, err := internalConfigForConfig(lintConfig, false)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ lint:
 	return err
 }
 
-func internalConfigForConfig(config bufconfig.LintConfig) (*internal.Config, error) {
+func internalConfigForConfig(config bufconfig.LintConfig, transformDeprecated bool) (*internal.Config, error) {
 	var versionSpec *internal.VersionSpec
 	switch fileVersion := config.FileVersion(); fileVersion {
 	case bufconfig.FileVersionV1Beta1:
@@ -201,6 +201,7 @@ func internalConfigForConfig(config bufconfig.LintConfig) (*internal.Config, err
 		ServiceSuffix:                        config.ServiceSuffix(),
 	}.NewConfig(
 		versionSpec,
+		transformDeprecated,
 	)
 }
 
@@ -216,14 +217,14 @@ func rulesForInternalRules(rules []*internal.Rule) []bufcheck.Rule {
 }
 
 func newLintConfigForVersionSpec(versionSpec *internal.VersionSpec) (bufconfig.LintConfig, error) {
-	undeprecatedIDs, err := internal.AllUndeprecatedIDsForVersionSpec(versionSpec)
+	ids, err := internal.AllIDsForVersionSpec(versionSpec, true)
 	if err != nil {
 		return nil, err
 	}
 	return bufconfig.NewLintConfig(
 		bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 			versionSpec.FileVersion,
-			undeprecatedIDs,
+			ids,
 		),
 		"",
 		false,

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -78,7 +78,11 @@ func RulesForConfig(config bufconfig.LintConfig) ([]bufcheck.Rule, error) {
 //
 // Should only be used for printing.
 func GetAllRulesV1Beta1() ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(newLintConfigForVersionSpec(buflintv1beta1.VersionSpec))
+	lintConfig, err := newLintConfigForVersionSpec(buflintv1beta1.VersionSpec)
+	if err != nil {
+		return nil, err
+	}
+	internalConfig, err := internalConfigForConfig(lintConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +93,11 @@ func GetAllRulesV1Beta1() ([]bufcheck.Rule, error) {
 //
 // Should only be used for printing.
 func GetAllRulesV1() ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(newLintConfigForVersionSpec(buflintv1.VersionSpec))
+	lintConfig, err := newLintConfigForVersionSpec(buflintv1.VersionSpec)
+	if err != nil {
+		return nil, err
+	}
+	internalConfig, err := internalConfigForConfig(lintConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -100,32 +108,15 @@ func GetAllRulesV1() ([]bufcheck.Rule, error) {
 //
 // Should only be used for printing.
 func GetAllRulesV2() ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(newLintConfigForVersionSpec(buflintv2.VersionSpec))
+	lintConfig, err := newLintConfigForVersionSpec(buflintv2.VersionSpec)
+	if err != nil {
+		return nil, err
+	}
+	internalConfig, err := internalConfigForConfig(lintConfig)
 	if err != nil {
 		return nil, err
 	}
 	return rulesForInternalRules(internalConfig.Rules), nil
-}
-
-// GetAllRulesAndCategoriesV1Beta1 returns all rules and categories for v1beta1 as a string slice.
-//
-// This is used for validation purposes only.
-func GetAllRulesAndCategoriesV1Beta1() []string {
-	return internal.AllCategoriesAndIDsForVersionSpec(buflintv1beta1.VersionSpec)
-}
-
-// GetAllRulesAndCategoriesV1 returns all rules and categories for v1 as a string slice.
-//
-// This is used for validation purposes only.
-func GetAllRulesAndCategoriesV1() []string {
-	return internal.AllCategoriesAndIDsForVersionSpec(buflintv1.VersionSpec)
-}
-
-// GetAllRulesAndCategoriesV2 returns all rules and categories for v2 as a string slice.
-//
-// This is used for validation purposes only.
-func GetAllRulesAndCategoriesV2() []string {
-	return internal.AllCategoriesAndIDsForVersionSpec(buflintv2.VersionSpec)
 }
 
 // PrintFileAnnotationSetConfigIgnoreYAMLV1 prints the FileAnnotationSet to the Writer
@@ -224,11 +215,15 @@ func rulesForInternalRules(rules []*internal.Rule) []bufcheck.Rule {
 	return s
 }
 
-func newLintConfigForVersionSpec(versionSpec *internal.VersionSpec) bufconfig.LintConfig {
+func newLintConfigForVersionSpec(versionSpec *internal.VersionSpec) (bufconfig.LintConfig, error) {
+	undeprecatedIDs, err := internal.AllUndeprecatedIDsForVersionSpec(versionSpec)
+	if err != nil {
+		return nil, err
+	}
 	return bufconfig.NewLintConfig(
 		bufconfig.NewEnabledCheckConfigForUseIDsAndCategories(
 			versionSpec.FileVersion,
-			internal.AllIDsForVersionSpec(versionSpec),
+			undeprecatedIDs,
 		),
 		"",
 		false,
@@ -236,5 +231,5 @@ func newLintConfigForVersionSpec(versionSpec *internal.VersionSpec) bufconfig.Li
 		false,
 		"",
 		false,
-	)
+	), nil
 }

--- a/private/bufpkg/bufcheck/buflint/buflint.go
+++ b/private/bufpkg/bufcheck/buflint/buflint.go
@@ -65,9 +65,11 @@ func NewHandler(logger *zap.Logger, tracer tracing.Tracer) Handler {
 
 // RulesForConfig returns the rules for a given config.
 //
+// Does NOT include deprecated rules.
+//
 // Should only be used for printing.
 func RulesForConfig(config bufconfig.LintConfig) ([]bufcheck.Rule, error) {
-	internalConfig, err := internalConfigForConfig(config, false)
+	internalConfig, err := internalConfigForConfig(config, true)
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufcheck/buflint/handler.go
+++ b/private/bufpkg/bufcheck/buflint/handler.go
@@ -60,7 +60,7 @@ func (h *handler) Check(
 	if err != nil {
 		return err
 	}
-	internalConfig, err := internalConfigForConfig(config)
+	internalConfig, err := internalConfigForConfig(config, true)
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
@@ -29,104 +29,78 @@ var (
 	CommentEnumRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_ENUM",
 		"enums have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentEnum),
 	)
 	// CommentEnumValueRuleBuilder is a rule builder.
 	CommentEnumValueRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_ENUM_VALUE",
 		"enum values have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentEnumValue),
 	)
 	// CommentFieldRuleBuilder is a rule builder.
 	CommentFieldRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_FIELD",
 		"fields have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentField),
 	)
 	// CommentMessageRuleBuilder is a rule builder.
 	CommentMessageRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_MESSAGE",
 		"messages have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentMessage),
 	)
 	// CommentOneofRuleBuilder is a rule builder.
 	CommentOneofRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_ONEOF",
 		"oneof have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentOneof),
 	)
 	// CommentRPCRuleBuilder is a rule builder.
 	CommentRPCRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_RPC",
 		"RPCs have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentRPC),
 	)
 	// CommentServiceRuleBuilder is a rule builder.
 	CommentServiceRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_SERVICE",
 		"services have non-empty comments",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckCommentService),
 	)
 	// DirectorySamePackageRuleBuilder is a rule builder.
 	DirectorySamePackageRuleBuilder = internal.NewNopRuleBuilder(
 		"DIRECTORY_SAME_PACKAGE",
 		"all files in a given directory are in the same package",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckDirectorySamePackage),
 	)
 	// EnumFirstValueZeroRuleBuilder is a rule builder.
 	EnumFirstValueZeroRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_FIRST_VALUE_ZERO",
 		"all first values of enums have a numeric value of 0",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckEnumFirstValueZero),
 	)
 	// EnumNoAllowAliasRuleBuilder is a rule builder.
 	EnumNoAllowAliasRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_NO_ALLOW_ALIAS",
 		"enums do not have the allow_alias option set",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckEnumNoAllowAlias),
 	)
 	// EnumPascalCaseRuleBuilder is a rule builder.
 	EnumPascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_PASCAL_CASE",
 		"enums are PascalCase",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckEnumPascalCase),
 	)
 	// EnumValuePrefixRuleBuilder is a rule builder.
 	EnumValuePrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_PREFIX",
 		"enum values are prefixed with ENUM_NAME_UPPER_SNAKE_CASE",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckEnumValuePrefix),
 	)
 	// EnumValueUpperSnakeCaseRuleBuilder is a rule builder.
 	EnumValueUpperSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_UPPER_SNAKE_CASE",
 		"enum values are UPPER_SNAKE_CASE",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckEnumValueUpperSnakeCase),
 	)
 	// EnumZeroValueSuffixRuleBuilder is a rule builder.
@@ -138,8 +112,6 @@ var (
 			}
 			return "enum zero values are suffixed with " + configBuilder.EnumZeroValueSuffix + " (suffix is configurable)", nil
 		},
-		false,
-		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.EnumZeroValueSuffix == "" {
 				return nil, errors.New("enum_zero_value_suffix is empty")
@@ -153,200 +125,150 @@ var (
 	FieldLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_LOWER_SNAKE_CASE",
 		"field names are lower_snake_case",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckFieldLowerSnakeCase),
 	)
 	// FieldNoDescriptorRuleBuilder is a rule builder.
 	FieldNoDescriptorRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DESCRIPTOR",
 		`field names are not name capitalization of "descriptor" with any number of prefix or suffix underscores`,
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckFieldNoDescriptor),
 	)
 	// FileLowerSnakeCaseRuleBuilder is a rule builder.
 	FileLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_LOWER_SNAKE_CASE",
 		"filenames are lower_snake_case",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckFileLowerSnakeCase),
 	)
 	// ImportNoPublicRuleBuilder is a rule builder.
 	ImportNoPublicRuleBuilder = internal.NewNopRuleBuilder(
 		"IMPORT_NO_PUBLIC",
 		"imports are not public",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckImportNoPublic),
 	)
 	// ImportNoWeakRuleBuilder is a rule builder.
 	ImportNoWeakRuleBuilder = internal.NewNopRuleBuilder(
 		"IMPORT_NO_WEAK",
 		"imports are not weak",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckImportNoWeak),
 	)
 	// ImportUsedRuleBuilder is a rule builder.
 	ImportUsedRuleBuilder = internal.NewNopRuleBuilder(
 		"IMPORT_USED",
 		"imports are used",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckImportUsed),
 	)
 	// MessagePascalCaseRuleBuilder is a rule builder.
 	MessagePascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_PASCAL_CASE",
 		"messages are PascalCase",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckMessagePascalCase),
 	)
 	// OneofLowerSnakeCaseRuleBuilder is a rule builder.
 	OneofLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"ONEOF_LOWER_SNAKE_CASE",
 		"oneof names are lower_snake_case",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckOneofLowerSnakeCase),
 	)
 	// PackageDefinedRuleBuilder is a rule builder.
 	PackageDefinedRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_DEFINED",
 		"all files have a package defined",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageDefined),
 	)
 	// PackageDirectoryMatchRuleBuilder is a rule builder.
 	PackageDirectoryMatchRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_DIRECTORY_MATCH",
 		"all files are in a directory that matches their package name",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageDirectoryMatch),
 	)
 	// PackageLowerSnakeCaseRuleBuilder is a rule builder.
 	PackageLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_LOWER_SNAKE_CASE",
 		"packages are lower_snake.case",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageLowerSnakeCase),
 	)
 	// PackageNoImportCycleRuleBuilder is a rule builder.
 	PackageNoImportCycleRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_NO_IMPORT_CYCLE",
 		"packages do not have import cycles",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageNoImportCycle),
 	)
 	// PackageSameCsharpNamespaceRuleBuilder is a rule builder.
 	PackageSameCsharpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_CSHARP_NAMESPACE",
 		"all files with a given package have the same value for the csharp_namespace option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameCsharpNamespace),
 	)
 	// PackageSameDirectoryRuleBuilder is a rule builder.
 	PackageSameDirectoryRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_DIRECTORY",
 		"all files with a given package are in the same directory",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameDirectory),
 	)
 	// PackageSameGoPackageRuleBuilder is a rule builder.
 	PackageSameGoPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_GO_PACKAGE",
 		"all files with a given package have the same value for the go_package option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameGoPackage),
 	)
 	// PackageSameJavaMultipleFilesRuleBuilder is a rule builder.
 	PackageSameJavaMultipleFilesRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_JAVA_MULTIPLE_FILES",
 		"all files with a given package have the same value for the java_multiple_files option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameJavaMultipleFiles),
 	)
 	// PackageSameJavaPackageRuleBuilder is a rule builder.
 	PackageSameJavaPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_JAVA_PACKAGE",
 		"all files with a given package have the same value for the java_package option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameJavaPackage),
 	)
 	// PackageSamePhpNamespaceRuleBuilder is a rule builder.
 	PackageSamePhpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_PHP_NAMESPACE",
 		"all files with a given package have the same value for the php_namespace option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSamePhpNamespace),
 	)
 	// PackageSameRubyPackageRuleBuilder is a rule builder.
 	PackageSameRubyPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_RUBY_PACKAGE",
 		"all files with a given package have the same value for the ruby_package option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameRubyPackage),
 	)
 	// PackageSameSwiftPrefixRuleBuilder is a rule builder.
 	PackageSameSwiftPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_SWIFT_PREFIX",
 		"all files with a given package have the same value for the swift_prefix option",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageSameSwiftPrefix),
 	)
 	// PackageVersionSuffixRuleBuilder is a rule builder.
 	PackageVersionSuffixRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_VERSION_SUFFIX",
 		`the last component of all packages is a version of the form v\d+, v\d+test.*, v\d+(alpha|beta)\d+, or v\d+p\d+(alpha|beta)\d+, where numbers are >=1`,
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckPackageVersionSuffix),
 	)
 	// ProtovalidateRuleBuilder is a rule builder.
 	ProtovalidateRuleBuilder = internal.NewNopRuleBuilder(
 		"PROTOVALIDATE",
 		"protovalidate rules are valid and all CEL expressions compile",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckProtovalidate),
 	)
 	// RPCNoClientStreamingRuleBuilder is a rule builder.
 	RPCNoClientStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_NO_CLIENT_STREAMING",
 		"RPCs are not client streaming",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckRPCNoClientStreaming),
 	)
 	// RPCNoServerStreamingRuleBuilder is a rule builder.
 	RPCNoServerStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_NO_SERVER_STREAMING",
 		"RPCs are not server streaming",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckRPCNoServerStreaming),
 	)
 	// RPCPascalCaseRuleBuilder is a rule builder.
 	RPCPascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_PASCAL_CASE",
 		"RPCs are PascalCase",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckRPCPascalCase),
 	)
 	// RPCRequestResponseUniqueRuleBuilder is a rule builder.
@@ -355,8 +277,6 @@ var (
 		func(configBuilder internal.ConfigBuilder) (string, error) {
 			return "RPC request and response types are only used in one RPC (configurable)", nil
 		},
-		false,
-		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCRequestResponseUnique(
@@ -376,8 +296,6 @@ var (
 		func(configBuilder internal.ConfigBuilder) (string, error) {
 			return "RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable)", nil
 		},
-		false,
-		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCRequestStandardName(
@@ -395,8 +313,6 @@ var (
 		func(configBuilder internal.ConfigBuilder) (string, error) {
 			return "RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable)", nil
 		},
-		false,
-		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCResponseStandardName(
@@ -412,8 +328,6 @@ var (
 	ServicePascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"SERVICE_PASCAL_CASE",
 		"services are PascalCase",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckServicePascalCase),
 	)
 	// ServiceSuffixRuleBuilder is a rule builder.
@@ -425,8 +339,6 @@ var (
 			}
 			return "services are suffixed with " + configBuilder.ServiceSuffix + " (suffix is configurable)", nil
 		},
-		false,
-		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.ServiceSuffix == "" {
 				return nil, errors.New("service_suffix is empty")
@@ -440,8 +352,6 @@ var (
 	SyntaxSpecifiedRuleBuilder = internal.NewNopRuleBuilder(
 		"SYNTAX_SPECIFIED",
 		"all files have a syntax specified",
-		false,
-		nil,
 		newAdapter(buflintcheck.CheckSyntaxSpecified),
 	)
 )

--- a/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
@@ -29,78 +29,104 @@ var (
 	CommentEnumRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_ENUM",
 		"enums have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentEnum),
 	)
 	// CommentEnumValueRuleBuilder is a rule builder.
 	CommentEnumValueRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_ENUM_VALUE",
 		"enum values have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentEnumValue),
 	)
 	// CommentFieldRuleBuilder is a rule builder.
 	CommentFieldRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_FIELD",
 		"fields have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentField),
 	)
 	// CommentMessageRuleBuilder is a rule builder.
 	CommentMessageRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_MESSAGE",
 		"messages have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentMessage),
 	)
 	// CommentOneofRuleBuilder is a rule builder.
 	CommentOneofRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_ONEOF",
 		"oneof have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentOneof),
 	)
 	// CommentRPCRuleBuilder is a rule builder.
 	CommentRPCRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_RPC",
 		"RPCs have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentRPC),
 	)
 	// CommentServiceRuleBuilder is a rule builder.
 	CommentServiceRuleBuilder = internal.NewNopRuleBuilder(
 		"COMMENT_SERVICE",
 		"services have non-empty comments",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckCommentService),
 	)
 	// DirectorySamePackageRuleBuilder is a rule builder.
 	DirectorySamePackageRuleBuilder = internal.NewNopRuleBuilder(
 		"DIRECTORY_SAME_PACKAGE",
 		"all files in a given directory are in the same package",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckDirectorySamePackage),
 	)
 	// EnumFirstValueZeroRuleBuilder is a rule builder.
 	EnumFirstValueZeroRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_FIRST_VALUE_ZERO",
 		"all first values of enums have a numeric value of 0",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckEnumFirstValueZero),
 	)
 	// EnumNoAllowAliasRuleBuilder is a rule builder.
 	EnumNoAllowAliasRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_NO_ALLOW_ALIAS",
 		"enums do not have the allow_alias option set",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckEnumNoAllowAlias),
 	)
 	// EnumPascalCaseRuleBuilder is a rule builder.
 	EnumPascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_PASCAL_CASE",
 		"enums are PascalCase",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckEnumPascalCase),
 	)
 	// EnumValuePrefixRuleBuilder is a rule builder.
 	EnumValuePrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_PREFIX",
 		"enum values are prefixed with ENUM_NAME_UPPER_SNAKE_CASE",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckEnumValuePrefix),
 	)
 	// EnumValueUpperSnakeCaseRuleBuilder is a rule builder.
 	EnumValueUpperSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"ENUM_VALUE_UPPER_SNAKE_CASE",
 		"enum values are UPPER_SNAKE_CASE",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckEnumValueUpperSnakeCase),
 	)
 	// EnumZeroValueSuffixRuleBuilder is a rule builder.
@@ -112,6 +138,8 @@ var (
 			}
 			return "enum zero values are suffixed with " + configBuilder.EnumZeroValueSuffix + " (suffix is configurable)", nil
 		},
+		false,
+		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.EnumZeroValueSuffix == "" {
 				return nil, errors.New("enum_zero_value_suffix is empty")
@@ -125,150 +153,200 @@ var (
 	FieldLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_LOWER_SNAKE_CASE",
 		"field names are lower_snake_case",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckFieldLowerSnakeCase),
 	)
 	// FieldNoDescriptorRuleBuilder is a rule builder.
 	FieldNoDescriptorRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DESCRIPTOR",
 		`field names are not name capitalization of "descriptor" with any number of prefix or suffix underscores`,
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckFieldNoDescriptor),
 	)
 	// FileLowerSnakeCaseRuleBuilder is a rule builder.
 	FileLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"FILE_LOWER_SNAKE_CASE",
 		"filenames are lower_snake_case",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckFileLowerSnakeCase),
 	)
 	// ImportNoPublicRuleBuilder is a rule builder.
 	ImportNoPublicRuleBuilder = internal.NewNopRuleBuilder(
 		"IMPORT_NO_PUBLIC",
 		"imports are not public",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckImportNoPublic),
 	)
 	// ImportNoWeakRuleBuilder is a rule builder.
 	ImportNoWeakRuleBuilder = internal.NewNopRuleBuilder(
 		"IMPORT_NO_WEAK",
 		"imports are not weak",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckImportNoWeak),
 	)
 	// ImportUsedRuleBuilder is a rule builder.
 	ImportUsedRuleBuilder = internal.NewNopRuleBuilder(
 		"IMPORT_USED",
 		"imports are used",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckImportUsed),
 	)
 	// MessagePascalCaseRuleBuilder is a rule builder.
 	MessagePascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"MESSAGE_PASCAL_CASE",
 		"messages are PascalCase",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckMessagePascalCase),
 	)
 	// OneofLowerSnakeCaseRuleBuilder is a rule builder.
 	OneofLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"ONEOF_LOWER_SNAKE_CASE",
 		"oneof names are lower_snake_case",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckOneofLowerSnakeCase),
 	)
 	// PackageDefinedRuleBuilder is a rule builder.
 	PackageDefinedRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_DEFINED",
 		"all files have a package defined",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageDefined),
 	)
 	// PackageDirectoryMatchRuleBuilder is a rule builder.
 	PackageDirectoryMatchRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_DIRECTORY_MATCH",
 		"all files are in a directory that matches their package name",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageDirectoryMatch),
 	)
 	// PackageLowerSnakeCaseRuleBuilder is a rule builder.
 	PackageLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_LOWER_SNAKE_CASE",
 		"packages are lower_snake.case",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageLowerSnakeCase),
 	)
 	// PackageNoImportCycleRuleBuilder is a rule builder.
 	PackageNoImportCycleRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_NO_IMPORT_CYCLE",
 		"packages do not have import cycles",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageNoImportCycle),
 	)
 	// PackageSameCsharpNamespaceRuleBuilder is a rule builder.
 	PackageSameCsharpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_CSHARP_NAMESPACE",
 		"all files with a given package have the same value for the csharp_namespace option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameCsharpNamespace),
 	)
 	// PackageSameDirectoryRuleBuilder is a rule builder.
 	PackageSameDirectoryRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_DIRECTORY",
 		"all files with a given package are in the same directory",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameDirectory),
 	)
 	// PackageSameGoPackageRuleBuilder is a rule builder.
 	PackageSameGoPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_GO_PACKAGE",
 		"all files with a given package have the same value for the go_package option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameGoPackage),
 	)
 	// PackageSameJavaMultipleFilesRuleBuilder is a rule builder.
 	PackageSameJavaMultipleFilesRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_JAVA_MULTIPLE_FILES",
 		"all files with a given package have the same value for the java_multiple_files option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameJavaMultipleFiles),
 	)
 	// PackageSameJavaPackageRuleBuilder is a rule builder.
 	PackageSameJavaPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_JAVA_PACKAGE",
 		"all files with a given package have the same value for the java_package option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameJavaPackage),
 	)
 	// PackageSamePhpNamespaceRuleBuilder is a rule builder.
 	PackageSamePhpNamespaceRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_PHP_NAMESPACE",
 		"all files with a given package have the same value for the php_namespace option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSamePhpNamespace),
 	)
 	// PackageSameRubyPackageRuleBuilder is a rule builder.
 	PackageSameRubyPackageRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_RUBY_PACKAGE",
 		"all files with a given package have the same value for the ruby_package option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameRubyPackage),
 	)
 	// PackageSameSwiftPrefixRuleBuilder is a rule builder.
 	PackageSameSwiftPrefixRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_SAME_SWIFT_PREFIX",
 		"all files with a given package have the same value for the swift_prefix option",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageSameSwiftPrefix),
 	)
 	// PackageVersionSuffixRuleBuilder is a rule builder.
 	PackageVersionSuffixRuleBuilder = internal.NewNopRuleBuilder(
 		"PACKAGE_VERSION_SUFFIX",
 		`the last component of all packages is a version of the form v\d+, v\d+test.*, v\d+(alpha|beta)\d+, or v\d+p\d+(alpha|beta)\d+, where numbers are >=1`,
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckPackageVersionSuffix),
 	)
 	// ProtovalidateRuleBuilder is a rule builder.
 	ProtovalidateRuleBuilder = internal.NewNopRuleBuilder(
 		"PROTOVALIDATE",
 		"protovalidate rules are valid and all CEL expressions compile",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckProtovalidate),
 	)
 	// RPCNoClientStreamingRuleBuilder is a rule builder.
 	RPCNoClientStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_NO_CLIENT_STREAMING",
 		"RPCs are not client streaming",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckRPCNoClientStreaming),
 	)
 	// RPCNoServerStreamingRuleBuilder is a rule builder.
 	RPCNoServerStreamingRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_NO_SERVER_STREAMING",
 		"RPCs are not server streaming",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckRPCNoServerStreaming),
 	)
 	// RPCPascalCaseRuleBuilder is a rule builder.
 	RPCPascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"RPC_PASCAL_CASE",
 		"RPCs are PascalCase",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckRPCPascalCase),
 	)
 	// RPCRequestResponseUniqueRuleBuilder is a rule builder.
@@ -277,6 +355,8 @@ var (
 		func(configBuilder internal.ConfigBuilder) (string, error) {
 			return "RPC request and response types are only used in one RPC (configurable)", nil
 		},
+		false,
+		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCRequestResponseUnique(
@@ -296,6 +376,8 @@ var (
 		func(configBuilder internal.ConfigBuilder) (string, error) {
 			return "RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable)", nil
 		},
+		false,
+		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCRequestStandardName(
@@ -313,6 +395,8 @@ var (
 		func(configBuilder internal.ConfigBuilder) (string, error) {
 			return "RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable)", nil
 		},
+		false,
+		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCResponseStandardName(
@@ -328,6 +412,8 @@ var (
 	ServicePascalCaseRuleBuilder = internal.NewNopRuleBuilder(
 		"SERVICE_PASCAL_CASE",
 		"services are PascalCase",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckServicePascalCase),
 	)
 	// ServiceSuffixRuleBuilder is a rule builder.
@@ -339,6 +425,8 @@ var (
 			}
 			return "services are suffixed with " + configBuilder.ServiceSuffix + " (suffix is configurable)", nil
 		},
+		false,
+		nil,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.ServiceSuffix == "" {
 				return nil, errors.New("service_suffix is empty")
@@ -352,6 +440,8 @@ var (
 	SyntaxSpecifiedRuleBuilder = internal.NewNopRuleBuilder(
 		"SYNTAX_SPECIFIED",
 		"all files have a syntax specified",
+		false,
+		nil,
 		newAdapter(buflintcheck.CheckSyntaxSpecified),
 	)
 )

--- a/private/bufpkg/bufcheck/internal/config.go
+++ b/private/bufpkg/bufcheck/internal/config.go
@@ -30,14 +30,23 @@ const (
 )
 
 // Config is the check config.
+//
+// This should only be built via a ConfigBuilder. If we were exposing this API publicly, we would
+// enforce this.
 type Config struct {
 	// Rules are the rules to run.
 	//
 	// Rules will be sorted by first categories, then id when Configs are
 	// created from this package, i.e. created wth ConfigBuilder.NewConfig.
+	//
+	// No Rule in a Config will be Deprecated when this is built via a ConfigBuilder (which
+	// is safe for Runners to assume) . These will all be filtered and replaced
+	// with the equivalent Rules via ReplacementIDs.
 	Rules []*Rule
 
-	IgnoreRootPaths     map[string]struct{}
+	IgnoreRootPaths map[string]struct{}
+	// Will not contain any Deprecated IDs. These will all be filtered and replaced
+	// with the equivalent Rules IDs via ReplacementIDs when this is built via a ConfigBuilder.
 	IgnoreIDToRootPaths map[string]map[string]struct{}
 
 	AllowCommentIgnores    bool
@@ -46,10 +55,13 @@ type Config struct {
 
 // ConfigBuilder is a config builder.
 type ConfigBuilder struct {
-	Use    []string
+	// May contain deprecated IDs.
+	Use []string
+	// May contain deprecated IDs.
 	Except []string
 
-	IgnoreRootPaths               []string
+	IgnoreRootPaths []string
+	// May contain deprecated IDs.
 	IgnoreIDOrCategoryToRootPaths map[string][]string
 
 	AllowCommentIgnores    bool
@@ -96,17 +108,23 @@ func newConfigForRuleBuilders(
 	// which would be a system error
 	idToRuleBuilder, err := getIDToRuleBuilder(ruleBuilders)
 	if err != nil {
-		return nil, syserror.Wrap(err)
+		return nil, err
+	}
+	deprecatedIDToReplacementIDs, err := getDeprecatedIDToReplacementIDs(idToRuleBuilder)
+	if err != nil {
+		return nil, err
 	}
 	categoryToIDs := getCategoryToIDs(idToCategories)
 	useIDMap, err := transformToIDMap(configBuilder.Use, idToCategories, categoryToIDs)
 	if err != nil {
 		return nil, err
 	}
+	useIDMap = transformIDsToUndeprecated(useIDMap, deprecatedIDToReplacementIDs)
 	exceptIDMap, err := transformToIDMap(configBuilder.Except, idToCategories, categoryToIDs)
 	if err != nil {
 		return nil, err
 	}
+	exceptIDMap = transformIDsToUndeprecated(exceptIDMap, deprecatedIDToReplacementIDs)
 
 	// this removes duplicates
 	// we already know that a given rule with the same ID is equivalent
@@ -148,6 +166,7 @@ func newConfigForRuleBuilders(
 	if err != nil {
 		return nil, err
 	}
+	ignoreIDToRootPathsUnnormalized = transformIDsToUndeprecated(ignoreIDToRootPathsUnnormalized, deprecatedIDToReplacementIDs)
 	ignoreIDToRootPaths := make(map[string]map[string]struct{})
 	for id, rootPaths := range ignoreIDToRootPathsUnnormalized {
 		for rootPath := range rootPaths {
@@ -192,6 +211,22 @@ func newConfigForRuleBuilders(
 		AllowCommentIgnores:    configBuilder.AllowCommentIgnores,
 		IgnoreUnstablePackages: configBuilder.IgnoreUnstablePackages,
 	}, nil
+}
+
+func transformIDsToUndeprecated[T any](idToValue map[string]T, deprecatedIDToReplacementIDs map[string][]string) map[string]T {
+	undeprecatedIDToValue := make(map[string]T, len(idToValue))
+	for id, value := range idToValue {
+		replacementIDs, ok := deprecatedIDToReplacementIDs[id]
+		if ok {
+			// May iterate over empty.
+			for _, replacementID := range replacementIDs {
+				undeprecatedIDToValue[replacementID] = value
+			}
+		} else {
+			undeprecatedIDToValue[id] = value
+		}
+	}
+	return undeprecatedIDToValue
 }
 
 func transformToIDMap(idsOrCategories []string, idToCategories map[string][]string, categoryToIDs map[string][]string) (map[string]struct{}, error) {
@@ -261,13 +296,33 @@ func getCategoryToIDs(idToCategories map[string][]string) map[string][]string {
 	return categoryToIDs
 }
 
+// []string{} as a value represents that the ID is deprecated but has no replacements.
+func getDeprecatedIDToReplacementIDs(idToRuleBuilder map[string]*RuleBuilder) (map[string][]string, error) {
+	m := make(map[string][]string)
+	for _, ruleBuilder := range idToRuleBuilder {
+		if ruleBuilder.Deprecated() {
+			replacementIDs := ruleBuilder.ReplacementIDs()
+			if replacementIDs == nil {
+				replacementIDs = []string{}
+			}
+			for _, replacementID := range replacementIDs {
+				if _, ok := idToRuleBuilder[replacementID]; !ok {
+					return nil, syserror.Newf("unknown rule given as a replacement ID: %q", replacementID)
+				}
+			}
+			m[ruleBuilder.ID()] = replacementIDs
+		}
+	}
+	return m, nil
+}
+
 func getIDToRuleBuilder(ruleBuilders []*RuleBuilder) (map[string]*RuleBuilder, error) {
 	m := make(map[string]*RuleBuilder)
 	for _, ruleBuilder := range ruleBuilders {
-		if _, ok := m[ruleBuilder.id]; ok {
-			return nil, fmt.Errorf("duplicate rule ID: %q", ruleBuilder.id)
+		if _, ok := m[ruleBuilder.ID()]; ok {
+			return nil, syserror.Newf("duplicate rule ID: %q", ruleBuilder.ID())
 		}
-		m[ruleBuilder.id] = ruleBuilder
+		m[ruleBuilder.ID()] = ruleBuilder
 	}
 	return m, nil
 }
@@ -276,9 +331,9 @@ func getRuleBuilderCategories(
 	ruleBuilder *RuleBuilder,
 	idToCategories map[string][]string,
 ) ([]string, error) {
-	categories, ok := idToCategories[ruleBuilder.id]
+	categories, ok := idToCategories[ruleBuilder.ID()]
 	if !ok {
-		return nil, fmt.Errorf("%q is not configured for categories", ruleBuilder.id)
+		return nil, syserror.Newf("%q is not configured for categories", ruleBuilder.ID())
 	}
 	// it is ok for categories to be empty, however the map must contain an entry
 	// or otherwise this is a system error

--- a/private/bufpkg/bufcheck/internal/internaltesting/internaltesting.go
+++ b/private/bufpkg/bufcheck/internal/internaltesting/internaltesting.go
@@ -29,8 +29,11 @@ func RunTestVersionSpec(t *testing.T, versionSpec *internal.VersionSpec) {
 }
 
 func runTestDefaultConfigBuilder(t *testing.T, versionSpec *internal.VersionSpec) {
-	_, err := internal.ConfigBuilder{}.NewConfig(versionSpec, true)
+	config, err := internal.ConfigBuilder{}.NewConfig(versionSpec, true)
 	assert.NoError(t, err)
+	for _, rule := range config.Rules {
+		assert.False(t, rule.Deprecated())
+	}
 	_, err = internal.ConfigBuilder{}.NewConfig(versionSpec, false)
 	assert.NoError(t, err)
 }

--- a/private/bufpkg/bufcheck/internal/internaltesting/internaltesting.go
+++ b/private/bufpkg/bufcheck/internal/internaltesting/internaltesting.go
@@ -35,10 +35,27 @@ func runTestDefaultConfigBuilder(t *testing.T, versionSpec *internal.VersionSpec
 
 func runTestRuleBuilders(t *testing.T, versionSpec *internal.VersionSpec) {
 	idsMap := make(map[string]struct{}, len(versionSpec.RuleBuilders))
+	deprecatedIDMap := make(map[string]struct{}, len(versionSpec.RuleBuilders))
 	for _, ruleBuilder := range versionSpec.RuleBuilders {
 		_, ok := idsMap[ruleBuilder.ID()]
 		assert.False(t, ok, "duplicated id %q", ruleBuilder.ID())
 		idsMap[ruleBuilder.ID()] = struct{}{}
+		if ruleBuilder.Deprecated() {
+			deprecatedIDMap[ruleBuilder.ID()] = struct{}{}
+		}
+	}
+	for _, ruleBuilder := range versionSpec.RuleBuilders {
+		if ruleBuilder.Deprecated() {
+			for _, replacementID := range ruleBuilder.ReplacementIDs() {
+				if _, ok := deprecatedIDMap[replacementID]; ok {
+					assert.False(t, true, "%q specifies %q as a replacement but %q is deprecated", ruleBuilder.ID(), replacementID, replacementID)
+				}
+			}
+		} else {
+			if len(ruleBuilder.ReplacementIDs()) > 0 {
+				assert.False(t, true, "undeprecated rule %q has replacement IDs", ruleBuilder.ID())
+			}
+		}
 	}
 	for id := range idsMap {
 		expectedID := stringutil.ToUpperSnakeCase(id)

--- a/private/bufpkg/bufcheck/internal/internaltesting/internaltesting.go
+++ b/private/bufpkg/bufcheck/internal/internaltesting/internaltesting.go
@@ -29,7 +29,9 @@ func RunTestVersionSpec(t *testing.T, versionSpec *internal.VersionSpec) {
 }
 
 func runTestDefaultConfigBuilder(t *testing.T, versionSpec *internal.VersionSpec) {
-	_, err := internal.ConfigBuilder{}.NewConfig(versionSpec)
+	_, err := internal.ConfigBuilder{}.NewConfig(versionSpec, true)
+	assert.NoError(t, err)
+	_, err = internal.ConfigBuilder{}.NewConfig(versionSpec, false)
 	assert.NoError(t, err)
 }
 

--- a/private/bufpkg/bufcheck/internal/rule.go
+++ b/private/bufpkg/bufcheck/internal/rule.go
@@ -40,10 +40,12 @@ type CheckFunc func(id string, ignoreFunc IgnoreFunc, previousFiles []bufprotoso
 
 // Rule provides a base embeddable rule.
 type Rule struct {
-	id         string
-	categories []string
-	purpose    string
-	checkFunc  CheckFunc
+	id             string
+	categories     []string
+	purpose        string
+	deprecated     bool
+	replacementIDs []string
+	checkFunc      CheckFunc
 }
 
 // newRule returns a new Rule.
@@ -54,6 +56,8 @@ func newRule(
 	id string,
 	categories []string,
 	purpose string,
+	deprecated bool,
+	replacementIDs []string,
 	checkFunc CheckFunc,
 ) *Rule {
 	c := make([]string, len(categories))
@@ -65,10 +69,12 @@ func newRule(
 		},
 	)
 	return &Rule{
-		id:         id,
-		categories: c,
-		purpose:    "Checks that " + purpose + ".",
-		checkFunc:  checkFunc,
+		id:             id,
+		categories:     c,
+		purpose:        "Checks that " + purpose + ".",
+		deprecated:     deprecated,
+		replacementIDs: replacementIDs,
+		checkFunc:      checkFunc,
 	}
 }
 
@@ -87,6 +93,14 @@ func (c *Rule) Purpose() string {
 	return c.purpose
 }
 
+func (c *Rule) Deprecated() bool {
+	return c.deprecated
+}
+
+func (c *Rule) ReplacementIDs() []string {
+	return c.replacementIDs
+}
+
 // MarshalJSON implements Rule.
 func (c *Rule) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ruleJSON{ID: c.id, Categories: c.categories, Purpose: c.purpose})
@@ -97,7 +111,9 @@ func (c *Rule) check(ignoreFunc IgnoreFunc, previousFiles []bufprotosource.File,
 }
 
 type ruleJSON struct {
-	ID         string   `json:"id" yaml:"id"`
-	Categories []string `json:"categories" yaml:"categories"`
-	Purpose    string   `json:"purpose" yaml:"purpose"`
+	ID           string   `json:"id" yaml:"id"`
+	Categories   []string `json:"categories" yaml:"categories"`
+	Purpose      string   `json:"purpose" yaml:"purpose"`
+	Deprecated   bool     `json:"deprecated" yaml:"deprecated"`
+	Replacements []string `json:"replacements" yaml:"replacements"`
 }

--- a/private/bufpkg/bufcheck/internal/rule_builder.go
+++ b/private/bufpkg/bufcheck/internal/rule_builder.go
@@ -21,21 +21,27 @@ import (
 
 // RuleBuilder is a rule builder.
 type RuleBuilder struct {
-	id         string
-	newPurpose func(ConfigBuilder) (string, error)
-	newCheck   func(ConfigBuilder) (CheckFunc, error)
+	id             string
+	newPurpose     func(ConfigBuilder) (string, error)
+	deprecated     bool
+	replacementIDs []string
+	newCheck       func(ConfigBuilder) (CheckFunc, error)
 }
 
 // NewRuleBuilder returns a new RuleBuilder.
 func NewRuleBuilder(
 	id string,
 	newPurpose func(ConfigBuilder) (string, error),
+	deprecated bool,
+	replacementIDs []string,
 	newCheck func(ConfigBuilder) (CheckFunc, error),
 ) *RuleBuilder {
 	return &RuleBuilder{
-		id:         id,
-		newPurpose: newPurpose,
-		newCheck:   newCheck,
+		id:             id,
+		newPurpose:     newPurpose,
+		deprecated:     deprecated,
+		replacementIDs: replacementIDs,
+		newCheck:       newCheck,
 	}
 }
 
@@ -44,11 +50,15 @@ func NewRuleBuilder(
 func NewNopRuleBuilder(
 	id string,
 	purpose string,
+	deprecated bool,
+	replacementIDs []string,
 	checkFunc CheckFunc,
 ) *RuleBuilder {
 	return NewRuleBuilder(
 		id,
 		newNopPurpose(purpose),
+		deprecated,
+		replacementIDs,
 		newNopCheckFunc(checkFunc),
 	)
 }
@@ -72,6 +82,8 @@ func (c *RuleBuilder) NewRule(configBuilder ConfigBuilder, categories []string) 
 		c.id,
 		categories,
 		purpose,
+		c.deprecated,
+		c.replacementIDs,
 		check,
 	), nil
 }
@@ -79,6 +91,16 @@ func (c *RuleBuilder) NewRule(configBuilder ConfigBuilder, categories []string) 
 // ID returns the id.
 func (c *RuleBuilder) ID() string {
 	return c.id
+}
+
+// Deprecated returns whether or not the Rule was deprecated.
+func (c *RuleBuilder) Deprecated() bool {
+	return c.deprecated
+}
+
+// ReplacementIDs returns the replacement IDs.
+func (c *RuleBuilder) ReplacementIDs() []string {
+	return c.replacementIDs
 }
 
 func newNopPurpose(purpose string) func(ConfigBuilder) (string, error) {

--- a/private/bufpkg/bufcheck/internal/rule_builder.go
+++ b/private/bufpkg/bufcheck/internal/rule_builder.go
@@ -28,39 +28,50 @@ type RuleBuilder struct {
 	newCheck       func(ConfigBuilder) (CheckFunc, error)
 }
 
-// NewRuleBuilder returns a new RuleBuilder.
+// NewRuleBuilder returns a new undeprecated RuleBuilder.
 func NewRuleBuilder(
 	id string,
 	newPurpose func(ConfigBuilder) (string, error),
-	deprecated bool,
-	replacementIDs []string,
 	newCheck func(ConfigBuilder) (CheckFunc, error),
 ) *RuleBuilder {
 	return &RuleBuilder{
 		id:             id,
 		newPurpose:     newPurpose,
-		deprecated:     deprecated,
-		replacementIDs: replacementIDs,
+		deprecated:     false,
+		replacementIDs: nil,
 		newCheck:       newCheck,
 	}
 }
 
-// NewNopRuleBuilder returns a new RuleBuilder for the direct
+// NewNopRuleBuilder returns a new undeprecated RuleBuilder for the direct
 // purpose and CheckFunc.
 func NewNopRuleBuilder(
 	id string,
 	purpose string,
-	deprecated bool,
-	replacementIDs []string,
 	checkFunc CheckFunc,
 ) *RuleBuilder {
 	return NewRuleBuilder(
 		id,
 		newNopPurpose(purpose),
-		deprecated,
-		replacementIDs,
 		newNopCheckFunc(checkFunc),
 	)
+}
+
+// NewDeprecatedRuleBuilder returns a new RuleBuilder for a deprecated Rule.
+//
+// replacementIDs may be nil or empty.
+func NewDeprecatedRuleBuilder(
+	id string,
+	purpose string,
+	replacementIDs []string,
+) *RuleBuilder {
+	return &RuleBuilder{
+		id:             id,
+		newPurpose:     newNopPurpose(purpose),
+		deprecated:     true,
+		replacementIDs: replacementIDs,
+		newCheck:       newNopCheckFunc(newNopCheck),
+	}
 }
 
 // NewRule returns a new Rule.
@@ -115,4 +126,8 @@ func newNopCheckFunc(
 	return func(ConfigBuilder) (CheckFunc, error) {
 		return f, nil
 	}
+}
+
+func newNopCheck(string, IgnoreFunc, []bufprotosource.File, []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
+	return nil, nil
 }

--- a/private/bufpkg/bufcheck/internal/version_spec.go
+++ b/private/bufpkg/bufcheck/internal/version_spec.go
@@ -51,17 +51,17 @@ func AllCategoriesForVersionSpec(versionSpec *VersionSpec) []string {
 	return categories
 }
 
-// AllUndeprecatedIDsForVersionSpec returns all ids for the VersionSpec.
+// AllIDsForVersionSpec returns all ids for the VersionSpec.
 //
 // Sorted lexographically.
-func AllUndeprecatedIDsForVersionSpec(versionSpec *VersionSpec) ([]string, error) {
+func AllIDsForVersionSpec(versionSpec *VersionSpec, includeDeprecated bool) ([]string, error) {
 	idToRuleBuilder, err := getIDToRuleBuilder(versionSpec.RuleBuilders)
 	if err != nil {
 		return nil, err
 	}
 	m := make(map[string]struct{})
 	for id, ruleBuilder := range idToRuleBuilder {
-		if ruleBuilder.Deprecated() {
+		if !includeDeprecated && ruleBuilder.Deprecated() {
 			continue
 		}
 		m[id] = struct{}{}

--- a/private/bufpkg/bufcheck/internal/version_spec.go
+++ b/private/bufpkg/bufcheck/internal/version_spec.go
@@ -51,27 +51,20 @@ func AllCategoriesForVersionSpec(versionSpec *VersionSpec) []string {
 	return categories
 }
 
-// AllIDsForVersionSpec returns all ids for the VersionSpec.
+// AllUndeprecatedIDsForVersionSpec returns all ids for the VersionSpec.
 //
 // Sorted lexographically.
-func AllIDsForVersionSpec(versionSpec *VersionSpec) []string {
-	m := make(map[string]struct{})
-	for id := range versionSpec.IDToCategories {
-		m[id] = struct{}{}
+func AllUndeprecatedIDsForVersionSpec(versionSpec *VersionSpec) ([]string, error) {
+	idToRuleBuilder, err := getIDToRuleBuilder(versionSpec.RuleBuilders)
+	if err != nil {
+		return nil, err
 	}
-	return slicesext.MapKeysToSortedSlice(m)
-}
-
-// AllCategoriesAndIDsForVersionSpec returns all categories and rules for the VersionSpec.
-//
-// Sorted lexographically.
-func AllCategoriesAndIDsForVersionSpec(versionSpec *VersionSpec) []string {
 	m := make(map[string]struct{})
-	for id, categories := range versionSpec.IDToCategories {
-		m[id] = struct{}{}
-		for _, category := range categories {
-			m[category] = struct{}{}
+	for id, ruleBuilder := range idToRuleBuilder {
+		if ruleBuilder.Deprecated() {
+			continue
 		}
+		m[id] = struct{}{}
 	}
-	return slicesext.MapKeysToSortedSlice(m)
+	return slicesext.MapKeysToSortedSlice(m), nil
 }

--- a/private/bufpkg/bufprotosource/bufprotosource.go
+++ b/private/bufpkg/bufprotosource/bufprotosource.go
@@ -254,7 +254,6 @@ type File interface {
 	CcGenericServices() bool
 	JavaGenericServices() bool
 	PyGenericServices() bool
-	PhpGenericServices() bool
 	CcEnableArenas() bool
 
 	SyntaxLocation() Location
@@ -276,7 +275,6 @@ type File interface {
 	CcGenericServicesLocation() Location
 	JavaGenericServicesLocation() Location
 	PyGenericServicesLocation() Location
-	PhpGenericServicesLocation() Location
 	CcEnableArenasLocation() Location
 
 	// FileDescriptor returns the backing FileDescriptor for this File.

--- a/private/bufpkg/bufprotosource/file.go
+++ b/private/bufpkg/bufprotosource/file.go
@@ -143,12 +143,6 @@ func (f *file) PyGenericServices() bool {
 	return f.fileDescriptor.GetOptions().GetPyGenericServices()
 }
 
-func (f *file) PhpGenericServices() bool {
-	// Support for PhpGenericServices was removed in
-	// https://github.com/protocolbuffers/protobuf/pull/15164
-	return false
-}
-
 func (f *file) CcEnableArenas() bool {
 	return f.fileDescriptor.GetOptions().GetCcEnableArenas()
 }
@@ -219,10 +213,6 @@ func (f *file) JavaGenericServicesLocation() Location {
 
 func (f *file) PyGenericServicesLocation() Location {
 	return f.getLocationByPathKey(pyGenericServicesPathKey)
-}
-
-func (f *file) PhpGenericServicesLocation() Location {
-	return f.getLocationByPathKey(phpGenericServicesPathKey)
 }
 
 func (f *file) CcEnableArenasLocation() Location {

--- a/private/bufpkg/bufprotosource/paths.go
+++ b/private/bufpkg/bufprotosource/paths.go
@@ -32,7 +32,6 @@ var (
 	ccGenericServicesPathKey    = getPathKey([]int32{8, 16})
 	javaGenericServicesPathKey  = getPathKey([]int32{8, 17})
 	pyGenericServicesPathKey    = getPathKey([]int32{8, 18})
-	phpGenericServicesPathKey   = getPathKey([]int32{8, 42})
 	ccEnableArenasPathKey       = getPathKey([]int32{8, 31})
 	syntaxPathKey               = getPathKey([]int32{12})
 )


### PR DESCRIPTION
This allows `Rules` to be deprecated and specify the IDs of their replacement `Rules`. If a Rule is deprecated:

- It is no longer printed via the `ls-rules` commands unless `--include-deprecated` is set.
- Any usage of the `Rule` is assumed to be the same as setting all its replacement `Rules`.
- If the deprecated `Rule` has no replacement `Rules`, the `Rule` becomes a no-op.

This is needed for editions work.