### PR TITLE
Include descriptor's location in set of ignore locations

### DIFF
--- a/private/bufpkg/bufcheck/buflint/buflint_test.go
+++ b/private/bufpkg/bufcheck/buflint/buflint_test.go
@@ -1259,7 +1259,7 @@ func testLintWithOptions(
 		assert.NoError(t, err)
 	} else {
 		var fileAnnotationSet bufanalysis.FileAnnotationSet
-		require.True(t, errors.As(err, &fileAnnotationSet))
+		require.True(t, errors.As(err, &fileAnnotationSet), "error has unexpected type: %T", err)
 		bufanalysistesting.AssertFileAnnotationsEqual(
 			t,
 			expectedFileAnnotations,

--- a/private/bufpkg/bufcheck/buflint/internal/buflintcheck/util.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintcheck/util.go
@@ -25,8 +25,14 @@ import (
 
 // addFunc adds a FileAnnotation.
 //
-// Both the Descriptor and Locations can be nil.
-type addFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{})
+// descriptor is what the FileAnnotation applies to.
+// location is the granular Location of the FileAnnotation.
+// extraIgnoreLocations are extra Locations to check for comment ignores. Note that if descriptor is a
+// bufprotosource.LocationDescriptor, descriptor.Location() is automatically added to extraIgnoreLocations if
+// location != descriptor.Location().
+//
+// descriptor, location, and extraIgnoreLocations can be nil.
+type addFunc func(descriptior bufprotosource.Descriptor, location bufprotosource.Location, extraIgnoreLocations []bufprotosource.Location, message string, args ...interface{})
 
 func fieldToLowerSnakeCase(s string) string {
 	// Try running this on googleapis and watch

--- a/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/adder.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintvalidate/adder.go
@@ -63,8 +63,7 @@ func (a *adder) addForPathf(path []int32, format string, args ...interface{}) {
 	a.addFunc(
 		a.field,
 		a.field.OptionExtensionLocation(validate.E_Field, append(combinedPath, path...)...),
-		// It is OK if a.field.Location() is nil per the docs of IgnoreFunc.
-		[]bufprotosource.Location{a.field.Location()},
+		nil,
 		format,
 		args...,
 	)
@@ -84,8 +83,7 @@ func (a *adder) addForPathsf(paths [][]int32, format string, args ...interface{}
 		a.addFunc(
 			a.field,
 			location,
-			// It is OK if a.field.Location() is nil per the docs of IgnoreFunc.
-			[]bufprotosource.Location{a.field.Location()},
+			nil,
 			format,
 			args...,
 		)

--- a/private/bufpkg/bufcheck/internal/helper.go
+++ b/private/bufpkg/bufcheck/internal/helper.go
@@ -110,10 +110,17 @@ func (h *Helper) addFileAnnotationf(
 	format string,
 	args ...interface{},
 ) {
+	baseLocs := []bufprotosource.Location{location}
+	if locDescriptor, ok := descriptor.(bufprotosource.LocationDescriptor); ok {
+		if descLocation := locDescriptor.Location(); descLocation != location {
+			// Include the location of the descriptor itself as a source of ignores.
+			baseLocs = append(baseLocs, descLocation)
+		}
+	}
 	if h.ignoreFunc != nil && h.ignoreFunc(
 		h.id,
 		append([]bufprotosource.Descriptor{descriptor}, extraIgnoreDescriptors...),
-		append([]bufprotosource.Location{location}, extraIgnoreLocations...),
+		append(baseLocs, extraIgnoreLocations...),
 	) {
 		return
 	}

--- a/private/bufpkg/bufcheck/internal/helper.go
+++ b/private/bufpkg/bufcheck/internal/helper.go
@@ -111,16 +111,22 @@ func (h *Helper) addFileAnnotationf(
 	args ...interface{},
 ) {
 	ignoreLocations := []bufprotosource.Location{location}
+	var descriptorLocation bufprotosource.Location
 	if locationDescriptor, ok := descriptor.(bufprotosource.LocationDescriptor); ok {
-		if descriptorLocation := locationDescriptor.Location(); descriptorLocation != location {
+		if descriptorLocation = locationDescriptor.Location(); descriptorLocation != location {
 			// Include the location of the descriptor itself as a source of ignores.
 			ignoreLocations = append(ignoreLocations, descriptorLocation)
+		}
+	}
+	for _, extraIgnoreLocation := range extraIgnoreLocations {
+		if extraIgnoreLocation != location && extraIgnoreLocation != descriptorLocation {
+			ignoreLocations = append(ignoreLocations, extraIgnoreLocation)
 		}
 	}
 	if h.ignoreFunc != nil && h.ignoreFunc(
 		h.id,
 		append([]bufprotosource.Descriptor{descriptor}, extraIgnoreDescriptors...),
-		append(ignoreLocations, extraIgnoreLocations...),
+		ignoreLocations,
 	) {
 		return
 	}

--- a/private/bufpkg/bufcheck/internal/helper.go
+++ b/private/bufpkg/bufcheck/internal/helper.go
@@ -110,17 +110,17 @@ func (h *Helper) addFileAnnotationf(
 	format string,
 	args ...interface{},
 ) {
-	baseLocs := []bufprotosource.Location{location}
-	if locDescriptor, ok := descriptor.(bufprotosource.LocationDescriptor); ok {
-		if descLocation := locDescriptor.Location(); descLocation != location {
+	ignoreLocations := []bufprotosource.Location{location}
+	if locationDescriptor, ok := descriptor.(bufprotosource.LocationDescriptor); ok {
+		if descriptorLocation := locationDescriptor.Location(); descriptorLocation != location {
 			// Include the location of the descriptor itself as a source of ignores.
-			baseLocs = append(baseLocs, descLocation)
+			ignoreLocations = append(ignoreLocations, descriptorLocation)
 		}
 	}
 	if h.ignoreFunc != nil && h.ignoreFunc(
 		h.id,
 		append([]bufprotosource.Descriptor{descriptor}, extraIgnoreDescriptors...),
-		append(baseLocs, extraIgnoreLocations...),
+		append(ignoreLocations, extraIgnoreLocations...),
 	) {
 		return
 	}


### PR DESCRIPTION
This is a proposal for an alternative to #3050. There are actually numerous places in the buf lint and breaking change rules where a location is provided for some element within a descriptor -- like a name, number, option, etc. But the descriptor's `source_code_info` only retains comments for complete declarations. So those other rules are subject to the same potential issue, and the fix is to include the descriptor's location as an ignore location in each of them.

Instead of updating every such rule, this change instead opts to address it more systematically, by _always_ using the descriptor's location as an ignore location (no need to explicitly pass it from every rule). So this undoes the two changes in the protovalidate checks as they are superseded by the change to the check helper that handles the addition of annotations.
