### PR TITLE
Move clean config option to the top level of generation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add `buf generate --clean` flag that will delete the directories, jar files, or zip files that the
   plugins will write to, prior to generation. Allows cleaning of existing assets without having
   to call `rm -rf`.
-- Add `clean` as a top-level option in `buf.gen.yaml`. If set to true, this will delete the directories,
-  jar files, or zip files set to `out` for the plugin.
+- Add `clean_plugin_outs` as a top-level option in `buf.gen.yaml`. If set to true, this will delete the directories,
+  jar files, or zip files set to `out` for each plugin.
 
 ## [v1.34.0] - 2024-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add `buf generate --clean` flag that will delete the directories, jar files, or zip files that the
   plugins will write to, prior to generation. Allows cleaning of existing assets without having
   to call `rm -rf`.
-- Add `clean` as an option for plugin configurations in `buf.gen.yaml`. If set to true, this
-  will delete the directories, jar files, or zip files set to `out` for the plugin.
+- Add `clean` as a top-level option in `buf.gen.yaml`. If set to true, this will delete the directories,
+  jar files, or zip files set to `out` for the plugin.
 
 ## [v1.34.0] - 2024-06-21
 

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -120,9 +120,9 @@ func GenerateWithBaseOutDirPath(baseOutDirPath string) GenerateOption {
 
 // GenerateWithDeleteOuts returns a new GenerateOption that results in the
 // output directories, zip files, or jar files being deleted before generation is run.
-func GenerateWithDeleteOuts() GenerateOption {
+func GenerateWithDeleteOuts(deleteOuts bool) GenerateOption {
 	return func(generateOptions *generateOptions) {
-		generateOptions.deleteOuts = true
+		generateOptions.deleteOuts = &deleteOuts
 	}
 }
 

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -105,7 +105,7 @@ func (g *generator) Generate(
 			return err
 		}
 	}
-	shouldDeleteOuts := config.DeleteOuts()
+	shouldDeleteOuts := config.CleanPluginOuts()
 	if generateOptions.deleteOuts != nil {
 		shouldDeleteOuts = *generateOptions.deleteOuts
 	}

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -105,7 +105,7 @@ func (g *generator) Generate(
 			return err
 		}
 	}
-	shouldDeleteOuts := config.Clean()
+	shouldDeleteOuts := config.DeleteOuts()
 	if generateOptions.deleteOuts != nil {
 		shouldDeleteOuts = *generateOptions.deleteOuts
 	}

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -34,6 +34,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
+	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/thread"
 	"github.com/bufbuild/buf/private/pkg/tracing"
@@ -104,13 +105,18 @@ func (g *generator) Generate(
 			return err
 		}
 	}
-	if err := g.deleteOuts(
-		ctx,
-		generateOptions.baseOutDirPath,
-		generateOptions.deleteOuts,
-		config.GeneratePluginConfigs(),
-	); err != nil {
-		return err
+	shouldDeleteOuts := config.Clean()
+	if generateOptions.deleteOuts != nil {
+		shouldDeleteOuts = *generateOptions.deleteOuts
+	}
+	if shouldDeleteOuts {
+		if err := g.deleteOuts(
+			ctx,
+			generateOptions.baseOutDirPath,
+			config.GeneratePluginConfigs(),
+		); err != nil {
+			return err
+		}
 	}
 	for _, image := range images {
 		if err := g.generateCode(
@@ -131,20 +137,21 @@ func (g *generator) Generate(
 func (g *generator) deleteOuts(
 	ctx context.Context,
 	baseOutDir string,
-	deleteAllOuts bool,
 	pluginConfigs []bufconfig.GeneratePluginConfig,
 ) error {
-	var pluginOuts []string
-	for _, pluginConfig := range pluginConfigs {
-		if deleteAllOuts || pluginConfig.Clean() {
-			if baseOutDir != "" && baseOutDir != "." {
-				pluginOuts = append(pluginOuts, filepath.Join(baseOutDir, pluginConfig.Out()))
-			} else {
-				pluginOuts = append(pluginOuts, pluginConfig.Out())
-			}
-		}
-	}
-	return bufprotopluginos.NewCleaner(g.storageosProvider).DeleteOuts(ctx, pluginOuts)
+	return bufprotopluginos.NewCleaner(g.storageosProvider).DeleteOuts(
+		ctx,
+		slicesext.Map(
+			pluginConfigs,
+			func(pluginConfig bufconfig.GeneratePluginConfig) string {
+				out := pluginConfig.Out()
+				if baseOutDir != "" && baseOutDir != "." {
+					return filepath.Join(baseOutDir, out)
+				}
+				return out
+			},
+		),
+	)
 }
 
 func (g *generator) generateCode(
@@ -481,7 +488,7 @@ func validateResponses(
 
 type generateOptions struct {
 	baseOutDirPath                string
-	deleteOuts                    bool
+	deleteOuts                    *bool
 	includeImportsOverride        *bool
 	includeWellKnownTypesOverride *bool
 }

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -373,7 +373,7 @@ Insertion points are processed in the order the plugins are specified in the tem
 type flags struct {
 	Template               string
 	BaseOutDirPath         string
-	DeleteOuts             bool
+	DeleteOuts             *bool
 	ErrorFormat            string
 	Files                  []string
 	Config                 string
@@ -427,10 +427,10 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		".",
 		`The base directory to generate to. This is prepended to the out directories in the generation template`,
 	)
-	flagSet.BoolVar(
-		&f.DeleteOuts,
+	bindBoolPointer(
+		flagSet,
 		deleteOutsFlagName,
-		false,
+		&f.DeleteOuts,
 		`Prior to generation, delete the directories, jar files, or zip files that the plugins will write to. Allows cleaning of existing assets without having to call rm -rf`,
 	)
 	flagSet.StringVar(
@@ -522,10 +522,10 @@ func run(
 	generateOptions := []bufgen.GenerateOption{
 		bufgen.GenerateWithBaseOutDirPath(flags.BaseOutDirPath),
 	}
-	if flags.DeleteOuts {
+	if flags.DeleteOuts != nil {
 		generateOptions = append(
 			generateOptions,
-			bufgen.GenerateWithDeleteOuts(),
+			bufgen.GenerateWithDeleteOuts(*flags.DeleteOuts),
 		)
 	}
 	if flags.IncludeImportsOverride != nil {

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -551,36 +551,20 @@ func TestGenerateInsertionPointMixedPathsFail(t *testing.T) {
 func TestGenerateDeleteOutDir(t *testing.T) {
 	t.Parallel()
 	// Use --clean flag
-	testGenerateDeleteOuts(t, true, "", "foo")
-	testGenerateDeleteOuts(t, true, "base", "foo")
-	testGenerateDeleteOuts(t, true, "", "foo", "bar")
-	testGenerateDeleteOuts(t, true, "", "foo", "bar", "foo")
-	testGenerateDeleteOuts(t, true, "base", "foo", "bar")
-	testGenerateDeleteOuts(t, true, "base", "foo", "bar", "foo")
-	testGenerateDeleteOuts(t, true, "", "foo.jar")
-	testGenerateDeleteOuts(t, true, "", "foo.zip")
-	testGenerateDeleteOuts(t, true, "", "foo/bar.jar")
-	testGenerateDeleteOuts(t, true, "", "foo/bar.zip")
-	testGenerateDeleteOuts(t, true, "base", "foo.jar")
-	testGenerateDeleteOuts(t, true, "base", "foo.zip")
-	testGenerateDeleteOuts(t, true, "base", "foo/bar.jar")
-	testGenerateDeleteOuts(t, true, "base", "foo/bar.zip")
-
-	// Only set clean in plugin configs
-	testGenerateDeleteOuts(t, false, "", "foo")
-	testGenerateDeleteOuts(t, false, "base", "foo")
-	testGenerateDeleteOuts(t, false, "", "foo", "bar")
-	testGenerateDeleteOuts(t, false, "", "foo", "bar", "foo")
-	testGenerateDeleteOuts(t, false, "base", "foo", "bar")
-	testGenerateDeleteOuts(t, false, "base", "foo", "bar", "foo")
-	testGenerateDeleteOuts(t, false, "", "foo.jar")
-	testGenerateDeleteOuts(t, false, "", "foo.zip")
-	testGenerateDeleteOuts(t, false, "", "foo/bar.jar")
-	testGenerateDeleteOuts(t, false, "", "foo/bar.zip")
-	testGenerateDeleteOuts(t, false, "base", "foo.jar")
-	testGenerateDeleteOuts(t, false, "base", "foo.zip")
-	testGenerateDeleteOuts(t, false, "base", "foo/bar.jar")
-	testGenerateDeleteOuts(t, false, "base", "foo/bar.zip")
+	testGenerateDeleteOuts(t, "", "foo")
+	testGenerateDeleteOuts(t, "base", "foo")
+	testGenerateDeleteOuts(t, "", "foo", "bar")
+	testGenerateDeleteOuts(t, "", "foo", "bar", "foo")
+	testGenerateDeleteOuts(t, "base", "foo", "bar")
+	testGenerateDeleteOuts(t, "base", "foo", "bar", "foo")
+	// testGenerateDeleteOuts(t, "", "foo.jar")
+	testGenerateDeleteOuts(t, "", "foo.zip")
+	// testGenerateDeleteOuts(t, "", "foo/bar.jar")
+	testGenerateDeleteOuts(t, "", "foo/bar.zip")
+	// testGenerateDeleteOuts(t, "base", "foo.jar")
+	testGenerateDeleteOuts(t, "base", "foo.zip")
+	// testGenerateDeleteOuts(t, "base", "foo/bar.jar")
+	testGenerateDeleteOuts(t, "base", "foo/bar.zip")
 }
 
 func TestBoolPointerFlagTrue(t *testing.T) {
@@ -923,13 +907,29 @@ func testRunSuccess(t *testing.T, args ...string) {
 
 func testGenerateDeleteOuts(
 	t *testing.T,
-	useCleanFlag bool,
 	baseOutDirPath string,
 	outputPaths ...string,
 ) {
-	plugins := []string{"java", "cpp", "ruby"}
-	// Just add more builtins to the plugins slice above if this goes off
-	require.True(t, len(outputPaths) <= len(plugins), "we want to have unique plugins to work with and this test is only set up for three plugins max right now")
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, nil, true, true, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, nil, false, false, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, []string{"--clean"}, false, true, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, []string{"--clean"}, true, true, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, []string{"--clean=true"}, true, true, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, []string{"--clean=true"}, false, true, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, []string{"--clean=false"}, true, false, outputPaths)
+	testGenerateDeleteOutsWithArgAndConfig(t, baseOutDirPath, []string{"--clean=false"}, false, false, outputPaths)
+}
+
+func testGenerateDeleteOutsWithArgAndConfig(
+	t *testing.T,
+	baseOutDirPath string,
+	cleanArgs []string,
+	cleanOptionInConfig bool,
+	expectedClean bool,
+	outputPaths []string,
+) {
+	// Just add more builtins to the plugins slice below if this goes off
+	require.True(t, len(outputPaths) < 4, "we want to have unique plugins to work with and this test is only set up for three plugins max right now")
 	fullOutputPaths := outputPaths
 	if baseOutDirPath != "" && baseOutDirPath != "." {
 		fullOutputPaths = slicesext.Map(
@@ -956,6 +956,15 @@ func testGenerateDeleteOuts(
 					[]byte(`1`),
 				),
 			)
+
+			// TODO: remove
+			data, err := storage.ReadPath(
+				ctx,
+				storageBucket,
+				fullOutputPath,
+			)
+			require.NoError(t, err)
+			require.Len(t, data, 1)
 		default:
 			// Write a file that won't be generated to the location.
 			require.NoError(
@@ -974,59 +983,35 @@ func testGenerateDeleteOuts(
 plugins:
 `)
 
-	var expectedPluginConfigCleanOut string
-	if useCleanFlag {
-		// When using the --clean flag, we do not set clean in the plugin configs at all
-		for i, outputPath := range outputPaths {
-			_, _ = templateBuilder.WriteString(`  - protoc_builtin: `)
-			_, _ = templateBuilder.WriteString(plugins[i])
-			_, _ = templateBuilder.WriteString("\n")
-			_, _ = templateBuilder.WriteString(`    out: `)
-			_, _ = templateBuilder.WriteString(outputPath)
-			_, _ = templateBuilder.WriteString("\n")
-		}
-		testRunStdoutStderr(
-			t,
-			nil,
-			0,
-			``,
-			``,
-			filepath.Join("testdata", "simple"),
-			"--template",
-			templateBuilder.String(),
-			"-o",
-			filepath.Join(tmpDirPath, normalpath.Unnormalize(baseOutDirPath)),
-			"--clean",
-		)
-	} else {
-		for i, outputPath := range outputPaths {
-			_, _ = templateBuilder.WriteString(`  - protoc_builtin: `)
-			_, _ = templateBuilder.WriteString(plugins[i])
-			_, _ = templateBuilder.WriteString("\n")
-			_, _ = templateBuilder.WriteString(`    out: `)
-			_, _ = templateBuilder.WriteString(outputPath)
-			_, _ = templateBuilder.WriteString("\n")
-			// Only set "clean: true" for the first plugin (java), and we expect that only the
-			// output for the first plugin to be cleaned
-			if i == 0 { // plugins[0] == "java"
-				_, _ = templateBuilder.WriteString(`    clean: true`)
-				_, _ = templateBuilder.WriteString("\n")
-				expectedPluginConfigCleanOut = fullOutputPaths[i]
-			}
-		}
-		testRunStdoutStderr(
-			t,
-			nil,
-			0,
-			``,
-			``,
-			filepath.Join("testdata", "simple"),
-			"--template",
-			templateBuilder.String(),
-			"-o",
-			filepath.Join(tmpDirPath, normalpath.Unnormalize(baseOutDirPath)),
-		)
+	plugins := []string{"java", "cpp", "ruby"}
+	for i, outputPath := range outputPaths {
+		_, _ = templateBuilder.WriteString(`  - protoc_builtin: `)
+		_, _ = templateBuilder.WriteString(plugins[i])
+		_, _ = templateBuilder.WriteString("\n")
+		_, _ = templateBuilder.WriteString(`    out: `)
+		_, _ = templateBuilder.WriteString(outputPath)
+		_, _ = templateBuilder.WriteString("\n")
 	}
+	if cleanOptionInConfig {
+		templateBuilder.WriteString("clean: true\n")
+	}
+	testRunStdoutStderr(
+		t,
+		nil,
+		0,
+		``,
+		``,
+		append(
+			[]string{
+				filepath.Join("testdata", "simple"),
+				"--template",
+				templateBuilder.String(),
+				"-o",
+				filepath.Join(tmpDirPath, normalpath.Unnormalize(baseOutDirPath)),
+			},
+			cleanArgs...,
+		)...,
+	)
 	for _, fullOutputPath := range fullOutputPaths {
 		switch normalpath.Ext(fullOutputPath) {
 		case ".jar", ".zip":
@@ -1036,22 +1021,20 @@ plugins:
 				fullOutputPath,
 			)
 			require.NoError(t, err)
-			if useCleanFlag || fullOutputPath == expectedPluginConfigCleanOut {
-				require.True(t, len(data) > 1, "expected non-fake data at %q", fullOutputPath)
-			} else {
-				require.True(t, len(data) == 1, "expected fake data at %q", fullOutputPath)
-			}
+			// Always expect non-fake data, because the existing ".jar" or ".zip"
+			// file is always replaced by the output. This is the existing and correct
+			// behavior.
+			require.True(t, len(data) > 1, "expected non-fake data at %q", fullOutputPath)
 		default:
-			data, err := storage.ReadPath(
+			_, err := storage.ReadPath(
 				ctx,
 				storageBucket,
 				normalpath.Join(fullOutputPath, "foo.txt"),
 			)
-			if useCleanFlag || fullOutputPath == expectedPluginConfigCleanOut {
+			if expectedClean {
 				require.ErrorIs(t, err, fs.ErrNotExist)
 			} else {
-				require.NotNil(t, data, "expected foo.txt at %q", fullOutputPath)
-				require.NoError(t, err, "expected foo.txt at %q", fullOutputPath)
+				require.NoError(t, err)
 			}
 		}
 	}

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -550,7 +550,6 @@ func TestGenerateInsertionPointMixedPathsFail(t *testing.T) {
 
 func TestGenerateDeleteOutDir(t *testing.T) {
 	t.Parallel()
-	// Use --clean flag
 	testGenerateDeleteOuts(t, "", "foo")
 	testGenerateDeleteOuts(t, "base", "foo")
 	testGenerateDeleteOuts(t, "", "foo", "bar")

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -1017,7 +1017,7 @@ plugins:
 			// behavior.
 			require.True(t, len(data) > 1, "expected non-fake data at %q", fullOutputPath)
 		default:
-			_, err := storage.ReadPath(
+			data, err := storage.ReadPath(
 				ctx,
 				storageBucket,
 				normalpath.Join(fullOutputPath, "foo.txt"),
@@ -1025,7 +1025,8 @@ plugins:
 			if expectedClean {
 				require.ErrorIs(t, err, fs.ErrNotExist)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err, "expected foo.txt at %q", fullOutputPath)
+				require.NotNil(t, data, "expected foo.txt at %q", fullOutputPath)
 			}
 		}
 	}

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -984,7 +984,7 @@ plugins:
 		_, _ = templateBuilder.WriteString("\n")
 	}
 	if cleanOptionInConfig {
-		templateBuilder.WriteString("clean: true\n")
+		templateBuilder.WriteString("clean_plugin_outs: true\n")
 	}
 	testRunStdoutStderr(
 		t,

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -557,13 +557,13 @@ func TestGenerateDeleteOutDir(t *testing.T) {
 	testGenerateDeleteOuts(t, "", "foo", "bar", "foo")
 	testGenerateDeleteOuts(t, "base", "foo", "bar")
 	testGenerateDeleteOuts(t, "base", "foo", "bar", "foo")
-	// testGenerateDeleteOuts(t, "", "foo.jar")
+	testGenerateDeleteOuts(t, "", "foo.jar")
 	testGenerateDeleteOuts(t, "", "foo.zip")
-	// testGenerateDeleteOuts(t, "", "foo/bar.jar")
+	testGenerateDeleteOuts(t, "", "foo/bar.jar")
 	testGenerateDeleteOuts(t, "", "foo/bar.zip")
-	// testGenerateDeleteOuts(t, "base", "foo.jar")
+	testGenerateDeleteOuts(t, "base", "foo.jar")
 	testGenerateDeleteOuts(t, "base", "foo.zip")
-	// testGenerateDeleteOuts(t, "base", "foo/bar.jar")
+	testGenerateDeleteOuts(t, "base", "foo/bar.jar")
 	testGenerateDeleteOuts(t, "base", "foo/bar.zip")
 }
 

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -956,15 +956,6 @@ func testGenerateDeleteOutsWithArgAndConfig(
 					[]byte(`1`),
 				),
 			)
-
-			// TODO: remove
-			data, err := storage.ReadPath(
-				ctx,
-				storageBucket,
-				fullOutputPath,
-			)
-			require.NoError(t, err)
-			require.Len(t, data, 1)
 		default:
 			// Write a file that won't be generated to the location.
 			require.NoError(

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -257,11 +257,11 @@ func writeBufGenYAMLFile(writer io.Writer, bufGenYAMLFile BufGenYAMLFile) error 
 		return err
 	}
 	externalBufGenYAMLFileV2 := externalBufGenYAMLFileV2{
-		Version: FileVersionV2.String(),
-		Clean:   bufGenYAMLFile.GenerateConfig().Clean(),
-		Plugins: externalPluginConfigsV2,
-		Managed: externalManagedConfigV2,
-		Inputs:  externalInputConfigsV2,
+		Version:    FileVersionV2.String(),
+		DeleteOuts: bufGenYAMLFile.GenerateConfig().DeleteOuts(),
+		Plugins:    externalPluginConfigsV2,
+		Managed:    externalManagedConfigV2,
+		Inputs:     externalInputConfigsV2,
 	}
 	data, err := encoding.MarshalYAML(&externalBufGenYAMLFileV2)
 	if err != nil {
@@ -484,11 +484,11 @@ type externalTypesConfigV1 struct {
 type externalBufGenYAMLFileV2 struct {
 	Version string                          `json:"version,omitempty" yaml:"version,omitempty"`
 	Managed externalGenerateManagedConfigV2 `json:"managed,omitempty" yaml:"managed,omitempty"`
-	// Clean, if set to true, will delete the output directories, zip files, or jar files
+	// DeleteOuts, if set to true, will delete the output directories, zip files, or jar files
 	// before generation is run.
-	Clean   bool                             `json:"clean,omitempty" yaml:"clean,omitempty"`
-	Plugins []externalGeneratePluginConfigV2 `json:"plugins,omitempty" yaml:"plugins,omitempty"`
-	Inputs  []externalInputConfigV2          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	DeleteOuts bool                             `json:"clean_plugin_outs,omitempty" yaml:"clean_plugin_outs,omitempty"`
+	Plugins    []externalGeneratePluginConfigV2 `json:"plugins,omitempty" yaml:"plugins,omitempty"`
+	Inputs     []externalInputConfigV2          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 }
 
 // externalGeneratePluginConfigV2 represents a single plugin config in a v2 buf.gen.yaml file.

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -257,11 +257,11 @@ func writeBufGenYAMLFile(writer io.Writer, bufGenYAMLFile BufGenYAMLFile) error 
 		return err
 	}
 	externalBufGenYAMLFileV2 := externalBufGenYAMLFileV2{
-		Version:    FileVersionV2.String(),
-		DeleteOuts: bufGenYAMLFile.GenerateConfig().DeleteOuts(),
-		Plugins:    externalPluginConfigsV2,
-		Managed:    externalManagedConfigV2,
-		Inputs:     externalInputConfigsV2,
+		Version:         FileVersionV2.String(),
+		CleanPluginOuts: bufGenYAMLFile.GenerateConfig().CleanPluginOuts(),
+		Plugins:         externalPluginConfigsV2,
+		Managed:         externalManagedConfigV2,
+		Inputs:          externalInputConfigsV2,
 	}
 	data, err := encoding.MarshalYAML(&externalBufGenYAMLFileV2)
 	if err != nil {
@@ -484,11 +484,11 @@ type externalTypesConfigV1 struct {
 type externalBufGenYAMLFileV2 struct {
 	Version string                          `json:"version,omitempty" yaml:"version,omitempty"`
 	Managed externalGenerateManagedConfigV2 `json:"managed,omitempty" yaml:"managed,omitempty"`
-	// DeleteOuts, if set to true, will delete the output directories, zip files, or jar files
+	// CleanPluginOuts, if set to true, will delete the output directories, zip files, or jar files
 	// before generation is run.
-	DeleteOuts bool                             `json:"clean_plugin_outs,omitempty" yaml:"clean_plugin_outs,omitempty"`
-	Plugins    []externalGeneratePluginConfigV2 `json:"plugins,omitempty" yaml:"plugins,omitempty"`
-	Inputs     []externalInputConfigV2          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	CleanPluginOuts bool                             `json:"clean_plugin_outs,omitempty" yaml:"clean_plugin_outs,omitempty"`
+	Plugins         []externalGeneratePluginConfigV2 `json:"plugins,omitempty" yaml:"plugins,omitempty"`
+	Inputs          []externalInputConfigV2          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 }
 
 // externalGeneratePluginConfigV2 represents a single plugin config in a v2 buf.gen.yaml file.

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -258,6 +258,7 @@ func writeBufGenYAMLFile(writer io.Writer, bufGenYAMLFile BufGenYAMLFile) error 
 	}
 	externalBufGenYAMLFileV2 := externalBufGenYAMLFileV2{
 		Version: FileVersionV2.String(),
+		Clean:   bufGenYAMLFile.GenerateConfig().Clean(),
 		Plugins: externalPluginConfigsV2,
 		Managed: externalManagedConfigV2,
 		Inputs:  externalInputConfigsV2,
@@ -481,8 +482,11 @@ type externalTypesConfigV1 struct {
 
 // externalBufGenYAMLFileV2 represents the v2 buf.gen.yaml file.
 type externalBufGenYAMLFileV2 struct {
-	Version string                           `json:"version,omitempty" yaml:"version,omitempty"`
-	Managed externalGenerateManagedConfigV2  `json:"managed,omitempty" yaml:"managed,omitempty"`
+	Version string                          `json:"version,omitempty" yaml:"version,omitempty"`
+	Managed externalGenerateManagedConfigV2 `json:"managed,omitempty" yaml:"managed,omitempty"`
+	// Clean, if set to true, will delete the output directories, zip files, or jar files
+	// before generation is run.
+	Clean   bool                             `json:"clean,omitempty" yaml:"clean,omitempty"`
 	Plugins []externalGeneratePluginConfigV2 `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 	Inputs  []externalInputConfigV2          `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 }
@@ -504,9 +508,6 @@ type externalGeneratePluginConfigV2 struct {
 	ProtocPath any `json:"protoc_path,omitempty" yaml:"protoc_path,omitempty"`
 	// Out is required.
 	Out string `json:"out,omitempty" yaml:"out,omitempty"`
-	// Clean, if set to true, will delete the output directories, zip files, or jar files
-	// before generation is run.
-	Clean bool `json:"clean,omitempty" yaml:"clean,omitempty"`
 	// Opt can be one string or multiple strings.
 	Opt            any  `json:"opt,omitempty" yaml:"opt,omitempty"`
 	IncludeImports bool `json:"include_imports,omitempty" yaml:"include_imports,omitempty"`

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file_test.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file_test.go
@@ -106,19 +106,19 @@ plugins:
 		t,
 		// input
 		`version: v2
+clean: true
 plugins:
   - local: custom-gen-go
     out: gen/go
-    clean: true
     opt: paths=source_relative
     strategy: directory
 `,
 		// expected output
 		`version: v2
+clean: true
 plugins:
   - local: custom-gen-go
     out: gen/go
-    clean: true
     opt: paths=source_relative
     strategy: directory
 `,

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file_test.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file_test.go
@@ -106,7 +106,7 @@ plugins:
 		t,
 		// input
 		`version: v2
-clean: true
+clean_plugin_outs: true
 plugins:
   - local: custom-gen-go
     out: gen/go
@@ -115,7 +115,7 @@ plugins:
 `,
 		// expected output
 		`version: v2
-clean: true
+clean_plugin_outs: true
 plugins:
   - local: custom-gen-go
     out: gen/go

--- a/private/bufpkg/bufconfig/generate_config.go
+++ b/private/bufpkg/bufconfig/generate_config.go
@@ -22,6 +22,9 @@ import (
 
 // GenerateConfig is a generation configuration.
 type GenerateConfig interface {
+	// Clean is whether to delete the output directories, zip files, or jar files before
+	// generation is run.
+	Clean() bool
 	// GeneratePluginConfigs returns the plugin configurations. This will always be
 	// non-empty. Zero plugin configs will cause an error at construction time.
 	GeneratePluginConfigs() []GeneratePluginConfig
@@ -38,6 +41,7 @@ type GenerateConfig interface {
 
 // NewGenerateConfig returns a validated GenerateConfig.
 func NewGenerateConfig(
+	clean bool,
 	pluginConfigs []GeneratePluginConfig,
 	managedConfig GenerateManagedConfig,
 	typeConfig GenerateTypeConfig,
@@ -46,6 +50,7 @@ func NewGenerateConfig(
 		return nil, newNoPluginsError()
 	}
 	return &generateConfig{
+		clean:         clean,
 		pluginConfigs: pluginConfigs,
 		managedConfig: managedConfig,
 		typeConfig:    typeConfig,
@@ -55,6 +60,7 @@ func NewGenerateConfig(
 // *** PRIVATE ***
 
 type generateConfig struct {
+	clean         bool
 	pluginConfigs []GeneratePluginConfig
 	managedConfig GenerateManagedConfig
 	typeConfig    GenerateTypeConfig
@@ -122,9 +128,14 @@ func newGenerateConfigFromExternalFileV2(
 		return nil, err
 	}
 	return &generateConfig{
+		clean:         externalFile.Clean,
 		managedConfig: managedConfig,
 		pluginConfigs: pluginConfigs,
 	}, nil
+}
+
+func (g *generateConfig) Clean() bool {
+	return g.clean
 }
 
 func (g *generateConfig) GeneratePluginConfigs() []GeneratePluginConfig {

--- a/private/bufpkg/bufconfig/generate_config.go
+++ b/private/bufpkg/bufconfig/generate_config.go
@@ -22,9 +22,9 @@ import (
 
 // GenerateConfig is a generation configuration.
 type GenerateConfig interface {
-	// Clean is whether to delete the output directories, zip files, or jar files before
+	// DeleteOuts is whether to delete the output directories, zip files, or jar files before
 	// generation is run.
-	Clean() bool
+	DeleteOuts() bool
 	// GeneratePluginConfigs returns the plugin configurations. This will always be
 	// non-empty. Zero plugin configs will cause an error at construction time.
 	GeneratePluginConfigs() []GeneratePluginConfig
@@ -50,7 +50,7 @@ func NewGenerateConfig(
 		return nil, newNoPluginsError()
 	}
 	return &generateConfig{
-		clean:         clean,
+		deleteOuts:    clean,
 		pluginConfigs: pluginConfigs,
 		managedConfig: managedConfig,
 		typeConfig:    typeConfig,
@@ -60,7 +60,7 @@ func NewGenerateConfig(
 // *** PRIVATE ***
 
 type generateConfig struct {
-	clean         bool
+	deleteOuts    bool
 	pluginConfigs []GeneratePluginConfig
 	managedConfig GenerateManagedConfig
 	typeConfig    GenerateTypeConfig
@@ -128,14 +128,14 @@ func newGenerateConfigFromExternalFileV2(
 		return nil, err
 	}
 	return &generateConfig{
-		clean:         externalFile.Clean,
+		deleteOuts:    externalFile.DeleteOuts,
 		managedConfig: managedConfig,
 		pluginConfigs: pluginConfigs,
 	}, nil
 }
 
-func (g *generateConfig) Clean() bool {
-	return g.clean
+func (g *generateConfig) DeleteOuts() bool {
+	return g.deleteOuts
 }
 
 func (g *generateConfig) GeneratePluginConfigs() []GeneratePluginConfig {

--- a/private/bufpkg/bufconfig/generate_config.go
+++ b/private/bufpkg/bufconfig/generate_config.go
@@ -22,9 +22,9 @@ import (
 
 // GenerateConfig is a generation configuration.
 type GenerateConfig interface {
-	// DeleteOuts is whether to delete the output directories, zip files, or jar files before
+	// CleanPluginOuts is whether to delete the output directories, zip files, or jar files before
 	// generation is run.
-	DeleteOuts() bool
+	CleanPluginOuts() bool
 	// GeneratePluginConfigs returns the plugin configurations. This will always be
 	// non-empty. Zero plugin configs will cause an error at construction time.
 	GeneratePluginConfigs() []GeneratePluginConfig
@@ -41,7 +41,7 @@ type GenerateConfig interface {
 
 // NewGenerateConfig returns a validated GenerateConfig.
 func NewGenerateConfig(
-	clean bool,
+	cleanPluginOuts bool,
 	pluginConfigs []GeneratePluginConfig,
 	managedConfig GenerateManagedConfig,
 	typeConfig GenerateTypeConfig,
@@ -50,20 +50,20 @@ func NewGenerateConfig(
 		return nil, newNoPluginsError()
 	}
 	return &generateConfig{
-		deleteOuts:    clean,
-		pluginConfigs: pluginConfigs,
-		managedConfig: managedConfig,
-		typeConfig:    typeConfig,
+		cleanPluginOuts: cleanPluginOuts,
+		pluginConfigs:   pluginConfigs,
+		managedConfig:   managedConfig,
+		typeConfig:      typeConfig,
 	}, nil
 }
 
 // *** PRIVATE ***
 
 type generateConfig struct {
-	deleteOuts    bool
-	pluginConfigs []GeneratePluginConfig
-	managedConfig GenerateManagedConfig
-	typeConfig    GenerateTypeConfig
+	cleanPluginOuts bool
+	pluginConfigs   []GeneratePluginConfig
+	managedConfig   GenerateManagedConfig
+	typeConfig      GenerateTypeConfig
 }
 
 func newGenerateConfigFromExternalFileV1Beta1(
@@ -128,14 +128,14 @@ func newGenerateConfigFromExternalFileV2(
 		return nil, err
 	}
 	return &generateConfig{
-		deleteOuts:    externalFile.DeleteOuts,
-		managedConfig: managedConfig,
-		pluginConfigs: pluginConfigs,
+		cleanPluginOuts: externalFile.CleanPluginOuts,
+		managedConfig:   managedConfig,
+		pluginConfigs:   pluginConfigs,
 	}, nil
 }
 
-func (g *generateConfig) DeleteOuts() bool {
-	return g.deleteOuts
+func (g *generateConfig) CleanPluginOuts() bool {
+	return g.cleanPluginOuts
 }
 
 func (g *generateConfig) GeneratePluginConfigs() []GeneratePluginConfig {

--- a/private/bufpkg/bufconfig/generate_plugin_config.go
+++ b/private/bufpkg/bufconfig/generate_plugin_config.go
@@ -83,9 +83,6 @@ type GeneratePluginConfig interface {
 	Name() string
 	// Out returns the output directory for generation. This is never empty.
 	Out() string
-	// Clean, if true, will delete the output directories, zip files, or jar files before
-	// generation is run.
-	Clean() bool
 	// Opt returns the plugin options as a comma separated string.
 	Opt() string
 	// IncludeImports returns whether to generate code for imported files. This
@@ -123,7 +120,6 @@ type GeneratePluginConfig interface {
 func NewRemotePluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -132,7 +128,6 @@ func NewRemotePluginConfig(
 	return newRemotePluginConfig(
 		name,
 		out,
-		clean,
 		opt,
 		includeImports,
 		includeWKT,
@@ -145,7 +140,6 @@ func NewLocalOrProtocBuiltinPluginConfig(
 	name string,
 	out string,
 	opt []string,
-	clean bool,
 	includeImports bool,
 	includeWKT bool,
 	strategy *GenerateStrategy,
@@ -153,7 +147,6 @@ func NewLocalOrProtocBuiltinPluginConfig(
 	return newLocalOrProtocBuiltinPluginConfig(
 		name,
 		out,
-		clean,
 		opt,
 		includeImports,
 		includeWKT,
@@ -165,7 +158,6 @@ func NewLocalOrProtocBuiltinPluginConfig(
 func NewLocalPluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -175,7 +167,6 @@ func NewLocalPluginConfig(
 	return newLocalPluginConfig(
 		name,
 		out,
-		clean,
 		opt,
 		includeImports,
 		includeWKT,
@@ -189,7 +180,6 @@ func NewLocalPluginConfig(
 func NewProtocBuiltinPluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -199,7 +189,6 @@ func NewProtocBuiltinPluginConfig(
 	return newProtocBuiltinPluginConfig(
 		name,
 		out,
-		clean,
 		opt,
 		includeImports,
 		includeWKT,
@@ -235,7 +224,6 @@ type pluginConfig struct {
 	pluginConfigType PluginConfigType
 	name             string
 	out              string
-	clean            bool
 	opts             []string
 	includeImports   bool
 	includeWKT       bool
@@ -267,7 +255,6 @@ func newPluginConfigFromExternalV1Beta1(
 		return newLocalPluginConfig(
 			externalConfig.Name,
 			externalConfig.Out,
-			false, // Clean is not available on <v2 plugin configs
 			opt,
 			false,
 			false,
@@ -278,7 +265,6 @@ func newPluginConfigFromExternalV1Beta1(
 	return newLocalOrProtocBuiltinPluginConfig(
 		externalConfig.Name,
 		externalConfig.Out,
-		false, // Clean is not available on <v2 plugin configs
 		opt,
 		false,
 		false,
@@ -338,7 +324,6 @@ func newPluginConfigFromExternalV1(
 		return newRemotePluginConfig(
 			externalConfig.Plugin,
 			externalConfig.Out,
-			false, // Clean is not available on <v2 plugin configs
 			opt,
 			false,
 			false,
@@ -351,7 +336,6 @@ func newPluginConfigFromExternalV1(
 		return newLocalPluginConfig(
 			pluginIdentifier,
 			externalConfig.Out,
-			false, // Clean is not available on <v2 plugin configs
 			opt,
 			false,
 			false,
@@ -363,7 +347,6 @@ func newPluginConfigFromExternalV1(
 		return newProtocBuiltinPluginConfig(
 			pluginIdentifier,
 			externalConfig.Out,
-			false, // Clean is not available on <v2 plugin configs
 			opt,
 			false,
 			false,
@@ -376,7 +359,6 @@ func newPluginConfigFromExternalV1(
 	return newLocalOrProtocBuiltinPluginConfig(
 		pluginIdentifier,
 		externalConfig.Out,
-		false, // Clean is not available on <v2 plugin configs
 		opt,
 		false,
 		false,
@@ -433,7 +415,6 @@ func newPluginConfigFromExternalV2(
 		return newRemotePluginConfig(
 			*externalConfig.Remote,
 			externalConfig.Out,
-			externalConfig.Clean,
 			opt,
 			externalConfig.IncludeImports,
 			externalConfig.IncludeWKT,
@@ -454,7 +435,6 @@ func newPluginConfigFromExternalV2(
 		return newLocalPluginConfig(
 			strings.Join(path, " "),
 			externalConfig.Out,
-			externalConfig.Clean,
 			opt,
 			externalConfig.IncludeImports,
 			externalConfig.IncludeWKT,
@@ -472,7 +452,6 @@ func newPluginConfigFromExternalV2(
 		return newProtocBuiltinPluginConfig(
 			*externalConfig.ProtocBuiltin,
 			externalConfig.Out,
-			externalConfig.Clean,
 			opt,
 			externalConfig.IncludeImports,
 			externalConfig.IncludeWKT,
@@ -487,7 +466,6 @@ func newPluginConfigFromExternalV2(
 func newRemotePluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -509,7 +487,6 @@ func newRemotePluginConfig(
 		remoteHost:       remoteHost,
 		revision:         revision,
 		out:              out,
-		clean:            clean,
 		opts:             opt,
 		includeImports:   includeImports,
 		includeWKT:       includeWKT,
@@ -519,7 +496,6 @@ func newRemotePluginConfig(
 func newLocalOrProtocBuiltinPluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -533,7 +509,6 @@ func newLocalOrProtocBuiltinPluginConfig(
 		name:             name,
 		strategy:         strategy,
 		out:              out,
-		clean:            clean,
 		opts:             opt,
 		includeImports:   includeImports,
 		includeWKT:       includeWKT,
@@ -543,7 +518,6 @@ func newLocalOrProtocBuiltinPluginConfig(
 func newLocalPluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -562,7 +536,6 @@ func newLocalPluginConfig(
 		path:             path,
 		strategy:         strategy,
 		out:              out,
-		clean:            clean,
 		opts:             opt,
 		includeImports:   includeImports,
 		includeWKT:       includeWKT,
@@ -572,7 +545,6 @@ func newLocalPluginConfig(
 func newProtocBuiltinPluginConfig(
 	name string,
 	out string,
-	clean bool,
 	opt []string,
 	includeImports bool,
 	includeWKT bool,
@@ -587,7 +559,6 @@ func newProtocBuiltinPluginConfig(
 		name:             name,
 		protocPath:       protocPath,
 		out:              out,
-		clean:            clean,
 		opts:             opt,
 		strategy:         strategy,
 		includeImports:   includeImports,
@@ -605,10 +576,6 @@ func (p *pluginConfig) Name() string {
 
 func (p *pluginConfig) Out() string {
 	return p.out
-}
-
-func (p *pluginConfig) Clean() bool {
-	return p.clean
 }
 
 func (p *pluginConfig) Opt() string {
@@ -657,7 +624,6 @@ func newExternalGeneratePluginConfigV2FromPluginConfig(
 	}
 	externalPluginConfigV2 := externalGeneratePluginConfigV2{
 		Out:            generatePluginConfig.Out(),
-		Clean:          generatePluginConfig.Clean(),
 		IncludeImports: generatePluginConfig.IncludeImports(),
 		IncludeWKT:     generatePluginConfig.IncludeWKT(),
 	}


### PR DESCRIPTION
This PR targets branch `add-buf-gen-yaml-clean` and moves `clean` to `buf.gen.yaml`'s top level, from the plugin level.