### PR TITLE
Fix error message for buf.yaml invalid version

### DIFF
--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -597,9 +597,9 @@ func getModuleConfigAndConfiguredDepModuleRefsV1Beta1OrV1(
 			return nil, nil, err
 		}
 	}
-	// Just a sanity check. This should have already been validated, but let's make sure.
+	// Ensure buf.yaml matches the expected version for a v1 module.
 	if bufYAMLFile.FileVersion() != bufconfig.FileVersionV1Beta1 && bufYAMLFile.FileVersion() != bufconfig.FileVersionV1 {
-		return nil, nil, syserror.Newf("buf.yaml at %s did not have version v1beta1 or v1", moduleDirPath)
+		return nil, nil, fmt.Errorf("buf.yaml at %s did not have version v1beta1 or v1", moduleDirPath)
 	}
 	moduleConfigs := bufYAMLFile.ModuleConfigs()
 	if len(moduleConfigs) != 1 {


### PR DESCRIPTION
For a v1 module config we expect to always receive `buf.yaml` as a v1 or v1beta1 source. Currently an invalid version will raise a system error:

`Failure: it looks like you have found a bug in buf. Please file an issue at https://github.com/bufbuild/buf/issues and provide the command you ran, as well as the following message: buf.yaml at proto did not have version v1beta1 or v1`

Downgrade the error to report version mismatch for config:

`Failure: buf.yaml at proto did not have version v1beta1 or v1`