### PR TITLE
Map target paths and target exclude paths for archive/git refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 - Fix archive and git inputs so that `--path` and `--exclude-path` paths are relative to
-  the `#subdir` rather than the root of the input. This fixes a unintended behavior change that was introduced in `v1.32.0`.
+  the `#subdir` rather than the root of the input. This fixes an unintended behavior change
+  that was introduced in `v1.32.0`.
 
 ## [v1.32.0] - 2024-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Fix archive and git inputs so that `--path` and `--exclude-path` paths are relative to
-  the `#subdir` rather than the root of the input.
+  the `#subdir` rather than the root of the input. This fixes a unintended behavior change that was introduced in `v1.32.0`.
 
 ## [v1.32.0] - 2024-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix archive and git inputs so that `--path` and `--exclude-path` paths are relative to
+  the `#subdir` rather than the root of the input.
 
 ## [v1.32.0] - 2024-05-16
 

--- a/data/template/buf.go.gen.yaml
+++ b/data/template/buf.go.gen.yaml
@@ -23,9 +23,9 @@ inputs:
     tag: v27.0-rc1
     subdir: src
     paths:
-     - src/google/protobuf/cpp_features.proto
+     - google/protobuf/cpp_features.proto
   - git_repo: https://github.com/protocolbuffers/protobuf.git
     tag: v27.0-rc1
     subdir: java/core/src/main/resources
     paths:
-     - java/core/src/main/resources/google/protobuf/java_features.proto
+     - google/protobuf/java_features.proto

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -573,6 +573,15 @@ func getReadBucketCloserForBucket(
 	if err := validatePaths(inputSubDirPath, targetPaths, targetExcludePaths); err != nil {
 		return nil, nil, err
 	}
+	// For archive and git refs, target paths and target exclude paths are expected to be
+	// mapped to the inputSubDirPath rather than the execution context.
+	// This affects buftarget when checking and mapping paths against the controlling
+	// workspace, so we need to ensure that all paths are properly mapped.
+	targetPaths, targetExcludePaths = mapTargetPathsAndTargetExcludePathsForArchiveAndGitRefs(
+		inputSubDirPath,
+		targetPaths,
+		targetExcludePaths,
+	)
 	bucketTargeting, err := buftarget.NewBucketTargeting(
 		ctx,
 		logger,
@@ -902,6 +911,43 @@ func validatePaths(
 		return err
 	}
 	return nil
+}
+
+func mapTargetPathsAndTargetExcludePathsForArchiveAndGitRefs(
+	inputSubDirPath string,
+	targetPaths []string,
+	targetExcludePaths []string,
+) ([]string, []string) {
+	// No need to remap
+	if inputSubDirPath == "." {
+		return targetPaths, targetExcludePaths
+	}
+	return slicesext.Map(
+			targetPaths,
+			func(targetPath string) string {
+				// If the targetPath is already contained/relative to the inputSubDirPath, we do not
+				// do any additional mapping.
+				if normalpath.ContainsPath(inputSubDirPath, targetPath, normalpath.Relative) {
+					return targetPath
+				}
+				// Otherwise we treat the targetPath as a sub-path of inputSubDirPath and return
+				// the joined path.
+				return normalpath.Join(inputSubDirPath, targetPath)
+			},
+		),
+		slicesext.Map(
+			targetExcludePaths,
+			func(targetExcludePath string) string {
+				// If the targetExcludePath is already contained/relative to the inputSubDirPath, we do not
+				// do any additional mapping.
+				if normalpath.ContainsPath(inputSubDirPath, targetExcludePath, normalpath.Relative) {
+					return targetExcludePath
+				}
+				// Otherwise we treat the targetExcludePath as a sub-path of inputSubDirPath and return
+				// the joined path.
+				return normalpath.Join(inputSubDirPath, targetExcludePath)
+			},
+		)
 }
 
 type getFileOptions struct {

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -925,26 +925,12 @@ func mapTargetPathsAndTargetExcludePathsForArchiveAndGitRefs(
 	return slicesext.Map(
 			targetPaths,
 			func(targetPath string) string {
-				// If the targetPath is already contained/relative to the inputSubDirPath, we do not
-				// do any additional mapping.
-				if normalpath.ContainsPath(inputSubDirPath, targetPath, normalpath.Relative) {
-					return targetPath
-				}
-				// Otherwise we treat the targetPath as a sub-path of inputSubDirPath and return
-				// the joined path.
 				return normalpath.Join(inputSubDirPath, targetPath)
 			},
 		),
 		slicesext.Map(
 			targetExcludePaths,
 			func(targetExcludePath string) string {
-				// If the targetExcludePath is already contained/relative to the inputSubDirPath, we do not
-				// do any additional mapping.
-				if normalpath.ContainsPath(inputSubDirPath, targetExcludePath, normalpath.Relative) {
-					return targetExcludePath
-				}
-				// Otherwise we treat the targetExcludePath as a sub-path of inputSubDirPath and return
-				// the joined path.
 				return normalpath.Join(inputSubDirPath, targetExcludePath)
 			},
 		)

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -293,6 +293,23 @@ func TestWorkspaceArchiveDir(t *testing.T) {
 			"--path",
 			filepath.Join("proto", "rpc.proto"),
 		)
+		// When passing --path and --exclude-path to archive refs, version of the CLI
+		// pre-1.31.0 maps the target path and target exclude paths relative to the subDir,
+		// rather than the execution context. This is inconsistent behaviour for CLI inputs,
+		// so in 1.32.0, we now map target paths and target exclude paths to the execution
+		// context/root of the bucket. However, we need to maintain backwards compatability,
+		// so we now support both.
+		testRunStdout(
+			t,
+			nil,
+			bufctl.ExitCodeFileAnnotation,
+			filepath.FromSlash(`proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".
+        proto/rpc.proto:3:1:Package name "example" should be suffixed with a correctly formed version, such as "example.v1".`),
+			"lint",
+			filepath.Join(zipDir, "archive.zip#subdir=proto"),
+			"--path",
+			filepath.Join("rpc.proto"),
+		)
 	}
 }
 

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -291,23 +291,6 @@ func TestWorkspaceArchiveDir(t *testing.T) {
 			"lint",
 			filepath.Join(zipDir, "archive.zip#subdir=proto"),
 			"--path",
-			filepath.Join("proto", "rpc.proto"),
-		)
-		// When passing --path and --exclude-path to archive refs, versions of the CLI
-		// pre-1.32.0 maps the target path and target exclude paths relative to the subDir,
-		// rather than the execution context. This is inconsistent behavior for CLI inputs,
-		// so in 1.32.0, we now map target paths and target exclude paths to the execution
-		// context/root of the bucket. However, we need to maintain backwards compatibility,
-		// so we now support both.
-		testRunStdout(
-			t,
-			nil,
-			bufctl.ExitCodeFileAnnotation,
-			filepath.FromSlash(`proto/rpc.proto:3:1:Files with package "example" must be within a directory "example" relative to root but were in directory ".".
-        proto/rpc.proto:3:1:Package name "example" should be suffixed with a correctly formed version, such as "example.v1".`),
-			"lint",
-			filepath.Join(zipDir, "archive.zip#subdir=proto"),
-			"--path",
 			filepath.Join("rpc.proto"),
 		)
 	}
@@ -359,7 +342,7 @@ func TestWorkspaceNestedArchive(t *testing.T) {
 			"lint",
 			filepath.Join(zipDir, "archive.zip#subdir=proto/internal"),
 			"--path",
-			filepath.Join("proto", "internal", "internal.proto"),
+			filepath.Join("internal.proto"),
 		)
 	}
 }

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -293,11 +293,11 @@ func TestWorkspaceArchiveDir(t *testing.T) {
 			"--path",
 			filepath.Join("proto", "rpc.proto"),
 		)
-		// When passing --path and --exclude-path to archive refs, version of the CLI
-		// pre-1.31.0 maps the target path and target exclude paths relative to the subDir,
-		// rather than the execution context. This is inconsistent behaviour for CLI inputs,
+		// When passing --path and --exclude-path to archive refs, versions of the CLI
+		// pre-1.32.0 maps the target path and target exclude paths relative to the subDir,
+		// rather than the execution context. This is inconsistent behavior for CLI inputs,
 		// so in 1.32.0, we now map target paths and target exclude paths to the execution
-		// context/root of the bucket. However, we need to maintain backwards compatability,
+		// context/root of the bucket. However, we need to maintain backwards compatibility,
 		// so we now support both.
 		testRunStdout(
 			t,

--- a/private/buf/cmd/buf/workspace_unix_test.go
+++ b/private/buf/cmd/buf/workspace_unix_test.go
@@ -160,7 +160,7 @@ func TestWorkspaceGit(t *testing.T) {
 		"build",
 		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
 		"--path",
-		filepath.Join("private", "buf", "cmd", "buf", "testdata", "workspace", "success", "dir", "proto", "rpc.proto"),
+		filepath.Join("rpc.proto"),
 	)
 	testRunStdout(
 		t,
@@ -188,7 +188,7 @@ func TestWorkspaceGit(t *testing.T) {
 		"lint",
 		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/dir/proto",
 		"--path",
-		filepath.Join("private", "buf", "cmd", "buf", "testdata", "workspace", "success", "dir", "proto", "rpc.proto"),
+		filepath.Join("rpc.proto"),
 	)
 	testRunStdout(
 		t,
@@ -206,7 +206,7 @@ func TestWorkspaceGit(t *testing.T) {
 		"build",
 		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/v2/dir/proto",
 		"--path",
-		filepath.Join("private", "buf", "cmd", "buf", "testdata", "workspace", "success", "v2", "dir", "proto", "rpc.proto"),
+		filepath.Join("rpc.proto"),
 	)
 	testRunStdout(
 		t,
@@ -234,6 +234,6 @@ func TestWorkspaceGit(t *testing.T) {
 		"lint",
 		"../../../../.git#ref=HEAD,subdir=private/buf/cmd/buf/testdata/workspace/success/v2/dir/proto",
 		"--path",
-		filepath.Join("private", "buf", "cmd", "buf", "testdata", "workspace", "success", "v2", "dir", "proto", "rpc.proto"),
+		filepath.Join("rpc.proto"),
 	)
 }


### PR DESCRIPTION
In CLI versions pre-1.32.0, for archive and git refs, we would map
the root of the bucket of archive and git refs to the `subDirPath`,
which is inconsistent with the behavior for dir refs (which maps
target paths and target exclude paths to the execution context).

In 1.32.0, we made changes to handle subDirPath, target paths,
and target exclude paths in a unified way, however this is not
backwards compatible with pre-1.32.0 versions. So, in order
to be backwards compatible, we need to remap the target
paths and target exclude paths.

I explored an option to check of the subDirPath contains
the target paths and target exclude paths before remapping,
however this is brittle, since we could hit an edge case with
directories that have the same name nested:

```
.
└── proto
    └── foo
        └── foo
```

Tests have been adjusted to reflect this change.