### PR TITLE
Fix git checkout for annotated tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix git input handling of annotated tags.
 
 ## [v1.35.1] - 2024-07-24
 

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -350,11 +350,11 @@ func getRefspecsForName(gitName Name) (fetchRef string, fallbackRef string, chec
 		return createFetchRefSpec(cloneBranch), "", checkout
 	} else if cloneBranch != "" {
 		// If a branch is specified, we fetch the branch directly.
-		return createFetchRefSpec(cloneBranch), "", cloneBranch
+		return cloneBranch, "", ""
 	} else if checkout != "" && checkout != "HEAD" {
 		// If a checkout ref is specified, we fetch the ref directly.
 		// We fallback to fetching the HEAD to resolve partial refs.
-		return createFetchRefSpec(checkout), "HEAD", checkout
+		return checkout, "HEAD", ""
 	}
 	return "HEAD", "", ""
 }

--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -146,6 +146,26 @@ func TestGitCloner(t *testing.T) {
 		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
+	t.Run("tag=remote-annotated-tag", func(t *testing.T) {
+		t.Parallel()
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewTagName("remote-annotated-tag"), false)
+
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
+		require.NoError(t, err)
+		assert.Equal(t, "// commit 4", string(content))
+		_, err = readBucket.Stat(ctx, "nonexistent")
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+	t.Run("ref=remote-annotated-tag", func(t *testing.T) {
+		t.Parallel()
+		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewRefName("remote-annotated-tag"), false)
+
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
+		require.NoError(t, err)
+		assert.Equal(t, "// commit 4", string(content))
+		_, err = readBucket.Stat(ctx, "nonexistent")
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
 
 	t.Run("branch_and_main_ref", func(t *testing.T) {
 		t.Parallel()
@@ -308,6 +328,7 @@ func createGitDirs(
 	runCommand(ctx, t, container, runner, "git", "-C", originPath, "add", "test.proto")
 	runCommand(ctx, t, container, runner, "git", "-C", originPath, "commit", "-m", "commit 4")
 	runCommand(ctx, t, container, runner, "git", "-C", originPath, "tag", "remote-tag")
+	runCommand(ctx, t, container, runner, "git", "-C", originPath, "tag", "-a", "remote-annotated-tag", "-m", "annotated tag")
 
 	runCommand(ctx, t, container, runner, "git", "-C", workPath, "fetch", "origin")
 	return originPath, workPath


### PR DESCRIPTION
Remove refspec annotation for tags. Annotated tags cannot be mapped to a local ref.

Fixes #3197
