### PR TITLE
Support `--tag`, `--branch`, and `--draft` with v2 workspaces

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -292,7 +292,14 @@ func validateLabelFlagCombinations(flags *flags) error {
 		usedFlags = append(usedFlags, draftFlagName)
 	}
 	if len(usedFlags) > 1 {
-		return appcmd.NewInvalidArgumentErrorf("These flags cannot be used in combination with one another: %s", usedFlags)
+		usedFlagsErrStr := strings.Join(
+			slicesext.Map(
+				usedFlags,
+				func(flag string) string { return fmt.Sprintf("--%s", flag) },
+			),
+			", ",
+		)
+		return appcmd.NewInvalidArgumentErrorf("These flags cannot be used in combination with one another: %s", usedFlagsErrStr)
 	}
 	return nil
 }

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -430,7 +430,7 @@ func getV1Beta1ProtoUploadRequestContent(
 }
 
 func validateModuleDefaultLabels(modules []*modulev1.Module) error {
-	var defaultLabelNames map[string]struct{}
+	defaultLabelNames := make(map[string]struct{})
 	for _, module := range modules {
 		defaultLabelNames[module.DefaultLabelName] = struct{}{}
 	}

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -430,20 +430,15 @@ func getV1Beta1ProtoUploadRequestContent(
 }
 
 func validateModuleDefaultLabels(modules []*modulev1.Module) error {
-	var moduleName string
-	var defaultLabelName string
+	var defaultLabelNames map[string]struct{}
 	for _, module := range modules {
-		if defaultLabelName != "" && module.DefaultLabelName != defaultLabelName {
-			return fmt.Errorf(
-				"different default label names found, %s has default label %q and %s has default label %q",
-				moduleName,
-				defaultLabelName,
-				module.Name,
-				module.DefaultLabelName,
-			)
-		}
-		moduleName = module.Name
-		defaultLabelName = module.DefaultLabelName
+		defaultLabelNames[module.DefaultLabelName] = struct{}{}
+	}
+	if len(defaultLabelNames) > 1 {
+		return fmt.Errorf(
+			"different default label names across modules found: %s",
+			slicesext.MapKeysToSlice(defaultLabelNames),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
This change allows users to push using `--tag`, `--branch`, or `--draft` with
`v2` workspaces.

Since `--branch` and `--draft` is no longer disallowed when pushing more than
one content module, we can now treat them as a single label.

For `--tag`, we push to all the tags as well as the default label of each module.
We disallow the use of `--tag` if the modules being pushed do not all have the
same default label. 