### PR TITLE
Update buf beta registry draft commands to use v1 API

### DIFF
--- a/private/buf/bufprint/bufprint.go
+++ b/private/buf/bufprint/bufprint.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"strconv"
 
+	modulev1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
@@ -130,8 +131,7 @@ func NewRepositoryCommitPrinter(writer io.Writer) RepositoryCommitPrinter {
 
 // RepositoryDraftPrinter is a repository draft printer.
 type RepositoryDraftPrinter interface {
-	PrintRepositoryDraft(ctx context.Context, format Format, repositoryCommit *registryv1alpha1.RepositoryCommit) error
-	PrintRepositoryDrafts(ctx context.Context, format Format, nextPageToken string, repositoryCommits ...*registryv1alpha1.RepositoryCommit) error
+	PrintRepositoryDrafts(ctx context.Context, format Format, nextPageToken string, drafts ...*modulev1.Label) error
 }
 
 // NewRepositoryDraftPrinter returns a new RepositoryDraftPrinter.

--- a/private/buf/bufprint/repository_commit_printer.go
+++ b/private/buf/bufprint/repository_commit_printer.go
@@ -89,14 +89,12 @@ func (p *repositoryCommitPrinter) printRepositoryCommitsText(outputRepositoryCom
 }
 
 type outputRepositoryCommit struct {
-	ID     string                `json:"id,omitempty"`
 	Commit string                `json:"commit,omitempty"`
 	Tags   []outputRepositoryTag `json:"tags,omitempty"`
 }
 
 func registryCommitToOutputCommit(repositoryCommit *registryv1alpha1.RepositoryCommit) outputRepositoryCommit {
 	return outputRepositoryCommit{
-		ID:     repositoryCommit.Id,
 		Commit: repositoryCommit.Name,
 		Tags:   registryTagsToOutputTags(repositoryCommit.Tags),
 	}


### PR DESCRIPTION
Migrate API usage in `buf beta registry draft [delete, list]` from v1alpha1 to v1.

There should be no change in the observed behavior of this command.