### PR TITLE
Add tests for buf config ls-modules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -276,3 +276,9 @@ issues:
       # This greatly simplifies creation of descriptors, and it's safe enough since
       # it's just test code.
       path: private/bufpkg/bufimage/source_retention_options_test\.go
+    - linters:
+        - paralleltest
+      path: private/buf/cmd/buf/buf_test.go
+      # The LsModules tests call chdir and cannot be parallelized.
+      text: "LsModules"
+      

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,6 +2,7 @@ version: v2
 modules:
   - path: proto
     name: buf.build/bufbuild/buf
+  - path: make
 lint:
   use:
     - DEFAULT

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,7 +2,6 @@ version: v2
 modules:
   - path: proto
     name: buf.build/bufbuild/buf
-  - path: make
 lint:
   use:
     - DEFAULT

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1446,21 +1446,21 @@ func TestLsModulesBothConfig(t *testing.T) {
 	}()
 
 	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "extraconfigv1")))
-	testRunStderr(
+	testRunStderrContainsNoWarn(
 		t,
 		nil,
 		1,
-		"Failure: found both buf.work.yaml and buf.yaml",
+		[]string{"buf.yaml", "buf.work.yaml"},
 		"config",
 		"ls-modules",
 	)
 
 	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "extraconfigv2")))
-	testRunStderr(
+	testRunStderrContainsNoWarn(
 		t,
 		nil,
 		1,
-		"Failure: found both buf.work.yaml and buf.yaml",
+		[]string{"buf.yaml", "buf.work.yaml"},
 		"config",
 		"ls-modules",
 	)

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -36,6 +36,7 @@ import (
 	imagev1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd/appcmdtesting"
+	"github.com/bufbuild/buf/private/pkg/osext"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/storage/storagetesting"
@@ -1025,6 +1026,495 @@ func TestCheckLsBreakingRulesFromConfigExceptDeprecated(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLsModulesWorkspaceV1(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspacev1")))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		`
+a_v1
+b_no_name_v1
+c_v1beta1
+d_no_file
+e_no_file
+f_no_name_v1beta1
+`,
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// sort by path
+		`
+a_v1
+b_no_name_v1
+c_v1beta1
+d_no_file
+e_no_file
+f_no_name_v1beta1
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// sort by name
+		`
+buf.build/bar/baz
+buf.build/foo/bar
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// sort by path
+		`
+{"path":"a_v1","name":"buf.build/foo/bar"}
+{"path":"b_no_name_v1","name":""}
+{"path":"c_v1beta1","name":"buf.build/bar/baz"}
+{"path":"d_no_file","name":""}
+{"path":"e_no_file","name":""}
+{"path":"f_no_name_v1beta1","name":""}
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+}
+
+func TestLsModulesWorkspaceV2(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspacev2")))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		`
+a
+b_no_name
+c
+d_no_name
+`,
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// sort by path
+		`
+a
+b_no_name
+c
+d_no_name
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// sort by name
+		`
+buf.build/bar/baz
+buf.build/foo/bar
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// sort by path
+		`
+{"path":"a","name":"buf.build/foo/bar"}
+{"path":"b_no_name","name":""}
+{"path":"c","name":"buf.build/bar/baz"}
+{"path":"d_no_name","name":""}
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+}
+
+func TestLsModulesModuleV1(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	// with name
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspacev1", "a_v1")))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		".",
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		".",
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`
+buf.build/foo/bar
+`,
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":"buf.build/foo/bar"}`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+	// without name
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspacev1", "b_no_name_v1")))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		".",
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		".",
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		"", // empty output
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":""}`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+}
+
+func TestLsModulesModuleV1Beta1(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	// with name
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspacev1", "c_v1beta1")))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		".",
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		".",
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		"buf.build/bar/baz",
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":"buf.build/bar/baz"}`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+	// without name
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspacev1", "f_no_name_v1beta1")))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		".",
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		".",
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		"", // empty output
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":""}`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+}
+
+func TestLsModulesNoConfig(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	// with name
+	require.NoError(t, osext.Chdir(t.TempDir()))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		// default format is path
+		".",
+		"config",
+		"ls-modules",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		".",
+		"config",
+		"ls-modules",
+		"--format",
+		"path",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		"",
+		"config",
+		"ls-modules",
+		"--format",
+		"name",
+	)
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":""}`,
+		"config",
+		"ls-modules",
+		"--format",
+		"json",
+	)
+}
+
+func TestLsModulesBothConfig(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "extraconfigv1")))
+	testRunStderr(
+		t,
+		nil,
+		1,
+		"Failure: found both buf.work.yaml and buf.yaml",
+		"config",
+		"ls-modules",
+	)
+
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "extraconfigv2")))
+	testRunStderr(
+		t,
+		nil,
+		1,
+		"Failure: found both buf.work.yaml and buf.yaml",
+		"config",
+		"ls-modules",
+	)
+}
+
+func TestLsModulesConfigFlag(t *testing.T) {
+	t.Parallel()
+
+	// v1beta1
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":"buf.build/bar/baz"}`,
+		"config",
+		"ls-modules",
+		"--config",
+		filepath.Join("testdata", "lsmodules", "workspacev1", "c_v1beta1", "buf.yaml"),
+		"--format",
+		"json",
+	)
+
+	// v1
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`{"path":".","name":"buf.build/foo/bar"}`,
+		"config",
+		"ls-modules",
+		"--config",
+		filepath.Join("testdata", "lsmodules", "workspacev1", "a_v1", "buf.yaml"),
+		"--format",
+		"json",
+	)
+
+	// v2
+	testRunStdout(
+		t,
+		nil,
+		0,
+		`
+{"path":"a","name":"buf.build/foo/bar"}
+{"path":"b_no_name","name":""}
+{"path":"c","name":"buf.build/bar/baz"}
+{"path":"d_no_name","name":""}
+`,
+		"config",
+		"ls-modules",
+		"--config",
+		filepath.Join("testdata", "lsmodules", "workspacev2", "buf.yaml"),
+		"--format",
+		"json",
+	)
 }
 
 func TestLsBreakingRulesDeprecated(t *testing.T) {

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1466,6 +1466,29 @@ func TestLsModulesBothConfig(t *testing.T) {
 	)
 }
 
+func TestLsModulesInvalidVersion(t *testing.T) {
+	// Cannot be parallel since we chdir.
+	pwd, err := osext.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		r := recover()
+		assert.NoError(t, osext.Chdir(pwd))
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	require.NoError(t, osext.Chdir(filepath.Join(pwd, "testdata", "lsmodules", "workspaceinvalid")))
+	testRunStderr(
+		t,
+		nil,
+		1,
+		`Failure: buf.work.yaml pointed to directory "proto" which has a v2 buf.yaml file`,
+		"config",
+		"ls-modules",
+	)
+}
+
 func TestLsModulesConfigFlag(t *testing.T) {
 	t.Parallel()
 

--- a/private/buf/cmd/buf/command/config/configlsmodules/configlsmodules.go
+++ b/private/buf/cmd/buf/command/config/configlsmodules/configlsmodules.go
@@ -140,7 +140,15 @@ func getExternalModules(
 		// This handles both buf.yaml file and no file courtesy of the above logic.
 		return getExternalModulesForBufYAMLFile(ctx, bufYAMLFile)
 	}
-	// We did have a buf.work.yaml file, handle it.
+	// We did have a buf.work.yaml file, but before handling it, check there is not a buf.yaml.
+	_, err = bufcli.GetBufYAMLFileForDirPath(ctx, ".")
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	if err == nil {
+		return nil, errors.New("found both buf.work.yaml and buf.yaml")
+	}
+	// Handle the buf.work.yaml.
 	return getExternalModulesForBufWorkYAMLFile(ctx, bufWorkYAMLFile)
 }
 

--- a/private/buf/cmd/buf/command/config/configlsmodules/configlsmodules.go
+++ b/private/buf/cmd/buf/command/config/configlsmodules/configlsmodules.go
@@ -146,7 +146,7 @@ func getExternalModules(
 		return nil, err
 	}
 	if err == nil {
-		return nil, errors.New("found both buf.work.yaml and buf.yaml")
+		return nil, errors.New("Both buf.work.yaml and buf.yaml found. It is not valid to have a buf.work.yaml and buf.yaml in the same directory, buf.work.yaml specifies a workspace of modules, while buf.yaml either specifies a single module or a workspace of modules itself.")
 	}
 	// Handle the buf.work.yaml.
 	return getExternalModulesForBufWorkYAMLFile(ctx, bufWorkYAMLFile)

--- a/private/buf/cmd/buf/testdata/lsmodules/extraconfigv1/buf.work.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/extraconfigv1/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - proto

--- a/private/buf/cmd/buf/testdata/lsmodules/extraconfigv1/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/extraconfigv1/buf.yaml
@@ -1,0 +1,1 @@
+version: v1

--- a/private/buf/cmd/buf/testdata/lsmodules/extraconfigv2/buf.work.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/extraconfigv2/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - proto

--- a/private/buf/cmd/buf/testdata/lsmodules/extraconfigv2/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/extraconfigv2/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: proto

--- a/private/buf/cmd/buf/testdata/lsmodules/workspaceinvalid/buf.work.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspaceinvalid/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - proto

--- a/private/buf/cmd/buf/testdata/lsmodules/workspaceinvalid/proto/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspaceinvalid/proto/buf.yaml
@@ -1,0 +1,2 @@
+# invalid because this directory is pointed to by a workspace
+version: v2

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev1/a_v1/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev1/a_v1/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/foo/bar

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev1/b_no_name_v1/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev1/b_no_name_v1/buf.yaml
@@ -1,0 +1,1 @@
+version: v1

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev1/buf.work.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev1/buf.work.yaml
@@ -1,0 +1,8 @@
+version: v1
+directories:
+  - e_no_file
+  - c_v1beta1
+  - f_no_name_v1beta1
+  - a_v1
+  - d_no_file
+  - b_no_name_v1

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev1/c_v1beta1/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev1/c_v1beta1/buf.yaml
@@ -1,0 +1,2 @@
+version: v1beta1
+name: buf.build/bar/baz

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev1/f_no_name_v1beta1/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev1/f_no_name_v1beta1/buf.yaml
@@ -1,0 +1,1 @@
+version: v1beta1

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev1/not_pointed_by_workspace/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev1/not_pointed_by_workspace/buf.yaml
@@ -1,0 +1,2 @@
+version: v1
+name: buf.build/acme/weather

--- a/private/buf/cmd/buf/testdata/lsmodules/workspacev2/buf.yaml
+++ b/private/buf/cmd/buf/testdata/lsmodules/workspacev2/buf.yaml
@@ -1,0 +1,8 @@
+version: v2
+modules:
+  - path: d_no_name
+  - path: c
+    name: buf.build/bar/baz
+  - path: a
+    name: buf.build/foo/bar
+  - path: b_no_name


### PR DESCRIPTION
This PR
* adds test for `buf config ls-modules`
* update the command to error when both `./buf.yaml` and `./buf.work.yaml` exist