### PR TITLE
Export target framework conversion functions

### DIFF
--- a/private/bufpkg/bufremoteplugin/bufremoteplugin.go
+++ b/private/bufpkg/bufremoteplugin/bufremoteplugin.go
@@ -332,7 +332,7 @@ func ProtoCargoConfigToCargoRegistryConfig(protoCargoConfig *registryv1alpha1.Ca
 
 // ProtoNugetConfigToNugetRegistryConfig converts protoConfig to an equivalent [*bufremotepluginconfig.NugetRegistryConfig].
 func ProtoNugetConfigToNugetRegistryConfig(protoConfig *registryv1alpha1.NugetConfig) (*bufremotepluginconfig.NugetRegistryConfig, error) {
-	targetFrameworks, err := slicesext.MapError(protoConfig.TargetFrameworks, dotnetTargetFrameworkToString)
+	targetFrameworks, err := slicesext.MapError(protoConfig.TargetFrameworks, DotnetTargetFrameworkToString)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func ProtoNugetConfigToNugetRegistryConfig(protoConfig *registryv1alpha1.NugetCo
 	for _, dependency := range protoConfig.RuntimeLibraries {
 		var depTargetFrameworks []string
 		if len(dependency.TargetFrameworks) > 0 {
-			depTargetFrameworks, err = slicesext.MapError(dependency.TargetFrameworks, dotnetTargetFrameworkToString)
+			depTargetFrameworks, err = slicesext.MapError(dependency.TargetFrameworks, DotnetTargetFrameworkToString)
 			if err != nil {
 				return nil, err
 			}
@@ -379,7 +379,7 @@ func CargoRegistryConfigToProtoCargoConfig(cargoConfig *bufremotepluginconfig.Ca
 
 // NugetRegistryConfigToProtoNugetConfig converts nugetConfig to an equivalent [*registryv1alpha1.NugetConfig].
 func NugetRegistryConfigToProtoNugetConfig(nugetConfig *bufremotepluginconfig.NugetRegistryConfig) (*registryv1alpha1.NugetConfig, error) {
-	targetFrameworks, err := slicesext.MapError(nugetConfig.TargetFrameworks, dotnetTargetFrameworkFromString)
+	targetFrameworks, err := slicesext.MapError(nugetConfig.TargetFrameworks, DotnetTargetFrameworkFromString)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func NugetRegistryConfigToProtoNugetConfig(nugetConfig *bufremotepluginconfig.Nu
 	for _, dependency := range nugetConfig.Deps {
 		var depTargetFrameworks []registryv1alpha1.DotnetTargetFramework
 		if len(dependency.TargetFrameworks) > 0 {
-			depTargetFrameworks, err = slicesext.MapError(dependency.TargetFrameworks, dotnetTargetFrameworkFromString)
+			depTargetFrameworks, err = slicesext.MapError(dependency.TargetFrameworks, DotnetTargetFrameworkFromString)
 			if err != nil {
 				return nil, err
 			}

--- a/private/bufpkg/bufremoteplugin/dotnet_target_framework.go
+++ b/private/bufpkg/bufremoteplugin/dotnet_target_framework.go
@@ -38,7 +38,9 @@ var (
 	}
 )
 
-func dotnetTargetFrameworkFromString(framework string) (registryv1alpha1.DotnetTargetFramework, error) {
+// DotnetTargetFrameworkFromString converts the target framework name to the equivalent enum.
+// It returns an error if the specified string is unknown.
+func DotnetTargetFrameworkFromString(framework string) (registryv1alpha1.DotnetTargetFramework, error) {
 	frameworkEnum, ok := stringToDotnetTargetFramework[framework]
 	if !ok {
 		return 0, fmt.Errorf("unknown target framework %q", framework)
@@ -46,7 +48,9 @@ func dotnetTargetFrameworkFromString(framework string) (registryv1alpha1.DotnetT
 	return frameworkEnum, nil
 }
 
-func dotnetTargetFrameworkToString(framework registryv1alpha1.DotnetTargetFramework) (string, error) {
+// DotnetTargetFrameworkToString converts the target framework enum to the equivalent string.
+// It returns an error if the specified enum is unspecified or unknown.
+func DotnetTargetFrameworkToString(framework registryv1alpha1.DotnetTargetFramework) (string, error) {
 	// This isn't performance critical code - just scan the existing mapping instead of storing in both directions.
 	for frameworkStr, frameworkEnum := range stringToDotnetTargetFramework {
 		if frameworkEnum == framework {

--- a/private/bufpkg/bufremoteplugin/dotnet_target_platform_test.go
+++ b/private/bufpkg/bufremoteplugin/dotnet_target_platform_test.go
@@ -34,9 +34,9 @@ func TestDotnetTargetPlatformMapping(t *testing.T) {
 			continue
 		}
 		// Verify round trip
-		strTargetFramework, err := dotnetTargetFrameworkToString(targetFramework)
+		strTargetFramework, err := DotnetTargetFrameworkToString(targetFramework)
 		require.NoErrorf(t, err, "missing mapping for target framework %v", targetFramework)
-		targetFrameworkFromStr, err := dotnetTargetFrameworkFromString(strTargetFramework)
+		targetFrameworkFromStr, err := DotnetTargetFrameworkFromString(strTargetFramework)
 		require.NoError(t, err)
 		assert.Equal(t, targetFramework, targetFrameworkFromStr)
 	}


### PR DESCRIPTION
The mapping functions for target frameworks are useful in other places, so export them for use.