### PR TITLE
Add a comment with link to docs for `buf config init`

### DIFF
--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -2049,7 +2049,8 @@ func TestModInitBasic(t *testing.T) {
 	t.Parallel()
 	testModInit(
 		t,
-		`version: v2
+		`# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
+version: v2
 lint:
   use:
     - DEFAULT

--- a/private/buf/cmd/buf/command/config/configinit/configinit.go
+++ b/private/buf/cmd/buf/command/config/configinit/configinit.go
@@ -168,7 +168,7 @@ func run(
 			moduleConfig,
 		},
 		nil,
-		bufconfig.BufYAMLFileWithIncludeDocsLink(true),
+		bufconfig.BufYAMLFileWithIncludeDocsLink(),
 	)
 	if err != nil {
 		return err

--- a/private/buf/cmd/buf/command/config/configinit/configinit.go
+++ b/private/buf/cmd/buf/command/config/configinit/configinit.go
@@ -168,6 +168,7 @@ func run(
 			moduleConfig,
 		},
 		nil,
+		bufconfig.BufYAMLFileWithIncludeDocsLink(true),
 	)
 	if err != nil {
 		return err

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -131,11 +131,11 @@ func NewBufYAMLFile(
 type BufYAMLFileOption func(*bufYAMLFileOptions)
 
 // BufYAMLFileWithIncludeDocsLink returns a new BufYAMLFileOption that specifies including
-// a comment with a link to the public docs at the top of the buf.yaml file. The comment
-// is included when set to true.
-func BufYAMLFileWithIncludeDocsLink(includeDocsLink bool) BufYAMLFileOption {
+// a comment with a link to the public docs for the appropriate buf.yaml version at the top
+// of the buf.yaml file.
+func BufYAMLFileWithIncludeDocsLink() BufYAMLFileOption {
 	return func(bufYAMLFileOptions *bufYAMLFileOptions) {
-		bufYAMLFileOptions.includeDocsLink = includeDocsLink
+		bufYAMLFileOptions.includeDocsLink = true
 	}
 }
 

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -365,6 +365,9 @@ func readBufYAMLFile(
 	if err != nil {
 		return nil, err
 	}
+	// Check if this file has the docs link comment from "buf config init" as its first line
+	// so we can preserve the comment in our round trip.
+	includeDocsLink := bytes.HasPrefix(data, []byte(fmt.Sprintf(docsLinkComment, fileVersion.String())))
 	switch fileVersion {
 	case FileVersionV1Beta1, FileVersionV1:
 		var externalBufYAMLFile externalBufYAMLFileV1Beta1V1
@@ -426,7 +429,7 @@ func readBufYAMLFile(
 			lintConfig,
 			breakingConfig,
 			configuredDepModuleRefs,
-			false, // TODO(doria): fix round trip
+			includeDocsLink,
 		)
 	case FileVersionV2:
 		var externalBufYAMLFile externalBufYAMLFileV2
@@ -574,7 +577,7 @@ func readBufYAMLFile(
 			topLevelLintConfig,
 			topLevelBreakingConfig,
 			configuredDepModuleRefs,
-			false, // TODO(doria): fix round trip
+			includeDocsLink,
 		)
 	default:
 		// This is a system error since we've already parsed.

--- a/private/bufpkg/bufconfig/buf_yaml_file_test.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file_test.go
@@ -16,6 +16,7 @@ package bufconfig
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -68,6 +69,34 @@ build:
   excludes:
     - tests
 `,
+	)
+
+	testReadWriteBufYAMLFileRoundTrip(
+		t,
+		//input
+		strings.Join(
+			[]string{
+				fmt.Sprintf(docsLinkComment, "v1"),
+				`version: v1
+build:
+  excludes:
+    - tests
+`,
+			},
+			"\n",
+		),
+		// expected output
+		strings.Join(
+			[]string{
+				fmt.Sprintf(docsLinkComment, "v1"),
+				`version: v1
+build:
+  excludes:
+    - tests
+`,
+			},
+			"\n",
+		),
 	)
 
 	testReadWriteBufYAMLFileRoundTrip(
@@ -290,6 +319,38 @@ modules:
   - path: baz
     name: buf.build/foo/baz
 `,
+	)
+
+	testReadWriteBufYAMLFileRoundTrip(
+		t,
+		// input
+		strings.Join(
+			[]string{
+				fmt.Sprintf(docsLinkComment, "v2"),
+				`version: v2
+modules:
+  - path: baz
+    name: buf.build/foo/baz
+  - path: bar
+    name: buf.build/foo/bar
+`,
+			},
+			"\n",
+		),
+		// expected output
+		strings.Join(
+			[]string{
+				fmt.Sprintf(docsLinkComment, "v2"),
+				`version: v2
+modules:
+  - path: bar
+    name: buf.build/foo/bar
+  - path: baz
+    name: buf.build/foo/baz
+`,
+			},
+			"\n",
+		),
 	)
 }
 


### PR DESCRIPTION
This adds a comment at the top of the `buf.yaml` file generated from
`buf config init` with a link to our public docs to make it easier for users
who are onboarding to get more information on `buf.yaml` configs.

Running `buf config init` generates a `buf.yaml` with the following contents:

```
# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
version: v2
lint:
  use:
    - DEFAULT
breaking:
  use:
    - FILE

```

The comment is preserved when round-tripping `buf.yaml`.

Fixes #3180