### PR TITLE
Update buf format to work correctly with editions

### DIFF
--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -243,11 +243,16 @@ func (f *formatter) writeFileHeader() {
 			continue
 		}
 	}
-	if f.fileNode.Syntax == nil && packageNode == nil && importNodes == nil && optionNodes == nil {
+	if f.fileNode.Syntax == nil && f.fileNode.Edition == nil &&
+		packageNode == nil && importNodes == nil && optionNodes == nil {
 		// There aren't any header values, so we can return early.
 		return
 	}
-	if syntaxNode := f.fileNode.Syntax; syntaxNode != nil {
+	editionNode := f.fileNode.Edition
+	if editionNode != nil {
+		f.writeEdition(editionNode)
+	}
+	if syntaxNode := f.fileNode.Syntax; syntaxNode != nil && editionNode == nil {
 		f.writeSyntax(syntaxNode)
 	}
 	if packageNode != nil {
@@ -346,6 +351,20 @@ func (f *formatter) writeSyntax(syntaxNode *ast.SyntaxNode) {
 	f.Space()
 	f.writeInline(syntaxNode.Syntax)
 	f.writeLineEnd(syntaxNode.Semicolon)
+}
+
+// writeEdition writes the edition.
+//
+// For example,
+//
+//	edition = "2023";
+func (f *formatter) writeEdition(editionNode *ast.EditionNode) {
+	f.writeStart(editionNode.Keyword)
+	f.Space()
+	f.writeInline(editionNode.Equals)
+	f.Space()
+	f.writeInline(editionNode.Edition)
+	f.writeLineEnd(editionNode.Semicolon)
 }
 
 // writePackage writes the package.
@@ -1078,6 +1097,10 @@ func (f *formatter) writeReserved(reservedNode *ast.ReservedNode) {
 	case reservedNode.Names != nil:
 		for _, nameNode := range reservedNode.Names {
 			elements = append(elements, nameNode)
+		}
+	case reservedNode.Identifiers != nil:
+		for _, identNode := range reservedNode.Identifiers {
+			elements = append(elements, identNode)
 		}
 	case reservedNode.Ranges != nil:
 		for _, rangeNode := range reservedNode.Ranges {

--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -32,12 +32,17 @@ import (
 func TestFormatter(t *testing.T) {
 	t.Parallel()
 	testFormatCustomOptions(t)
+	testFormatEditions(t)
 	testFormatProto2(t)
 	testFormatProto3(t)
 }
 
 func testFormatCustomOptions(t *testing.T) {
 	testFormatNoDiff(t, "testdata/customoptions")
+}
+
+func testFormatEditions(t *testing.T) {
+	testFormatNoDiff(t, "testdata/editions")
 }
 
 func testFormatProto2(t *testing.T) {

--- a/private/buf/bufformat/testdata/editions/editions.golden.proto
+++ b/private/buf/bufformat/testdata/editions/editions.golden.proto
@@ -1,0 +1,39 @@
+edition = "2023";
+
+package a.b.c;
+
+import "google/protobuf/descriptor.proto";
+
+option features.(string_feature) = "abc";
+option features.field_presence = IMPLICIT;
+option features.message_encoding = DELIMITED;
+
+extend google.protobuf.FeatureSet {
+  string string_feature = 9995;
+}
+
+extend google.protobuf.FieldOptions {
+  string string_option = 50000;
+}
+
+message Foo {
+  uint64 id = 1 [(string_option) = "xyz"];
+  string str = 2 [
+    features.field_presence = EXPLICIT,
+    default = "str"
+  ];
+  Foo child = 3;
+  Enum en = 4;
+
+  reserved abc, def, ghi_jkl, __xyz__;
+  reserved 10, 11, 12;
+}
+
+enum Enum {
+  ZERO = 0;
+  ONE = 1;
+  TWO = 2;
+
+  reserved 10, 11;
+  reserved TEN, ELEVEN, __100__;
+}

--- a/private/buf/bufformat/testdata/editions/editions.proto
+++ b/private/buf/bufformat/testdata/editions/editions.proto
@@ -1,0 +1,37 @@
+edition = "2023";
+
+package a.b.c;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FeatureSet {
+  string string_feature = 9995;
+}
+
+option features.(string_feature) = "abc";
+
+option features.message_encoding = DELIMITED;
+option features.field_presence = IMPLICIT;
+
+extend google.protobuf.FieldOptions {
+  string string_option = 50000;
+}
+
+message Foo {
+  uint64 id = 1 [(string_option) = "xyz"];
+  string str = 2 [features.field_presence = EXPLICIT, default = "str"];
+  Foo child = 3;
+  Enum en = 4;
+
+  reserved abc, def, ghi_jkl, __xyz__;
+  reserved 10, 11, 12;
+}
+
+enum Enum {
+  ZERO = 0;
+  ONE = 1;
+  TWO = 2;
+
+  reserved 10, 11;
+  reserved TEN, ELEVEN, __100__;
+}


### PR DESCRIPTION
Thanks @stefanvanburen for noticing this!

The formatter needed to be updated to be aware of the `edition` AST node (which appears instead of `syntax` in Editions files) and also needed updates to reserved names, which use identifiers instead of string literals in Editions.