### PR TITLE
Add `module` config option to protoc plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix archive and git inputs so that `--path` and `--exclude-path` paths are relative to
   the `#subdir` rather than the root of the input. This fixes an unintended behavior change
   that was introduced in `v1.32.0`.
+- Add `module` input for protoc-gen-buf-lint and protoc-gen-buf-breaking to allow
+  users to specify the module for v2 config files.
 
 ## [v1.32.0] - 2024-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Fix archive and git inputs so that `--path` and `--exclude-path` paths are relative to
   the `#subdir` rather than the root of the input. This fixes an unintended behavior change
   that was introduced in `v1.32.0`.
-- Add `module` input for protoc-gen-buf-lint and protoc-gen-buf-breaking to allow
-  users to specify the module for v2 config files.
+- Add `module` input for `protoc-gen-buf-lint` and `protoc-gen-buf-breaking` to allow
+  users to specify the module for `v2` configuration files.
 
 ## [v1.32.0] - 2024-05-16
 

--- a/private/buf/cmd/internal/internal.go
+++ b/private/buf/cmd/internal/internal.go
@@ -29,6 +29,7 @@ import (
 func GetModuleConfigForProtocPlugin(
 	ctx context.Context,
 	configOverride string,
+	module string,
 ) (bufconfig.ModuleConfig, error) {
 	bufYAMLFile, err := bufcli.GetBufYAMLFileForDirPathOrOverride(
 		ctx,
@@ -41,13 +42,19 @@ func GetModuleConfigForProtocPlugin(
 		}
 		return nil, err
 	}
+	if module == "" {
+		module = "."
+	}
 	for _, moduleConfig := range bufYAMLFile.ModuleConfigs() {
 		// If we have a v1beta1 or v1 buf.yaml, dirPath will be ".". Using the ModuleConfig from
 		// a v1beta1 or v1 buf.yaml file matches the pre-refactor behavior.
 		//
-		// If we have a v2 buf.yaml, we say that we need to have a module with dirPath of ".", otherwise
+		// If we have a v2 buf.yaml, users will habe to provide a dirPath or module, otherwise
 		// we can't deduce what ModuleConfig to use.
-		if dirPath := moduleConfig.DirPath(); dirPath == "." {
+		if dirPath := moduleConfig.DirPath(); dirPath == module {
+			return moduleConfig, nil
+		}
+		if fullName := moduleConfig.ModuleFullName(); fullName != nil && fullName.String() == module {
 			return moduleConfig, nil
 		}
 	}

--- a/private/buf/cmd/internal/internal.go
+++ b/private/buf/cmd/internal/internal.go
@@ -49,7 +49,7 @@ func GetModuleConfigForProtocPlugin(
 		// If we have a v1beta1 or v1 buf.yaml, dirPath will be ".". Using the ModuleConfig from
 		// a v1beta1 or v1 buf.yaml file matches the pre-refactor behavior.
 		//
-		// If we have a v2 buf.yaml, users have to provide a dirPath or module, otherwise
+		// If we have a v2 buf.yaml, users have to provide a module path or full name, otherwise
 		// we can't deduce what ModuleConfig to use.
 		if dirPath := moduleConfig.DirPath(); dirPath == module {
 			return moduleConfig, nil

--- a/private/buf/cmd/internal/internal.go
+++ b/private/buf/cmd/internal/internal.go
@@ -49,7 +49,7 @@ func GetModuleConfigForProtocPlugin(
 		// If we have a v1beta1 or v1 buf.yaml, dirPath will be ".". Using the ModuleConfig from
 		// a v1beta1 or v1 buf.yaml file matches the pre-refactor behavior.
 		//
-		// If we have a v2 buf.yaml, users will habe to provide a dirPath or module, otherwise
+		// If we have a v2 buf.yaml, users have to provide a dirPath or module, otherwise
 		// we can't deduce what ModuleConfig to use.
 		if dirPath := moduleConfig.DirPath(); dirPath == module {
 			return moduleConfig, nil

--- a/private/buf/cmd/protoc-gen-buf-breaking/breaking.go
+++ b/private/buf/cmd/protoc-gen-buf-breaking/breaking.go
@@ -107,6 +107,7 @@ func handle(
 	moduleConfig, err := internal.GetModuleConfigForProtocPlugin(
 		ctx,
 		encoding.GetJSONStringOrStringValue(externalConfig.InputConfig),
+		externalConfig.Module,
 	)
 	if err != nil {
 		return err
@@ -144,6 +145,7 @@ type externalConfig struct {
 	// This was never actually used, but we keep it around for we can do unmarshal strict without breaking anyone.
 	AgainstInputConfig json.RawMessage `json:"against_input_config,omitempty" yaml:"against_input_config,omitempty"`
 	InputConfig        json.RawMessage `json:"input_config,omitempty" yaml:"input_config,omitempty"`
+	Module             string          `json:"module,omitempty" yaml:"module,omitempty"`
 	LimitToInputFiles  bool            `json:"limit_to_input_files,omitempty" yaml:"limit_to_input_files,omitempty"`
 	ExcludeImports     bool            `json:"exclude_imports,omitempty" yaml:"exclude_imports,omitempty"`
 	LogLevel           string          `json:"log_level,omitempty" yaml:"log_level,omitempty"`

--- a/private/buf/cmd/protoc-gen-buf-lint/lint.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint.go
@@ -68,6 +68,7 @@ func handle(
 	moduleConfig, err := internal.GetModuleConfigForProtocPlugin(
 		ctx,
 		encoding.GetJSONStringOrStringValue(externalConfig.InputConfig),
+		externalConfig.Module,
 	)
 	if err != nil {
 		return err
@@ -114,6 +115,7 @@ func handle(
 
 type externalConfig struct {
 	InputConfig json.RawMessage `json:"input_config,omitempty" yaml:"input_config,omitempty"`
+	Module      string          `json:"module,omitempty" yaml:"module,omitempty"`
 	LogLevel    string          `json:"log_level,omitempty" yaml:"log_level,omitempty"`
 	LogFormat   string          `json:"log_format,omitempty" yaml:"log_format,omitempty"`
 	ErrorFormat string          `json:"error_format,omitempty" yaml:"error_format,omitempty"`

--- a/private/buf/cmd/protoc-gen-buf-lint/lint_test.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint_test.go
@@ -182,6 +182,26 @@ func TestRunLint7(t *testing.T) {
 	)
 }
 
+func TestRunLint8(t *testing.T) {
+	t.Parallel()
+	testRunLint(
+		t,
+		filepath.Join("testdata", "fail"),
+		[]string{
+			filepath.Join("testdata", "fail", "buf", "buf.proto"),
+			filepath.Join("testdata", "fail", "buf", "buf_two.proto"),
+		},
+		`{"input_config":"testdata/fail/v2.yaml","module":"fail"}`,
+		[]string{
+			normalpath.Join("buf", "buf.proto"),
+		},
+		0,
+		`
+		buf/buf.proto:3:1:Files with package "other" must be within a directory "other" relative to root but were in directory "buf".
+		`,
+	)
+}
+
 func TestRunLint_UnusedImports(t *testing.T) {
 	unusedImportsFileComponents := [][]string{
 		{"buf", "v1", "a.proto"},

--- a/private/buf/cmd/protoc-gen-buf-lint/testdata/fail/v2.yaml
+++ b/private/buf/cmd/protoc-gen-buf-lint/testdata/fail/v2.yaml
@@ -1,0 +1,6 @@
+version: v2
+modules:
+  - path: fail
+lint:
+  use:
+    - PACKAGE_DIRECTORY_MATCH


### PR DESCRIPTION
Add `module` config option to protoc plugins. With v2 config the plugins only work if they find a module in the current directory. With this change users can provide the module that they are running the plugin against. Module accepts both the directory path and module full name.