### PR TITLE
Fix missing insertion point error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix issue where `buf generate` would succeed on missing insertion points and 
+  panic on empty insertion point files.
 
 ## [v1.33.0] - 2024-06-13
 

--- a/private/bufpkg/bufprotoplugin/bufprotoplugin_test.go
+++ b/private/bufpkg/bufprotoplugin/bufprotoplugin_test.go
@@ -123,6 +123,36 @@ at varied indentation levels
 
 		assert.Equal(t, expectContent, postInsertionContent)
 	})
+	t.Run("invalid_empty", func(t *testing.T) {
+		t.Parallel()
+		insertionPointName := "missing"
+		insertionPointContent := ""
+		insertionPointConsumer := &pluginpb.CodeGeneratorResponse_File{
+			Name:           &targetFileName,
+			InsertionPoint: &insertionPointName,
+			Content:        &insertionPointContent,
+		}
+		_, err := writeInsertionPoint(
+			context.Background(),
+			insertionPointConsumer,
+			strings.NewReader(targetFileContent),
+		)
+		require.ErrorContains(t, err, "could not find insertion point")
+	})
+	t.Run("invalid_not_found", func(t *testing.T) {
+		insertionPointName := "not_found"
+		insertionPointConsumer := &pluginpb.CodeGeneratorResponse_File{
+			Name:           &targetFileName,
+			InsertionPoint: &insertionPointName,
+			Content:        &insertionPointContent,
+		}
+		_, err := writeInsertionPoint(
+			context.Background(),
+			insertionPointConsumer,
+			strings.NewReader(targetFileContent),
+		)
+		require.ErrorContains(t, err, "could not find insertion point")
+	})
 }
 
 func BenchmarkWriteInsertionPoint(b *testing.B) {

--- a/private/bufpkg/bufprotoplugin/bufprotoplugin_test.go
+++ b/private/bufpkg/bufprotoplugin/bufprotoplugin_test.go
@@ -140,6 +140,7 @@ at varied indentation levels
 		require.ErrorContains(t, err, "could not find insertion point")
 	})
 	t.Run("invalid_not_found", func(t *testing.T) {
+		t.Parallel()
 		insertionPointName := "not_found"
 		insertionPointConsumer := &pluginpb.CodeGeneratorResponse_File{
 			Name:           &targetFileName,


### PR DESCRIPTION
On missing an insertion point, fail with a user facing error and avoid panic'ing due to an invalid slice when the insertion point file is empty.

Fixes #1649

From the issue, `buf` will now correctly return an error like:
```
Failure: plugin prost-crate: could not find insertion point "features" in "Cargo.toml"
```