### PR TITLE
Add `buf beta registry label` archive and unarchive commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   Editions files. This new rule is not active by default in existing v1 and
   v1beta1 configurations, for backwards-compatibility reasons. Migrate your
   config to v2 to use them.
+- Add `buf beta registry label archive` and `buf beta registry label unarchive` commands
+  for managing labels on the BSR.
 
 ## [v1.32.0-beta.1] - 2024-04-23
 

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -35,6 +35,8 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/commit/commitlist"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/draft/draftdelete"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/draft/draftlist"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/label/labelarchive"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/label/labelunarchive"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/organization/organizationcreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/organization/organizationdelete"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/organization/organizationget"
@@ -248,6 +250,14 @@ func NewRootCommand(name string) *appcmd.Command {
 								SubCommands: []*appcmd.Command{
 									pluginpush.NewCommand("push", builder),
 									plugindelete.NewCommand("delete", builder),
+								},
+							},
+							{
+								Use:   "label",
+								Short: "Manage labels on the Buf Schema Registry",
+								SubCommands: []*appcmd.Command{
+									labelarchive.NewCommand("archive", builder),
+									labelunarchive.NewCommand("unarchive", builder),
 								},
 							},
 						},

--- a/private/buf/cmd/buf/command/beta/registry/label/labelarchive/labelarchive.go
+++ b/private/buf/cmd/buf/command/beta/registry/label/labelarchive/labelarchive.go
@@ -34,7 +34,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repository:label",
+		Use:   name + " <buf.build/owner/repository:label>",
 		Short: "Archive a label for a repository",
 		Args:  appcmd.ExactArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/label/labelarchive/labelarchive.go
+++ b/private/buf/cmd/buf/command/beta/registry/label/labelarchive/labelarchive.go
@@ -1,0 +1,95 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labelarchive
+
+import (
+	"context"
+
+	v1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufapi"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/spf13/pflag"
+)
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <buf.build/owner/repository:label",
+		Short: "Archive a label for a repository",
+		Args:  appcmd.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct{}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
+	if err != nil {
+		return err
+	}
+	moduleRef, err := bufmodule.ParseModuleRef(container.Arg(0))
+	if err != nil {
+		return appcmd.NewInvalidArgumentError(err.Error())
+	}
+	labelServiceClient := bufapi.NewClientProvider(clientConfig).V1LabelServiceClient(moduleRef.ModuleFullName().Registry())
+	// ArchiveLabelsResponse is empty.
+	// This command is currently archiving one label at a time. This UX may change in the future.
+	_, err = labelServiceClient.ArchiveLabels(
+		ctx,
+		connect.NewRequest(
+			&v1.ArchiveLabelsRequest{
+				LabelRefs: []*v1.LabelRef{
+					{
+						Value: &v1.LabelRef_Name_{
+							Name: &v1.LabelRef_Name{
+								Owner:  moduleRef.ModuleFullName().Owner(),
+								Module: moduleRef.ModuleFullName().Name(),
+								Label:  moduleRef.Ref(),
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/label/labelarchive/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/label/labelarchive/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package labelarchive
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/beta/registry/label/labelunarchive/labelunarchive.go
+++ b/private/buf/cmd/buf/command/beta/registry/label/labelunarchive/labelunarchive.go
@@ -1,0 +1,95 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labelunarchive
+
+import (
+	"context"
+
+	v1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufapi"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/spf13/pflag"
+)
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <buf.build/owner/repository:label",
+		Short: "Unarchive a label for a repository",
+		Args:  appcmd.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct{}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
+	if err != nil {
+		return err
+	}
+	moduleRef, err := bufmodule.ParseModuleRef(container.Arg(0))
+	if err != nil {
+		return appcmd.NewInvalidArgumentError(err.Error())
+	}
+	labelServiceClient := bufapi.NewClientProvider(clientConfig).V1LabelServiceClient(moduleRef.ModuleFullName().Registry())
+	// UnarchiveLabelsResponse is empty.
+	// This command is currently unarchiving one label at a time. This UX may change in the future.
+	_, err = labelServiceClient.UnarchiveLabels(
+		ctx,
+		connect.NewRequest(
+			&v1.UnarchiveLabelsRequest{
+				LabelRefs: []*v1.LabelRef{
+					{
+						Value: &v1.LabelRef_Name_{
+							Name: &v1.LabelRef_Name{
+								Owner:  moduleRef.ModuleFullName().Owner(),
+								Module: moduleRef.ModuleFullName().Name(),
+								Label:  moduleRef.Ref(),
+							},
+						},
+					},
+				},
+			},
+		),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/beta/registry/label/labelunarchive/labelunarchive.go
+++ b/private/buf/cmd/buf/command/beta/registry/label/labelunarchive/labelunarchive.go
@@ -34,7 +34,7 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <buf.build/owner/repository:label",
+		Use:   name + " <buf.build/owner/repository:label>",
 		Short: "Unarchive a label for a repository",
 		Args:  appcmd.ExactArgs(1),
 		Run: builder.NewRunFunc(

--- a/private/buf/cmd/buf/command/beta/registry/label/labelunarchive/usage.gen.go
+++ b/private/buf/cmd/buf/command/beta/registry/label/labelunarchive/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package labelunarchive
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This adds two very simple `beta registry` commands for managing
labels. `buf beta registry label archive` allows the user to archive a
specified label, `<registry>/<owner>/<module>/<label>`, and
`buf beta registry label unarchive` allows the user to unarchive a
specified label in the same format.