### PR TITLE
Update code generation to enforce supported features for editions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -285,5 +285,5 @@ issues:
     - linters:
         - gochecknoinits
       # must use init to safely enable editions support for testing
-      # (temporary)
+      # TODO: this is temporary; remove it when editions support is ready
       path: private/buf/bufgen/features_test.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -282,3 +282,8 @@ issues:
       # Only safe way to opt-in to protocompile editions support. Temporary and
       # will be removed once opt-in is not necessary.
       path: private/bufpkg/bufimage/build_image.go
+    - linters:
+        - gochecknoinits
+      # must use init to safely enable editions support for testing
+      # (temporary)
+      path: private/buf/bufgen/features_test.go

--- a/private/buf/bufgen/features.go
+++ b/private/buf/bufgen/features.go
@@ -15,14 +15,13 @@
 package bufgen
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"go.uber.org/multierr"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
@@ -38,16 +37,16 @@ var featureToFeatureChecker = map[pluginpb.CodeGeneratorResponse_Feature]feature
 // requiredFeatures maps a feature to the set of files in an image that
 // make use of that feature.
 type requiredFeatures struct {
-	featureToFilename map[pluginpb.CodeGeneratorResponse_Feature][]string
-	editionToFilename map[descriptorpb.Edition][]string
-	minEdition        descriptorpb.Edition
-	maxEdition        descriptorpb.Edition
+	featureToFilenames map[pluginpb.CodeGeneratorResponse_Feature][]string
+	editionToFilenames map[descriptorpb.Edition][]string
+	minEdition         descriptorpb.Edition
+	maxEdition         descriptorpb.Edition
 }
 
 func newRequiredFeatures() *requiredFeatures {
 	return &requiredFeatures{
-		featureToFilename: map[pluginpb.CodeGeneratorResponse_Feature][]string{},
-		editionToFilename: map[descriptorpb.Edition][]string{},
+		featureToFilenames: map[pluginpb.CodeGeneratorResponse_Feature][]string{},
+		editionToFilenames: map[descriptorpb.Edition][]string{},
 	}
 }
 
@@ -66,7 +65,7 @@ func computeRequiredFeatures(image bufimage.Image) *requiredFeatures {
 		// Collect all required feature enum values.
 		for feature, checker := range featureToFeatureChecker {
 			if checker(imageFile.FileDescriptorProto()) {
-				features.featureToFilename[feature] = append(features.featureToFilename[feature], imageFile.Path())
+				features.featureToFilenames[feature] = append(features.featureToFilenames[feature], imageFile.Path())
 			}
 		}
 		// We also collect the range of required editions.
@@ -74,7 +73,7 @@ func computeRequiredFeatures(image bufimage.Image) *requiredFeatures {
 			continue
 		}
 		edition := imageFile.FileDescriptorProto().GetEdition()
-		features.editionToFilename[edition] = append(features.editionToFilename[edition], imageFile.Path())
+		features.editionToFilenames[edition] = append(features.editionToFilenames[edition], imageFile.Path())
 		if features.minEdition == 0 || edition < features.minEdition {
 			features.minEdition = edition
 		}
@@ -90,7 +89,7 @@ func checkRequiredFeatures(
 	responses []*pluginpb.CodeGeneratorResponse,
 	configs []bufconfig.GeneratePluginConfig,
 ) error {
-	var errorDetails bytes.Buffer
+	var errs []error
 	for responseIndex, response := range responses {
 		if response == nil || response.GetError() != "" {
 			// plugin failed, nothing to check
@@ -101,19 +100,19 @@ func checkRequiredFeatures(
 		var failedFeatures []pluginpb.CodeGeneratorResponse_Feature
 		var failedEditions []descriptorpb.Edition
 		supported := response.GetSupportedFeatures() // bit mask of features the plugin supports
-		for feature, files := range required.featureToFilename {
+		for feature, files := range required.featureToFilenames {
 			featureMask := uint64(feature)
 			if supported&featureMask != featureMask {
 				// doh! Supported features don't include this one
-				failed.featureToFilename[feature] = files
+				failed.featureToFilenames[feature] = files
 				failedFeatures = append(failedFeatures, feature)
 			}
 		}
-		if supported&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 && len(required.editionToFilename) > 0 {
+		if supported&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 && len(required.editionToFilenames) > 0 {
 			// Plugin supports editions, and files include editions. So make sure
 			// the plugin supports precisely the right editions.
-			requiredEditions := make([]descriptorpb.Edition, 0, len(required.editionToFilename))
-			for edition := range required.editionToFilename {
+			requiredEditions := make([]descriptorpb.Edition, 0, len(required.editionToFilenames))
+			for edition := range required.editionToFilenames {
 				requiredEditions = append(requiredEditions, edition)
 			}
 			sort.Slice(requiredEditions, func(i, j int) bool {
@@ -122,7 +121,7 @@ func checkRequiredFeatures(
 			for _, requiredEdition := range requiredEditions {
 				if int32(requiredEdition) < response.GetMinimumEdition() ||
 					int32(requiredEdition) > response.GetMaximumEdition() {
-					failed.editionToFilename[requiredEdition] = required.editionToFilename[requiredEdition]
+					failed.editionToFilenames[requiredEdition] = required.editionToFilenames[requiredEdition]
 					failedEditions = append(failedEditions, requiredEdition)
 				}
 			}
@@ -130,51 +129,29 @@ func checkRequiredFeatures(
 
 		pluginName := configs[responseIndex].Name()
 		if len(failedFeatures) > 0 {
-			_, _ = fmt.Fprintf(
-				&errorDetails,
-				"Plugin %q does not support required feature(s).\n",
-				pluginName)
 			sort.Slice(failedFeatures, func(i, j int) bool {
 				return failedFeatures[i] < failedFeatures[j]
 			})
 			for _, feature := range failedFeatures {
-				files := failed.featureToFilename[feature]
-				_, _ = fmt.Fprintf(
-					&errorDetails,
-					"  Feature %q is required by %d file(s):\n",
-					featureName(feature), len(files))
-				_, _ = fmt.Fprintf(
-					&errorDetails,
-					"    %s\n",
-					strings.Join(files, ","))
+				for _, file := range failed.featureToFilenames[feature] {
+					errs = append(errs, fmt.Errorf("plugin %q does not support feature %q which is required by %q",
+						pluginName, featureName(feature), file))
+				}
 			}
 		}
-
 		if len(failedEditions) > 0 {
-			_, _ = fmt.Fprintf(
-				&errorDetails,
-				"Plugin %q does not support required edition(s).\n",
-				pluginName)
 			sort.Slice(failedEditions, func(i, j int) bool {
 				return failedEditions[i] < failedEditions[j]
 			})
 			for _, edition := range failedEditions {
-				files := failed.editionToFilename[edition]
-				_, _ = fmt.Fprintf(
-					&errorDetails,
-					"  Edition %q is required by %d file(s):\n",
-					editionName(edition), len(files))
-				_, _ = fmt.Fprintf(
-					&errorDetails,
-					"    %s\n",
-					strings.Join(files, ","))
+				for _, file := range failed.editionToFilenames[edition] {
+					errs = append(errs, fmt.Errorf("plugin %q does not support edition %q which is required by %q",
+						pluginName, editionName(edition), file))
+				}
 			}
 		}
 	}
-	if errorDetails.Len() > 0 {
-		return errors.New(errorDetails.String())
-	}
-	return nil
+	return multierr.Combine(errs...)
 }
 
 func featureName(feature pluginpb.CodeGeneratorResponse_Feature) string {

--- a/private/buf/bufgen/features.go
+++ b/private/buf/bufgen/features.go
@@ -22,36 +22,62 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/app"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
 // requiredFeatures maps a feature to the set of files in an image that
 // make use of that feature.
-type requiredFeatures map[pluginpb.CodeGeneratorResponse_Feature][]string
+type requiredFeatures struct {
+	flags                  map[pluginpb.CodeGeneratorResponse_Feature][]string
+	editions               map[descriptorpb.Edition][]string
+	minEdition, maxEdition descriptorpb.Edition
+}
+
+func newRequiredFeatures() *requiredFeatures {
+	return &requiredFeatures{
+		flags:    map[pluginpb.CodeGeneratorResponse_Feature][]string{},
+		editions: map[descriptorpb.Edition][]string{},
+	}
+}
 
 type featureChecker func(options *descriptorpb.FileDescriptorProto) bool
 
 // Map of all known features to functions that can check whether a given file
 // uses said feature.
 var allFeatures = map[pluginpb.CodeGeneratorResponse_Feature]featureChecker{
-	pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL: fileHasProto3Optional,
+	pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL:   fileHasProto3Optional,
+	pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS: fileHasEditions,
 }
 
 // computeRequiredFeatures returns a map of required features to the files in
 // the image that require that feature. After plugins are invoked, the plugins'
 // responses are checked to make sure any required features were supported.
-func computeRequiredFeatures(image bufimage.Image) requiredFeatures {
-	features := requiredFeatures{}
-	for feature, checker := range allFeatures {
-		for _, imageFile := range image.Files() {
-			if imageFile.IsImport() {
-				// we only want to check the sources in the module, not their dependencies
-				continue
-			}
+func computeRequiredFeatures(image bufimage.Image) *requiredFeatures {
+	features := newRequiredFeatures()
+	for _, imageFile := range image.Files() {
+		if imageFile.IsImport() {
+			// we only want to check the sources in the module, not their dependencies
+			continue
+		}
+		// Collect all required feature enum values.
+		for feature, checker := range allFeatures {
 			if checker(imageFile.FileDescriptorProto()) {
-				features[feature] = append(features[feature], imageFile.Path())
+				features.flags[feature] = append(features.flags[feature], imageFile.Path())
 			}
+		}
+		// We also collect the range of required editions.
+		if !fileHasEditions(imageFile.FileDescriptorProto()) {
+			continue
+		}
+		edition := imageFile.FileDescriptorProto().GetEdition()
+		features.editions[edition] = append(features.editions[edition], imageFile.Path())
+		if features.minEdition == 0 || edition < features.minEdition {
+			features.minEdition = edition
+		}
+		if edition > features.maxEdition {
+			features.maxEdition = edition
 		}
 	}
 	return features
@@ -59,49 +85,126 @@ func computeRequiredFeatures(image bufimage.Image) requiredFeatures {
 
 func checkRequiredFeatures(
 	container app.StderrContainer,
-	required requiredFeatures,
+	required *requiredFeatures,
 	responses []*pluginpb.CodeGeneratorResponse,
 	configs []bufconfig.GeneratePluginConfig,
-) {
+) error {
+	var failedPlugins []string
 	for responseIndex, response := range responses {
 		if response == nil || response.GetError() != "" {
 			// plugin failed, nothing to check
 			continue
 		}
-		failed := requiredFeatures{}
+
+		failed := newRequiredFeatures()
 		var failedFeatures []pluginpb.CodeGeneratorResponse_Feature
+		var failedEditions []descriptorpb.Edition
 		supported := response.GetSupportedFeatures() // bit mask of features the plugin supports
-		for feature, files := range required {
-			featureMask := (uint64)(feature)
+		for feature, files := range required.flags {
+			featureMask := uint64(feature)
 			if supported&featureMask != featureMask {
 				// doh! Supported features don't include this one
-				failed[feature] = files
+				failed.flags[feature] = files
 				failedFeatures = append(failedFeatures, feature)
 			}
 		}
-		if len(failed) > 0 {
-			// TODO: plugin config to turn this into an error
-			_, _ = fmt.Fprintf(container.Stderr(), "Warning: plugin %q does not support required features.\n",
-				configs[responseIndex].Name())
-			sort.Slice(failedFeatures, func(i, j int) bool {
-				return failedFeatures[i].Number() < failedFeatures[j].Number()
+		if supported&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 && len(required.editions) > 0 {
+			// Plugin supports editions, and files include editions. So make sure
+			// the plugin supports precisely the right editions.
+			requiredEditions := make([]descriptorpb.Edition, 0, len(required.editions))
+			for edition := range required.editions {
+				requiredEditions = append(requiredEditions, edition)
+			}
+			sort.Slice(requiredEditions, func(i, j int) bool {
+				return requiredEditions[i] < requiredEditions[j]
 			})
-			for _, feature := range failedFeatures {
-				files := failed[feature]
-				_, _ = fmt.Fprintf(container.Stderr(), "  Feature %q is required by %d file(s):\n",
-					featureName(feature), len(files))
-				_, _ = fmt.Fprintf(container.Stderr(), "    %s\n", strings.Join(files, ","))
+			for _, requiredEdition := range requiredEditions {
+				if int32(requiredEdition) < response.GetMinimumEdition() ||
+					int32(requiredEdition) > response.GetMaximumEdition() {
+					failed.editions[requiredEdition] = required.editions[requiredEdition]
+					failedEditions = append(failedEditions, requiredEdition)
+				}
 			}
 		}
+
+		pluginName := configs[responseIndex].Name()
+		if len(failedFeatures) > 0 {
+			_, _ = fmt.Fprintf(
+				container.Stderr(),
+				"Plugin %q does not support required feature(s).\n",
+				pluginName)
+			sort.Slice(failedFeatures, func(i, j int) bool {
+				return failedFeatures[i] < failedFeatures[j]
+			})
+			for _, feature := range failedFeatures {
+				files := failed.flags[feature]
+				_, _ = fmt.Fprintf(
+					container.Stderr(),
+					"  Feature %q is required by %d file(s):\n",
+					featureName(feature), len(files))
+				_, _ = fmt.Fprintf(
+					container.Stderr(),
+					"    %s\n",
+					strings.Join(files, ","))
+			}
+		}
+
+		if len(failedEditions) > 0 {
+			_, _ = fmt.Fprintf(
+				container.Stderr(),
+				"Plugin %q does not support required edition(s).\n",
+				pluginName)
+			sort.Slice(failedEditions, func(i, j int) bool {
+				return failedEditions[i] < failedEditions[j]
+			})
+			for _, edition := range failedEditions {
+				files := failed.editions[edition]
+				_, _ = fmt.Fprintf(
+					container.Stderr(),
+					"  Edition %q is required by %d file(s):\n",
+					editionName(edition), len(files))
+				_, _ = fmt.Fprintf(
+					container.Stderr(),
+					"    %s\n",
+					strings.Join(files, ","))
+			}
+		}
+
+		if len(failedFeatures) > 0 || len(failedEditions) > 0 {
+			failedPlugins = append(failedPlugins, pluginName)
+		}
+	}
+	switch len(failedPlugins) {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("plugin %s is unable to generate code for all input files", failedPlugins[0])
+	default:
+		return fmt.Errorf("plugins [%v] are unable to generate code for all input files", strings.Join(failedPlugins, ","))
 	}
 }
 
 func featureName(feature pluginpb.CodeGeneratorResponse_Feature) string {
 	// FEATURE_PROTO3_OPTIONAL -> "proto3 optional"
+	return enumReadableName(feature, "FEATURE")
+}
+
+func editionName(edition descriptorpb.Edition) string {
+	// EDITION_2023 -> "2023"
+	return enumReadableName(edition, "EDITION")
+}
+
+func enumReadableName(
+	enum interface {
+		protoreflect.Enum
+		String() string
+	},
+	prefix string,
+) string {
 	return strings.TrimSpace(
 		strings.ToLower(
 			strings.ReplaceAll(
-				strings.TrimPrefix(feature.String(), "FEATURE"),
+				strings.TrimPrefix(enum.String(), prefix),
 				"_", " ")))
 }
 
@@ -130,4 +233,8 @@ func messageHasProto3Optional(descriptorProto *descriptorpb.DescriptorProto) boo
 		}
 	}
 	return false
+}
+
+func fileHasEditions(fileDescriptorProto *descriptorpb.FileDescriptorProto) bool {
+	return fileDescriptorProto.GetSyntax() == "editions"
 }

--- a/private/buf/bufgen/features.go
+++ b/private/buf/bufgen/features.go
@@ -91,7 +91,6 @@ func checkRequiredFeatures(
 	configs []bufconfig.GeneratePluginConfig,
 ) error {
 	var errorDetails bytes.Buffer
-	var failedPlugins []string
 	for responseIndex, response := range responses {
 		if response == nil || response.GetError() != "" {
 			// plugin failed, nothing to check
@@ -170,10 +169,6 @@ func checkRequiredFeatures(
 					"    %s\n",
 					strings.Join(files, ","))
 			}
-		}
-
-		if len(failedFeatures) > 0 || len(failedEditions) > 0 {
-			failedPlugins = append(failedPlugins, pluginName)
 		}
 	}
 	if errorDetails.Len() > 0 {

--- a/private/buf/bufgen/features_test.go
+++ b/private/buf/bufgen/features_test.go
@@ -1,0 +1,317 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufgen
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
+	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/pkg/app"
+	"github.com/bufbuild/buf/private/pkg/protodescriptor"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+func init() {
+	protodescriptor.AllowEditionsForTesting()
+}
+
+func TestComputeRequiredFeatures(t *testing.T) {
+	t.Parallel()
+	noRequiredFeatures := makeImageNoRequiredFeatures(t)
+	requiresProto3Optional := makeImageRequiresProto3Optional(t)
+	requiresEditions := makeImageRequiresEditions(t)
+	requiresBoth := makeImageRequiresBoth(t)
+
+	required := computeRequiredFeatures(noRequiredFeatures)
+	assert.Empty(t, required.flags)
+	assert.Empty(t, required.editions)
+
+	required = computeRequiredFeatures(requiresProto3Optional)
+	assert.Equal(t, map[pluginpb.CodeGeneratorResponse_Feature][]string{
+		pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL: {"proto3_optional.proto"},
+	}, required.flags)
+	assert.Empty(t, required.editions)
+
+	required = computeRequiredFeatures(requiresEditions)
+	assert.Equal(t, map[pluginpb.CodeGeneratorResponse_Feature][]string{
+		pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS: {"editions.proto"},
+	}, required.flags)
+	assert.Equal(t, map[descriptorpb.Edition][]string{
+		descriptorpb.Edition_EDITION_2023: {"editions.proto"},
+	}, required.editions)
+	// Note that we can't really test a wider range here right now because
+	// we don't support building an editions file for anything other than
+	// edition 2023 right now.
+	assert.Equal(t, descriptorpb.Edition_EDITION_2023, required.minEdition)
+	assert.Equal(t, descriptorpb.Edition_EDITION_2023, required.maxEdition)
+
+	required = computeRequiredFeatures(requiresBoth)
+	assert.Equal(t, map[pluginpb.CodeGeneratorResponse_Feature][]string{
+		pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL:   {"proto3_optional.proto"},
+		pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS: {"editions.proto"},
+	}, required.flags)
+	assert.Equal(t, map[descriptorpb.Edition][]string{
+		descriptorpb.Edition_EDITION_2023: {"editions.proto"},
+	}, required.editions)
+	assert.Equal(t, descriptorpb.Edition_EDITION_2023, required.minEdition)
+	assert.Equal(t, descriptorpb.Edition_EDITION_2023, required.maxEdition)
+}
+
+func TestCheckRequiredFeatures(t *testing.T) {
+	t.Parallel()
+	noRequiredFeatures := makeImageNoRequiredFeatures(t)
+	requiresProto3Optional := makeImageRequiresProto3Optional(t)
+	requiresEditions := makeImageRequiresEditions(t)
+	requiresBoth := makeImageRequiresBoth(t)
+
+	supportsNoFeatures := &pluginpb.CodeGeneratorResponse{}
+	supportsBoth := &pluginpb.CodeGeneratorResponse{
+		SupportedFeatures: proto.Uint64(uint64(
+			pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL |
+				pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS,
+		)),
+		MinimumEdition: (*int32)(descriptorpb.Edition_EDITION_2023.Enum()),
+		MaximumEdition: (*int32)(descriptorpb.Edition_EDITION_2024.Enum()),
+	}
+	supportsEditionsButOutOfRange := &pluginpb.CodeGeneratorResponse{
+		SupportedFeatures: proto.Uint64(uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS)),
+		MinimumEdition:    (*int32)(descriptorpb.Edition_EDITION_2024.Enum()),
+		MaximumEdition:    (*int32)(descriptorpb.Edition_EDITION_MAX.Enum()),
+	}
+
+	// Successful cases
+	testCheckRequiredFeatures(t, noRequiredFeatures, supportsNoFeatures, "")
+	testCheckRequiredFeatures(t, requiresProto3Optional, supportsBoth, "")
+	testCheckRequiredFeatures(t, requiresEditions, supportsBoth, "")
+	testCheckRequiredFeatures(t, requiresBoth, supportsBoth, "")
+
+	// Error cases
+	testCheckRequiredFeatures(t, requiresProto3Optional, supportsNoFeatures,
+		`Plugin "test" does not support required feature(s).
+  Feature "proto3 optional" is required by 1 file(s):
+    proto3_optional.proto
+`)
+	testCheckRequiredFeatures(t, requiresEditions, supportsNoFeatures,
+		`Plugin "test" does not support required feature(s).
+  Feature "supports editions" is required by 1 file(s):
+    editions.proto
+`)
+	testCheckRequiredFeatures(t, requiresBoth, supportsNoFeatures,
+		`Plugin "test" does not support required feature(s).
+  Feature "proto3 optional" is required by 1 file(s):
+    proto3_optional.proto
+  Feature "supports editions" is required by 1 file(s):
+    editions.proto
+`)
+	testCheckRequiredFeatures(t, requiresEditions, supportsEditionsButOutOfRange,
+		`Plugin "test" does not support required edition(s).
+  Edition "2023" is required by 1 file(s):
+    editions.proto
+`)
+}
+
+func testCheckRequiredFeatures(
+	t *testing.T,
+	image bufimage.Image,
+	codeGenResponse *pluginpb.CodeGeneratorResponse,
+	expectedOutput string,
+) {
+	t.Helper()
+	required := computeRequiredFeatures(image)
+	var stderr bytes.Buffer
+	err := checkRequiredFeatures(
+		newMockStderrContainer(&stderr),
+		required,
+		[]*pluginpb.CodeGeneratorResponse{
+			codeGenResponse,
+			// this makes sure we handle multiple responses; this one never fails
+			{
+				SupportedFeatures: proto.Uint64(math.MaxUint), // all features enabled
+				MinimumEdition:    proto.Int32(0),
+				MaximumEdition:    proto.Int32(int32(descriptorpb.Edition_EDITION_MAX)),
+			},
+		},
+		[]bufconfig.GeneratePluginConfig{
+			newMockPluginConfig("test"),
+			newMockPluginConfig("never_fails"),
+		},
+	)
+	if expectedOutput != "" {
+		require.ErrorContains(t, err, "plugin test is unable to generate code for all input files")
+		require.Equal(t, expectedOutput, stderr.String())
+	} else {
+		require.NoError(t, err)
+	}
+}
+
+func makeImageNoRequiredFeatures(t *testing.T) bufimage.Image {
+	t.Helper()
+	testFile, err := bufimage.NewImageFile(
+		&descriptorpb.FileDescriptorProto{
+			Name:   proto.String("test.proto"),
+			Syntax: proto.String("proto3"),
+			Dependency: []string{
+				"imported_editions.proto",
+				"imported_proto3_optional.proto",
+			},
+		},
+		nil,
+		uuid.UUID{},
+		"test.proto",
+		"test.proto",
+		false,
+		false,
+		[]int32{0, 1},
+	)
+	require.NoError(t, err)
+	// Imported files can use features since we're not doing code gen for them.
+	importedFileEditions := makeImageFileRequiresEditions(t, "imported_editions.proto", true)
+	importedFileProto3Optional := makeImageFileRequiresProto3Optional(t, "imported_proto3_optional.proto", true)
+	image, err := bufimage.NewImage([]bufimage.ImageFile{importedFileEditions, importedFileProto3Optional, testFile})
+	require.NoError(t, err)
+	return image
+}
+
+func makeImageRequiresProto3Optional(t *testing.T) bufimage.Image {
+	t.Helper()
+	proto3OptionalFile := makeImageFileRequiresProto3Optional(t, "proto3_optional.proto", false)
+	image, err := bufimage.NewImage([]bufimage.ImageFile{proto3OptionalFile})
+	require.NoError(t, err)
+	return image
+}
+
+func makeImageRequiresEditions(t *testing.T) bufimage.Image {
+	t.Helper()
+	editionsFile := makeImageFileRequiresEditions(t, "editions.proto", false)
+	image, err := bufimage.NewImage([]bufimage.ImageFile{editionsFile})
+	require.NoError(t, err)
+	return image
+}
+
+func makeImageRequiresBoth(t *testing.T) bufimage.Image {
+	t.Helper()
+	editionsFile := makeImageFileRequiresEditions(t, "editions.proto", false)
+	proto3OptionalFile := makeImageFileRequiresProto3Optional(t, "proto3_optional.proto", false)
+	image, err := bufimage.NewImage([]bufimage.ImageFile{editionsFile, proto3OptionalFile})
+	require.NoError(t, err)
+	return image
+}
+
+func makeImageFileRequiresProto3Optional(t *testing.T, name string, isImport bool) bufimage.ImageFile {
+	t.Helper()
+	imageFile, err := bufimage.NewImageFile(
+		&descriptorpb.FileDescriptorProto{
+			Syntax: proto.String("proto3"),
+			Name:   proto.String(name),
+			MessageType: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("Foo"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:           proto.String("bar"),
+							Label:          descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+							Type:           descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							JsonName:       proto.String("bar"),
+							OneofIndex:     proto.Int32(0),
+							Proto3Optional: proto.Bool(true),
+						},
+					},
+					OneofDecl: []*descriptorpb.OneofDescriptorProto{
+						{
+							Name: proto.String("_bar"),
+						},
+					},
+				},
+			},
+		},
+		nil,
+		uuid.UUID{},
+		name,
+		name,
+		isImport,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	return imageFile
+}
+
+func makeImageFileRequiresEditions(t *testing.T, name string, isImport bool) bufimage.ImageFile {
+	t.Helper()
+	imageFile, err := bufimage.NewImageFile(
+		&descriptorpb.FileDescriptorProto{
+			Syntax:  proto.String("editions"),
+			Edition: descriptorpb.Edition_EDITION_2023.Enum(),
+			Name:    proto.String(name),
+			MessageType: []*descriptorpb.DescriptorProto{
+				{
+					Name: proto.String("Bar"),
+					Field: []*descriptorpb.FieldDescriptorProto{
+						{
+							Name:     proto.String("baz"),
+							Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+							Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+							JsonName: proto.String("baz"),
+						},
+					},
+				},
+			},
+		},
+		nil,
+		uuid.UUID{},
+		name,
+		name,
+		isImport,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	return imageFile
+}
+
+type mockStderrContainer struct {
+	writer io.Writer
+}
+
+func newMockStderrContainer(w io.Writer) app.StderrContainer {
+	return mockStderrContainer{w}
+}
+
+func (m mockStderrContainer) Stderr() io.Writer {
+	return m.writer
+}
+
+type mockPluginConfig struct {
+	bufconfig.GeneratePluginConfig
+
+	name string
+}
+
+func newMockPluginConfig(name string) bufconfig.GeneratePluginConfig {
+	return mockPluginConfig{name: name}
+}
+
+func (p mockPluginConfig) Name() string {
+	return p.name
+}

--- a/private/buf/bufgen/features_test.go
+++ b/private/buf/bufgen/features_test.go
@@ -41,22 +41,22 @@ func TestComputeRequiredFeatures(t *testing.T) {
 	requiresBoth := makeImageRequiresBoth(t)
 
 	required := computeRequiredFeatures(noRequiredFeatures)
-	assert.Empty(t, required.featureToFilename)
-	assert.Empty(t, required.editionToFilename)
+	assert.Empty(t, required.featureToFilenames)
+	assert.Empty(t, required.editionToFilenames)
 
 	required = computeRequiredFeatures(requiresProto3Optional)
 	assert.Equal(t, map[pluginpb.CodeGeneratorResponse_Feature][]string{
 		pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL: {"proto3_optional.proto"},
-	}, required.featureToFilename)
-	assert.Empty(t, required.editionToFilename)
+	}, required.featureToFilenames)
+	assert.Empty(t, required.editionToFilenames)
 
 	required = computeRequiredFeatures(requiresEditions)
 	assert.Equal(t, map[pluginpb.CodeGeneratorResponse_Feature][]string{
 		pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS: {"editions.proto"},
-	}, required.featureToFilename)
+	}, required.featureToFilenames)
 	assert.Equal(t, map[descriptorpb.Edition][]string{
 		descriptorpb.Edition_EDITION_2023: {"editions.proto"},
-	}, required.editionToFilename)
+	}, required.editionToFilenames)
 	// Note that we can't really test a wider range here right now because
 	// we don't support building an editions file for anything other than
 	// edition 2023 right now.
@@ -67,10 +67,10 @@ func TestComputeRequiredFeatures(t *testing.T) {
 	assert.Equal(t, map[pluginpb.CodeGeneratorResponse_Feature][]string{
 		pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL:   {"proto3_optional.proto"},
 		pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS: {"editions.proto"},
-	}, required.featureToFilename)
+	}, required.featureToFilenames)
 	assert.Equal(t, map[descriptorpb.Edition][]string{
 		descriptorpb.Edition_EDITION_2023: {"editions.proto"},
-	}, required.editionToFilename)
+	}, required.editionToFilenames)
 	assert.Equal(t, descriptorpb.Edition_EDITION_2023, required.minEdition)
 	assert.Equal(t, descriptorpb.Edition_EDITION_2023, required.maxEdition)
 }
@@ -105,27 +105,14 @@ func TestCheckRequiredFeatures(t *testing.T) {
 
 	// Error cases
 	testCheckRequiredFeatures(t, requiresProto3Optional, supportsNoFeatures,
-		`Plugin "test" does not support required feature(s).
-  Feature "proto3 optional" is required by 1 file(s):
-    proto3_optional.proto
-`)
+		`plugin "test" does not support feature "proto3 optional" which is required by "proto3_optional.proto"`)
 	testCheckRequiredFeatures(t, requiresEditions, supportsNoFeatures,
-		`Plugin "test" does not support required feature(s).
-  Feature "supports editions" is required by 1 file(s):
-    editions.proto
-`)
+		`plugin "test" does not support feature "supports editions" which is required by "editions.proto"`)
 	testCheckRequiredFeatures(t, requiresBoth, supportsNoFeatures,
-		`Plugin "test" does not support required feature(s).
-  Feature "proto3 optional" is required by 1 file(s):
-    proto3_optional.proto
-  Feature "supports editions" is required by 1 file(s):
-    editions.proto
-`)
+		`plugin "test" does not support feature "proto3 optional" which is required by "proto3_optional.proto"; `+
+			`plugin "test" does not support feature "supports editions" which is required by "editions.proto"`)
 	testCheckRequiredFeatures(t, requiresEditions, supportsEditionsButOutOfRange,
-		`Plugin "test" does not support required edition(s).
-  Edition "2023" is required by 1 file(s):
-    editions.proto
-`)
+		`plugin "test" does not support edition "2023" which is required by "editions.proto"`)
 }
 
 func testCheckRequiredFeatures(

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -274,7 +274,9 @@ func (g *generator) execPlugins(
 	if err := validateResponses(responses, pluginConfigs); err != nil {
 		return nil, err
 	}
-	checkRequiredFeatures(container, requiredFeatures, responses, pluginConfigs)
+	if err := checkRequiredFeatures(container, requiredFeatures, responses, pluginConfigs); err != nil {
+		return nil, err
+	}
 	return responses, nil
 }
 

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -274,7 +274,7 @@ func (g *generator) execPlugins(
 	if err := validateResponses(responses, pluginConfigs); err != nil {
 		return nil, err
 	}
-	if err := checkRequiredFeatures(container, requiredFeatures, responses, pluginConfigs); err != nil {
+	if err := checkRequiredFeatures(requiredFeatures, responses, pluginConfigs); err != nil {
 		return nil, err
 	}
 	return responses, nil

--- a/private/bufpkg/bufprotoplugin/bufprotoplugin.go
+++ b/private/bufpkg/bufprotoplugin/bufprotoplugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/protoplugin"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -144,6 +145,29 @@ func ValidatePluginResponses(pluginResponses []*PluginResponse) error {
 				)
 			}
 			seen[fileName] = pluginResponse.PluginName
+		}
+		if pluginResponse.Response.GetSupportedFeatures()&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 {
+			// If plugin says it supports editions, it must set min and max edition.
+			if pluginResponse.Response.MinimumEdition == nil {
+				return fmt.Errorf(
+					"plugin %q advertises that it supports editions but did not indicate a minimum supported edition",
+					pluginResponse.PluginName,
+				)
+			}
+			if pluginResponse.Response.MaximumEdition == nil {
+				return fmt.Errorf(
+					"plugin %q advertises that it supports editions but did not indicate a maximum supported edition",
+					pluginResponse.PluginName,
+				)
+			}
+			if pluginResponse.Response.GetMaximumEdition() < pluginResponse.Response.GetMinimumEdition() {
+				return fmt.Errorf(
+					"plugin %q indicates a maximum supported edition (%d) that is less than its minimum supported edition (%d)",
+					pluginResponse.PluginName,
+					descriptorpb.Edition(pluginResponse.Response.GetMaximumEdition()),
+					descriptorpb.Edition(pluginResponse.Response.GetMinimumEdition()),
+				)
+			}
 		}
 	}
 	return nil

--- a/private/pkg/protodescriptor/protodescriptor.go
+++ b/private/pkg/protodescriptor/protodescriptor.go
@@ -138,6 +138,14 @@ func ValidateFileDescriptor(fileDescriptor FileDescriptor) error {
 		return fmt.Errorf("%s uses edition %s, but editions are not yet supported in buf",
 			fileDescriptor.GetName(), strings.TrimPrefix(fileDescriptor.GetEdition().String(), "EDITION_"))
 	}
+	if fileDescriptor.GetSyntax() == "editions" && fileDescriptor.GetEdition() != descriptorpb.Edition_EDITION_2023 {
+		// Currently, we could only support edition 2023.
+		// TODO: For maximum safety, we probably want to ask protocompile if it supports
+		//       the edition, too. It's a little unlikely that we'd update buf CLI to
+		//       support an edition before protocompile, but just in case.
+		return fmt.Errorf("%s uses unsupported edition %s",
+			fileDescriptor.GetName(), strings.TrimPrefix(fileDescriptor.GetEdition().String(), "EDITION_"))
+	}
 	return nil
 }
 

--- a/private/pkg/protodescriptor/protodescriptor.go
+++ b/private/pkg/protodescriptor/protodescriptor.go
@@ -144,7 +144,7 @@ func ValidateFileDescriptor(fileDescriptor FileDescriptor) error {
 		//       the edition, too. It's a little unlikely that we'd update buf CLI to
 		//       support an edition before protocompile, but just in case.
 		return fmt.Errorf("%s uses unsupported edition %s",
-			fileDescriptor.GetName(), strings.TrimPrefix(fileDescriptor.GetEdition().String(), "EDITION_"))
+			fileDescriptor.GetName(), fileDescriptor.GetEdition())
 	}
 	return nil
 }


### PR DESCRIPTION
This adds support for the new "supports editions" feature in `plugin.proto` and also updates code generation to use the plugin's min and max supported edition (when that new feature is supported).

This also makes the result, if the plugin does not support a feature, an _error_ instead of just a _warning_.

Currently, the structure of the code is that it writes all of the details about inadequate support to `stderr` and then returns an error. Perhaps it should pack all of those details about inadequate support _into_ the error that it returns? Looking for feedback on that, as well as on the format of the output when a plugin has inadequate support.