### PR TITLE
Set Editions-related fields in CodeGeneratorResponse when proxying to protoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Update `buf generate` to allow the use of Editions syntax when doing local code
+  generation by proxying to a `protoc` binary (for languages where code gen is
+  implemented inside of `protoc` instead of in a plugin: Java, C++, Python, etc).
 
 ## [v1.33.0] - 2024-06-13
 

--- a/private/buf/bufprotopluginexec/protoc_proxy_handler.go
+++ b/private/buf/bufprotopluginexec/protoc_proxy_handler.go
@@ -167,8 +167,8 @@ func (h *protocProxyHandler) Handle(
 	if getFeatureProto3OptionalSupported(protocVersion) {
 		responseWriter.SetFeatureProto3Optional()
 	}
-	if supported, min, max := getFeatureEditionsSupported(protocVersion); supported {
-		responseWriter.SetFeatureSupportsEditions(min, max)
+	if supported, maxEdition := getFeatureEditionsSupported(protocVersion); supported {
+		responseWriter.SetFeatureSupportsEditions(descriptorpb.Edition_EDITION_PROTO2, maxEdition)
 	}
 	// no need for symlinks here, and don't want to support
 	readWriteBucket, err := h.storageosProvider.NewReadWriteBucket(tmpDir.AbsPath())

--- a/private/buf/bufprotopluginexec/protoc_proxy_handler.go
+++ b/private/buf/bufprotopluginexec/protoc_proxy_handler.go
@@ -167,6 +167,9 @@ func (h *protocProxyHandler) Handle(
 	if getFeatureProto3OptionalSupported(protocVersion) {
 		responseWriter.SetFeatureProto3Optional()
 	}
+	if supported, min, max := getFeatureEditionsSupported(protocVersion); supported {
+		responseWriter.SetFeatureSupportsEditions(min, max)
+	}
 	// no need for symlinks here, and don't want to support
 	readWriteBucket, err := h.storageosProvider.NewReadWriteBucket(tmpDir.AbsPath())
 	if err != nil {

--- a/private/buf/bufprotopluginexec/version.go
+++ b/private/buf/bufprotopluginexec/version.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -118,6 +119,23 @@ func getFeatureProto3OptionalSupported(version *pluginpb.Version) bool {
 	}
 	// version.GetMajor() > 3
 	return true
+}
+
+// Should I notify that I am OK with editions (and, if so, which ones)?
+func getFeatureEditionsSupported(version *pluginpb.Version) (supported bool, min, max descriptorpb.Edition) {
+	if version.GetMajor() > 5 || (version.GetMajor() == 5 && version.GetMinor() >= 27) {
+		// TODO: Update this to include later editions as they are supported in later versions of protoc.
+		return true, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023
+	}
+	return false, 0, 0
+	// TODO: We will likely want to add a getSetExperimentalEditionsFlag() in the future.
+	//       But we don't need it now because the versions in which it was available
+	//       (v24.0 - v26.x) are not really suitable for using it since the implementation
+	//       of Editions actually underwent considerable changes between v26 and the final
+	//       product in v27. So the earlier experimental support is not desirable to enable.
+	//       Most of the changes were in Editions itself, not in Edition 2023. So future
+	//       editions may go smoother, so it may be useful to enable experimental editions
+	//       for code gen in future versions of protoc.
 }
 
 // Is kotlin supported as a builtin plugin?

--- a/private/buf/bufprotopluginexec/version.go
+++ b/private/buf/bufprotopluginexec/version.go
@@ -122,12 +122,20 @@ func getFeatureProto3OptionalSupported(version *pluginpb.Version) bool {
 }
 
 // Should I notify that I am OK with editions (and, if so, which ones)?
-func getFeatureEditionsSupported(version *pluginpb.Version) (supported bool, min, max descriptorpb.Edition) {
-	if version.GetMajor() > 5 || (version.GetMajor() == 5 && version.GetMinor() >= 27) {
-		// TODO: Update this to include later editions as they are supported in later versions of protoc.
-		return true, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023
+func getFeatureEditionsSupported(version *pluginpb.Version) (supported bool, max descriptorpb.Edition) {
+	majorVersion := version.GetMajor()
+	if version.GetSuffix() == "buf" && majorVersion == 5 {
+		// Buf reported 5.27.0 instead of 27.0 in v1.32 and v1.33.
+		majorVersion = version.GetMinor()
 	}
-	return false, 0, 0
+
+	if majorVersion < 27 {
+		return false, 0
+	}
+
+	// TODO: Update this to include later editions as they are supported in later versions of protoc.
+	return true, descriptorpb.Edition_EDITION_2023
+
 	// TODO: We will likely want to add a getSetExperimentalEditionsFlag() in the future.
 	//       But we don't need it now because the versions in which it was available
 	//       (v24.0 - v26.x) are not really suitable for using it since the implementation

--- a/private/buf/bufprotopluginexec/version_test.go
+++ b/private/buf/bufprotopluginexec/version_test.go
@@ -58,29 +58,27 @@ func TestGetFeatureProto3OptionalSupported(t *testing.T) {
 
 func TestGetFeatureEditionsSupported(t *testing.T) {
 	t.Parallel()
-	assertEditionsNotSupported(t, newVersion(2, 12, 4, ""))
-	assertEditionsNotSupported(t, newVersion(3, 11, 4, ""))
-	assertEditionsNotSupported(t, newVersion(4, 21, 1, ""))
-	assertEditionsNotSupported(t, newVersion(4, 21, 1, "buf"))
-	assertEditionsNotSupported(t, newVersion(5, 25, 0, ""))
-	assertEditionsNotSupported(t, newVersion(5, 26, 3, ""))
+	assertEditionsNotSupported(t, newVersion(3, 20, 0, ""))
+	assertEditionsNotSupported(t, newVersion(3, 20, 0, "buf"))
+	assertEditionsNotSupported(t, newVersion(21, 0, 0, ""))
+	assertEditionsNotSupported(t, newVersion(3, 21, 0, "buf"))
+	assertEditionsNotSupported(t, newVersion(26, 3, 0, ""))
 	assertEditionsNotSupported(t, newVersion(5, 26, 3, "buf"))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(5, 27, 0, ""))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
+		newVersion(27, 0, 0, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
 		newVersion(5, 27, 0, "buf"))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(5, 27, 1, ""))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(5, 27, 1, "buf"))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(5, 30, 0, ""))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(5, 30, 0, "buf"))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(8, 9, 0, ""))
-	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
-		newVersion(8, 9, 0, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
+		newVersion(27, 0, 0, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
+		newVersion(27, 1, 0, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
+		newVersion(27, 1, 0, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
+		newVersion(30, 0, 0, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023,
+		newVersion(30, 0, 0, "buf"))
 }
 
 func TestGetKotlinSupportedAsBuiltin(t *testing.T) {
@@ -155,13 +153,12 @@ func testParseVersionForCLIVersionError(
 }
 
 func assertEditionsNotSupported(t *testing.T, version *pluginpb.Version) {
-	supported, _, _ := getFeatureEditionsSupported(version)
+	supported, _ := getFeatureEditionsSupported(version)
 	assert.False(t, supported)
 }
 
-func assertEditionsSupported(t *testing.T, min, max descriptorpb.Edition, version *pluginpb.Version) {
-	supported, actualMin, actualMax := getFeatureEditionsSupported(version)
+func assertEditionsSupported(t *testing.T, max descriptorpb.Edition, version *pluginpb.Version) {
+	supported, actualMax := getFeatureEditionsSupported(version)
 	assert.True(t, supported)
-	assert.Equal(t, actualMin, min)
 	assert.Equal(t, actualMax, max)
 }

--- a/private/buf/bufprotopluginexec/version_test.go
+++ b/private/buf/bufprotopluginexec/version_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -53,6 +54,33 @@ func TestGetFeatureProto3OptionalSupported(t *testing.T) {
 	assert.True(t, getFeatureProto3OptionalSupported(newVersion(3, 14, 1, "")))
 	assert.True(t, getFeatureProto3OptionalSupported(newVersion(3, 15, 0, "")))
 	assert.True(t, getFeatureProto3OptionalSupported(newVersion(21, 0, 0, "")))
+}
+
+func TestGetFeatureEditionsSupported(t *testing.T) {
+	t.Parallel()
+	assertEditionsNotSupported(t, newVersion(2, 12, 4, ""))
+	assertEditionsNotSupported(t, newVersion(3, 11, 4, ""))
+	assertEditionsNotSupported(t, newVersion(4, 21, 1, ""))
+	assertEditionsNotSupported(t, newVersion(4, 21, 1, "buf"))
+	assertEditionsNotSupported(t, newVersion(5, 25, 0, ""))
+	assertEditionsNotSupported(t, newVersion(5, 26, 3, ""))
+	assertEditionsNotSupported(t, newVersion(5, 26, 3, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(5, 27, 0, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(5, 27, 0, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(5, 27, 1, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(5, 27, 1, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(5, 30, 0, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(5, 30, 0, "buf"))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(8, 9, 0, ""))
+	assertEditionsSupported(t, descriptorpb.Edition_EDITION_2023, descriptorpb.Edition_EDITION_2023,
+		newVersion(8, 9, 0, "buf"))
 }
 
 func TestGetKotlinSupportedAsBuiltin(t *testing.T) {
@@ -124,4 +152,16 @@ func testParseVersionForCLIVersionError(
 ) {
 	_, err := parseVersionForCLIVersion(value)
 	assert.Error(t, err)
+}
+
+func assertEditionsNotSupported(t *testing.T, version *pluginpb.Version) {
+	supported, _, _ := getFeatureEditionsSupported(version)
+	assert.False(t, supported)
+}
+
+func assertEditionsSupported(t *testing.T, min, max descriptorpb.Edition, version *pluginpb.Version) {
+	supported, actualMin, actualMax := getFeatureEditionsSupported(version)
+	assert.True(t, supported)
+	assert.Equal(t, actualMin, min)
+	assert.Equal(t, actualMax, max)
 }

--- a/private/buf/cmd/buf/command/alpha/protoc/protoc.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/protoc.go
@@ -73,8 +73,10 @@ Additional flags:
 		BindFlags:     flagsBuilder.Bind,
 		NormalizeFlag: flagsBuilder.Normalize,
 		Version: fmt.Sprintf(
-			"%v.%v.%v-buf",
-			bufprotopluginexec.DefaultVersion.GetMajor(),
+			"%v.%v-buf",
+			// DefaultVersion has an extra major version that corresponds to
+			// backwards-compatibility level of C++ runtime. The actual version
+			// of the compiler is just the minor and patch versions.
 			bufprotopluginexec.DefaultVersion.GetMinor(),
 			bufprotopluginexec.DefaultVersion.GetPatch(),
 		),


### PR DESCRIPTION
v27 of `protoc` fully supports Editions, but when using the buf CLI and proxying to it (for generating Java, C++, Python, etc), it refuses to accept Editions. The reason is that buf CLI's proxying code wasn't setting the Editions-related fields in the code generator response. This fixes that.

This also updates `buf alpha protoc --version` to print `27.0-buf` instead of `5.27.0-buf`. This mirrors `protoc`, which prints `libprotoc 27.0`. (The "5" major version is the backwards-compatibility level of the C++ runtime and `protoc` stopped reporting that initial extra version number starting in v21, which was v3.21 of the C++ runtime.)