### PR TITLE
Add lint rule to prevent use of "required"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -286,4 +286,4 @@ issues:
         - gochecknoinits
       # must use init to safely enable editions support for testing
       # TODO: this is temporary; remove it when editions support is ready
-      path: private/buf/bufgen/features_test.go|private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go
+      path: private/buf/bufgen/features_test.go|private/bufpkg/bufcheck/bufbreaking/bufbreaking_test.go|private/bufpkg/bufcheck/buflint/buflint_test.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Adds a new `FIELD_NOT_REQUIRED` lint rule that prevents use of required
+  in proto2 files and of `features.field_presence = LEGACY_REQUIRED` in
+  Editions files. This new rule is not active by default in existing v1 and
+  v1beta1 configurations, for backwards-compatibility reasons. Migrate your
+  config to v2 to use them.
 
 ## [v1.32.0-beta.1] - 2024-04-23
 

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -497,7 +497,7 @@ func TestFailCheckBreaking5(t *testing.T) {
 	)
 }
 
-func TestCheckLsLintRules1(t *testing.T) {
+func TestCheckLsLintRulesModAll(t *testing.T) {
 	t.Parallel()
 	expectedStdout := `
 ID                                CATEGORIES               PURPOSE
@@ -557,7 +557,7 @@ PACKAGE_NO_IMPORT_CYCLE                                    Checks that packages 
 	)
 }
 
-func TestCheckLsLintRules2(t *testing.T) {
+func TestCheckLsLintRulesFromConfig(t *testing.T) {
 	t.Parallel()
 	testRunStdout(
 		t,
@@ -575,7 +575,7 @@ func TestCheckLsLintRules2(t *testing.T) {
 	)
 }
 
-func TestCheckLsLintRules3(t *testing.T) {
+func TestCheckLsLintRulesV1Beta1(t *testing.T) {
 	t.Parallel()
 	expectedStdout := `
 ID                                CATEGORIES                                  PURPOSE
@@ -590,7 +590,7 @@ PACKAGE_SAME_PHP_NAMESPACE        MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Ch
 PACKAGE_SAME_RUBY_PACKAGE         MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the ruby_package option.
 PACKAGE_SAME_SWIFT_PREFIX         MINIMAL, BASIC, DEFAULT, PACKAGE_AFFINITY   Checks that all files with a given package have the same value for the swift_prefix option.
 ENUM_NO_ALLOW_ALIAS               MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that enums do not have the allow_alias option set.
-FIELD_NO_DESCRIPTOR               MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that field names are not name capitalization of "descriptor" with any number of prefix or suffix underscores.
+FIELD_NO_DESCRIPTOR               MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that field names are not any capitalization of "descriptor" with any number of prefix or suffix underscores.
 IMPORT_NO_PUBLIC                  MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that imports are not public.
 IMPORT_NO_WEAK                    MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that imports are not weak.
 PACKAGE_DEFINED                   MINIMAL, BASIC, DEFAULT, SENSIBLE           Checks that all files have a package defined.
@@ -630,6 +630,68 @@ ENUM_FIRST_VALUE_ZERO             OTHER                                       Ch
 		"ls-lint-rules",
 		"--version",
 		"v1beta1",
+	)
+}
+
+func TestCheckLsLintRulesV2(t *testing.T) {
+	t.Parallel()
+	expectedStdout := `
+ID                                CATEGORIES               PURPOSE
+DIRECTORY_SAME_PACKAGE            MINIMAL, BASIC, DEFAULT  Checks that all files in a given directory are in the same package.
+PACKAGE_DEFINED                   MINIMAL, BASIC, DEFAULT  Checks that all files have a package defined.
+PACKAGE_DIRECTORY_MATCH           MINIMAL, BASIC, DEFAULT  Checks that all files are in a directory that matches their package name.
+PACKAGE_NO_IMPORT_CYCLE           MINIMAL, BASIC, DEFAULT  Checks that packages do not have import cycles.
+PACKAGE_SAME_DIRECTORY            MINIMAL, BASIC, DEFAULT  Checks that all files with a given package are in the same directory.
+ENUM_FIRST_VALUE_ZERO             BASIC, DEFAULT           Checks that all first values of enums have a numeric value of 0.
+ENUM_NO_ALLOW_ALIAS               BASIC, DEFAULT           Checks that enums do not have the allow_alias option set.
+ENUM_PASCAL_CASE                  BASIC, DEFAULT           Checks that enums are PascalCase.
+ENUM_VALUE_UPPER_SNAKE_CASE       BASIC, DEFAULT           Checks that enum values are UPPER_SNAKE_CASE.
+FIELD_LOWER_SNAKE_CASE            BASIC, DEFAULT           Checks that field names are lower_snake_case.
+FIELD_NOT_REQUIRED                BASIC, DEFAULT           Checks that fields are not configured to be required.
+IMPORT_NO_PUBLIC                  BASIC, DEFAULT           Checks that imports are not public.
+IMPORT_NO_WEAK                    BASIC, DEFAULT           Checks that imports are not weak.
+IMPORT_USED                       BASIC, DEFAULT           Checks that imports are used.
+MESSAGE_PASCAL_CASE               BASIC, DEFAULT           Checks that messages are PascalCase.
+ONEOF_LOWER_SNAKE_CASE            BASIC, DEFAULT           Checks that oneof names are lower_snake_case.
+PACKAGE_LOWER_SNAKE_CASE          BASIC, DEFAULT           Checks that packages are lower_snake.case.
+PACKAGE_SAME_CSHARP_NAMESPACE     BASIC, DEFAULT           Checks that all files with a given package have the same value for the csharp_namespace option.
+PACKAGE_SAME_GO_PACKAGE           BASIC, DEFAULT           Checks that all files with a given package have the same value for the go_package option.
+PACKAGE_SAME_JAVA_MULTIPLE_FILES  BASIC, DEFAULT           Checks that all files with a given package have the same value for the java_multiple_files option.
+PACKAGE_SAME_JAVA_PACKAGE         BASIC, DEFAULT           Checks that all files with a given package have the same value for the java_package option.
+PACKAGE_SAME_PHP_NAMESPACE        BASIC, DEFAULT           Checks that all files with a given package have the same value for the php_namespace option.
+PACKAGE_SAME_RUBY_PACKAGE         BASIC, DEFAULT           Checks that all files with a given package have the same value for the ruby_package option.
+PACKAGE_SAME_SWIFT_PREFIX         BASIC, DEFAULT           Checks that all files with a given package have the same value for the swift_prefix option.
+RPC_PASCAL_CASE                   BASIC, DEFAULT           Checks that RPCs are PascalCase.
+SERVICE_PASCAL_CASE               BASIC, DEFAULT           Checks that services are PascalCase.
+SYNTAX_SPECIFIED                  BASIC, DEFAULT           Checks that all files have a syntax specified.
+ENUM_VALUE_PREFIX                 DEFAULT                  Checks that enum values are prefixed with ENUM_NAME_UPPER_SNAKE_CASE.
+ENUM_ZERO_VALUE_SUFFIX            DEFAULT                  Checks that enum zero values are suffixed with _UNSPECIFIED (suffix is configurable).
+FILE_LOWER_SNAKE_CASE             DEFAULT                  Checks that filenames are lower_snake_case.
+PACKAGE_VERSION_SUFFIX            DEFAULT                  Checks that the last component of all packages is a version of the form v\d+, v\d+test.*, v\d+(alpha|beta)\d+, or v\d+p\d+(alpha|beta)\d+, where numbers are >=1.
+PROTOVALIDATE                     DEFAULT                  Checks that protovalidate rules are valid and all CEL expressions compile.
+RPC_REQUEST_RESPONSE_UNIQUE       DEFAULT                  Checks that RPC request and response types are only used in one RPC (configurable).
+RPC_REQUEST_STANDARD_NAME         DEFAULT                  Checks that RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable).
+RPC_RESPONSE_STANDARD_NAME        DEFAULT                  Checks that RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable).
+SERVICE_SUFFIX                    DEFAULT                  Checks that services are suffixed with Service (suffix is configurable).
+COMMENT_ENUM                      COMMENTS                 Checks that enums have non-empty comments.
+COMMENT_ENUM_VALUE                COMMENTS                 Checks that enum values have non-empty comments.
+COMMENT_FIELD                     COMMENTS                 Checks that fields have non-empty comments.
+COMMENT_MESSAGE                   COMMENTS                 Checks that messages have non-empty comments.
+COMMENT_ONEOF                     COMMENTS                 Checks that oneof have non-empty comments.
+COMMENT_RPC                       COMMENTS                 Checks that RPCs have non-empty comments.
+COMMENT_SERVICE                   COMMENTS                 Checks that services have non-empty comments.
+RPC_NO_CLIENT_STREAMING           UNARY_RPC                Checks that RPCs are not client streaming.
+RPC_NO_SERVER_STREAMING           UNARY_RPC                Checks that RPCs are not server streaming.
+		`
+	testRunStdout(
+		t,
+		nil,
+		0,
+		expectedStdout,
+		"config",
+		"ls-lint-rules",
+		"--version",
+		"v2",
 	)
 }
 

--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck/buflint"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,10 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
+
+func init() {
+	protodescriptor.AllowEditionsForTesting()
+}
 
 // Hint on how to get these:
 // 1. cd into the specific directory
@@ -388,6 +393,18 @@ func TestRunFieldNoDescriptor(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 66, 19, 66, 30, "FIELD_NO_DESCRIPTOR"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 67, 19, 67, 31, "FIELD_NO_DESCRIPTOR"),
 		bufanalysistesting.NewFileAnnotation(t, "a.proto", 68, 19, 68, 33, "FIELD_NO_DESCRIPTOR"),
+	)
+}
+
+func TestRunFieldNotRequired(t *testing.T) {
+	t.Parallel()
+	testLint(
+		t,
+		"field_not_required",
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 13, 19, 13, 20, "FIELD_NOT_REQUIRED"),
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 28, 19, 28, 20, "FIELD_NOT_REQUIRED"),
+		bufanalysistesting.NewFileAnnotation(t, "b.proto", 13, 10, 13, 11, "FIELD_NOT_REQUIRED"),
+		bufanalysistesting.NewFileAnnotation(t, "b.proto", 28, 10, 28, 11, "FIELD_NOT_REQUIRED"),
 	)
 }
 

--- a/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
@@ -130,8 +130,14 @@ var (
 	// FieldNoDescriptorRuleBuilder is a rule builder.
 	FieldNoDescriptorRuleBuilder = internal.NewNopRuleBuilder(
 		"FIELD_NO_DESCRIPTOR",
-		`field names are not name capitalization of "descriptor" with any number of prefix or suffix underscores`,
+		`field names are not any capitalization of "descriptor" with any number of prefix or suffix underscores`,
 		newAdapter(buflintcheck.CheckFieldNoDescriptor),
+	)
+	// FieldNotRequiredRuleBuilder is a rule builder.
+	FieldNotRequiredRuleBuilder = internal.NewNopRuleBuilder(
+		"FIELD_NOT_REQUIRED",
+		`fields are not configured to be required`,
+		newAdapter(buflintcheck.CheckFieldNotRequired),
 	)
 	// FileLowerSnakeCaseRuleBuilder is a rule builder.
 	FileLowerSnakeCaseRuleBuilder = internal.NewNopRuleBuilder(

--- a/private/bufpkg/bufcheck/buflint/internal/buflintv2/buflintv2.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintv2/buflintv2.go
@@ -16,8 +16,9 @@
 //
 // It uses buflintcheck and buflintbuild.
 //
-// The only change from v1 to v2 was that PACKAGE_NO_IMPORT_CYCLE was added
-// to MINIMAL, BASIC, DEFAULT.
+// The only changes from v1 to v2 are:
+// 1. New rule PACKAGE_NO_IMPORT_CYCLE was added to MINIMAL, BASIC, DEFAULT.
+// 2. New rule FIELD_NO_REQUIRED was added to BASIC and DEFAULT.
 package buflintv2
 
 import (

--- a/private/bufpkg/bufcheck/buflint/internal/buflintv2/vars.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintv2/vars.go
@@ -37,6 +37,7 @@ var (
 		buflintbuild.EnumValueUpperSnakeCaseRuleBuilder,
 		buflintbuild.EnumZeroValueSuffixRuleBuilder,
 		buflintbuild.FieldLowerSnakeCaseRuleBuilder,
+		buflintbuild.FieldNotRequiredRuleBuilder,
 		buflintbuild.FileLowerSnakeCaseRuleBuilder,
 		buflintbuild.ImportNoPublicRuleBuilder,
 		buflintbuild.ImportNoWeakRuleBuilder,
@@ -123,6 +124,10 @@ var (
 			"DEFAULT",
 		},
 		"FIELD_LOWER_SNAKE_CASE": {
+			"BASIC",
+			"DEFAULT",
+		},
+		"FIELD_NOT_REQUIRED": {
 			"BASIC",
 			"DEFAULT",
 		},

--- a/private/bufpkg/bufcheck/buflint/testdata/field_not_required/a.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/field_not_required/a.proto
@@ -1,0 +1,31 @@
+syntax = "proto2";
+
+package a;
+
+message One {
+  optional string a = 1;
+  repeated string b = 2;
+  optional string c = 3;
+  repeated string d = 4;
+  optional string e = 5;
+  optional string f = 6;
+  optional string g = 7;
+  required string h = 8;
+  extensions 10 to 100;
+}
+
+message Two {
+  message Three {
+    message Four {
+      optional string a = 1;
+      optional string b = 2;
+      optional string c = 3;
+    }
+    repeated string a = 1;
+    repeated string b = 2;
+    optional string c = 3;
+  }
+  required string a = 1;
+  optional string b = 2;
+  repeated string c = 3;
+}

--- a/private/bufpkg/bufcheck/buflint/testdata/field_not_required/b.proto
+++ b/private/bufpkg/bufcheck/buflint/testdata/field_not_required/b.proto
@@ -1,0 +1,31 @@
+edition = "2023";
+
+package b;
+
+message One {
+  string a = 1;
+  repeated string b = 2;
+  string c = 3;
+  repeated string d = 4;
+  string e = 5;
+  string f = 6;
+  string g = 7;
+  string h = 8 [features.field_presence = LEGACY_REQUIRED];
+  extensions 10 to 100;
+}
+
+message Two {
+  message Three {
+    message Four {
+      string a = 1;
+      string b = 2;
+      string c = 3;
+    }
+    repeated string a = 1;
+    repeated string b = 2;
+    string c = 3;
+  }
+  string a = 1 [features.field_presence = LEGACY_REQUIRED];
+  string b = 2;
+  repeated string c = 3;
+}

--- a/private/bufpkg/bufcheck/buflint/testdata/field_not_required/buf.yaml
+++ b/private/bufpkg/bufcheck/buflint/testdata/field_not_required/buf.yaml
@@ -1,0 +1,4 @@
+version: v2
+lint:
+  use:
+    - FIELD_NOT_REQUIRED


### PR DESCRIPTION
This adds a new lint rule to disallow use of required fields.

Since this could break existing codebases that use `buf lint` and also use required fields, this is being added just to the v2 config.