### PR TITLE
Allow user to override --source-control-url and --create-default-label when using --git-metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- Allow user to override `--source-control-url` when using `--git-metadata` with `buf push`.
+- Allow user to override `--source-control-url` and `--create-default-label` when using
+  `--git-metadata` with `buf push`.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Allow user to override `--source-control-url` when using `--git-metadata` with `buf push`.
 
 ## [v1.32.2] - 2024-05-28
 


### PR DESCRIPTION
This allows the user to override the behaviour of `--source-control-url`
and `--create-default-label` with their own values when using `--git-metadata`
flag with `buf push`.
The previous behaviour disallowed the user to set these values themselves
if the `--git-metadata` flag was set.