### PR TITLE
Only archive and unarchive labels for target modules

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/archive/archive.go
+++ b/private/buf/cmd/buf/command/beta/registry/archive/archive.go
@@ -106,6 +106,9 @@ func run(
 	}
 	registryToModuleFullNames := map[string][]bufmodule.ModuleFullName{}
 	for _, module := range workspace.Modules() {
+		if !module.IsTarget() {
+			continue
+		}
 		if moduleFullName := module.ModuleFullName(); moduleFullName != nil {
 			moduleFullNames, ok := registryToModuleFullNames[moduleFullName.Registry()]
 			if !ok {

--- a/private/buf/cmd/buf/command/beta/registry/unarchive/unarchive.go
+++ b/private/buf/cmd/buf/command/beta/registry/unarchive/unarchive.go
@@ -106,6 +106,9 @@ func run(
 	}
 	registryToModuleFullNames := map[string][]bufmodule.ModuleFullName{}
 	for _, module := range workspace.Modules() {
+		if !module.IsTarget() {
+			continue
+		}
 		if moduleFullName := module.ModuleFullName(); moduleFullName != nil {
 			moduleFullNames, ok := registryToModuleFullNames[moduleFullName.Registry()]
 			if !ok {


### PR DESCRIPTION
We should only be archiving and unarchiving labels
for target modules.