### PR TITLE
Add exclude unnamed flag for push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update `buf format -w` so that it does not touch files whose contents don't actually
   change. This eliminates noisy notifications to file-system-watcher tools that are
   watching the directory that contains proto sources.
+- Add `buf push --ignore-unnamed` flag to ignore unnamed modules when pushing to the BSR.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   advertise incomplete support for editions, which triggers `buf` to report an error.
   With this fix, these plugins can be used again as long as none of the input files use
   editions syntax.
-- Add `buf push --ignore-unnamed` flag to ignore unnamed modules when pushing to the BSR.
+- Add `buf push --skip-unnamed` flag to skip unnamed modules when pushing to the BSR.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   advertise incomplete support for editions, which triggers `buf` to report an error.
   With this fix, these plugins can be used again as long as none of the input files use
   editions syntax.
-- Add `buf push --skip-unnamed` flag to skip unnamed modules when pushing to the BSR.
+- Add `buf push --exclude-unnamed` flag to exclude unnamed modules when pushing to the BSR.
 
 ## [v1.32.2] - 2024-05-28
 

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -47,7 +47,7 @@ const (
 	createDefaultLabelFlagName = "create-default-label"
 	sourceControlURLFlagName   = "source-control-url"
 	gitMetadataFlagName        = "git-metadata"
-	skipUnnamedFlagName        = "skip-unnamed"
+	excludeUnnamedFlagName     = "exclude-unnamed"
 
 	// All deprecated.
 	tagFlagName      = "tag"
@@ -93,7 +93,7 @@ type flags struct {
 	CreateVisibility   string
 	CreateDefaultLabel string
 	SourceControlURL   string
-	SkipUnnamed        bool
+	ExcludeUnnamed     bool
 	GitMetadata        bool
 	// special
 	InputHashtag string
@@ -168,8 +168,8 @@ If you set the --%s flag and/or --%s flag yourself, then the value(s) will be us
 		),
 	)
 	flagSet.BoolVar(
-		&f.SkipUnnamed,
-		skipUnnamedFlagName,
+		&f.ExcludeUnnamed,
+		excludeUnnamedFlagName,
 		false,
 		"Only push named modules to the BSR. Named modules must not have any unnamed dependencies.",
 	)
@@ -236,8 +236,8 @@ func run(
 	if flags.SourceControlURL != "" {
 		uploadOptions = append(uploadOptions, bufmodule.UploadWithSourceControlURL(flags.SourceControlURL))
 	}
-	if flags.SkipUnnamed {
-		uploadOptions = append(uploadOptions, bufmodule.UploadWithSkipUnnamed())
+	if flags.ExcludeUnnamed {
+		uploadOptions = append(uploadOptions, bufmodule.UploadWithExcludeUnnamed())
 	}
 
 	commits, err := uploader.Upload(ctx, workspace, uploadOptions...)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -47,7 +47,7 @@ const (
 	createDefaultLabelFlagName = "create-default-label"
 	sourceControlURLFlagName   = "source-control-url"
 	gitMetadataFlagName        = "git-metadata"
-	ignoreUnnamedFlagName      = "ignore-unnamed"
+	skipUnnamedFlagName        = "skip-unnamed"
 
 	// All deprecated.
 	tagFlagName      = "tag"
@@ -93,7 +93,7 @@ type flags struct {
 	CreateVisibility   string
 	CreateDefaultLabel string
 	SourceControlURL   string
-	IgnoredUnnamed     bool
+	SkipUnnamed        bool
 	GitMetadata        bool
 	// special
 	InputHashtag string
@@ -168,10 +168,10 @@ If you set the --%s flag and/or --%s flag yourself, then the value(s) will be us
 		),
 	)
 	flagSet.BoolVar(
-		&f.IgnoredUnnamed,
-		ignoreUnnamedFlagName,
+		&f.SkipUnnamed,
+		skipUnnamedFlagName,
 		false,
-		"Ignore unnamed modules. Named modules must not have any unnamed dependencies.",
+		"Skip unnamed modules will only push named modules. Named modules must not have any unnamed dependencies.",
 	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)
@@ -236,8 +236,8 @@ func run(
 	if flags.SourceControlURL != "" {
 		uploadOptions = append(uploadOptions, bufmodule.UploadWithSourceControlURL(flags.SourceControlURL))
 	}
-	if flags.IgnoredUnnamed {
-		uploadOptions = append(uploadOptions, bufmodule.UploadWithIgnoreUnnamed())
+	if flags.SkipUnnamed {
+		uploadOptions = append(uploadOptions, bufmodule.UploadWithSkipUnnamed())
 	}
 
 	commits, err := uploader.Upload(ctx, workspace, uploadOptions...)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -47,6 +47,7 @@ const (
 	createDefaultLabelFlagName = "create-default-label"
 	sourceControlURLFlagName   = "source-control-url"
 	gitMetadataFlagName        = "git-metadata"
+	ignoreUnnamedFlagName      = "ignore-unnamed"
 
 	// All deprecated.
 	tagFlagName      = "tag"
@@ -92,6 +93,7 @@ type flags struct {
 	CreateVisibility   string
 	CreateDefaultLabel string
 	SourceControlURL   string
+	IgnoredUnnamed     bool
 	GitMetadata        bool
 	// special
 	InputHashtag string
@@ -165,6 +167,12 @@ If you set the --%s flag and/or --%s flag yourself, then the value(s) will be us
 			createDefaultLabelFlagName,
 		),
 	)
+	flagSet.BoolVar(
+		&f.IgnoredUnnamed,
+		ignoreUnnamedFlagName,
+		false,
+		"Ignore unnamed modules. Unnamed modules must not be depended on by any named modules.",
+	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)
 	_ = flagSet.MarkHidden(tagFlagName)
@@ -227,6 +235,9 @@ func run(
 	}
 	if flags.SourceControlURL != "" {
 		uploadOptions = append(uploadOptions, bufmodule.UploadWithSourceControlURL(flags.SourceControlURL))
+	}
+	if flags.IgnoredUnnamed {
+		uploadOptions = append(uploadOptions, bufmodule.UploadWithIgnoreUnnamed())
 	}
 
 	commits, err := uploader.Upload(ctx, workspace, uploadOptions...)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -171,7 +171,7 @@ If you set the --%s flag and/or --%s flag yourself, then the value(s) will be us
 		&f.SkipUnnamed,
 		skipUnnamedFlagName,
 		false,
-		"Skip unnamed modules will only push named modules. Named modules must not have any unnamed dependencies.",
+		"Only push named modules to the BSR. Named modules must not have any unnamed dependencies.",
 	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -171,7 +171,7 @@ If you set the --%s flag and/or --%s flag yourself, then the value(s) will be us
 		&f.IgnoredUnnamed,
 		ignoreUnnamedFlagName,
 		false,
-		"Ignore unnamed modules. Unnamed modules must not be depended on by any named modules.",
+		"Ignore unnamed modules. Named modules must not have any unnamed dependencies.",
 	)
 
 	flagSet.StringSliceVarP(&f.Tags, tagFlagName, tagFlagShortName, nil, useLabelInstead)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -244,7 +244,9 @@ func run(
 	if err != nil {
 		return err
 	}
-
+	if len(commits) == 0 {
+		return nil
+	}
 	if workspace.IsV2() {
 		_, err := container.Stdout().Write(
 			[]byte(
@@ -262,15 +264,13 @@ func run(
 		return err
 	}
 	// v1 workspace, fallback to old behavior for backwards compatibility.
-	switch len(commits) {
-	case 0:
-		return nil
-	case 1:
-		_, err := container.Stdout().Write([]byte(uuidutil.ToDashless(commits[0].ModuleKey().CommitID()) + "\n"))
-		return err
-	default:
+	if len(commits) > 1 {
 		return syserror.Newf("Received multiple commits back for a v1 module. We should only ever have created a single commit for a v1 module.")
 	}
+	_, err = container.Stdout().Write(
+		[]byte(uuidutil.ToDashless(commits[0].ModuleKey().CommitID()) + "\n"),
+	)
+	return err
 }
 
 func getBuildableWorkspace(

--- a/private/bufpkg/bufmodule/bufmoduleapi/registry.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/registry.go
@@ -118,11 +118,14 @@ func getRegistries[T hasModuleFullName](s []T) ([]string, error) {
 //
 // Returns error if there is more than one module.
 func getSingleRegistryForContentModules(contentModules []bufmodule.Module) (string, error) {
+	if len(contentModules) == 0 {
+		return "", syserror.New("requires at least one module to resolve registry")
+	}
 	var registry string
 	for _, module := range contentModules {
 		moduleFullName := module.ModuleFullName()
 		if moduleFullName == nil {
-			return "", newRequireModuleFullNameOnUploadError(module)
+			return "", syserror.Newf("expected module name for %q", module.OpaqueID())
 		}
 		moduleRegistry := moduleFullName.Registry()
 		if registry != "" && moduleRegistry != registry {

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -113,8 +113,8 @@ func (a *uploader) Upload(
 	contentModules, err = slicesext.FilterError(contentModules, func(module bufmodule.Module) (bool, error) {
 		moduleName := module.ModuleFullName()
 		if moduleName == nil {
-			if uploadOptions.IgnoreUnnamed() {
-				a.logger.Warn("Ignoring unnamed module", zap.String("module", module.OpaqueID()))
+			if uploadOptions.SkipUnnamed() {
+				a.logger.Warn("Skipping unnamed module", zap.String("module", module.OpaqueID()))
 				return false, nil
 			}
 			return false, fmt.Errorf("A name must be specified in buf.yaml to push module %q.", module.OpaqueID())

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -109,7 +109,7 @@ func (a *uploader) Upload(
 		return nil, err
 	}
 	// Only push named modules to the registry. Any dependencies for named modules must have a name.
-	// Local unnamed modules can be ignored if the IgnoreUnnamed option is set.
+	// Local unnamed modules can be skippedl if the UploadWithSkipUnnamed option is set.
 	contentModules, err = slicesext.FilterError(contentModules, func(module bufmodule.Module) (bool, error) {
 		moduleName := module.ModuleFullName()
 		if moduleName == nil {

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -109,7 +109,7 @@ func (a *uploader) Upload(
 		return nil, err
 	}
 	// Only push named modules to the registry. Any dependencies for named modules must have a name.
-	// Local unnamed modules are ignored.
+	// Local unnamed modules can be ignored if the IgnoreUnnamed option is set.
 	contentModules, err = slicesext.FilterError(contentModules, func(module bufmodule.Module) (bool, error) {
 		moduleName := module.ModuleFullName()
 		if moduleName == nil {

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -109,7 +109,7 @@ func (a *uploader) Upload(
 		return nil, err
 	}
 	// Only push named modules to the registry. Any dependencies for named modules must have a name.
-	// Local unnamed modules can be skippedl if the UploadWithSkipUnnamed option is set.
+	// Local unnamed modules can be skipped if the UploadWithSkipUnnamed option is set.
 	contentModules, err = slicesext.FilterError(contentModules, func(module bufmodule.Module) (bool, error) {
 		moduleName := module.ModuleFullName()
 		if moduleName == nil {

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -108,12 +108,12 @@ func (a *uploader) Upload(
 		return nil, err
 	}
 	// Only push named modules to the registry. Any dependencies for named modules must have a name.
-	// Local unnamed modules can be skipped if the UploadWithSkipUnnamed option is set.
+	// Local unnamed modules can be excluded if the UploadWithExcludeUnnamed option is set.
 	contentModules, err = slicesext.FilterError(contentModules, func(module bufmodule.Module) (bool, error) {
 		moduleName := module.ModuleFullName()
 		if moduleName == nil {
-			if uploadOptions.SkipUnnamed() {
-				a.logger.Warn("Skipping unnamed module", zap.String("module", module.OpaqueID()))
+			if uploadOptions.ExcludeUnnamed() {
+				a.logger.Warn("Excluding unnamed module", zap.String("module", module.OpaqueID()))
 				return false, nil
 			}
 			return false, fmt.Errorf("A name must be specified in buf.yaml to push module %q.", module.OpaqueID())

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -113,7 +113,11 @@ func (a *uploader) Upload(
 	contentModules, err = slicesext.FilterError(contentModules, func(module bufmodule.Module) (bool, error) {
 		moduleName := module.ModuleFullName()
 		if moduleName == nil {
-			return false, nil
+			if uploadOptions.IgnoreUnnamed() {
+				a.logger.Warn("Ignoring unnamed module", zap.String("module", module.OpaqueID()))
+				return false, nil
+			}
+			return false, fmt.Errorf("A name must be specified in buf.yaml to push module %q.", module.OpaqueID())
 		}
 		deps, err := module.ModuleDeps()
 		if err != nil {

--- a/private/bufpkg/bufmodule/uploader.go
+++ b/private/bufpkg/bufmodule/uploader.go
@@ -78,10 +78,10 @@ func UploadWithSourceControlURL(sourceControlURL string) UploadOption {
 	}
 }
 
-// UploadWithIgnoreUnnamed returns a new UploadOption that will ignore unnamed modules.
-func UploadWithIgnoreUnnamed() UploadOption {
+// UploadWithSkipUnnamed returns a new UploadOption that will skip unnamed modules.
+func UploadWithSkipUnnamed() UploadOption {
 	return func(uploadOptions *uploadOptions) {
-		uploadOptions.ignoreUnnamed = true
+		uploadOptions.skipUnnamed = true
 	}
 }
 
@@ -116,8 +116,8 @@ type UploadOptions interface {
 	// SourceControlURL returns the source control URL set by the user for the module
 	// contents uploaded. We set the same source control URL for all module contents.
 	SourceControlURL() string
-	// IgnoreUnnamed returns whether to ignore unnamed modules.
-	IgnoreUnnamed() bool
+	// SkipUnnamed returns whether to skip unnamed modules.
+	SkipUnnamed() bool
 
 	isUploadOptions()
 }
@@ -149,7 +149,7 @@ type uploadOptions struct {
 	createModuleVisibility ModuleVisibility
 	createDefaultLabel     string
 	sourceControlURL       string
-	ignoreUnnamed          bool
+	skipUnnamed            bool
 }
 
 func newUploadOptions() *uploadOptions {
@@ -180,8 +180,8 @@ func (u *uploadOptions) SourceControlURL() string {
 	return u.sourceControlURL
 }
 
-func (u *uploadOptions) IgnoreUnnamed() bool {
-	return u.ignoreUnnamed
+func (u *uploadOptions) SkipUnnamed() bool {
+	return u.skipUnnamed
 }
 
 func (u *uploadOptions) validate() error {

--- a/private/bufpkg/bufmodule/uploader.go
+++ b/private/bufpkg/bufmodule/uploader.go
@@ -78,10 +78,10 @@ func UploadWithSourceControlURL(sourceControlURL string) UploadOption {
 	}
 }
 
-// UploadWithSkipUnnamed returns a new UploadOption that will skip unnamed modules.
-func UploadWithSkipUnnamed() UploadOption {
+// UploadWithExcludeUnnamed returns a new UploadOption that will exclude unnamed modules.
+func UploadWithExcludeUnnamed() UploadOption {
 	return func(uploadOptions *uploadOptions) {
-		uploadOptions.skipUnnamed = true
+		uploadOptions.excludeUnnamed = true
 	}
 }
 
@@ -116,8 +116,8 @@ type UploadOptions interface {
 	// SourceControlURL returns the source control URL set by the user for the module
 	// contents uploaded. We set the same source control URL for all module contents.
 	SourceControlURL() string
-	// SkipUnnamed returns whether to skip unnamed modules.
-	SkipUnnamed() bool
+	// ExcludeUnnamed returns whether to exclude unnamed modules.
+	ExcludeUnnamed() bool
 
 	isUploadOptions()
 }
@@ -149,7 +149,7 @@ type uploadOptions struct {
 	createModuleVisibility ModuleVisibility
 	createDefaultLabel     string
 	sourceControlURL       string
-	skipUnnamed            bool
+	excludeUnnamed         bool
 }
 
 func newUploadOptions() *uploadOptions {
@@ -180,8 +180,8 @@ func (u *uploadOptions) SourceControlURL() string {
 	return u.sourceControlURL
 }
 
-func (u *uploadOptions) SkipUnnamed() bool {
-	return u.skipUnnamed
+func (u *uploadOptions) ExcludeUnnamed() bool {
+	return u.excludeUnnamed
 }
 
 func (u *uploadOptions) validate() error {

--- a/private/bufpkg/bufmodule/uploader.go
+++ b/private/bufpkg/bufmodule/uploader.go
@@ -78,6 +78,13 @@ func UploadWithSourceControlURL(sourceControlURL string) UploadOption {
 	}
 }
 
+// UploadWithIgnoreUnnamed returns a new UploadOption that will ignore unnamed modules.
+func UploadWithIgnoreUnnamed() UploadOption {
+	return func(uploadOptions *uploadOptions) {
+		uploadOptions.ignoreUnnamed = true
+	}
+}
+
 // UploadOptions are the possible options for upload.
 //
 // This is used by Uploader implementations.
@@ -109,6 +116,8 @@ type UploadOptions interface {
 	// SourceControlURL returns the source control URL set by the user for the module
 	// contents uploaded. We set the same source control URL for all module contents.
 	SourceControlURL() string
+	// IgnoreUnnamed returns whether to ignore unnamed modules.
+	IgnoreUnnamed() bool
 
 	isUploadOptions()
 }
@@ -140,6 +149,7 @@ type uploadOptions struct {
 	createModuleVisibility ModuleVisibility
 	createDefaultLabel     string
 	sourceControlURL       string
+	ignoreUnnamed          bool
 }
 
 func newUploadOptions() *uploadOptions {
@@ -168,6 +178,10 @@ func (u *uploadOptions) CreateDefaultLabel() string {
 
 func (u *uploadOptions) SourceControlURL() string {
 	return u.sourceControlURL
+}
+
+func (u *uploadOptions) IgnoreUnnamed() bool {
+	return u.ignoreUnnamed
 }
 
 func (u *uploadOptions) validate() error {


### PR DESCRIPTION
This PR adds the flag `--exclude-unnamed` for `push`. On `push`, this flag will allow for unnamed modules to be present in the `buf.yaml` config. Modules are filtered by name before pushing to the remote. Local only modules, modules without a name, are excluded. All dependencies for a named module must have a valid name.

As an example the following config will work with `buf push --exclude-unnamed` as long as the module `foo` does not depend on `bar`:
```yaml
version: v2
modules:
  - path: foo
    name: buf.build/example/foo
  - path: bar
```