### PR TITLE
Fix b5 digest calculation for remote modules

### DIFF
--- a/private/bufpkg/bufmodule/added_module.go
+++ b/private/bufpkg/bufmodule/added_module.go
@@ -282,7 +282,10 @@ func (a *addedModule) ToModule(
 		}
 		switch digestType {
 		case DigestTypeB4:
-			// Convert B4 ModuleKeys to B5 by fetching the commits from the commit provider.
+			// The declared ModuleKey dependencies for a commit may be stored in v1 buf.lock file,
+			// in which case they will use B4 digests. B4 digests aren't allowed to be used as
+			// input to the B5 digest calculation, so we perform a call to convert all ModuleKeys
+			// from B4 to B5 by using the commit provider.
 			commitKeysToFetch := make([]CommitKey, len(declaredDepModuleKeys))
 			for i, declaredDepModuleKey := range declaredDepModuleKeys {
 				commitKey, err := NewCommitKey(declaredDepModuleKey.ModuleFullName().Registry(), declaredDepModuleKey.CommitID(), DigestTypeB5)

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -234,16 +234,15 @@ func ModuleDirectModuleDeps(module Module) ([]ModuleDep, error) {
 type module struct {
 	ModuleReadBucket
 
-	ctx                    context.Context
-	getBucket              func() (storage.ReadBucket, error)
-	bucketID               string
-	moduleFullName         ModuleFullName
-	commitID               uuid.UUID
-	isTarget               bool
-	isLocal                bool
-	getV1BufYAMLObjectData func() (ObjectData, error)
-	getV1BufLockObjectData func() (ObjectData, error)
-
+	ctx                        context.Context
+	getBucket                  func() (storage.ReadBucket, error)
+	bucketID                   string
+	moduleFullName             ModuleFullName
+	commitID                   uuid.UUID
+	isTarget                   bool
+	isLocal                    bool
+	getV1BufYAMLObjectData     func() (ObjectData, error)
+	getV1BufLockObjectData     func() (ObjectData, error)
 	getDeclaredDepModuleKeysB5 func() ([]ModuleKey, error)
 
 	moduleSet ModuleSet
@@ -264,11 +263,11 @@ func newModule(
 	isLocal bool,
 	getV1BufYAMLObjectData func() (ObjectData, error),
 	getV1BufLockObjectData func() (ObjectData, error),
+	getDeclaredDepModuleKeysB5 func() ([]ModuleKey, error),
 	targetPaths []string,
 	targetExcludePaths []string,
 	protoFileTargetPath string,
 	includePackageFiles bool,
-	getDeclaredDepModuleKeysB5 func() ([]ModuleKey, error),
 ) (*module, error) {
 	// TODO FUTURE: get these validations into a common place
 	if protoFileTargetPath != "" && (len(targetPaths) > 0 || len(targetExcludePaths) > 0) {

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -393,15 +393,16 @@ func (m *module) ModuleSet() ModuleSet {
 func (m *module) withIsTarget(isTarget bool) (Module, error) {
 	// We don't just call newModule directly as we don't want to double syncext.OnceValues stuff.
 	newModule := &module{
-		ctx:                    m.ctx,
-		getBucket:              m.getBucket,
-		bucketID:               m.bucketID,
-		moduleFullName:         m.moduleFullName,
-		commitID:               m.commitID,
-		isTarget:               isTarget,
-		isLocal:                m.isLocal,
-		getV1BufYAMLObjectData: m.getV1BufYAMLObjectData,
-		getV1BufLockObjectData: m.getV1BufLockObjectData,
+		ctx:                        m.ctx,
+		getBucket:                  m.getBucket,
+		bucketID:                   m.bucketID,
+		moduleFullName:             m.moduleFullName,
+		commitID:                   m.commitID,
+		isTarget:                   isTarget,
+		isLocal:                    m.isLocal,
+		getV1BufYAMLObjectData:     m.getV1BufYAMLObjectData,
+		getV1BufLockObjectData:     m.getV1BufLockObjectData,
+		getDeclaredDepModuleKeysB5: m.getDeclaredDepModuleKeysB5,
 	}
 	moduleReadBucket, ok := m.ModuleReadBucket.(*moduleReadBucket)
 	if !ok {

--- a/private/bufpkg/bufmodule/module_data.go
+++ b/private/bufpkg/bufmodule/module_data.go
@@ -49,7 +49,7 @@ type ModuleData interface {
 	//
 	// This is used for digest calculations. It is not used otherwise.
 	V1Beta1OrV1BufYAMLObjectData() (ObjectData, error)
-	// V1Beta1OrV1BufYAMLObjectData gets the v1beta1 or v1 buf.lock ObjectData.
+	// V1Beta1OrV1BufLockObjectData gets the v1beta1 or v1 buf.lock ObjectData.
 	//
 	// This may not be present. It will only be potentially present for v1 buf.lock files.
 	//

--- a/private/bufpkg/bufmodule/module_key_provider.go
+++ b/private/bufpkg/bufmodule/module_key_provider.go
@@ -23,7 +23,7 @@ type ModuleKeyProvider interface {
 	// GetModuleKeysForModuleRefs gets the ModuleKeys for the given ModuleRefs.
 	//
 	// Returned ModuleKeys will be in the same order as the input ModuleRefs.
-
+	//
 	// The input ModuleRefs are expected to be unique by ModuleFullName. The implementation
 	// may error if this is not the case.
 	//

--- a/private/bufpkg/bufmodule/module_set_builder.go
+++ b/private/bufpkg/bufmodule/module_set_builder.go
@@ -339,6 +339,7 @@ func (b *moduleSetBuilder) AddLocalModule(
 		localModuleOptions.targetExcludePaths,
 		localModuleOptions.protoFileTargetPath,
 		localModuleOptions.includePackageFiles,
+		nil,
 	)
 	if err != nil {
 		return b.addError(err)
@@ -408,7 +409,7 @@ func (b *moduleSetBuilder) Build() (_ ModuleSet, retErr error) {
 	modules, err := slicesext.MapError(
 		addedModules,
 		func(addedModule *addedModule) (Module, error) {
-			return addedModule.ToModule(ctx, b.moduleDataProvider)
+			return addedModule.ToModule(ctx, b.moduleDataProvider, b.commitProvider)
 		},
 	)
 	if err != nil {

--- a/private/bufpkg/bufmodule/module_set_builder.go
+++ b/private/bufpkg/bufmodule/module_set_builder.go
@@ -335,11 +335,15 @@ func (b *moduleSetBuilder) AddLocalModule(
 		true,
 		func() (ObjectData, error) { return localModuleOptions.v1BufYAMLObjectData, nil },
 		func() (ObjectData, error) { return localModuleOptions.v1BufLockObjectData, nil },
+		func() ([]ModuleKey, error) {
+			// See comment in added_module.go when we construct remote Modules for why
+			// we have this function in the first place.
+			return nil, syserror.Newf("getDeclaredDepModuleKeysB5 should never be called for a local Module")
+		},
 		localModuleOptions.targetPaths,
 		localModuleOptions.targetExcludePaths,
 		localModuleOptions.protoFileTargetPath,
 		localModuleOptions.includePackageFiles,
-		nil,
 	)
 	if err != nil {
 		return b.addError(err)


### PR DESCRIPTION
When a remote module is added to the workspace, the b5 digest of it should not be calculated based on the state of other modules in the workspace (which may point to later commits). Instead, the digest should be used from the ModuleKey for the remote module (if the key references a b5 digest) or it should be fetched from the CommitProvider.