### PR TITLE
Add `--create-default-label` flag to `buf push`

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -125,6 +125,7 @@ func (a *uploader) Upload(
 				primaryRegistry,
 				contentModule,
 				uploadOptions.CreateModuleVisibility(),
+				uploadOptions.CreateDefaultLabel(),
 			)
 			if err != nil {
 				return nil, err
@@ -328,6 +329,7 @@ func (a *uploader) createContentModuleIfNotExist(
 	primaryRegistry string,
 	contentModule bufmodule.Module,
 	createModuleVisibility bufmodule.ModuleVisibility,
+	createDefaultLabel string,
 ) (*modulev1.Module, error) {
 	v1ProtoCreateModuleVisibility, err := moduleVisibilityToV1Proto(createModuleVisibility)
 	if err != nil {
@@ -344,8 +346,9 @@ func (a *uploader) createContentModuleIfNotExist(
 								Name: contentModule.ModuleFullName().Owner(),
 							},
 						},
-						Name:       contentModule.ModuleFullName().Name(),
-						Visibility: v1ProtoCreateModuleVisibility,
+						Name:             contentModule.ModuleFullName().Name(),
+						Visibility:       v1ProtoCreateModuleVisibility,
+						DefaultLabelName: createDefaultLabel,
 					},
 				},
 			},
@@ -426,7 +429,7 @@ func getV1Beta1ProtoUploadRequestContent(
 		return nil, err
 	}
 
-	return &modulev1beta1.UploadRequest_Content{
+	uploadRequestContent := &modulev1beta1.UploadRequest_Content{
 		ModuleRef: &modulev1beta1.ModuleRef{
 			Value: &modulev1beta1.ModuleRef_Name_{
 				Name: &modulev1beta1.ModuleRef_Name{
@@ -435,10 +438,13 @@ func getV1Beta1ProtoUploadRequestContent(
 				},
 			},
 		},
-		Files:            v1beta1ProtoFiles,
-		ScopedLabelRefs:  v1beta1ProtoScopedLabelRefs,
-		SourceControlUrl: sourceControlURL,
-	}, nil
+		Files:           v1beta1ProtoFiles,
+		ScopedLabelRefs: v1beta1ProtoScopedLabelRefs,
+	}
+	if sourceControlURL != "" {
+		uploadRequestContent.SourceControlUrl = sourceControlURL
+	}
+	return uploadRequestContent, nil
 }
 
 func remoteDepToV1Beta1ProtoUploadRequestDepRef(

--- a/private/bufpkg/bufmodule/uploader.go
+++ b/private/bufpkg/bufmodule/uploader.go
@@ -60,11 +60,13 @@ func UploadWithTags(tags ...string) UploadOption {
 }
 
 // UploadWithCreateIfNotExist returns a new UploadOption that will result in the
-// Modules being created on the registry with the given visibility if they do not exist.
-func UploadWithCreateIfNotExist(createModuleVisibility ModuleVisibility) UploadOption {
+// Modules being created on the registry with the given visibility and default label if they do not exist.
+// If not default label name is provided, the module will be created with the default label "main".
+func UploadWithCreateIfNotExist(createModuleVisibility ModuleVisibility, createDefaultLabel string) UploadOption {
 	return func(uploadOptions *uploadOptions) {
 		uploadOptions.createIfNotExist = true
 		uploadOptions.createModuleVisibility = createModuleVisibility
+		uploadOptions.createDefaultLabel = createDefaultLabel
 	}
 }
 
@@ -90,6 +92,9 @@ type UploadOptions interface {
 	//
 	// Will always be present if CreateIfNotExist() is true.
 	CreateModuleVisibility() ModuleVisibility
+	// CreateDefaultLabel returns the default label to create Modules with. If this is an
+	// emptry string, then the Modules will be created with default label "main".
+	CreateDefaultLabel() string
 	// Tags returns unique and sorted set of tags to be added as labels.
 	// Tags are set using the `--tag` flag when calling `buf push`, and represent labels
 	// that are set **in addition to** the default label when uploading module content.
@@ -133,6 +138,7 @@ type uploadOptions struct {
 	tags                   []string
 	createIfNotExist       bool
 	createModuleVisibility ModuleVisibility
+	createDefaultLabel     string
 	sourceControlURL       string
 }
 
@@ -154,6 +160,10 @@ func (u *uploadOptions) CreateIfNotExist() bool {
 
 func (u *uploadOptions) CreateModuleVisibility() ModuleVisibility {
 	return u.createModuleVisibility
+}
+
+func (u *uploadOptions) CreateDefaultLabel() string {
+	return u.createDefaultLabel
 }
 
 func (u *uploadOptions) SourceControlURL() string {

--- a/private/bufpkg/bufmodule/uploader.go
+++ b/private/bufpkg/bufmodule/uploader.go
@@ -61,7 +61,7 @@ func UploadWithTags(tags ...string) UploadOption {
 
 // UploadWithCreateIfNotExist returns a new UploadOption that will result in the
 // Modules being created on the registry with the given visibility and default label if they do not exist.
-// If not default label name is provided, the module will be created with the default label "main".
+// If the default label name is not provided, the module will be created with the default label "main".
 func UploadWithCreateIfNotExist(createModuleVisibility ModuleVisibility, createDefaultLabel string) UploadOption {
 	return func(uploadOptions *uploadOptions) {
 		uploadOptions.createIfNotExist = true


### PR DESCRIPTION
This adds the `--create-default-label` flag to `buf push`, which allows
the user to set a default label name for a module they are creating with `--create`.
We do not allow this to be set if `--create` is not set, however, the user does
not need to set this if they are using `--create`. If this is not set during `--create`,
then the module will have a default label of "main".