### PR TITLE
Only validate min/max editions in code gen response when input uses editions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 - Update `buf format -w` so that it does not touch files whose contents don't actually
   change. This eliminates noisy notifications to file-system-watcher tools that are
   watching the directory that contains proto sources.
+- Update `buf generate` to work with plugins provided by protoc for versions v24.0
+  to v25.3. Editions support was experimental in these releases, and the plugins
+  advertise incomplete support for editions, which triggers `buf` to report an error.
+  With this fix, these plugins can be used again as long as none of the input files use
+  editions syntax.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/private/buf/bufgen/features.go
+++ b/private/buf/bufgen/features.go
@@ -111,9 +111,32 @@ func checkRequiredFeatures(
 				failedFeatures = append(failedFeatures, feature)
 			}
 		}
+		pluginName := configs[responseIndex].Name()
 		if supported&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 && len(required.editionToFilenames) > 0 {
-			// Plugin supports editions, and files include editions. So make sure
-			// the plugin supports precisely the right editions.
+			// Plugin supports editions, and files include editions.
+			// First, let's make sure that the plugin set the min/max edition fields correctly.
+			if response.MinimumEdition == nil {
+				return fmt.Errorf(
+					"plugin %q advertises that it supports editions but did not indicate a minimum supported edition",
+					pluginName,
+				)
+			}
+			if response.MaximumEdition == nil {
+				return fmt.Errorf(
+					"plugin %q advertises that it supports editions but did not indicate a maximum supported edition",
+					pluginName,
+				)
+			}
+			if response.GetMaximumEdition() < response.GetMinimumEdition() {
+				return fmt.Errorf(
+					"plugin %q indicates a maximum supported edition (%d) that is less than its minimum supported edition (%d)",
+					pluginName,
+					descriptorpb.Edition(response.GetMaximumEdition()),
+					descriptorpb.Edition(response.GetMinimumEdition()),
+				)
+			}
+
+			// And also make sure the plugin supports precisely the right editions.
 			requiredEditions := make([]descriptorpb.Edition, 0, len(required.editionToFilenames))
 			for edition := range required.editionToFilenames {
 				requiredEditions = append(requiredEditions, edition)
@@ -130,7 +153,6 @@ func checkRequiredFeatures(
 			}
 		}
 
-		pluginName := configs[responseIndex].Name()
 		if len(failedFeatures) > 0 {
 			sort.Slice(failedFeatures, func(i, j int) bool {
 				return failedFeatures[i] < failedFeatures[j]

--- a/private/buf/bufgen/features.go
+++ b/private/buf/bufgen/features.go
@@ -129,7 +129,7 @@ func checkRequiredFeatures(
 			}
 			if response.GetMaximumEdition() < response.GetMinimumEdition() {
 				return fmt.Errorf(
-					"plugin %q indicates a maximum supported edition (%d) that is less than its minimum supported edition (%d)",
+					"plugin %q indicates a maximum supported edition (%v) that is less than its minimum supported edition (%v)",
 					pluginName,
 					descriptorpb.Edition(response.GetMaximumEdition()),
 					descriptorpb.Edition(response.GetMinimumEdition()),

--- a/private/bufpkg/bufprotoplugin/bufprotoplugin.go
+++ b/private/bufpkg/bufprotoplugin/bufprotoplugin.go
@@ -28,7 +28,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/protoplugin"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -146,29 +145,10 @@ func ValidatePluginResponses(pluginResponses []*PluginResponse) error {
 			}
 			seen[fileName] = pluginResponse.PluginName
 		}
-		if pluginResponse.Response.GetSupportedFeatures()&uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS) != 0 {
-			// If plugin says it supports editions, it must set min and max edition.
-			if pluginResponse.Response.MinimumEdition == nil {
-				return fmt.Errorf(
-					"plugin %q advertises that it supports editions but did not indicate a minimum supported edition",
-					pluginResponse.PluginName,
-				)
-			}
-			if pluginResponse.Response.MaximumEdition == nil {
-				return fmt.Errorf(
-					"plugin %q advertises that it supports editions but did not indicate a maximum supported edition",
-					pluginResponse.PluginName,
-				)
-			}
-			if pluginResponse.Response.GetMaximumEdition() < pluginResponse.Response.GetMinimumEdition() {
-				return fmt.Errorf(
-					"plugin %q indicates a maximum supported edition (%d) that is less than its minimum supported edition (%d)",
-					pluginResponse.PluginName,
-					descriptorpb.Edition(pluginResponse.Response.GetMaximumEdition()),
-					descriptorpb.Edition(pluginResponse.Response.GetMinimumEdition()),
-				)
-			}
-		}
+		// Note: we used to verify that the plugin set min/max edition correctly if it set the
+		// SUPPORTS_EDITIONS feature. But some plugins in the protoc codebase, from when editions
+		// were still experimental, advertise SUPPORTS_EDITIONS but did not set those fields. So
+		// we defer the check and only complain if/when the input actually contains Editions files.
 	}
 	return nil
 }


### PR DESCRIPTION
This works around an issue with some pre-v27.0 releases of protoc and the code generators there in (such as Java, C++, Python, etc).

Some of the languages advertised support for features, but in an experimental way, that did _not_ include the minimum and maximum edition fields being set. With v1.32.0+ of buf, code gen always fails because the min/max editions are missing. This changes the validation so that it only occurs when an actual input file uses editions. So if editions aren't used at all, the plugin's output will be used without any error messages.
