### PR TITLE
Fix studio agent flaky test

### DIFF
--- a/private/buf/bufstudioagent/bufstudioagent_test.go
+++ b/private/buf/bufstudioagent/bufstudioagent_test.go
@@ -199,6 +199,9 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		listener, err := net.ListenTCP("tcp", tcpAddr)
 		require.NoError(t, err)
 		done := make(chan struct{})
+		t.Cleanup(func() {
+			done <- struct{}{}
+		})
 		go func() {
 			for {
 				select {
@@ -229,9 +232,10 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 		request.Header.Set("Content-Type", "text/plain")
 		response, err := agentServer.Client().Do(request)
 		require.NoError(t, err)
-		defer response.Body.Close()
+		t.Cleanup(func() {
+			response.Body.Close()
+		})
 		assert.Equal(t, http.StatusBadGateway, response.StatusCode)
-		done <- struct{}{}
 	})
 }
 

--- a/private/buf/bufstudioagent/bufstudioagent_test.go
+++ b/private/buf/bufstudioagent/bufstudioagent_test.go
@@ -209,13 +209,18 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 					listener.Close()
 					return
 				default:
-					err := listener.SetDeadline(time.Now().Add(time.Second))
-					require.NoError(t, err)
+					// Do not call require.NoError to handle errors because it calls t.FailNow,
+					// which is not safe from a goroutine, see https://pkg.go.dev/testing#T.FailNow
+					if err := listener.SetDeadline(time.Now().Add(time.Millisecond * 10)); err != nil {
+						continue
+					}
 					conn, err := listener.Accept()
 					if err != nil {
 						continue
 					}
-					require.NoError(t, conn.Close())
+					if err := conn.Close(); err != nil {
+						continue
+					}
 				}
 			}
 		}()

--- a/private/buf/bufstudioagent/bufstudioagent_test.go
+++ b/private/buf/bufstudioagent/bufstudioagent_test.go
@@ -212,13 +212,18 @@ func testPlainPostHandlerErrors(t *testing.T, upstreamServer *httptest.Server) {
 					// Do not call require.NoError to handle errors because it calls t.FailNow,
 					// which is not safe from a goroutine, see https://pkg.go.dev/testing#T.FailNow
 					if err := listener.SetDeadline(time.Now().Add(time.Millisecond * 10)); err != nil {
+						t.Error(err)
 						continue
 					}
 					conn, err := listener.Accept()
 					if err != nil {
+						if err, ok := err.(net.Error); !ok || !err.Timeout() {
+							t.Error(err)
+						}
 						continue
 					}
 					if err := conn.Close(); err != nil {
+						t.Error(err)
 						continue
 					}
 				}


### PR DESCRIPTION
Tests `TestPlainPostHandlerTLS/invalid_upstream` and `TestPlainPostHandlerH2C/invalid_upstream` are [flaky](https://github.com/bufbuild/buf/actions/runs/9599996622/job/26475130640?pr=3102), because the listener only calls `Accept` once, and when it accepts a connection from something other than the agent, the listener calls it a day, leaving the agent hanging.

This PR makes the listener repeatedly accept new connections until it has accepted a connection from the agent.

Running `go test -count=1 -timeout=20s -race github.com/bufbuild/buf/private/buf/bufstudioagent` on main on my laptop would fail (with timeout) this test within the first 5 times, and trying it on this branch, it doesn't fail (tried 100 times and it hasn't failed).

TLDR: random ports can make connection with the listener and we need to account for that.