### PR TITLE
Install zip before using it in the release process

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -154,7 +154,7 @@ bufgeneratesteps:: \
 
 .PHONY: bufrelease
 bufrelease: $(MINISIGN)
-	DOCKER_IMAGE=golang:1.22-bookworm bash make/buf/scripts/release.bash
+	bash make/buf/scripts/release.bash
 
 .PHONY: bufbinarysize
 bufbinarysize:

--- a/make/buf/dockerfiles/Dockerfile.release
+++ b/make/buf/dockerfiles/Dockerfile.release
@@ -2,4 +2,4 @@ FROM golang:1.22-bookworm
 RUN  apt-get -y update \
      && apt-get -y autoremove \
      && apt-get clean \
-     && apt-get install -y zip \
+     && apt-get install -y zip

--- a/make/buf/dockerfiles/Dockerfile.release
+++ b/make/buf/dockerfiles/Dockerfile.release
@@ -1,0 +1,5 @@
+FROM golang:1.22-bookworm
+RUN  apt-get -y update \
+     && apt-get -y autoremove \
+     && apt-get clean \
+     && apt-get install -y zip \

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -140,6 +140,11 @@ for os in Darwin Linux; do
   done
 done
 
+apt-get -y update
+apt-get -y autoremove
+apt-get clean
+apt-get install -y zip
+
 for os in Windows; do
   for arch in x86_64 arm64; do
     dir="${os}/${arch}/${BASE_NAME}"

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -3,6 +3,8 @@
 set -eo pipefail
 set -x
 
+RELEASE_DOCKER_FILE="make/buf/dockerfiles/Dockerfile.release"
+RELEASE_DOCKER_IMAGE="bufrelease-tag"
 DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
 cd "${DIR}"
 
@@ -48,15 +50,13 @@ if [ -z "${INSIDE_DOCKER}" ]; then
       fail "RELEASE_MINISIGN_PRIVATE_KEY and RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD must be set."
     fi
   fi
-  if [ -z "${DOCKER_IMAGE}" ]; then
-    fail "DOCKER_IMAGE must be set"
-  fi
+  docker build -f "${RELEASE_DOCKER_FILE}" -t "${RELEASE_DOCKER_IMAGE}" .
   docker run --volume \
     "${DIR}:/app" \
     --workdir "/app" \
     --rm \
     -e INSIDE_DOCKER=1 \
-    "${DOCKER_IMAGE}" \
+    "${RELEASE_DOCKER_IMAGE}" \
     bash -x make/buf/scripts/release.bash
   if [ "$(uname -s)" == "Linux" ]; then
     sudo chown -R "$(id -u):$(id -g)" .build
@@ -139,11 +139,6 @@ for os in Darwin Linux; do
     tar -C "${tar_context_dir}" -cvzf "${tarball}" "${tar_dir}"
   done
 done
-
-apt-get -y update
-apt-get -y autoremove
-apt-get clean
-apt-get install -y zip
 
 for os in Windows; do
   for arch in x86_64 arm64; do


### PR DESCRIPTION
This installs `zip` with `apt-get` in `release.bash`, when it's run inside a docker image.