### PR TITLE
Set top-level `LintConfig` and `BreakingConfig` and use for image inputs

### DIFF
--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"path/filepath"
 	"sort"
 
 	"github.com/bufbuild/buf/private/buf/buffetch"
@@ -393,23 +394,49 @@ func (c *controller) GetTargetImageWithConfigs(
 			// We did not find a buf.yaml in our current directory, and there was no config override.
 			// Use the defaults.
 		} else {
-			switch fileVersion := bufYAMLFile.FileVersion(); fileVersion {
-			case bufconfig.FileVersionV1Beta1, bufconfig.FileVersionV1:
-				moduleConfigs := bufYAMLFile.ModuleConfigs()
-				if len(moduleConfigs) != 1 {
-					return nil, fmt.Errorf("expected 1 ModuleConfig for FileVersion %v, got %d", len(moduleConfigs), fileVersion)
+			// We take the top-level lint and breaking config from buf.yaml.
+			//
+			// In the case of v1 buf.yaml files, there is only ever one top-level config, so it
+			// should be populated and we use that.
+			// In the case of v2 buf.yaml files, this may be empty, since there may not be a
+			// top-level config. If that happens, we print a warning to the user and let them
+			// know that we are using v2 defaults.
+			// In the case where there is a top-level config and individual module configs, we
+			// print out a message to the user to let them know we are using the top-level config.
+			var configInfo string
+			// If configuration is read from an override, we determine if it was a raw config or
+			// a path to a valid override file.
+			if override := functionOptions.configOverride; override != "" {
+				switch filepath.Ext(override) {
+				case ".json", ".yaml", ".yml":
+					configInfo = functionOptions.configOverride
+				default:
+					configInfo = fmt.Sprintf("from --config")
 				}
-				lintConfig = moduleConfigs[0].LintConfig()
-				breakingConfig = moduleConfigs[0].BreakingConfig()
-			case bufconfig.FileVersionV2:
-				// Use the default LintConfig and BreakingConfig from the file. This is
-				// the top-level lint and/or breaking config(s) if any are set or the default v2
-				// configs. v2 buf.yamls may contain multiple modules, we don't know what lint or
-				// breaking config to apply.
-				lintConfig = bufYAMLFile.DefaultLintConfig()
-				breakingConfig = bufYAMLFile.DefaultBreakingConfig()
-			default:
-				return nil, syserror.Newf("unknown FileVersion: %v", fileVersion)
+			} else {
+				// Otherwise we use the file path
+				configInfo = bufYAMLFile.ObjectData().Name()
+			}
+			if topLevelModuleConfig := bufYAMLFile.TopLevelModuleConfig(); topLevelModuleConfig != nil {
+				if bufYAMLFile.FileVersion() == bufconfig.FileVersionV2 && len(bufYAMLFile.ModuleConfigs()) > 1 {
+					c.logger.Sugar().Warnf(
+						`Configuration %s has multiple modules. The top-level lint/breaking configuration is used with your image, since Buf cannot deduce which specific module configuration to use otherwise.`,
+						configInfo,
+					)
+				}
+				lintConfig = topLevelModuleConfig.LintConfig()
+				breakingConfig = topLevelModuleConfig.BreakingConfig()
+			} else {
+				// Ensure that this is a v2 config
+				if fileVersion := bufYAMLFile.FileVersion(); fileVersion != bufconfig.FileVersionV2 {
+					return nil, syserror.Newf("non-v2 version with no top-level module config: %s", fileVersion)
+				}
+				c.logger.Sugar().Warnf(
+					`Configuration %s does not have a top-level lint/breaking configuration. Buf cannot deduce which specific module configuration to use with your image, so the default configuration is used instead.`,
+					configInfo,
+				)
+				lintConfig = bufconfig.DefaultLintConfigV2
+				breakingConfig = bufconfig.DefaultBreakingConfigV2
 			}
 		}
 		return []ImageWithConfig{

--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -378,8 +378,8 @@ func (c *controller) GetTargetImageWithConfigs(
 		if err != nil {
 			return nil, err
 		}
-		lintConfig := bufconfig.DefaultLintConfigV1
-		breakingConfig := bufconfig.DefaultBreakingConfigV1
+		lintConfig := bufconfig.DefaultLintConfigV2
+		breakingConfig := bufconfig.DefaultBreakingConfigV2
 		bufYAMLFile, err := bufconfig.GetBufYAMLFileForPrefixOrOverride(
 			ctx,
 			bucket,
@@ -402,9 +402,12 @@ func (c *controller) GetTargetImageWithConfigs(
 				lintConfig = moduleConfigs[0].LintConfig()
 				breakingConfig = moduleConfigs[0].BreakingConfig()
 			case bufconfig.FileVersionV2:
-				// Do nothing. Use the default LintConfig and BreakingConfig. With
-				// the new buf.yamls with multiple modules, we don't know what lint or
+				// Use the default LintConfig and BreakingConfig from the file. This is
+				// the top-level lint and/or breaking config(s) if any are set or the default v2
+				// configs. v2 buf.yamls may contain multiple modules, we don't know what lint or
 				// breaking config to apply.
+				lintConfig = bufYAMLFile.DefaultLintConfig()
+				breakingConfig = bufYAMLFile.DefaultBreakingConfig()
 			default:
 				return nil, syserror.Newf("unknown FileVersion: %v", fileVersion)
 			}

--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -411,7 +411,7 @@ func (c *controller) GetTargetImageWithConfigs(
 				case ".json", ".yaml", ".yml":
 					configInfo = functionOptions.configOverride
 				default:
-					configInfo = fmt.Sprintf("from --config")
+					configInfo = "from --config"
 				}
 			} else {
 				// Otherwise we use the file path

--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -378,8 +378,8 @@ func (c *controller) GetTargetImageWithConfigs(
 		if err != nil {
 			return nil, err
 		}
-		lintConfig := bufconfig.DefaultLintConfigV2
-		breakingConfig := bufconfig.DefaultBreakingConfigV2
+		lintConfig := bufconfig.DefaultLintConfigV1
+		breakingConfig := bufconfig.DefaultBreakingConfigV1
 		bufYAMLFile, err := bufconfig.GetBufYAMLFileForPrefixOrOverride(
 			ctx,
 			bucket,

--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -94,7 +94,7 @@ type Ref interface {
 	internalRef() internal.Ref
 }
 
-// MessageRef is an message file reference.
+// MessageRef is a message file reference.
 type MessageRef interface {
 	Ref
 	MessageEncoding() MessageEncoding

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -2464,6 +2464,23 @@ a/v3/a.proto:7:10:Field "2" on message "Foo" changed name from "value" to "Value
 		"--exclude-path",
 		filepath.Join("a", "v3", "foo"),
 	)
+	testRunStdoutStderrNoWarn(
+		t,
+		nil,
+		bufctl.ExitCodeFileAnnotation,
+		`a/v3/a.proto:6:3:Field "1" with name "key" on message "Foo" changed type from "string" to "int32". See https://developers.google.com/protocol-buffers/docs/proto3#updating for wire compatibility rules.`,
+		"",
+		"breaking",
+		filepath.Join(tempDir, "current.binpb"),
+		"--against",
+		filepath.Join(tempDir, "previous.binpb"),
+		"--path",
+		filepath.Join("a", "v3"),
+		"--exclude-path",
+		filepath.Join("a", "v3", "foo"),
+		"--config",
+		`{"version":"v2","breaking":{"use":["WIRE"]}}`,
+	)
 }
 
 func TestVersion(t *testing.T) {

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -517,7 +517,7 @@ func readBufYAMLFile(
 			topLevelModuleConfig, err = newModuleConfig(
 				".", // The top-level module path is always "."
 				topLevelModuleFullName,
-				map[string][]string{".": []string{}}, // No top-level module config for excludes
+				map[string][]string{".": {}}, // No top-level module config for excludes
 				topLevelLintConfig,
 				topLevelBreakingConfig,
 			)

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -76,13 +76,13 @@ type BufYAMLFile interface {
 	ModuleConfigs() []ModuleConfig
 	// DefaultLintConfig returns the DefaultLintConfig for the File.
 	//
-	// For v1 buf.yaml files, this will be the default v1 lint config.
+	// For v1 buf.yaml files, there is only ever a single ModuleConfig, so that is returned.
 	// For v2 buf.yaml files, if a top-level lint config exists, then it will be the top-level
 	// lint config. Otherwise it is the default v2 lint config.
 	DefaultLintConfig() LintConfig
 	// DefaultBreakingConfig returns the DefaultBreakingConfig for the File.
 	//
-	// For v1 buf.yaml, this will be the default v1 breaking config.
+	// For v1 buf.yaml files, there is only ever a single ModuleConfig, so that is returned.
 	// For v2 buf.yaml files, if a top-level breaking config exists, then it will be the top-level
 	// breaking config. Otherwise it is the default v2 breaking config.
 	DefaultBreakingConfig() BreakingConfig
@@ -301,10 +301,16 @@ func (c *bufYAMLFile) ModuleConfigs() []ModuleConfig {
 }
 
 func (c *bufYAMLFile) DefaultLintConfig() LintConfig {
+	if c.defaultLintConfig == nil {
+		return c.moduleConfigs[0].LintConfig()
+	}
 	return c.defaultLintConfig
 }
 
 func (c *bufYAMLFile) DefaultBreakingConfig() BreakingConfig {
+	if c.defaultBreakingConfig == nil {
+		return c.moduleConfigs[0].BreakingConfig()
+	}
 	return c.defaultBreakingConfig
 }
 

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -76,13 +76,13 @@ type BufYAMLFile interface {
 	ModuleConfigs() []ModuleConfig
 	// DefaultLintConfig returns the DefaultLintConfig for the File.
 	//
-	// For v1 buf.yaml files, there is only ever a single ModuleConfig, so that is returned.
+	// For v1 buf.yaml files, there is only ever a single ModuleConfig, so its LintConfig is returned.
 	// For v2 buf.yaml files, if a top-level lint config exists, then it will be the top-level
 	// lint config. Otherwise it is the default v2 lint config.
 	DefaultLintConfig() LintConfig
 	// DefaultBreakingConfig returns the DefaultBreakingConfig for the File.
 	//
-	// For v1 buf.yaml files, there is only ever a single ModuleConfig, so that is returned.
+	// For v1 buf.yaml files, there is only ever a single ModuleConfig, so its BreakingConfig is returned.
 	// For v2 buf.yaml files, if a top-level breaking config exists, then it will be the top-level
 	// breaking config. Otherwise it is the default v2 breaking config.
 	DefaultBreakingConfig() BreakingConfig

--- a/private/bufpkg/bufconfig/lint_config.go
+++ b/private/bufpkg/bufconfig/lint_config.go
@@ -34,7 +34,7 @@ var (
 		false,
 		false,
 		"",
-		false,
+		true, // We default to allowing comment ignores in v2
 	)
 )
 


### PR DESCRIPTION
This PR exposes the top-level lint and breaking configs for `buf.yaml` files.

For `v1` `buf.yaml` files, there is only ever one `ModuleConfig`, so the
corresponding lint and breaking configs are used.

For `v2` `buf.yaml` files, if a top-level lint and/or breaking config exists, then
we return those.
Otherwise, `TopLevelLintConfig()`/`TopLevelBreakingConfig` will return `nil`.

We use the top-level lint/breaking configs, if possible, with image inputs, since we
cannot determine which specific `v2` module config to use with images. In
the case where there is no top-level config, we fall back to defaults.

Fixes #3080 