### PR TITLE
Improve efficiency of resolver backed by protocompile output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.33.0-20240401180337-569d290ee4cc.1
 	connectrpc.com/connect v1.16.1
 	connectrpc.com/otelconnect v0.7.0
-	github.com/bufbuild/protocompile v0.12.0
+	github.com/bufbuild/protocompile v0.13.0
 	github.com/bufbuild/protoplugin v0.0.0-20240323223605-e2735f6c31ee
 	github.com/bufbuild/protovalidate-go v0.6.2
 	github.com/bufbuild/protoyaml-go v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/bufbuild/protocompile v0.12.0 h1:KnGWHxI4IX+/44yQTyOl9VYzfk6TUWuYepTwnUFuRI0=
-github.com/bufbuild/protocompile v0.12.0/go.mod h1:dr++fGGeMPWHv7jPeT06ZKukm45NJscd7rUxQVzEKRk=
+github.com/bufbuild/protocompile v0.13.0 h1:6cwUB0Y2tSvmNxsbunwzmIto3xOlJOV7ALALuVOs92M=
+github.com/bufbuild/protocompile v0.13.0/go.mod h1:dr++fGGeMPWHv7jPeT06ZKukm45NJscd7rUxQVzEKRk=
 github.com/bufbuild/protoplugin v0.0.0-20240323223605-e2735f6c31ee h1:E6ET8YUcYJ1lAe6ctR3as7yqzW2BNItDFnaB5zQq/8M=
 github.com/bufbuild/protoplugin v0.0.0-20240323223605-e2735f6c31ee/go.mod h1:HjGFxsck9RObrTJp2hXQZfWhPgZqnR6sR1U5fCA/Kus=
 github.com/bufbuild/protovalidate-go v0.6.2 h1:U/V3CGF0kPlR12v41rjO4DrYZtLcS4ZONLmWN+rJVCQ=

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -33,7 +33,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufcurl"
-	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
@@ -901,11 +900,7 @@ func run(ctx context.Context, container appext.Container, f *flags) (err error) 
 		if err != nil {
 			return err
 		}
-		res, err := protoencoding.NewResolver(bufimage.ImageToFileDescriptorProtos(image)...)
-		if err != nil {
-			return err
-		}
-		resolvers = append(resolvers, res)
+		resolvers = append(resolvers, image.Resolver())
 	}
 	res := protoencoding.CombineResolvers(resolvers...)
 

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -357,10 +357,11 @@ func NewImageForProto(protoImage *imagev1.Image, options ...NewImageForProtoOpti
 	if newImageOptions.noReparse && newImageOptions.computeUnusedImports {
 		return nil, fmt.Errorf("cannot use both WithNoReparse and WithComputeUnusedImports options; they are mutually exclusive")
 	}
-	var resolver protoencoding.Resolver
+	// TODO FUTURE: right now, NewResolver sets AllowUnresolvable to true all the time
+	// we want to make this into a check, and we verify if we need this for the individual command
+	resolver := protoencoding.NewLazyResolver(protoImage.File...)
 	if !newImageOptions.noReparse {
-		var err error
-		if resolver, err = reparseImageProto(protoImage, newImageOptions.computeUnusedImports); err != nil {
+		if err := reparseImageProto(protoImage, resolver, newImageOptions.computeUnusedImports); err != nil {
 			return nil, err
 		}
 	}
@@ -480,7 +481,7 @@ func ImageWithoutImports(image Image) Image {
 			newImageFiles = append(newImageFiles, imageFile)
 		}
 	}
-	return newImageNoValidate(newImageFiles)
+	return newImageNoValidate(newImageFiles, image.Resolver())
 }
 
 // ImageWithOnlyPaths returns a copy of the Image that only includes the files
@@ -669,12 +670,9 @@ type newImageForProtoOptions struct {
 	computeUnusedImports bool
 }
 
-func reparseImageProto(protoImage *imagev1.Image, computeUnusedImports bool) (protoencoding.Resolver, error) {
-	// TODO FUTURE: right now, NewResolver sets AllowUnresolvable to true all the time
-	// we want to make this into a check, and we verify if we need this for the individual command
-	resolver := protoencoding.NewLazyResolver(protoImage.File...)
+func reparseImageProto(protoImage *imagev1.Image, resolver protoencoding.Resolver, computeUnusedImports bool) error {
 	if err := protoencoding.ReparseUnrecognized(resolver, protoImage.ProtoReflect()); err != nil {
-		return nil, fmt.Errorf("could not reparse image: %v", err)
+		return fmt.Errorf("could not reparse image: %v", err)
 	}
 	if computeUnusedImports {
 		tracker := &importTracker{
@@ -708,7 +706,7 @@ func reparseImageProto(protoImage *imagev1.Image, computeUnusedImports bool) (pr
 			}
 		}
 	}
-	return resolver, nil
+	return nil
 }
 
 // We pass in the pathToImageFileInfo here because we also call this in

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -270,12 +270,10 @@ func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedF
 	// So we serialize and then de-serialize, and use only the filtered results to parse extensions. That
 	// way, the result will omit custom options that aren't present in the filtered set (as they will be
 	// considered unrecognized fields).
-	resolver, err := protoencoding.NewResolver(bufimage.ImageToFileDescriptorProtos(filteredImage)...)
-	require.NoError(t, err)
 	data, err := proto.Marshal(bufimage.ImageToFileDescriptorSet(filteredImage))
 	require.NoError(t, err)
 	fileDescriptorSet := &descriptorpb.FileDescriptorSet{}
-	err = proto.UnmarshalOptions{Resolver: resolver}.Unmarshal(data, fileDescriptorSet)
+	err = proto.UnmarshalOptions{Resolver: filteredImage.Resolver()}.Unmarshal(data, fileDescriptorSet)
 	require.NoError(t, err)
 
 	reflectDescriptors, err := desc.CreateFileDescriptorsFromSet(fileDescriptorSet)

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -494,27 +494,6 @@ func (r *resolverForFiles) FindExtensionByNumber(message protoreflect.FullName, 
 	return dynamicpb.NewExtensionType(ext), nil
 }
 
-type container interface {
-	Messages() protoreflect.MessageDescriptors
-	Extensions() protoreflect.ExtensionDescriptors
-}
-
-func findExtension(d container, message protoreflect.FullName, field protoreflect.FieldNumber) protoreflect.ExtensionDescriptor {
-	exts := d.Extensions()
-	for i, length := 0, exts.Len(); i < length; i++ {
-		ext := exts.Get(i)
-		if ext.Number() == field && ext.ContainingMessage().FullName() == message {
-			return ext
-		}
-	}
-	for i := 0; i < d.Messages().Len(); i++ {
-		if ext := findExtension(d.Messages().Get(i), message, field); ext != nil {
-			return ext
-		}
-	}
-	return nil // could not be found
-}
-
 func (r *resolverForFiles) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
 	descriptor, err := r.FindDescriptorByName(message)
 	if err != nil {
@@ -542,6 +521,27 @@ func (r *resolverForFiles) FindEnumByName(enum protoreflect.FullName) (protorefl
 		return nil, fmt.Errorf("element %q is not an enum", enum)
 	}
 	return dynamicpb.NewEnumType(en), nil
+}
+
+type container interface {
+	Messages() protoreflect.MessageDescriptors
+	Extensions() protoreflect.ExtensionDescriptors
+}
+
+func findExtension(d container, message protoreflect.FullName, field protoreflect.FieldNumber) protoreflect.ExtensionDescriptor {
+	exts := d.Extensions()
+	for i, length := 0, exts.Len(); i < length; i++ {
+		ext := exts.Get(i)
+		if ext.Number() == field && ext.ContainingMessage().FullName() == message {
+			return ext
+		}
+	}
+	for i := 0; i < d.Messages().Len(); i++ {
+		if ext := findExtension(d.Messages().Get(i), message, field); ext != nil {
+			return ext
+		}
+	}
+	return nil // could not be found
 }
 
 func addFileToMapRec(pathToFile map[string]linker.File, file linker.File) {

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -528,7 +528,7 @@ func (r *resolverForFiles) FindMessageByName(message protoreflect.FullName) (pro
 }
 
 func (r *resolverForFiles) FindMessageByURL(url string) (protoreflect.MessageType, error) {
-	pos := strings.IndexByte(url, '/')
+	pos := strings.LastIndexByte(url, '/')
 	return r.FindMessageByName(protoreflect.FullName(url[pos+1:]))
 }
 

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
@@ -33,6 +34,7 @@ import (
 	"github.com/bufbuild/protocompile/protoutil"
 	"github.com/bufbuild/protocompile/reporter"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
@@ -80,14 +82,15 @@ func buildImage(
 	if buildResult.Err != nil {
 		return nil, buildResult.Err
 	}
-	fileDescriptors, err := checkAndSortFileDescriptors(buildResult.FileDescriptors, paths)
+	sortedFiles, err := checkAndSortFiles(buildResult.Files, paths)
 	if err != nil {
 		return nil, err
 	}
 	image, err := getImage(
 		ctx,
 		excludeSourceCodeInfo,
-		fileDescriptors,
+		sortedFiles,
+		buildResult.Symbols,
 		parserAccessorHandler,
 		buildResult.SyntaxUnspecifiedFilenames,
 		buildResult.FilenameToUnusedDependencyFilenames,
@@ -118,10 +121,12 @@ func getBuildResult(
 	if noParallelism {
 		parallelism = 1
 	}
+	symbols := &linker.Symbols{}
 	compiler := protocompile.Compiler{
 		MaxParallelism: parallelism,
 		SourceInfoMode: sourceInfoMode,
 		Resolver:       &protocompile.SourceResolver{Accessor: parserAccessorHandler.Open},
+		Symbols:        symbols,
 		Reporter: reporter.NewReporter(
 			func(errorWithPos reporter.ErrorWithPos) error {
 				errorsWithPos = append(errorsWithPos, errorWithPos)
@@ -137,10 +142,7 @@ func getBuildResult(
 	if err != nil {
 		if err == reporter.ErrInvalidSource {
 			if len(errorsWithPos) == 0 {
-				return newBuildResult(
-					nil,
-					nil,
-					nil,
+				return newFailedBuildResult(
 					errors.New("got invalid source error from parse but no errors reported"),
 				)
 			}
@@ -149,9 +151,9 @@ func getBuildResult(
 				bufprotocompile.WithExternalPathResolver(parserAccessorHandler.ExternalPath),
 			)
 			if err != nil {
-				return newBuildResult(nil, nil, nil, err)
+				return newFailedBuildResult(err)
 			}
-			return newBuildResult(nil, nil, nil, fileAnnotationSet)
+			return newFailedBuildResult(fileAnnotationSet)
 		}
 		if errorWithPos, ok := err.(reporter.ErrorWithPos); ok {
 			fileAnnotation, err := bufprotocompile.FileAnnotationForErrorWithPos(
@@ -159,25 +161,19 @@ func getBuildResult(
 				bufprotocompile.WithExternalPathResolver(parserAccessorHandler.ExternalPath),
 			)
 			if err != nil {
-				return newBuildResult(nil, nil, nil, err)
+				return newFailedBuildResult(err)
 			}
-			return newBuildResult(nil, nil, nil, bufanalysis.NewFileAnnotationSet(fileAnnotation))
+			return newFailedBuildResult(bufanalysis.NewFileAnnotationSet(fileAnnotation))
 		}
-		return newBuildResult(nil, nil, nil, err)
+		return newFailedBuildResult(err)
 	} else if len(errorsWithPos) > 0 {
 		// https://github.com/jhump/protoreflect/pull/331
-		return newBuildResult(
-			nil,
-			nil,
-			nil,
+		return newFailedBuildResult(
 			errors.New("got no error from parse but errors reported"),
 		)
 	}
 	if len(compiledFiles) != len(paths) {
-		return newBuildResult(
-			nil,
-			nil,
-			nil,
+		return newFailedBuildResult(
 			fmt.Errorf("expected FileDescriptors to be of length %d but was %d", len(paths), len(compiledFiles)),
 		)
 	}
@@ -187,10 +183,7 @@ func getBuildResult(
 		// doing another rough verification
 		// NO LONGER NEED TO DO SUFFIX SINCE WE KNOW THE ROOT FILE NAME
 		if path != filename {
-			return newBuildResult(
-				nil,
-				nil,
-				nil,
+			return newFailedBuildResult(
 				fmt.Errorf("expected fileDescriptor name %s to be a equal to %s", filename, path),
 			)
 		}
@@ -203,16 +196,16 @@ func getBuildResult(
 	}
 	return newBuildResult(
 		compiledFiles,
+		symbols,
 		syntaxUnspecifiedFilenames,
 		filenameToUnusedDependencyFilenames,
-		nil,
 	)
 }
 
-// We need to sort the FileDescriptors as they may/probably are out of order
+// We need to sort the files as they may/probably are out of order
 // relative to input order after concurrent builds. This mimics the output
 // order of protoc.
-func checkAndSortFileDescriptors(
+func checkAndSortFiles(
 	fileDescriptors linker.Files,
 	rootRelFilePaths []string,
 ) (linker.Files, error) {
@@ -247,11 +240,12 @@ func checkAndSortFileDescriptors(
 // getImage gets the Image for the protoreflect.FileDescriptors.
 //
 // This mimics protoc's output order.
-// This assumes checkAndSortFileDescriptors was called.
+// This assumes checkAndSortFiles was called.
 func getImage(
 	ctx context.Context,
 	excludeSourceCodeInfo bool,
-	sortedFileDescriptors linker.Files,
+	sortedFiles linker.Files,
+	symbols *linker.Symbols,
 	parserAccessorHandler *parserAccessorHandler,
 	syntaxUnspecifiedFilenames map[string]struct{},
 	filenameToUnusedDependencyFilenames map[string]map[string]struct{},
@@ -265,14 +259,14 @@ func getImage(
 	// all input protoreflect.FileDescriptors are not imports, we derive the imports
 	// from GetDependencies.
 	nonImportFilenames := map[string]struct{}{}
-	for _, fileDescriptor := range sortedFileDescriptors {
+	for _, fileDescriptor := range sortedFiles {
 		nonImportFilenames[fileDescriptor.Path()] = struct{}{}
 	}
 
 	var imageFiles []ImageFile
 	var err error
 	alreadySeen := map[string]struct{}{}
-	for _, fileDescriptor := range sortedFileDescriptors {
+	for _, fileDescriptor := range sortedFiles {
 		imageFiles, err = getImageFilesRec(
 			ctx,
 			excludeSourceCodeInfo,
@@ -288,7 +282,7 @@ func getImage(
 			return nil, err
 		}
 	}
-	return newImage(imageFiles, false, newResolverForBuildResult(sortedFileDescriptors))
+	return newImage(imageFiles, false, newResolverForFiles(sortedFiles, symbols))
 }
 
 func getImageFilesRec(
@@ -398,7 +392,8 @@ func maybeAddUnusedImport(
 }
 
 type buildResult struct {
-	FileDescriptors                     linker.Files
+	Files                               linker.Files
+	Symbols                             *linker.Symbols
 	SyntaxUnspecifiedFilenames          map[string]struct{}
 	FilenameToUnusedDependencyFilenames map[string]map[string]struct{}
 	Err                                 error
@@ -406,16 +401,20 @@ type buildResult struct {
 
 func newBuildResult(
 	fileDescriptors linker.Files,
+	symbols *linker.Symbols,
 	syntaxUnspecifiedFilenames map[string]struct{},
 	filenameToUnusedDependencyFilenames map[string]map[string]struct{},
-	err error,
 ) *buildResult {
 	return &buildResult{
-		FileDescriptors:                     fileDescriptors,
+		Files:                               fileDescriptors,
+		Symbols:                             symbols,
 		SyntaxUnspecifiedFilenames:          syntaxUnspecifiedFilenames,
 		FilenameToUnusedDependencyFilenames: filenameToUnusedDependencyFilenames,
-		Err:                                 err,
 	}
+}
+
+func newFailedBuildResult(err error) *buildResult {
+	return &buildResult{Err: err}
 }
 
 type buildImageOptions struct {
@@ -427,25 +426,132 @@ func newBuildImageOptions() *buildImageOptions {
 	return &buildImageOptions{}
 }
 
-// resolverForBuildResult implements protoencoding.Resolver and is backed
-// by a linker.Resolver which is the result of a protocompile operation.
-// The linker.Resolver provides all necessary methods except FindEnumByName.
-type resolverForBuildResult struct {
-	linker.Resolver
+// resolverForFiles implements protoencoding.Resolver and is backed
+// by a linker.Files and the *linker.Symbols symbol table produced
+// when compiling the files. The symbol table is used as an index
+// for more efficient lookup.
+type resolverForFiles struct {
+	pathToFile map[string]linker.File
+	symbols    *linker.Symbols
 }
 
-func newResolverForBuildResult(result linker.Files) protoencoding.Resolver {
-	return &resolverForBuildResult{Resolver: result.AsResolver()}
+func newResolverForFiles(files linker.Files, symbols *linker.Symbols) protoencoding.Resolver {
+	// Expand the set of files so it includes the entire transitive graph
+	pathToFile := make(map[string]linker.File, len(files))
+	for _, file := range files {
+		addFileToMapRec(pathToFile, file)
+	}
+	return &resolverForFiles{pathToFile: pathToFile, symbols: symbols}
 }
 
-func (r *resolverForBuildResult) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
-	descriptor, err := r.Resolver.FindDescriptorByName(enum)
+func (r *resolverForFiles) FindFileByPath(path string) (protoreflect.FileDescriptor, error) {
+	file, ok := r.pathToFile[path]
+	if !ok {
+		return nil, protoregistry.NotFound
+	}
+	return file, nil
+}
+
+func (r *resolverForFiles) FindDescriptorByName(name protoreflect.FullName) (protoreflect.Descriptor, error) {
+	span := r.symbols.Lookup(name)
+	if span == nil {
+		return nil, protoregistry.NotFound
+	}
+	descriptor := r.pathToFile[span.Start().Filename].FindDescriptorByName(name)
+	if descriptor == nil {
+		return nil, protoregistry.NotFound
+	}
+	return descriptor, nil
+}
+
+func (r *resolverForFiles) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	descriptor, err := r.FindDescriptorByName(field)
 	if err != nil {
 		return nil, err
 	}
-	enumDescriptor, ok := descriptor.(protoreflect.EnumDescriptor)
+	ext, ok := descriptor.(protoreflect.ExtensionDescriptor)
 	if !ok {
-		return nil, fmt.Errorf("%s is a %T, not a protoreflect.EnumDescriptor", enum, descriptor)
+		return nil, fmt.Errorf("element %q is not an extension", field)
 	}
-	return dynamicpb.NewEnumType(enumDescriptor), nil
+	if xtd, ok := ext.(protoreflect.ExtensionTypeDescriptor); ok {
+		return xtd.Type(), nil
+	}
+	return dynamicpb.NewExtensionType(ext), nil
+}
+
+func (r *resolverForFiles) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	span := r.symbols.LookupExtension(message, field)
+	if span == nil {
+		return nil, protoregistry.NotFound
+	}
+	ext := findExtension(r.pathToFile[span.Start().Filename], message, field)
+	if ext == nil {
+		return nil, protoregistry.NotFound
+	}
+	if xtd, ok := ext.(protoreflect.ExtensionTypeDescriptor); ok {
+		return xtd.Type(), nil
+	}
+	return dynamicpb.NewExtensionType(ext), nil
+}
+
+type container interface {
+	Messages() protoreflect.MessageDescriptors
+	Extensions() protoreflect.ExtensionDescriptors
+}
+
+func findExtension(d container, message protoreflect.FullName, field protoreflect.FieldNumber) protoreflect.ExtensionDescriptor {
+	exts := d.Extensions()
+	for i, length := 0, exts.Len(); i < length; i++ {
+		ext := exts.Get(i)
+		if ext.Number() == field && ext.ContainingMessage().FullName() == message {
+			return ext
+		}
+	}
+	for i := 0; i < d.Messages().Len(); i++ {
+		if ext := findExtension(d.Messages().Get(i), message, field); ext != nil {
+			return ext
+		}
+	}
+	return nil // could not be found
+}
+
+func (r *resolverForFiles) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	descriptor, err := r.FindDescriptorByName(message)
+	if err != nil {
+		return nil, err
+	}
+	msg, ok := descriptor.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("element %q is not a message", message)
+	}
+	return dynamicpb.NewMessageType(msg), nil
+}
+
+func (r *resolverForFiles) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	pos := strings.IndexByte(url, '/')
+	return r.FindMessageByName(protoreflect.FullName(url[pos+1:]))
+}
+
+func (r *resolverForFiles) FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error) {
+	descriptor, err := r.FindDescriptorByName(enum)
+	if err != nil {
+		return nil, err
+	}
+	en, ok := descriptor.(protoreflect.EnumDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("element %q is not an enum", enum)
+	}
+	return dynamicpb.NewEnumType(en), nil
+}
+
+func addFileToMapRec(pathToFile map[string]linker.File, file linker.File) {
+	if _, alreadyAdded := pathToFile[file.Path()]; alreadyAdded {
+		return
+	}
+	pathToFile[file.Path()] = file
+	imports := file.Imports()
+	for i, length := 0, imports.Len(); i < length; i++ {
+		importedFile := file.FindImportByPath(imports.Get(i).Path())
+		addFileToMapRec(pathToFile, importedFile)
+	}
 }

--- a/private/bufpkg/bufimage/image.go
+++ b/private/bufpkg/bufimage/image.go
@@ -87,7 +87,7 @@ func newImage(files []ImageFile, reorder bool, resolver protoencoding.Resolver) 
 	}, nil
 }
 
-func newImageNoValidate(files []ImageFile) *image {
+func newImageNoValidate(files []ImageFile, resolver protoencoding.Resolver) *image {
 	pathToImageFile := make(map[string]ImageFile, len(files))
 	for _, file := range files {
 		path := file.Path()
@@ -96,6 +96,7 @@ func newImageNoValidate(files []ImageFile) *image {
 	return &image{
 		files:           files,
 		pathToImageFile: pathToImageFile,
+		resolver:        resolver,
 	}
 }
 


### PR DESCRIPTION
For another arc of work (related to #2913), I was benchmarking the creation of resolvers and their use in re-parsing unrecognized fields (i.e. custom options) when loading images from a binary-encoded descriptor protos.

I happened to be using the _full_ `googleapis/googleapis` for the benchmark (nearly 5000 files), which really tickles the inefficiency of this resolver, since its look-ups were linear _with the number of files_.

So now, we use the compiler's symbol table as an index, to dead-reckon which file a symbol or extension is in. That improved the benchmarks drastically; using this resolver is now more efficient than creating and using a `*protoregistry.Types` (and less memory needed, too, since there are no additional data structures to create beyond the compiler's data structures).

I've also updated numerous calls to `protoencoding.NewResolver` to instead use `Image.Resolver()` since, in many cases, that's the resolver they want and were re-creating.