### PR TITLE
Fix config flag message grammar for build

### DIFF
--- a/private/buf/cmd/buf/command/build/build.go
+++ b/private/buf/cmd/buf/command/build/build.go
@@ -122,7 +122,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The file or data to use to use for configuration`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 	flagSet.StringSliceVar(
 		&f.Types,

--- a/private/buf/cmd/buf/command/lsfiles/lsfiles.go
+++ b/private/buf/cmd/buf/command/lsfiles/lsfiles.go
@@ -103,7 +103,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Config,
 		configFlagName,
 		"",
-		`The buf.yaml configuration file or data to use`,
+		`The buf.yaml file or data to use for configuration`,
 	)
 	flagSet.StringVar(
 		&f.Format,


### PR DESCRIPTION
Small fix for the flag help message grammar on the build flag `--config` and change lsfiles `--config` flag to be consistent with others.