### PR TITLE
Simplify handling of custom features in buf breaking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.33.0-20240401180337-569d290ee4cc.1
 	connectrpc.com/connect v1.16.1
 	connectrpc.com/otelconnect v0.7.0
-	github.com/bufbuild/protocompile v0.13.1-0.20240509185927-54ef548a6198
+	github.com/bufbuild/protocompile v0.13.1-0.20240510201831-27e5e21d3950
 	github.com/bufbuild/protoplugin v0.0.0-20240323223605-e2735f6c31ee
 	github.com/bufbuild/protovalidate-go v0.6.2
 	github.com/bufbuild/protoyaml-go v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/bufbuild/protocompile v0.13.1-0.20240509185927-54ef548a6198 h1:F6BJmDCt7Uas+cW2iq9dA6NclN6EcXZt7JXB2V8pm3c=
-github.com/bufbuild/protocompile v0.13.1-0.20240509185927-54ef548a6198/go.mod h1:QJcgsTVPSBEMt+/3i2M/RpwjZc+DAXyPPDg0slmMk4c=
+github.com/bufbuild/protocompile v0.13.1-0.20240510201831-27e5e21d3950 h1:I7WH25vm79O8IxwQORl1/KZHizb4dcVKjQxWjkvNFlk=
+github.com/bufbuild/protocompile v0.13.1-0.20240510201831-27e5e21d3950/go.mod h1:QJcgsTVPSBEMt+/3i2M/RpwjZc+DAXyPPDg0slmMk4c=
 github.com/bufbuild/protoplugin v0.0.0-20240323223605-e2735f6c31ee h1:E6ET8YUcYJ1lAe6ctR3as7yqzW2BNItDFnaB5zQq/8M=
 github.com/bufbuild/protoplugin v0.0.0-20240323223605-e2735f6c31ee/go.mod h1:HjGFxsck9RObrTJp2hXQZfWhPgZqnR6sR1U5fCA/Kus=
 github.com/bufbuild/protovalidate-go v0.6.2 h1:U/V3CGF0kPlR12v41rjO4DrYZtLcS4ZONLmWN+rJVCQ=

--- a/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/customfeatures/customfeatures.go
+++ b/private/bufpkg/bufcheck/bufbreaking/internal/bufbreakingcheck/customfeatures/customfeatures.go
@@ -19,9 +19,7 @@ import (
 
 	"github.com/bufbuild/buf/private/gen/proto/go/google/protobuf"
 	"github.com/bufbuild/protocompile/protoutil"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
 // ResolveCppFeature returns a value for the given field name of the (pb.cpp) custom feature
@@ -36,72 +34,12 @@ func ResolveJavaFeature(field protoreflect.FieldDescriptor, fieldName protorefle
 	return resolveFeature(field, protobuf.E_Java.TypeDescriptor(), fieldName, expectedKind)
 }
 
-type resolverForExtension struct {
-	extension protoreflect.ExtensionType
-}
-
-func (r resolverForExtension) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
-	if field == r.extension.TypeDescriptor().FullName() {
-		return r.extension, nil
-	}
-	return nil, protoregistry.NotFound
-}
-
-func (r resolverForExtension) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
-	descriptor := r.extension.TypeDescriptor()
-	if message == descriptor.ContainingMessage().FullName() && field == descriptor.Number() {
-		return r.extension, nil
-	}
-	return nil, protoregistry.NotFound
-}
-
-type fieldDescriptorWithOptions struct {
-	protoreflect.FieldDescriptor
-	parent  protoreflect.Descriptor
-	options proto.Message
-}
-
-func (f *fieldDescriptorWithOptions) Options() proto.Message {
-	return f.options
-}
-
-func (f *fieldDescriptorWithOptions) Parent() protoreflect.Descriptor {
-	return f.parent
-}
-
-type messageDescriptorWithOptions struct {
-	protoreflect.MessageDescriptor
-	parent  protoreflect.Descriptor
-	options proto.Message
-}
-
-func (f *messageDescriptorWithOptions) Options() proto.Message {
-	return f.options
-}
-
-func (f *messageDescriptorWithOptions) Parent() protoreflect.Descriptor {
-	return f.parent
-}
-
-type fileDescriptorWithOptions struct {
-	protoreflect.FileDescriptor
-	options proto.Message
-}
-
-func (f *fileDescriptorWithOptions) Options() proto.Message {
-	return f.options
-}
-
 func resolveFeature(
 	field protoreflect.FieldDescriptor,
 	extension protoreflect.ExtensionTypeDescriptor,
 	fieldName protoreflect.Name,
 	expectedKind protoreflect.Kind,
 ) (protoreflect.Value, error) {
-	field, err := reparseFeaturesInField(field, resolverForExtension{extension.Type()})
-	if err != nil {
-		return protoreflect.Value{}, err
-	}
 	featureField := extension.Message().Fields().ByName(fieldName)
 	if featureField == nil {
 		return protoreflect.Value{}, fmt.Errorf("unable to resolve field descriptor for %s.%s", extension.Message().FullName(), fieldName)
@@ -115,100 +53,4 @@ func resolveFeature(
 		extension.Type(),
 		featureField,
 	)
-}
-
-// reparseFeaturesInField re-parses any features in the given field's options and returns a new descriptor
-// that returns options with the re-parsed features. This recursively applies up the hierarchy to the
-// field's parent and all ancestors.
-//
-// We need to reparse the features to make sure that custom feature values are using the right extension
-// descriptors. The protobuf-go runtime is quite strict, so we could get panic issues if we queried using
-// one extension descriptor, but the value in the message actually refers to a different extension
-// descriptor for the same field number (like an analogous descriptor provided by protocompile).
-func reparseFeaturesInField(field protoreflect.FieldDescriptor, resolver protoregistry.ExtensionTypeResolver) (protoreflect.FieldDescriptor, error) {
-	// TODO: This is inefficient, to reparse the features for each field. We repeatedly reparse
-	//       features for the parent/ancestor message(s). Ideally we could cache/re-use the
-	//       reparsed features when checking other fields.
-	opts, err := reparseFeatures(field.Options(), resolver)
-	if err != nil {
-		return nil, err
-	}
-	parent := field.Parent()
-	switch descriptor := parent.(type) {
-	case protoreflect.MessageDescriptor:
-		parent, err = reparseFeaturesInMessage(descriptor, resolver)
-		if err != nil {
-			return nil, err
-		}
-	case protoreflect.FileDescriptor:
-		parent, err = reparseFeaturesInFile(descriptor, resolver)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("field has unexpected parent type %T", parent)
-	}
-	return &fieldDescriptorWithOptions{FieldDescriptor: field, parent: parent, options: opts}, nil
-}
-
-func reparseFeaturesInMessage(message protoreflect.MessageDescriptor, resolver protoregistry.ExtensionTypeResolver) (protoreflect.MessageDescriptor, error) {
-	opts, err := reparseFeatures(message.Options(), resolver)
-	if err != nil {
-		return nil, err
-	}
-	parent := message.Parent()
-	switch descriptor := parent.(type) {
-	case protoreflect.MessageDescriptor:
-		parent, err = reparseFeaturesInMessage(descriptor, resolver)
-		if err != nil {
-			return nil, err
-		}
-	case protoreflect.FileDescriptor:
-		parent, err = reparseFeaturesInFile(descriptor, resolver)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("message has unexpected parent type %T", parent)
-	}
-	return &messageDescriptorWithOptions{MessageDescriptor: message, parent: parent, options: opts}, nil
-}
-
-func reparseFeaturesInFile(file protoreflect.FileDescriptor, resolver protoregistry.ExtensionTypeResolver) (protoreflect.FileDescriptor, error) {
-	opts, err := reparseFeatures(file.Options(), resolver)
-	if err != nil {
-		return nil, err
-	}
-	return &fileDescriptorWithOptions{FileDescriptor: file, options: opts}, nil
-}
-
-func reparseFeatures(options proto.Message, resolver protoregistry.ExtensionTypeResolver) (proto.Message, error) {
-	optionsDescriptor := options.ProtoReflect().Descriptor()
-	featuresField := optionsDescriptor.Fields().ByName("features")
-	if featuresField == nil {
-		return nil, fmt.Errorf("options message does not have features field")
-	}
-	if featuresField.Message() == nil {
-		return nil, fmt.Errorf("options message does not have expected features field: expecting message, got %v", featuresField.Kind())
-	}
-	features := options.ProtoReflect().Get(featuresField).Message()
-	if !features.IsValid() {
-		// features are absent so nothing to reparse
-		return options, nil
-	}
-	data, err := proto.Marshal(features.Interface())
-	if err != nil {
-		return nil, err
-	}
-	if len(data) == 0 {
-		// empty features, nothing to reparse
-		return options, nil
-	}
-	reparsedFeatures := features.Type().New()
-	if err := (proto.UnmarshalOptions{Resolver: resolver}).Unmarshal(data, reparsedFeatures.Interface()); err != nil {
-		return nil, err
-	}
-	options = proto.Clone(options) // make a copy so we don't mutate the original protos
-	options.ProtoReflect().Set(featuresField, protoreflect.ValueOfMessage(reparsedFeatures))
-	return options, nil
 }


### PR DESCRIPTION
This is for the logic for querying the `(pb.cpp)` and `(pb.java)` custom features ("custom" because they are extension fields in `FeatureSet` instead of regular fields).

The gist is that, with some improved handling over in protocompile for custom features and potentially mismatching descriptors, we can get rid of a bunch of special logic in here. (Yay!)

This is just a draft PR right now because it's pointing to a commit in protocompile that hasn't yet merged to main (here: https://github.com/bufbuild/protocompile/pull/306). When that PR is merged, I'll update the `go.mod` pin and mark this as ready for review.
