### PR TITLE
Only check directories in workspace targeting fallback logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix the git input parameter `ref` to align with the `git` notion of a ref. This allows for the use 
   of branch names, tag names, and commit hashes.
+- Fix bug to check the directory of target proto file paths in fallback logic when scanning
+  for workspace and/or module config files
 
 ## [v1.35.0] - 2024-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Fix the git input parameter `ref` to align with the `git` notion of a ref. This allows for the use 
   of branch names, tag names, and commit hashes.
-- Fix bug to check the directory of target proto file paths in fallback logic when scanning
-  for workspace and/or module config files
+- Fix unexpected `buf build` errors with absolute path directory inputs without workspace and/or
+  module configurations (e.g. `buf.yaml`, `buf.work.yaml`) and proto file paths set to the `--path` flag.
 
 ## [v1.35.0] - 2024-07-22
 

--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -625,6 +625,14 @@ func checkForControllingWorkspaceOrV1Module(
 	ignoreWorkspaceCheck bool,
 ) (buftarget.ControllingWorkspace, error) {
 	path = normalpath.Normalize(path)
+	// We attempt to check that the provided target path is not a file by checking the extension.
+	// Any valid proto file provided as a target would have the .proto extension, so we treat
+	// any path given without as a directory.
+	// This could be a file without an extension, in which case an error would be returned
+	// to the user when we attempt to check for a controlling workspace.
+	if normalpath.Ext(path) != "" {
+		path = normalpath.Dir(path)
+	}
 	// Keep track of any v1 module found along the way. If we find a v1 or v2 workspace, we
 	// return that over the v1 module, but we return this as the fallback.
 	var fallbackV1Module buftarget.ControllingWorkspace

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -89,6 +89,34 @@ func TestSuccessProfile1(t *testing.T) {
 	testRunStdoutProfile(t, nil, 0, ``, "build", filepath.Join("testdata", "success"))
 }
 
+func TestSuccessDir(t *testing.T) {
+	t.Parallel()
+	testRunStdout(t, nil, 0, ``, "build", filepath.Join("testdata", "successnobufyaml"))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		``,
+		"build",
+		filepath.Join("testdata", "successnobufyaml"),
+		"--path",
+		filepath.Join("testdata", "successnobufyaml", "buf", "buf.proto"),
+	)
+	wd, err := osext.Getwd()
+	require.NoError(t, err)
+	testRunStdout(t, nil, 0, ``, "build", filepath.Join(wd, "testdata", "successnobufyaml"))
+	testRunStdout(
+		t,
+		nil,
+		0,
+		``,
+		"build",
+		filepath.Join(wd, "testdata", "successnobufyaml"),
+		"--path",
+		filepath.Join(wd, "testdata", "successnobufyaml", "buf", "buf.proto"),
+	)
+}
+
 func TestFail1(t *testing.T) {
 	t.Parallel()
 	testRunStdout(

--- a/private/buf/cmd/buf/testdata/successnobufyaml/buf/buf.proto
+++ b/private/buf/cmd/buf/testdata/successnobufyaml/buf/buf.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package buf;
+
+import "google/protobuf/descriptor.proto";
+
+message Foo {
+  int64 one = 1;
+  google.protobuf.DescriptorProto two = 2;
+}


### PR DESCRIPTION
When calling our fallback logic checking for workspaces, we
check in the target paths to see if a valid workspace/module
is found. However, we should only be checking directories and
not target paths, such as `--path path/to/my.proto` (we want to
check `path/to`).

Tests have been added for both the relative and absolute directory
inputs without `buf.yaml` files.

Fixes #3183