### PR TITLE
Complete move of StripSourceRetentionOptions to protoplugin

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/protocompile/options"
+	"github.com/bufbuild/protoplugin/protopluginutil"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -985,7 +985,7 @@ func newImageFilterOptions() *imageFilterOptions {
 }
 
 func stripSourceRetentionOptionsFromFile(imageFile bufimage.ImageFile) (bufimage.ImageFile, error) {
-	updatedFileDescriptor, err := options.StripSourceRetentionOptionsFromFile(imageFile.FileDescriptorProto())
+	updatedFileDescriptor, err := protopluginutil.StripSourceRetentionOptions(imageFile.FileDescriptorProto())
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/uuidutil"
-	"github.com/bufbuild/protocompile/options"
+	"github.com/bufbuild/protoplugin/protopluginutil"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -444,7 +444,7 @@ func imageToCodeGeneratorRequest(
 			request.SourceFileDescriptors = append(request.SourceFileDescriptors, fileDescriptorProto)
 			// And the corresponding descriptor in ProtoFile will have source-retention options stripped.
 			var err error
-			fileDescriptorProto, err = options.StripSourceRetentionOptionsFromFile(fileDescriptorProto)
+			fileDescriptorProto, err = protopluginutil.StripSourceRetentionOptions(fileDescriptorProto)
 			if err != nil {
 				return nil, fmt.Errorf("failed to strip source-retention options for file %q when constructing a CodeGeneratorRequest: %w", imageFile.Path(), err)
 			}


### PR DESCRIPTION
We had said months ago that we wanted to do this so that protoplugin could utilize this for a testing framework. I did the port, but never updated buf. This completes it, and I think after this we can delete `options.StripSourceRetentionOptionsFromFile` from `protocompile`.