### PR TITLE
Bump buf-action CI from v0.2 to v1

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.3
+      - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-action@v0.2
+      - uses: bufbuild/buf-action@v0.3
         with:
-          username: ${{ secrets.BUF_USERNAME }}
           token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
Removes the `username` config for v0.3, upgrades to v1.