### PR TITLE
Use dynamicpb.NewTypes in protoencoding.NewResolver

### DIFF
--- a/private/pkg/protoencoding/resolver.go
+++ b/private/pkg/protoencoding/resolver.go
@@ -41,62 +41,12 @@ func newResolver[F protodescriptor.FileDescriptor](fileDescriptors ...F) (Resolv
 	if err != nil {
 		return nil, err
 	}
-	types := &protoregistry.Types{}
-	var rangeErr error
-	files.RangeFiles(func(fileDescriptor protoreflect.FileDescriptor) bool {
-		if err := registerDescriptors(types, fileDescriptor); err != nil {
-			rangeErr = err
-			return false
-		}
-		return true
-	})
-	if rangeErr != nil {
-		return nil, rangeErr
-	}
-	return &resolver{Files: files, Types: types}, nil
+	return &resolver{Files: files, Types: dynamicpb.NewTypes(files)}, nil
 }
 
 type resolver struct {
 	*protoregistry.Files
-	*protoregistry.Types
-}
-
-type descriptorContainer interface {
-	Messages() protoreflect.MessageDescriptors
-	Enums() protoreflect.EnumDescriptors
-	Extensions() protoreflect.ExtensionDescriptors
-}
-
-func registerDescriptors(types *protoregistry.Types, container descriptorContainer) error {
-	messageDescriptors := container.Messages()
-	for i, messagesLen := 0, messageDescriptors.Len(); i < messagesLen; i++ {
-		messageDescriptor := messageDescriptors.Get(i)
-		if err := types.RegisterMessage(dynamicpb.NewMessageType(messageDescriptor)); err != nil {
-			return err
-		}
-		// nested types, too
-		if err := registerDescriptors(types, messageDescriptor); err != nil {
-			return err
-		}
-	}
-
-	enumDescriptors := container.Enums()
-	for i, enumsLen := 0, enumDescriptors.Len(); i < enumsLen; i++ {
-		enumDescriptor := enumDescriptors.Get(i)
-		if err := types.RegisterEnum(dynamicpb.NewEnumType(enumDescriptor)); err != nil {
-			return err
-		}
-	}
-
-	extensionDescriptors := container.Extensions()
-	for i, extensionsLen := 0, extensionDescriptors.Len(); i < extensionsLen; i++ {
-		extensionDescriptor := extensionDescriptors.Get(i)
-		if err := types.RegisterExtension(dynamicpb.NewExtensionType(extensionDescriptor)); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	*dynamicpb.Types
 }
 
 type lazyResolver struct {


### PR DESCRIPTION
The `dynamicpb.NewTypes` function is fairly recent and is a perfect fit for `protoencoding.NewResolver`. This makes creation of the resolver a little more efficient since we don't have to redundantly register all types in `*protoregistry.Types` instance.