### PR TITLE
Fix append calls that should have copied the slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@
 - Update `buf format -w` so that it does not touch files whose contents don't actually
   change. This eliminates noisy notifications to file-system-watcher tools that are
   watching the directory that contains proto sources.
-- Fixes issue where `buf breaking` or `buf lint` might fail when a `.proto` file contains
-  a message or field definition nested deeply in other message definitions.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update `buf format -w` so that it does not touch files whose contents don't actually
   change. This eliminates noisy notifications to file-system-watcher tools that are
   watching the directory that contains proto sources.
+- Fixes issue where `buf lint` fails when the message is deeply nested.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 - Update `buf format -w` so that it does not touch files whose contents don't actually
   change. This eliminates noisy notifications to file-system-watcher tools that are
   watching the directory that contains proto sources.
-- Fixes issue where `buf lint` fails when the message is deeply nested.
+- Fixes issue where `buf breaking` or `buf lint` might fail when a `.proto` file contains
+  a message or field definition nested deeply in other message definitions.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -658,7 +658,7 @@ func (t *targetedModuleReadBucket) WalkFileInfos(
 			return fn(fileInfo)
 		},
 		append(
-			options,
+			slicesext.Copy(options),
 			WalkFileInfosWithOnlyTargetFiles(),
 		)...,
 	)

--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -657,9 +657,9 @@ func (t *targetedModuleReadBucket) WalkFileInfos(
 		func(fileInfo FileInfo) error {
 			return fn(fileInfo)
 		},
-		append(
-			slicesext.Copy(options),
-			WalkFileInfosWithOnlyTargetFiles(),
+		slicesext.Concat(
+			options,
+			[]WalkFileInfosOption{WalkFileInfosWithOnlyTargetFiles()},
 		)...,
 	)
 }

--- a/private/bufpkg/bufprotosource/bufprotosource_test.go
+++ b/private/bufpkg/bufprotosource/bufprotosource_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufprotosource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufimage"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule/bufmoduletesting"
+	"github.com/bufbuild/buf/private/pkg/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFiles(t *testing.T) {
+	t.Parallel()
+	moduleSet, err := bufmoduletesting.NewModuleSetForDirPath("testdata/nested")
+	require.NoError(t, err)
+	image, err := bufimage.BuildImage(
+		context.Background(),
+		tracing.NopTracer,
+		bufmodule.ModuleSetToModuleReadBucketWithOnlyProtoFiles(moduleSet),
+	)
+	require.NoError(t, err)
+	files, err := NewFiles(context.Background(), image)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	file := files[0]
+	for _, message := range file.Messages() {
+		testMessageName(
+			t,
+			map[string]string{
+				"A":         "A",
+				"B":         "A.B",
+				"C":         "A.B.C",
+				"D":         "A.B.C.D",
+				"E":         "A.B.C.D.E",
+				"F":         "A.B.C.D.E.F",
+				"Message10": "A.B.C.D.E.F.Message10",
+				"Message11": "A.B.C.D.E.F.Message10.Message11",
+				"Message20": "A.B.C.D.E.F.Message20",
+				"Message21": "A.B.C.D.E.F.Message20.Message21",
+			},
+			message,
+		)
+	}
+}
+
+func testMessageName(t *testing.T, nameToExpectedNestedName map[string]string, message Message) {
+	expectedName, ok := nameToExpectedNestedName[message.Name()]
+	require.True(t, ok)
+	require.Equal(t, expectedName, message.NestedName())
+	for _, nestedMessage := range message.Messages() {
+		testMessageName(t, nameToExpectedNestedName, nestedMessage)
+	}
+}

--- a/private/bufpkg/bufprotosource/bufprotosource_test.go
+++ b/private/bufpkg/bufprotosource/bufprotosource_test.go
@@ -65,5 +65,7 @@ func testMessageName(t *testing.T, nameToExpectedNestedName map[string]string, m
 	require.Equal(t, expectedName, message.NestedName())
 	for _, nestedMessage := range message.Messages() {
 		testMessageName(t, nameToExpectedNestedName, nestedMessage)
+		_, err := message.AsDescriptor()
+		require.NoError(t, err)
 	}
 }

--- a/private/bufpkg/bufprotosource/file.go
+++ b/private/bufpkg/bufprotosource/file.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
+	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -400,7 +401,7 @@ func (f *file) populateEnum(
 			),
 			enumValueDescriptorProto.GetName(),
 			getEnumValueNamePath(enumIndex, enumValueIndex, nestedMessageIndexes...),
-			append(nestedMessageNames, enum.Name()),
+			append(slicesext.Copy(nestedMessageNames), enum.Name()),
 		)
 		if err != nil {
 			return nil, err
@@ -499,7 +500,7 @@ func (f *file) populateMessage(
 			),
 			oneofDescriptorProto.GetName(),
 			getMessageOneofNamePath(oneofIndex, topLevelMessageIndex, nestedMessageIndexes...),
-			append(nestedMessageNames, message.Name()),
+			append(slicesext.Copy(nestedMessageNames), message.Name()),
 		)
 		if err != nil {
 			return nil, err
@@ -526,7 +527,7 @@ func (f *file) populateMessage(
 			),
 			fieldDescriptorProto.GetName(),
 			getMessageFieldNamePath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
-			append(nestedMessageNames, message.Name()),
+			append(slicesext.Copy(nestedMessageNames), message.Name()),
 		)
 		if err != nil {
 			return nil, err
@@ -592,7 +593,7 @@ func (f *file) populateMessage(
 			),
 			fieldDescriptorProto.GetName(),
 			getMessageExtensionNamePath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
-			append(nestedMessageNames, message.Name()),
+			append(slicesext.Copy(nestedMessageNames), message.Name()),
 		)
 		if err != nil {
 			return nil, err
@@ -703,7 +704,7 @@ func (f *file) populateMessage(
 			// this is all of the message indexes including this one
 			// TODO we should refactor get.*Path messages to be more consistent
 			append([]int{topLevelMessageIndex}, nestedMessageIndexes...),
-			append(nestedMessageNames, message.Name()),
+			append(slicesext.Copy(nestedMessageNames), message.Name()),
 			message,
 		)
 		if err != nil {
@@ -715,8 +716,8 @@ func (f *file) populateMessage(
 		nestedMessage, err := f.populateMessage(
 			nestedMessageDescriptorProto,
 			topLevelMessageIndex,
-			append(nestedMessageIndexes, nestedMessageIndex),
-			append(nestedMessageNames, message.Name()),
+			append(slicesext.Copy(nestedMessageIndexes), nestedMessageIndex),
+			append(slicesext.Copy(nestedMessageNames), message.Name()),
 			message,
 		)
 		if err != nil {

--- a/private/bufpkg/bufprotosource/file.go
+++ b/private/bufpkg/bufprotosource/file.go
@@ -401,7 +401,7 @@ func (f *file) populateEnum(
 			),
 			enumValueDescriptorProto.GetName(),
 			getEnumValueNamePath(enumIndex, enumValueIndex, nestedMessageIndexes...),
-			append(slicesext.Copy(nestedMessageNames), enum.Name()),
+			slicesext.Concat(nestedMessageNames, []string{enum.Name()}),
 		)
 		if err != nil {
 			return nil, err
@@ -500,7 +500,7 @@ func (f *file) populateMessage(
 			),
 			oneofDescriptorProto.GetName(),
 			getMessageOneofNamePath(oneofIndex, topLevelMessageIndex, nestedMessageIndexes...),
-			append(slicesext.Copy(nestedMessageNames), message.Name()),
+			slicesext.Concat(nestedMessageNames, []string{message.Name()}),
 		)
 		if err != nil {
 			return nil, err
@@ -527,7 +527,7 @@ func (f *file) populateMessage(
 			),
 			fieldDescriptorProto.GetName(),
 			getMessageFieldNamePath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
-			append(slicesext.Copy(nestedMessageNames), message.Name()),
+			slicesext.Concat(nestedMessageNames, []string{message.Name()}),
 		)
 		if err != nil {
 			return nil, err
@@ -593,7 +593,7 @@ func (f *file) populateMessage(
 			),
 			fieldDescriptorProto.GetName(),
 			getMessageExtensionNamePath(fieldIndex, topLevelMessageIndex, nestedMessageIndexes...),
-			append(slicesext.Copy(nestedMessageNames), message.Name()),
+			slicesext.Concat(nestedMessageNames, []string{message.Name()}),
 		)
 		if err != nil {
 			return nil, err
@@ -704,7 +704,7 @@ func (f *file) populateMessage(
 			// this is all of the message indexes including this one
 			// TODO we should refactor get.*Path messages to be more consistent
 			append([]int{topLevelMessageIndex}, nestedMessageIndexes...),
-			append(slicesext.Copy(nestedMessageNames), message.Name()),
+			slicesext.Concat(nestedMessageNames, []string{message.Name()}),
 			message,
 		)
 		if err != nil {
@@ -716,8 +716,8 @@ func (f *file) populateMessage(
 		nestedMessage, err := f.populateMessage(
 			nestedMessageDescriptorProto,
 			topLevelMessageIndex,
-			append(slicesext.Copy(nestedMessageIndexes), nestedMessageIndex),
-			append(slicesext.Copy(nestedMessageNames), message.Name()),
+			slicesext.Concat(nestedMessageIndexes, []int{nestedMessageIndex}),
+			slicesext.Concat(nestedMessageNames, []string{message.Name()}),
 			message,
 		)
 		if err != nil {

--- a/private/bufpkg/bufprotosource/testdata/nested/foo.proto
+++ b/private/bufpkg/bufprotosource/testdata/nested/foo.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+message A {
+  message B {
+    message C {
+      message D {
+        message E {
+          message F {
+            message Message10 {
+              message Message11 {}
+            }
+            message Message20 {
+              message Message21 {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/private/pkg/slicesext/slicesext.go
+++ b/private/pkg/slicesext/slicesext.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copied from https://github.com/golang/go/blob/b788e91badd523e5bb0fc8d50cd76b8ae04ffb20/LICENSE:
+// Some implementations are copied from "slices", and hence
+// https://github.com/golang/go/blob/b788e91badd523e5bb0fc8d50cd76b8ae04ffb20/LICENSE:
 // Copyright (c) 2009 The Go Authors. All rights reserved.
 
 // Redistribution and use in source and binary forms, with or without

--- a/private/pkg/slicesext/slicesext.go
+++ b/private/pkg/slicesext/slicesext.go
@@ -12,6 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copied from https://github.com/golang/go/blob/b788e91badd523e5bb0fc8d50cd76b8ae04ffb20/LICENSE:
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 // Package slicesext provides extra functionality on top of the slices package.
 package slicesext
 

--- a/private/pkg/slicesext/slicesext.go
+++ b/private/pkg/slicesext/slicesext.go
@@ -150,6 +150,40 @@ func Copy[T any](s []T) []T {
 	return sc
 }
 
+// Grow increases the slice's capacity, if necessary, to guarantee space for
+// another n elements. After Grow(n), at least n elements can be appended
+// to the slice without another allocation. If n is negative or too large to
+// allocate the memory, Grow panics.
+//
+// TODO FUTURE: Delete this in favor of slices.Grow.
+func Grow[S ~[]E, E any](s S, n int) S {
+	if n < 0 {
+		panic("cannot be negative")
+	}
+	if n -= cap(s) - len(s); n > 0 {
+		s = append(s[:cap(s)], make([]E, n)...)[:len(s)]
+	}
+	return s
+}
+
+// Concat returns a new slice concatenating the passed in slices.
+//
+// TODO FUTURE: Delete this in favor of slices.Concat.
+func Concat[S ~[]E, E any](slices ...S) S {
+	size := 0
+	for _, s := range slices {
+		size += len(s)
+		if size < 0 {
+			panic("len out of range")
+		}
+	}
+	newslice := Grow[S](nil, size)
+	for _, s := range slices {
+		newslice = append(newslice, s...)
+	}
+	return newslice
+}
+
 // Equal reports whether two slices are equal: the same length and all
 // elements equal. If the lengths are different, Equal returns false.
 // Otherwise, the elements are compared in increasing index order, and the


### PR DESCRIPTION
There are usages of `append` where the result is not assigned back to the variable. After going through them, most of do not break. In fact, it only breaks things when one slice is stored as a variable or a struct's field, and a prefix of this slice is appended to.

This PR fixes problematic appends in `populateMessage`, which breaks in certain cases (see the test case added).

It also fixes the append in `WalkFileInfos`.