### PR TITLE
Bump buf-action CI from 0.1 to 0.2

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.1
+      - uses: bufbuild/buf-action@v0.2
         with:
           username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
Bumps to the latest release, no changes in behaviour.