### PR TITLE
Fix location of map entries in bufprotosource

### DIFF
--- a/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+++ b/private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
@@ -16,7 +16,6 @@ package bufbreaking_test
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -299,23 +298,24 @@ func TestRunBreakingFieldSameOneof(t *testing.T) {
 
 func TestRunBreakingFieldSameType(t *testing.T) {
 	t.Parallel()
-	// TODO: double check all this
 	testBreaking(
 		t,
 		"breaking_field_same_type",
-		bufanalysistesting.NewFileAnnotationNoLocation(t, "1.proto", "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 8, 12, 8, 17, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 9, 12, 9, 15, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 11, 3, 11, 6, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 12, 3, 12, 6, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "1.proto", 13, 3, 13, 18, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 19, 16, 19, 21, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 20, 16, 20, 19, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 22, 7, 22, 10, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 23, 7, 23, 10, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "1.proto", 24, 7, 24, 22, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 36, 14, 36, 19, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 37, 14, 37, 17, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 39, 5, 39, 8, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 40, 5, 40, 8, "FIELD_SAME_TYPE"),
+		bufanalysistesting.NewFileAnnotation(t, "1.proto", 41, 5, 41, 20, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 57, 5, 57, 10, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 58, 5, 58, 9, "FIELD_SAME_TYPE"),
 		bufanalysistesting.NewFileAnnotation(t, "3.proto", 8, 3, 8, 7, "FIELD_SAME_TYPE"),
@@ -857,7 +857,7 @@ func testBreaking(
 		assert.NoError(t, err)
 	} else {
 		var fileAnnotationSet bufanalysis.FileAnnotationSet
-		require.True(t, errors.As(err, &fileAnnotationSet))
+		require.ErrorAs(t, err, &fileAnnotationSet)
 		bufanalysistesting.AssertFileAnnotationsEqual(
 			t,
 			expectedFileAnnotations,

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/bufbreakingcheck.go
@@ -307,27 +307,6 @@ func checkFieldSameOneof(add addFunc, corpus *corpus, previousField bufprotosour
 	return nil
 }
 
-// TODO: locations not working for map entries
-// TODO: weird output for map entries:
-//
-// breaking_field_same_type/1.proto:1:1:Field "2" on message "SixEntry" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:1:1:Field "2" on message "SixEntry" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:1:1:Field "2" on message "SixEntry" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:8:3:Field "1" on message "Two" changed type from "int32" to "int64".
-// breaking_field_same_type/1.proto:9:3:Field "2" on message "Two" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:11:3:Field "4" on message "Two" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:12:3:Field "5" on message "Two" changed type from ".a.Two.FiveEntry" to ".a.Two".
-// breaking_field_same_type/1.proto:19:7:Field "1" on message "Five" changed type from "int32" to "int64".
-// breaking_field_same_type/1.proto:20:7:Field "2" on message "Five" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:22:7:Field "4" on message "Five" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:23:7:Field "5" on message "Five" changed type from ".a.Three.Four.Five.FiveEntry" to ".a.Two".
-// breaking_field_same_type/1.proto:36:5:Field "1" on message "Seven" changed type from "int32" to "int64".
-// breaking_field_same_type/1.proto:37:5:Field "2" on message "Seven" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:39:5:Field "4" on message "Seven" changed type from ".a.One" to ".a.Two".
-// breaking_field_same_type/1.proto:40:5:Field "5" on message "Seven" changed type from ".a.Three.Seven.FiveEntry" to ".a.Two".
-// breaking_field_same_type/2.proto:64:5:Field "1" on message "Nine" changed type from "int32" to "int64".
-// breaking_field_same_type/2.proto:65:5:Field "2" on message "Nine" changed type from ".a.One" to ".a.Nine".
-
 // CheckFieldSameType is a check function.
 var CheckFieldSameType = newFieldDescriptorPairCheckFunc(checkFieldSameType)
 

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -146,6 +146,7 @@ func TestRunComments(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 264, 3, 264, 30, "COMMENT_FIELD"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 273, 3, 273, 72, "COMMENT_RPC"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 277, 3, 277, 72, "COMMENT_RPC"),
+		bufanalysistesting.NewFileAnnotation(t, "b.proto", 13, 3, 13, 31, "COMMENT_MESSAGE"),
 	)
 }
 

--- a/private/bufpkg/bufcheck/buflint/testdata/comments/a.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/comments/a.proto
@@ -16,7 +16,7 @@ message MessageFoo {
       FOO_ONE = 1;
     }
     message MessageBaz {
-      int64 foo = 1;
+      optional int64 foo = 1;
       oneof bar {
         int64 baz = 2;
       }

--- a/private/bufpkg/bufcheck/buflint/testdata/comments/b.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/comments/b.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package a;
+
+// Comment for FooWithGroup
+message FooWithGroup {
+  // Comment for Group1
+  optional group Group1 = 1 {
+    // Comment for s
+    optional string s = 1;
+  }
+
+  optional group Group2 = 2 {}
+}

--- a/private/bufpkg/bufprotosource/field.go
+++ b/private/bufpkg/bufprotosource/field.go
@@ -184,11 +184,19 @@ func (f *field) NumberLocation() Location {
 }
 
 func (f *field) TypeLocation() Location {
-	return f.getLocation(f.typePath)
+	loc := f.getLocation(f.typePath)
+	if loc == nil {
+		return f.maybeMapEntryLocation()
+	}
+	return loc
 }
 
 func (f *field) TypeNameLocation() Location {
-	return f.getLocation(f.typeNamePath)
+	loc := f.getLocation(f.typeNamePath)
+	if loc == nil {
+		return f.maybeMapEntryLocation()
+	}
+	return loc
 }
 
 func (f *field) JSONNameLocation() Location {
@@ -213,4 +221,27 @@ func (f *field) ExtendeeLocation() Location {
 
 func (f *field) AsDescriptor() (protoreflect.FieldDescriptor, error) {
 	return asDescriptor[protoreflect.FieldDescriptor](&f.descriptor, f.FullName(), "a field")
+}
+
+func (f *field) Location() Location {
+	loc := f.namedDescriptor.Location()
+	if loc == nil {
+		return f.maybeMapEntryLocation()
+	}
+	return loc
+}
+
+func (f *field) NameLocation() Location {
+	loc := f.namedDescriptor.NameLocation()
+	if loc == nil {
+		return f.maybeMapEntryLocation()
+	}
+	return loc
+}
+
+func (f *field) maybeMapEntryLocation() Location {
+	if message, _ := f.parentMessage.(*message); message != nil {
+		return message.maybeMapEntryLocation()
+	}
+	return nil
 }

--- a/private/bufpkg/bufprotosource/location_store.go
+++ b/private/bufpkg/bufprotosource/location_store.go
@@ -34,6 +34,10 @@ func newLocationStore(sourceCodeInfoLocations []*descriptorpb.SourceCodeInfo_Loc
 	}
 }
 
+func (l *locationStore) isEmpty() bool {
+	return len(l.sourceCodeInfoLocations) == 0
+}
+
 func (l *locationStore) getLocation(path []int32) Location {
 	return l.getLocationByPathKey(getPathKey(path))
 }


### PR DESCRIPTION
This fixes the location reported for synthetic map entries and map entry fields. I ran into this because I needed to test the UTF8 validation feature in editions with maps with string keys and values.

Now that these messages and fields can report locations, this tickled an issue in the tests for the "comments" linter - now that it no longer returns a nil location, the linter wanted to find comments there. So I've updated that linter to ignore them. For consistency, I've also added ignore code for other generated elements that won't have comments: group fields and proto3-optional oneofs. The latter isn't strictly necessary since the location for synthetic oneofs currently returns nil. But for groups, it would complain that the field had no comments, even if there were a comment there, because the compiler attributes the comment to the corresponding nested message, not the field. I've updated the test to verify this is working correctly.