### PR TITLE
Set environment when running git commands

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -443,7 +443,7 @@ func getGitMetadataUploadOptions(
 	if err := validateInputIsValidDirAndGitCheckout(ctx, runner, container, input); err != nil {
 		return nil, err
 	}
-	uncommittedFiles, err := git.CheckForUncommittedGitChanges(ctx, runner, input)
+	uncommittedFiles, err := git.CheckForUncommittedGitChanges(ctx, runner, container, input)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +457,7 @@ func getGitMetadataUploadOptions(
 		}
 		return nil, err
 	}
-	currentGitCommit, err := git.GetCurrentHEADGitCommit(ctx, runner, input)
+	currentGitCommit, err := git.GetCurrentHEADGitCommit(ctx, runner, container, input)
 	if err != nil {
 		return nil, err
 	}

--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -247,11 +247,13 @@ func CheckDirectoryIsValidGitCheckout(
 func CheckForUncommittedGitChanges(
 	ctx context.Context,
 	runner command.Runner,
+	envContainer app.EnvContainer,
 	dir string,
 ) ([]string, error) {
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
 	var modifiedFiles []string
+	envMap := app.EnvironMap(envContainer)
 	// Unstaged changes
 	if err := runner.Run(
 		ctx,
@@ -260,6 +262,7 @@ func CheckForUncommittedGitChanges(
 		command.RunWithStdout(stdout),
 		command.RunWithStderr(stderr),
 		command.RunWithDir(dir),
+		command.RunWithEnv(envMap),
 	); err != nil {
 		return nil, fmt.Errorf("failed to get unstaged changes: %w: %s", err, stderr.String())
 	}
@@ -275,6 +278,7 @@ func CheckForUncommittedGitChanges(
 		command.RunWithStdout(stdout),
 		command.RunWithStderr(stderr),
 		command.RunWithDir(dir),
+		command.RunWithEnv(envMap),
 	); err != nil {
 		return nil, fmt.Errorf("failed to get staged changes: %w: %s", err, stderr.String())
 	}
@@ -287,6 +291,7 @@ func CheckForUncommittedGitChanges(
 func GetCurrentHEADGitCommit(
 	ctx context.Context,
 	runner command.Runner,
+	envContainer app.EnvContainer,
 	dir string,
 ) (string, error) {
 	stdout := bytes.NewBuffer(nil)
@@ -298,6 +303,7 @@ func GetCurrentHEADGitCommit(
 		command.RunWithStdout(stdout),
 		command.RunWithStderr(stderr),
 		command.RunWithDir(dir),
+		command.RunWithEnv(app.EnvironMap(envContainer)),
 	); err != nil {
 		return "", fmt.Errorf("failed to get current HEAD commit: %w: %s", err, stderr.String())
 	}

--- a/private/pkg/git/remote.go
+++ b/private/pkg/git/remote.go
@@ -134,15 +134,16 @@ func getRemote(
 	hostname, repositoryPath, err := getRemoteURLMetadata(
 		ctx,
 		runner,
+		envContainer,
 		dir,
 		name,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get remote URL metadata: %w", err)
 	}
 	headBranch, err := getRemoteHEADBranch(ctx, runner, envContainer, dir, name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get remote HEAD branch: %w", err)
 	}
 	return newRemote(
 		name,
@@ -185,6 +186,7 @@ func validateRemoteExists(
 func getRemoteURLMetadata(
 	ctx context.Context,
 	runner command.Runner,
+	envContainer app.EnvContainer,
 	dir string,
 	remote string,
 ) (string, string, error) {
@@ -199,6 +201,7 @@ func getRemoteURLMetadata(
 		command.RunWithStdout(stdout),
 		command.RunWithStderr(stderr),
 		command.RunWithDir(dir),
+		command.RunWithEnv(app.EnvironMap(envContainer)),
 	); err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Git commands often need to shell out to other commands, and so running consistently with the environment set (in particular PATH) fixes issues running in certain environments.

Additionally, wrap a few errors to make it easier to determine the reason for failures with the --git-metadata flag.