### PR TITLE
Improve auth error for BSR remotes

### DIFF
--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -334,10 +334,10 @@ func wrapError(err error) error {
 			}
 			// Invalid token found in env var.
 			if authErr.HasToken() && authErr.TokenEnvKey() != "" {
-				return fmt.Errorf("Failure: the %[1]s environment variable is set, but is not valid. "+
+				return fmt.Errorf("Failure: the %[1]s environment variable is not valid for %[2]s. "+
 					"Set %[1]s to a valid Buf API token, or unset it. "+
 					"For details, visit https://buf.build/docs/bsr/authentication",
-					authErr.TokenEnvKey(),
+					authErr.TokenEnvKey(), authErr.Remote(),
 				)
 			}
 			if authErr.Remote() != bufconnect.DefaultRemote {


### PR DESCRIPTION
Users interacting with a remote BSR may see an auth error when using the env variable BUF_TOKEN. This is reported as:

`Failure: the BUF_TOKEN environment variable is set, but is not valid.`

To help users identify which remote was used, we now report the remote in the error message:

`Failure: the BUF_TOKEN environment variable is not valid for buf.build.`

This can help clarify which remote was used. As an example this can be caused when a modules dependencies are on a different BSR instance then the parent module.