### PR TITLE
Update previous workflow to build 1.20.x

### DIFF
--- a/.github/workflows/previous.yaml
+++ b/.github/workflows/previous.yaml
@@ -7,6 +7,9 @@ env:
   MAKEFLAGS: "-j 2"
 jobs:
   test-previous:
+    strategy:
+      matrix:
+        go-version: ['1.20.x', '1.21.x']
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -14,7 +17,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: ${{ matrix.go-version }}
       - name: cache
         uses: actions/cache@v4
         with:
@@ -24,8 +27,8 @@ jobs:
             ~/.cache/buf/${{ runner.os }}/x86_64/gocache
             ~/.cache/buf/${{ runner.os }}/x86_64/include
             ~/.cache/buf/${{ runner.os }}/x86_64/versions
-          key: ${{ runner.os }}-buf-${{ hashFiles('**/go.sum', 'make/**') }}
+          key: ${{ runner.os }}-${{ matrix.go-version }}-buf-${{ hashFiles('**/go.sum', 'make/**') }}
           restore-keys: |
-            ${{ runner.os }}-buf-
+            ${{ runner.os }}-${{ matrix.go-version }}-buf-
       - name: make-test
         run: make test

--- a/private/buf/bufcurl/tls.go
+++ b/private/buf/bufcurl/tls.go
@@ -52,7 +52,7 @@ func MakeVerboseTLSConfig(settings *TLSSettings, authority string, printer verbo
 	// we verify manually so that we can emit verbose output while doing so
 	conf.InsecureSkipVerify = true
 	conf.VerifyConnection = func(state tls.ConnectionState) error {
-		printer.Printf("* TLS connection using %s / %s", tls.VersionName(state.Version), tls.CipherSuiteName(state.CipherSuite))
+		printer.Printf("* TLS connection using %s / %s", tlsVersionName(state.Version), tls.CipherSuiteName(state.CipherSuite))
 		if state.DidResume {
 			printer.Printf("* (TLS session resumed)")
 		}

--- a/private/buf/bufcurl/tls_version_name_go120.go
+++ b/private/buf/bufcurl/tls_version_name_go120.go
@@ -19,7 +19,7 @@ package bufcurl
 import "crypto/tls"
 
 func tlsVersionName(tlsVersion uint16) string {
-	// TODO: once we can use Go 1.20, it will provide tls.VersionName that we can use
+	// TODO: once we can use Go 1.21, it will provide tls.VersionName that we can use
 	//       https://github.com/golang/go/issues/46308
 	switch tlsVersion {
 	case tls.VersionTLS10:

--- a/private/buf/bufcurl/tls_version_name_go120.go
+++ b/private/buf/bufcurl/tls_version_name_go120.go
@@ -1,0 +1,36 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.21
+
+package bufcurl
+
+import "crypto/tls"
+
+func tlsVersionName(tlsVersion uint16) string {
+	// TODO: once we can use Go 1.20, it will provide tls.VersionName that we can use
+	//       https://github.com/golang/go/issues/46308
+	switch tlsVersion {
+	case tls.VersionTLS10:
+		return "TLSv1.0"
+	case tls.VersionTLS11:
+		return "TLSv1.1"
+	case tls.VersionTLS12:
+		return "TLSv1.2"
+	case tls.VersionTLS13:
+		return "TLSv1.3"
+	default:
+		return "(unrecognized TLS version)"
+	}
+}

--- a/private/buf/bufcurl/tls_version_name_go121.go
+++ b/private/buf/bufcurl/tls_version_name_go121.go
@@ -1,0 +1,23 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.21
+
+package bufcurl
+
+import "crypto/tls"
+
+func tlsVersionName(tlsVersion uint16) string {
+	return tls.VersionName(tlsVersion)
+}


### PR DESCRIPTION
Ensure we run the previous build workflow on all supported older versions of Go. Fix use of newer tls.VersionName function introduced in Go 1.21 behind a build constraint.