### PR TITLE
Add `--source-control-url` flag for buf push

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -122,7 +122,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.SourceControlURL,
 		sourceControlURLFlagName,
 		"",
-		"The URL for viewing the source code of the modules pushed.",
+		"The URL for viewing the source code of the specific contents of the modules pushed (e.g. the specific commit in source control).",
 	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -39,6 +39,7 @@ const (
 	disableSymlinksFlagName  = "disable-symlinks"
 	createFlagName           = "create"
 	createVisibilityFlagName = "create-visibility"
+	sourceControlURLFlagName = "source-control-url"
 
 	// All deprecated.
 	tagFlagName      = "tag"
@@ -80,6 +81,7 @@ type flags struct {
 	DisableSymlinks  bool
 	Create           bool
 	CreateVisibility string
+	SourceControlURL string
 	// special
 	InputHashtag string
 }
@@ -115,6 +117,12 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 			"Create the repository if it does not exist. Must set --%s",
 			createVisibilityFlagName,
 		),
+	)
+	flagSet.StringVar(
+		&f.SourceControlURL,
+		sourceControlURLFlagName,
+		"",
+		"The URL for viewing the source code of the modules pushed.",
 	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)
@@ -159,6 +167,9 @@ func run(
 			return err
 		}
 		uploadOptions = append(uploadOptions, bufmodule.UploadWithCreateIfNotExist(createModuleVisiblity))
+	}
+	if flags.SourceControlURL != "" {
+		uploadOptions = append(uploadOptions, bufmodule.UploadWithSourceControlURL(flags.SourceControlURL))
 	}
 
 	commits, err := uploader.Upload(ctx, workspace, uploadOptions...)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -122,7 +122,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.SourceControlURL,
 		sourceControlURLFlagName,
 		"",
-		"The URL for viewing the source code of the specific contents of the modules pushed (e.g. the specific commit in source control).",
+		"The URL for viewing the source code of the pushed modules (e.g. the specific commit in source control).",
 	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)


### PR DESCRIPTION
This PR adds the `--source-control-url` flag to `buf push`.
The `--source-control-url` flag allows the user to set a URL specific to the contents
of the modules pushed (e.g. the specific commit to browse in source control).

While the API allows for each module content to have a different source control URL,
similar to labels, we are setting a single source control URL for all module contents pushed.