### PR TITLE
Indent `buf format` help examples

### DIFF
--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -70,92 +70,92 @@ Examples:
 
 Write the current directory's formatted content to stdout:
 
-$ buf format
+    $ buf format
 
 Most people will want to rewrite the files defined in the current directory in-place with -w:
 
-$ buf format -w
+    $ buf format -w
 
 Display a diff between the original and formatted content with -d
 Write a diff instead of the formatted file:
 
-$ buf format simple/simple.proto -d
+    $ buf format simple/simple.proto -d
 
-$ diff -u simple/simple.proto.orig simple/simple.proto
---- simple/simple.proto.orig	2022-03-24 09:44:10.000000000 -0700
-+++ simple/simple.proto	2022-03-24 09:44:10.000000000 -0700
-@@ -2,8 +2,7 @@
+    $ diff -u simple/simple.proto.orig simple/simple.proto
+    --- simple/simple.proto.orig	2022-03-24 09:44:10.000000000 -0700
+    +++ simple/simple.proto	2022-03-24 09:44:10.000000000 -0700
+    @@ -2,8 +2,7 @@
 
-package simple;
+    package simple;
 
--
-message Object {
--    string key = 1;
--   bytes value = 2;
-+  string key = 1;
-+  bytes value = 2;
-}
+    -
+    message Object {
+    -    string key = 1;
+    -   bytes value = 2;
+    +  string key = 1;
+    +  bytes value = 2;
+    }
 
 Use the --exit-code flag to exit with a non-zero exit code if there is a diff:
 
-$ buf format --exit-code
-$ buf format -w --exit-code
-$ buf format -d --exit-code
+    $ buf format --exit-code
+    $ buf format -w --exit-code
+    $ buf format -d --exit-code
 
 Format a file, directory, or module reference by specifying a source e.g.
 Write the formatted file to stdout:
 
-$ buf format simple/simple.proto
+    $ buf format simple/simple.proto
 
-syntax = "proto3";
+    syntax = "proto3";
 
-package simple;
+    package simple;
 
-message Object {
-string key = 1;
-bytes value = 2;
-}
+    message Object {
+      string key = 1;
+      bytes value = 2;
+    }
 
 Write the formatted directory to stdout:
 
-$ buf format simple
-...
+    $ buf format simple
+    ...
 
 Write the formatted module reference to stdout:
 
-$ buf format buf.build/acme/petapis
-...
+    $ buf format buf.build/acme/petapis
+    ...
 
 Write the result to a specified output file or directory with -o e.g.
 
 Write the formatted file to another file:
 
-$ buf format simple/simple.proto -o simple/simple.formatted.proto
+    $ buf format simple/simple.proto -o simple/simple.formatted.proto
 
 Write the formatted directory to another directory, creating it if it doesn't exist:
 
-$ buf format proto -o formatted
+    $ buf format proto -o formatted
 
 This also works with module references:
 
-$ buf format buf.build/acme/weather -o formatted
+    $ buf format buf.build/acme/weather -o formatted
 
 Rewrite the file(s) in-place with -w. e.g.
 
 Rewrite a single file in-place:
 
-$ buf format simple.proto -w
+    $ buf format simple.proto -w
 
 Rewrite an entire directory in-place:
 
-$ buf format proto -w
+    $ buf format proto -w
 
 Write a diff and rewrite the file(s) in-place:
 
-$ buf format simple -d -w
+    $ buf format simple -d -w
 
-$ diff -u simple/simple.proto.orig simple/simple.proto
-...
+    $ diff -u simple/simple.proto.orig simple/simple.proto
+    ...
 
 The -w and -o flags cannot be used together in a single invocation.
 `,


### PR DESCRIPTION
Similar to the `--help` for `buf generate`, `buf convert` and `buf export`. Should make the [generated docs](https://buf.build/docs/reference/cli/buf/format) also look better.