### PR TITLE
Return a more user-friendly error in workspace targeting for overlaps

### DIFF
--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -700,7 +700,7 @@ func checkForOverlap(
 				return err
 			}
 			if empty {
-				return nil, bufmodule.ErrNoTargetProtoFiles
+				return bufmodule.ErrNoTargetProtoFiles
 			}
 			return fmt.Errorf("failed to build input %q because it is contained by module at path %q specified in your configuration, you must provide the workspace or module as the input, and filter to this path using --path", inputPath, moduleDirPath)
 		}

--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -693,13 +693,14 @@ func checkForOverlap(
 			// but does not exist, for example, moduleDirPath == "." and inputPath == "fake-path",
 			// or moduleDirPath == "real-path" and inputPath == "real-path/fake-path", the error
 			// returned below is not very clear (in particular the first case, "." and "fake-path").
-			// We do a check here to return a clearer error to the user.
+			// We do a check here and return ErrNoTargetProtoFiles if the inputPath is empty
+			// and/or it does not exist.
 			empty, err := storage.IsEmpty(ctx, bucket, inputPath)
 			if err != nil {
 				return err
 			}
 			if empty {
-				return fmt.Errorf("input path %q does not exist", inputPath)
+				return nil, bufmodule.ErrNoTargetProtoFiles
 			}
 			return fmt.Errorf("failed to build input %q because it is contained by module at path %q specified in your configuration, you must provide the workspace or module as the input, and filter to this path using --path", inputPath, moduleDirPath)
 		}

--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -224,7 +224,7 @@ func v2WorkspaceTargeting(
 		// Check if the input is overlapping within a module dir path. If so, return a nicer
 		// error. In the future, we want to remove special treatment for input dir, and it
 		// should be treated just like any target path.
-		return nil, checkForOverlap(bucketTargeting.SubDirPath(), moduleDirPaths)
+		return nil, checkForOverlap(ctx, bucket, bucketTargeting.SubDirPath(), moduleDirPaths)
 	}
 	if !hadIsTargetModule {
 		// It would be nice to have a better error message than this in the long term.
@@ -327,7 +327,7 @@ func v1WorkspaceTargeting(
 		// Check if the input is overlapping within a module dir path. If so, return a nicer
 		// error. In the future, we want to remove special treatment for input dir, and it
 		// should be treated just like any target path.
-		return nil, checkForOverlap(bucketTargeting.SubDirPath(), moduleDirPaths)
+		return nil, checkForOverlap(ctx, bucket, bucketTargeting.SubDirPath(), moduleDirPaths)
 	}
 	if !hadIsTargetModule {
 		// It would be nice to have a better error message than this in the long term.
@@ -681,9 +681,30 @@ func checkForControllingWorkspaceOrV1Module(
 	return fallbackV1Module, nil
 }
 
-func checkForOverlap(inputPath string, moduleDirPaths []string) error {
+func checkForOverlap(
+	ctx context.Context,
+	bucket storage.ReadBucket,
+	inputPath string,
+	moduleDirPaths []string,
+) error {
 	for _, moduleDirPath := range moduleDirPaths {
 		if normalpath.ContainsPath(moduleDirPath, inputPath, normalpath.Relative) {
+			// In the case where the inputPath would appear to be relative to moduleDirPath,
+			// but does not exist, for example, moduleDirPath == "." and inputPath == "fake-path",
+			// or moduleDirPath == "real-path" and inputPath == "real-path/fake-path", the error
+			// returned below is not very clear (in particular the first case, "." and "fake-path").
+			// We do a check here to return a clearer error to the user.
+			//
+			// It should be noted that if the inputPath exists and contains many files, this may not
+			// be very performant, since storage.IsEmpty will do a full walk, however, it does
+			// not do any processing on ObjectInfo, so this should be reasonable.
+			empty, err := storage.IsEmpty(ctx, bucket, inputPath)
+			if err != nil {
+				return err
+			}
+			if empty {
+				return fmt.Errorf("input path %q does not exist", inputPath)
+			}
 			return fmt.Errorf("failed to build input %q because it is contained by module at path %q specified in your configuration, you must provide the workspace or module as the input, and filter to this path using --path", inputPath, moduleDirPath)
 		}
 	}

--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -694,10 +694,6 @@ func checkForOverlap(
 			// or moduleDirPath == "real-path" and inputPath == "real-path/fake-path", the error
 			// returned below is not very clear (in particular the first case, "." and "fake-path").
 			// We do a check here to return a clearer error to the user.
-			//
-			// It should be noted that if the inputPath exists and contains many files, this may not
-			// be very performant, since storage.IsEmpty will do a full walk, however, it does
-			// not do any processing on ObjectInfo, so this should be reasonable.
 			empty, err := storage.IsEmpty(ctx, bucket, inputPath)
 			if err != nil {
 				return err

--- a/private/buf/cmd/buf/testdata/workspace/fail/v2/overlap/buf.yaml
+++ b/private/buf/cmd/buf/testdata/workspace/fail/v2/overlap/buf.yaml
@@ -1,0 +1,1 @@
+version: v2

--- a/private/buf/cmd/buf/testdata/workspace/fail/v2/overlap/proto/buf/buf.proto
+++ b/private/buf/cmd/buf/testdata/workspace/fail/v2/overlap/proto/buf/buf.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package buf;
+
+message Buf {}

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -1143,7 +1143,7 @@ func TestWorkspaceInputOverlapNonExistentDirFail(t *testing.T) {
 		nil,
 		1,
 		``,
-		`Failure: input path "proto/fake-dir" does not exist`,
+		`Failure: no .proto files were targeted. This can occur if no .proto files are found in your input, --path points to files that do not exist, or --exclude-path excludes all files.`,
 		"build",
 		filepath.Join("testdata", "workspace", "fail", "overlap", "proto", "fake-dir"),
 	)
@@ -1152,7 +1152,7 @@ func TestWorkspaceInputOverlapNonExistentDirFail(t *testing.T) {
 		nil,
 		1,
 		``,
-		`Failure: input path "fake-dir" does not exist`,
+		`Failure: no .proto files were targeted. This can occur if no .proto files are found in your input, --path points to files that do not exist, or --exclude-path excludes all files.`,
 		"build",
 		filepath.Join("testdata", "workspace", "fail", "v2", "overlap", "fake-dir"),
 	)

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -1134,6 +1134,30 @@ func TestWorkspaceInputOverlapFail(t *testing.T) {
 	testRunStdout(t, nil, 0, ``, "build", filepath.Join("testdata", "workspace", "success", "dir", "other"))
 }
 
+func TestWorkspaceInputOverlapNonExistentDirFail(t *testing.T) {
+	// The target input is a non-existent directory and the workspace contains a single
+	// module at the root, ".".
+	t.Parallel()
+	testRunStdoutStderrNoWarn(
+		t,
+		nil,
+		1,
+		``,
+		`Failure: input path "proto/fake-dir" does not exist`,
+		"build",
+		filepath.Join("testdata", "workspace", "fail", "overlap", "proto", "fake-dir"),
+	)
+	testRunStdoutStderrNoWarn(
+		t,
+		nil,
+		1,
+		``,
+		`Failure: input path "fake-dir" does not exist`,
+		"build",
+		filepath.Join("testdata", "workspace", "fail", "v2", "overlap", "fake-dir"),
+	)
+}
+
 func TestWorkspaceNoVersionFail(t *testing.T) {
 	// The buf.work.yaml must specify a version.
 	t.Parallel()


### PR DESCRIPTION
In the past, if the an overlap is found between `moduleDirPath` and `inputPath`,
but `inputPath` does not exist (e.g. `moduleDirPath == "."` and `inputPath == "fake-path"`)
then it would return the error:

```
failed to build input "fake-path" because it is contained by module at path "." specified in your configuration, you must provide the workspace or module as the input, and filter to this path using --path"
```

Which isn't particularly clear, since `fake-path` doesn't exist. Added a check to return a
nicer error to the user by checking `inputPath`. Also included test cases for `v1` and `v2`
workspaces.
