### PR TITLE
Remove username prompt on buf registry login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `buf generate --clean` flag that will delete the directories, jar files, or zip files that the
   plugins will write to, prior to generation. Allows cleaning of existing assets without having
   to call `rm -rf`.
+- Remove username prompt on `buf registry login`. A username is no longer required to log in.
 
 ## [v1.34.0] - 2024-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Add `buf generate --clean` flag that will delete the directories, jar files, or zip files that the
   plugins will write to, prior to generation. Allows cleaning of existing assets without having
   to call `rm -rf`.
-- Remove username prompt on `buf registry login`. A username is no longer required to log in.
+- Deprecate `--username` flag on and username prompt on `buf registry login`. A username is no longer
+  required to log in.
 
 ## [v1.34.0] - 2024-06-21
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -75,7 +75,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"",
 		"The username to use.",
 	)
-	_ = flagSet.MarkDeprecated(usernameFlagName, "This flag no longer has any effect")
+	_ = flagSet.MarkDeprecated(usernameFlagName, "This flag is no longer needed as the username is automatically derived from the token")
 	_ = flagSet.MarkHidden(usernameFlagName)
 	flagSet.BoolVar(
 		&f.TokenStdin,

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -47,7 +47,7 @@ func NewCommand(
 	return &appcmd.Command{
 		Use:   name + " <domain>",
 		Short: `Log in to the Buf Schema Registry`,
-		Long: fmt.Sprintf(`This prompts for your BSR username and a BSR token and updates your %s file with these credentials.
+		Long: fmt.Sprintf(`This prompts for your BSR token and updates your %s file with these credentials.
 The <domain> argument will default to buf.build if not specified.`, netrc.Filename),
 		Args: appcmd.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
@@ -73,7 +73,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Username,
 		usernameFlagName,
 		"",
-		"The username to use. This command prompts for a username by default",
+		"The username to use. If provided, the command will validate that the token is associated with this username",
 	)
 	flagSet.BoolVar(
 		&f.TokenStdin,
@@ -135,23 +135,12 @@ func inner(
 		remote = container.Arg(0)
 	}
 	// Do not print unless we are prompting
-	if flags.Username == "" && !flags.TokenStdin {
+	if !flags.TokenStdin {
 		if _, err := fmt.Fprintf(
 			container.Stdout(),
-			"Log in with your Buf Schema Registry username. If you don't have a username, create one at https://%s.\n\n",
+			"Enter the BSR token created at https://%s/settings/user.\n\n",
 			remote,
 		); err != nil {
-			return err
-		}
-	}
-	username := flags.Username
-	if username == "" {
-		var err error
-		username, err = bufcli.PromptUser(container, "Username: ")
-		if err != nil {
-			if errors.Is(err, bufcli.ErrNotATTY) {
-				return errors.New("cannot perform an interactive login from a non-TTY device")
-			}
 			return err
 		}
 	}
@@ -197,14 +186,14 @@ func inner(
 	if user == nil {
 		return errors.New("no user found for provided token")
 	}
-	if user.Username != username {
+	if flags.Username != "" && user.Username != flags.Username {
 		return errors.New("the username associated with the provided token does not match the provided username")
 	}
 	if err := netrc.PutMachines(
 		container,
 		netrc.NewMachine(
 			remote,
-			username,
+			user.Username,
 			token,
 		),
 	); err != nil {
@@ -217,9 +206,9 @@ func inner(
 	if err != nil {
 		return err
 	}
-	loggedInMessage := fmt.Sprintf("Credentials saved to %s.\n", netrcFilePath)
+	loggedInMessage := fmt.Sprintf("Logged in as %s. Credentials saved to %s.\n", user.Username, netrcFilePath)
 	// Unless we did not prompt at all, print a newline first
-	if flags.Username == "" || !flags.TokenStdin {
+	if !flags.TokenStdin {
 		loggedInMessage = "\n" + loggedInMessage
 	}
 	if _, err := container.Stdout().Write([]byte(loggedInMessage)); err != nil {

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -75,8 +75,8 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"",
 		"The username to use.",
 	)
-	flagSet.MarkDeprecated(usernameFlagName, "This flag no longer has any effect")
-	flagSet.MarkHidden(usernameFlagName)
+	_ = flagSet.MarkDeprecated(usernameFlagName, "This flag no longer has any effect")
+	_ = flagSet.MarkHidden(usernameFlagName)
 	flagSet.BoolVar(
 		&f.TokenStdin,
 		tokenStdinFlagName,

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -188,9 +188,6 @@ func inner(
 	if user == nil {
 		return errors.New("no user found for provided token")
 	}
-	if flags.Username != "" && user.Username != flags.Username {
-		return errors.New("the username associated with the provided token does not match the provided username")
-	}
 	if err := netrc.PutMachines(
 		container,
 		netrc.NewMachine(

--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -73,8 +73,10 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Username,
 		usernameFlagName,
 		"",
-		"The username to use. If provided, the command will validate that the token is associated with this username",
+		"The username to use.",
 	)
+	flagSet.MarkDeprecated(usernameFlagName, "This flag no longer has any effect")
+	flagSet.MarkHidden(usernameFlagName)
 	flagSet.BoolVar(
 		&f.TokenStdin,
 		tokenStdinFlagName,


### PR DESCRIPTION
This removes the requirement to provide your username when calling `buf registry login`. On login the token is validated by fetching the current user. The username is used only to validate that the current token is associated with the user but is otherwise redundant. The flag has now been marked deprecated and is hidden.

The output of the login command is also updated to be more user friendly prompting the user to visit the web UI to create a token if they do not have one. On successful login the user is informed that they are logged in as the current user.

Token via prompt:
```
$ buf registry login
Enter the BSR token created at https://buf.build/settings/user.

Token:
Logged in as emcfarlane. Credentials saved to /Users/edward/.netrc.
```

Token via stdin:
```
$ echo ${BUF_TOKEN} | buf registry login buf.build --token-stdin
Logged in as emcfarlane. Credentials saved to /Users/edward/.netrc.
```