### PR TITLE
Fix deprecated flag casing

### DIFF
--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -76,7 +76,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"",
 		"The username to use.",
 	)
-	_ = flagSet.MarkDeprecated(usernameFlagName, "This flag is no longer needed as the username is automatically derived from the token")
+	_ = flagSet.MarkDeprecated(usernameFlagName, "this flag is no longer needed as the username is automatically derived from the token")
 	_ = flagSet.MarkHidden(usernameFlagName)
 	flagSet.BoolVar(
 		&f.TokenStdin,


### PR DESCRIPTION
Noticed while using this flag that the message comes out after a comma, so the capital letter is incorrect:

```
Flag --username has been deprecated, This flag is no longer needed as the username is automatically derived from the token
```