### PR TITLE
Update breaking checks for field types to consider message encoding feature

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -286,4 +286,4 @@ issues:
         - gochecknoinits
       # must use init to safely enable editions support for testing
       # TODO: this is temporary; remove it when editions support is ready
-      path: private/buf/bufgen/features_test.go
+      path: private/buf/bufgen/features_test.go|private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go

--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/bufbreaking"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,10 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
+
+func init() {
+	protodescriptor.AllowEditionsForTesting()
+}
 
 func TestRunBreakingEnumNoDelete(t *testing.T) {
 	t.Parallel()
@@ -310,8 +315,10 @@ func TestRunBreakingFieldSameType(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 37, 14, 37, 17, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 39, 5, 39, 8, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 40, 5, 40, 8, "FIELD_SAME_TYPE"),
-		bufanalysistesting.NewFileAnnotation(t, "2.proto", 64, 5, 64, 10, "FIELD_SAME_TYPE"),
-		bufanalysistesting.NewFileAnnotation(t, "2.proto", 65, 5, 65, 9, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "2.proto", 57, 5, 57, 10, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "2.proto", 58, 5, 58, 9, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "3.proto", 8, 3, 8, 7, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "3.proto", 9, 3, 9, 7, "FIELD_SAME_TYPE"),
 	)
 }
 
@@ -339,6 +346,8 @@ func TestRunBreakingFieldWireCompatibleType(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 79, 3, 79, 6, "FIELD_WIRE_COMPATIBLE_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 80, 3, 80, 6, "FIELD_WIRE_COMPATIBLE_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 85, 3, 85, 9, "FIELD_WIRE_COMPATIBLE_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "3.proto", 6, 3, 6, 7, "FIELD_WIRE_COMPATIBLE_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "3.proto", 7, 3, 7, 7, "FIELD_WIRE_COMPATIBLE_TYPE"),
 	)
 }
 func TestRunBreakingFieldWireJSONCompatibleType(t *testing.T) {
@@ -366,6 +375,8 @@ func TestRunBreakingFieldWireJSONCompatibleType(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 83, 3, 83, 6, "FIELD_WIRE_JSON_COMPATIBLE_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 87, 3, 87, 8, "FIELD_WIRE_JSON_COMPATIBLE_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 88, 3, 88, 9, "FIELD_WIRE_JSON_COMPATIBLE_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "3.proto", 6, 3, 6, 7, "FIELD_WIRE_JSON_COMPATIBLE_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "3.proto", 7, 3, 7, 7, "FIELD_WIRE_JSON_COMPATIBLE_TYPE"),
 	)
 }
 

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -335,11 +336,22 @@ func checkFieldSameOneof(add addFunc, corpus *corpus, previousField bufprotosour
 // breaking_field_same_type/2.proto:65:5:Field "2" on message "Nine" changed type from ".a.One" to ".a.Nine".
 
 // CheckFieldSameType is a check function.
-var CheckFieldSameType = newFieldPairCheckFunc(checkFieldSameType)
+var CheckFieldSameType = newFieldDescriptorPairCheckFunc(checkFieldSameType)
 
-func checkFieldSameType(add addFunc, corpus *corpus, previousField bufprotosource.Field, field bufprotosource.Field) error {
-	if previousField.Type() != field.Type() {
-		addFieldChangedType(add, previousField, field)
+func checkFieldSameType(
+	add addFunc,
+	_ *corpus,
+	previousField bufprotosource.Field,
+	previousDescriptor protoreflect.FieldDescriptor,
+	field bufprotosource.Field,
+	descriptor protoreflect.FieldDescriptor,
+) error {
+	// We use descriptor.Kind(), instead of field.Type(), because it also includes
+	// a check of resolved features in Editions files so it can distinguish between
+	// normal (length-prefixed) and delimited (aka "group" encoded) messages, which
+	// are not compatible.
+	if previousDescriptor.Kind() != descriptor.Kind() {
+		addFieldChangedType(add, previousField, previousDescriptor, field, descriptor)
 		return nil
 	}
 
@@ -355,32 +367,43 @@ func checkFieldSameType(add addFunc, corpus *corpus, previousField bufprotosourc
 }
 
 // CheckFieldWireCompatibleType is a check function.
-var CheckFieldWireCompatibleType = newFieldPairCheckFunc(checkFieldWireCompatibleType)
+var CheckFieldWireCompatibleType = newFieldDescriptorPairCheckFunc(checkFieldWireCompatibleType)
 
-func checkFieldWireCompatibleType(add addFunc, corpus *corpus, previousField bufprotosource.Field, field bufprotosource.Field) error {
-	previousWireCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireCompatiblityGroup[previousField.Type()]
+func checkFieldWireCompatibleType(
+	add addFunc,
+	corpus *corpus,
+	previousField bufprotosource.Field,
+	previousDescriptor protoreflect.FieldDescriptor,
+	field bufprotosource.Field,
+	descriptor protoreflect.FieldDescriptor,
+) error {
+	// We use descriptor.Kind(), instead of field.Type(), because it also includes
+	// a check of resolved features in Editions files so it can distinguish between
+	// normal (length-prefixed) and delimited (aka "group" encoded) messages, which
+	// are not compatible.
+	previousWireCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireCompatiblityGroup[previousDescriptor.Kind()]
 	if !ok {
-		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", previousField.Type())
+		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", previousDescriptor.Kind())
 	}
-	wireCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireCompatiblityGroup[field.Type()]
+	wireCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireCompatiblityGroup[descriptor.Kind()]
 	if !ok {
-		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", field.Type())
+		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", descriptor.Kind())
 	}
 	if previousWireCompatibilityGroup != wireCompatibilityGroup {
 		extraMessages := []string{
 			"See https://developers.google.com/protocol-buffers/docs/proto3#updating for wire compatibility rules.",
 		}
 		switch {
-		case previousField.Type() == descriptorpb.FieldDescriptorProto_TYPE_STRING && field.Type() == descriptorpb.FieldDescriptorProto_TYPE_BYTES:
+		case previousDescriptor.Kind() == protoreflect.StringKind && descriptor.Kind() == protoreflect.BytesKind:
 			// It is OK to evolve from string to bytes
 			return nil
-		case previousField.Type() == descriptorpb.FieldDescriptorProto_TYPE_BYTES && field.Type() == descriptorpb.FieldDescriptorProto_TYPE_STRING:
+		case previousDescriptor.Kind() == protoreflect.BytesKind && descriptor.Kind() == protoreflect.StringKind:
 			extraMessages = append(
 				extraMessages,
-				"Note that while string and bytes are compatible if the data is valid UTF-8, there is no way to enforce that a field is UTF-8, so these fields may be incompatible.",
+				"Note that while string and bytes are compatible if the data is valid UTF-8, there is no way to enforce that a bytes field is UTF-8, so these fields may be incompatible.",
 			)
 		}
-		addFieldChangedType(add, previousField, field, extraMessages...)
+		addFieldChangedType(add, previousField, previousDescriptor, field, descriptor, extraMessages...)
 		return nil
 	}
 	switch field.Type() {
@@ -399,33 +422,45 @@ func checkFieldWireCompatibleType(add addFunc, corpus *corpus, previousField buf
 }
 
 // CheckFieldWireJSONCompatibleType is a check function.
-var CheckFieldWireJSONCompatibleType = newFieldPairCheckFunc(checkFieldWireJSONCompatibleType)
+var CheckFieldWireJSONCompatibleType = newFieldDescriptorPairCheckFunc(checkFieldWireJSONCompatibleType)
 
-func checkFieldWireJSONCompatibleType(add addFunc, corpus *corpus, previousField bufprotosource.Field, field bufprotosource.Field) error {
-	previousWireJSONCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireJSONCompatiblityGroup[previousField.Type()]
+func checkFieldWireJSONCompatibleType(
+	add addFunc,
+	corpus *corpus,
+	previousField bufprotosource.Field,
+	previousDescriptor protoreflect.FieldDescriptor,
+	field bufprotosource.Field,
+	descriptor protoreflect.FieldDescriptor,
+) error {
+	// We use descriptor.Kind(), instead of field.Type(), because it also includes
+	// a check of resolved features in Editions files so it can distinguish between
+	// normal (length-prefixed) and delimited (aka "group" encoded) messages, which
+	// are not compatible.
+	previousWireJSONCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireJSONCompatiblityGroup[previousDescriptor.Kind()]
 	if !ok {
-		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", previousField.Type())
+		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", previousDescriptor.Kind())
 	}
-	wireJSONCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireJSONCompatiblityGroup[field.Type()]
+	wireJSONCompatibilityGroup, ok := fieldDescriptorProtoTypeToWireJSONCompatiblityGroup[descriptor.Kind()]
 	if !ok {
-		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", field.Type())
+		return fmt.Errorf("unknown FieldDescriptorProtoType: %v", descriptor.Kind())
 	}
 	if previousWireJSONCompatibilityGroup != wireJSONCompatibilityGroup {
 		addFieldChangedType(
 			add,
 			previousField,
+			previousDescriptor,
 			field,
+			descriptor,
 			"See https://developers.google.com/protocol-buffers/docs/proto3#updating for wire compatibility rules and https://developers.google.com/protocol-buffers/docs/proto3#json for JSON compatibility rules.",
 		)
 		return nil
 	}
-	switch field.Type() {
-	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
+	switch descriptor.Kind() {
+	case protoreflect.EnumKind:
 		if previousField.TypeName() != field.TypeName() {
 			return checkEnumWireCompatibleForField(add, corpus, previousField, field)
 		}
-	case descriptorpb.FieldDescriptorProto_TYPE_GROUP,
-		descriptorpb.FieldDescriptorProto_TYPE_MESSAGE:
+	case protoreflect.GroupKind, protoreflect.MessageKind:
 		if previousField.TypeName() != field.TypeName() {
 			addEnumGroupMessageFieldChangedTypeName(add, previousField, field)
 			return nil
@@ -469,7 +504,14 @@ func checkEnumWireCompatibleForField(add addFunc, corpus *corpus, previousField 
 	return nil
 }
 
-func addFieldChangedType(add addFunc, previousField bufprotosource.Field, field bufprotosource.Field, extraMessages ...string) {
+func addFieldChangedType(
+	add addFunc,
+	previousField bufprotosource.Field,
+	previousDescriptor protoreflect.FieldDescriptor,
+	field bufprotosource.Field,
+	descriptor protoreflect.FieldDescriptor,
+	extraMessages ...string,
+) {
 	combinedExtraMessage := ""
 	if len(extraMessages) > 0 {
 		// protect against mistakenly added empty extra messages
@@ -478,10 +520,8 @@ func addFieldChangedType(add addFunc, previousField bufprotosource.Field, field 
 		}
 	}
 	var fieldLocation bufprotosource.Location
-	switch field.Type() {
-	case descriptorpb.FieldDescriptorProto_TYPE_MESSAGE,
-		descriptorpb.FieldDescriptorProto_TYPE_ENUM,
-		descriptorpb.FieldDescriptorProto_TYPE_GROUP:
+	switch descriptor.Kind() {
+	case protoreflect.MessageKind, protoreflect.EnumKind, protoreflect.GroupKind:
 		fieldLocation = field.TypeNameLocation()
 	default:
 		fieldLocation = field.TypeLocation()
@@ -495,8 +535,8 @@ func addFieldChangedType(add addFunc, previousField bufprotosource.Field, field 
 		`Field %q on message %q changed type from %q to %q.%s`,
 		previousNumberString,
 		field.ParentMessage().Name(),
-		protodescriptor.FieldDescriptorProtoTypePrettyString(previousField.Type()),
-		protodescriptor.FieldDescriptorProtoTypePrettyString(field.Type()),
+		fieldDescriptorTypePrettyString(previousDescriptor),
+		fieldDescriptorTypePrettyString(descriptor),
 		combinedExtraMessage,
 	)
 }

--- a/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_same_type/2.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_same_type/2.proto
@@ -52,13 +52,6 @@ message Three2 {
   }
 }
 
-message Nine2 {
-  oneof foo {
-    int32 one = 1;
-    One two = 2;
-  }
-}
-
 message Nine {
   oneof foo {
     int64 one = 1;

--- a/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_same_type/3.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_same_type/3.proto
@@ -1,0 +1,25 @@
+edition = "2023";
+
+package a;
+
+import "2.proto";
+
+message One3 {
+  One3 normal = 1 [features.message_encoding=DELIMITED];
+  One3 delimited = 2;
+  One3 normal_b = 3;
+  One3 delimited_b = 4 [features.message_encoding=DELIMITED];
+}
+
+message Nine2 {
+  oneof foo {
+    int32 one = 1;
+    One two = 2;
+  }
+}
+
+message Ten2 {
+  Foo foo = 1 [features.message_encoding=DELIMITED];
+  message Foo {
+  }
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_wire_compatible_type/3.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_wire_compatible_type/3.proto
@@ -1,0 +1,10 @@
+edition = "2023";
+
+package a;
+
+message Message {
+  Message normal = 1 [features.message_encoding=DELIMITED];
+  Message delimited = 2;
+  Message normal_b = 3;
+  Message delimited_b = 4 [features.message_encoding=DELIMITED];
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_wire_json_compatible_type/3.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata/breaking_field_wire_json_compatible_type/3.proto
@@ -1,0 +1,10 @@
+edition = "2023";
+
+package a;
+
+message Message {
+  Message normal = 1 [features.message_encoding=DELIMITED];
+  Message delimited = 2;
+  Message normal_b = 3;
+  Message delimited_b = 4 [features.message_encoding=DELIMITED];
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_same_type/2.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_same_type/2.proto
@@ -53,3 +53,8 @@ message Nine2 {
     One two = 2;
   }
 }
+
+message Ten2 {
+  optional group Foo = 1 {
+  }
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_same_type/3.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_same_type/3.proto
@@ -1,0 +1,10 @@
+edition = "2023";
+
+package a;
+
+message One3 {
+  One3 normal = 1;
+  One3 delimited = 2 [features.message_encoding=DELIMITED];
+  One3 normal_b = 3;
+  One3 delimited_b = 4 [features.message_encoding=DELIMITED];
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_wire_compatible_type/2.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_wire_compatible_type/2.proto
@@ -1,0 +1,10 @@
+edition = "2023";
+
+package a;
+
+message Message {
+  Message normal = 1;
+  Message delimited = 2 [features.message_encoding=DELIMITED];
+  Message normal_b = 3;
+  Message delimited_b = 4 [features.message_encoding=DELIMITED];
+}

--- a/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_wire_json_compatible_type/2.proto
+++ b/private/bufpkg/bufcheck/bufbreaking/testdata_previous/breaking_field_wire_json_compatible_type/2.proto
@@ -1,0 +1,10 @@
+edition = "2023";
+
+package a;
+
+message Message {
+  Message normal = 1;
+  Message delimited = 2 [features.message_encoding=DELIMITED];
+  Message normal_b = 3;
+  Message delimited_b = 4 [features.message_encoding=DELIMITED];
+}


### PR DESCRIPTION
This is for Editions support: with editions, just looking at the field descriptor's `type` field won't tell you if the message is length-prefixed (normal) or delimited (a la groups). But they are not compatible. The protobuf-go runtime _does_ return `GroupKind` when the field uses delimited encoding, even though the underlying descriptor proto would report "MESSAGE" as its type. So we leverage that, so we don't have to reinvent anything regarding feature resolution.

The tests are updated to make sure that only the messages with changed encoding are flagged. The `FIELD_SAME_TYPE` test even includes a group in "proto2" being moved to a delimited message in editions, and it (correctly) does _not_ trigger a breaking change error.