### PR TITLE
[WIP] Split imports as well for directory strategy in buf generate

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -324,6 +324,13 @@ func (g *generator) execLocalPlugin(
 	if err != nil {
 		return nil, err
 	}
+	// fmt.Println("IMAGES:")
+	// for _, image := range pluginImages {
+	// 	fmt.Println("files:", slicesext.Map(image.Files(), func(file bufimage.ImageFileForGeneration) string {
+	// 		return fmt.Sprintf("%s (%v)", file.Path(), file.ToGenerate())
+	// 	}))
+	// }
+	// fmt.Println("<<<<<<<<")
 	requests, err := bufimage.ImagesToCodeGeneratorRequests(
 		pluginImages,
 		pluginConfig.Opt(),
@@ -334,6 +341,13 @@ func (g *generator) execLocalPlugin(
 	if err != nil {
 		return nil, err
 	}
+	// fmt.Println("REQUESTS:")
+	// for _, request := range requests {
+	// 	fmt.Println("file_to_generate:", request.FileToGenerate, "proto_file", slicesext.Map(request.ProtoFile, func(file *descriptorpb.FileDescriptorProto) string {
+	// 		return file.GetName()
+	// 	}))
+	// }
+	// fmt.Println("<<<<<<<<")
 	response, err := g.pluginexecGenerator.Generate(
 		ctx,
 		container,

--- a/private/buf/bufgen/image_provider.go
+++ b/private/buf/bufgen/image_provider.go
@@ -29,7 +29,7 @@ import (
 // strategy.
 type imageProvider struct {
 	image       bufimage.Image
-	imagesByDir []bufimage.Image
+	imagesByDir []bufimage.ImageForGeneration
 	lock        sync.Mutex
 }
 
@@ -39,16 +39,16 @@ func newImageProvider(image bufimage.Image) *imageProvider {
 	}
 }
 
-func (p *imageProvider) GetImages(strategy Strategy) ([]bufimage.Image, error) {
+func (p *imageProvider) GetImages(strategy Strategy) ([]bufimage.ImageForGeneration, error) {
 	switch strategy {
 	case StrategyAll:
-		return []bufimage.Image{p.image}, nil
+		return []bufimage.ImageForGeneration{bufimage.NewImageForGenerationFromImageSimple(p.image)}, nil
 	case StrategyDirectory:
 		p.lock.Lock()
 		defer p.lock.Unlock()
 		if p.imagesByDir == nil {
 			var err error
-			p.imagesByDir, err = bufimage.ImageByDir(p.image)
+			p.imagesByDir, err = bufimage.ImageByDirSplitImports(p.image)
 			if err != nil {
 				return nil, err
 			}

--- a/private/buf/cmd/buf/command/alpha/protoc/plugin.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/plugin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"go.uber.org/zap"
@@ -60,7 +61,7 @@ func executePlugin(
 		runner,
 	)
 	requests, err := bufimage.ImagesToCodeGeneratorRequests(
-		images,
+		slicesext.Map(images, bufimage.NewImageForGenerationFromImageSimple),
 		strings.Join(pluginInfo.Opt, ","),
 		bufprotopluginexec.DefaultVersion,
 		false,

--- a/private/buf/cmd/protoc-gen-buf-lint/lint_test.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint_test.go
@@ -365,7 +365,7 @@ func testBuildRequest(
 	}
 	image, err := bufimage.NewImage(imageFiles)
 	require.NoError(t, err)
-	codeGenReq, err := bufimage.ImageToCodeGeneratorRequest(image, parameter, nil, false, false)
+	codeGenReq, err := bufimage.ImageToCodeGeneratorRequest(bufimage.NewImageForGenerationFromImageSimple(image), parameter, nil, false, false)
 	require.NoError(t, err)
 	request, err := protoplugin.NewRequest(codeGenReq)
 	require.NoError(t, err)

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -222,6 +222,39 @@ func ImageFileWithIsImport(imageFile ImageFile, isImport bool) ImageFile {
 	)
 }
 
+// TODO: this can be just a struct if moved to a different package
+// ImageFileForGeneration is an ImageFile for generation, or a dependency for such a file.
+type ImageFileForGeneration interface {
+	ImageFile
+
+	// ToGenerate returns whether the file may be generated.
+	//
+	// This is not necessarily the same as IsImport(), especially when strategy is set to directory.
+	//
+	// If it returns true, the file
+	//
+	// If it returns false, it will not be generated regardless of --include-imports and --include-wkt.
+	ToGenerate() bool
+}
+
+// NewImageFileForGeneration returns an image file to generate.
+func NewImageFileForGeneration(imageFile ImageFile, toGenerate bool) ImageFileForGeneration {
+	return &imageFileForGeneration{
+		ImageFile:  imageFile,
+		toGenerate: toGenerate,
+	}
+}
+
+// TODO: maybe move to different file
+type imageFileForGeneration struct {
+	ImageFile
+	toGenerate bool
+}
+
+func (f *imageFileForGeneration) ToGenerate() bool {
+	return f.toGenerate
+}
+
 // Image is a buf image.
 type Image interface {
 	// Files are the files that comprise the image.
@@ -251,6 +284,47 @@ type Image interface {
 // If imageFiles is empty, returns error
 func NewImage(imageFiles []ImageFile) (Image, error) {
 	return newImage(imageFiles, false, nil)
+}
+
+// ImageForGeneration is a buf image to be generated.
+type ImageForGeneration interface {
+	// Files are the files that comprise the image.
+	//
+	// Not all files should be generated.
+	Files() []ImageFileForGeneration
+}
+
+// TODO: rename and add doc
+func NewImageForGenerationFromImageSimple(image Image) ImageForGeneration {
+	return &imageForGeneration{
+		files: slicesext.Map(image.Files(), func(imageFile ImageFile) ImageFileForGeneration {
+			return &imageFileForGeneration{
+				ImageFile:  imageFile,
+				toGenerate: true,
+			}
+		}),
+	}
+}
+
+func newImageForGeneration(image Image, filesToGenerate map[string]struct{}) ImageForGeneration {
+	return &imageForGeneration{
+		files: slicesext.Map(image.Files(), func(imageFile ImageFile) ImageFileForGeneration {
+			_, ok := filesToGenerate[imageFile.Path()]
+			return &imageFileForGeneration{
+				ImageFile:  imageFile,
+				toGenerate: ok,
+			}
+		}),
+	}
+}
+
+// TODO: move to another file
+type imageForGeneration struct {
+	files []ImageFileForGeneration
+}
+
+func (i *imageForGeneration) Files() []ImageFileForGeneration {
+	return i.files
 }
 
 // BuildImage runs compilation.
@@ -514,6 +588,67 @@ func ImageWithOnlyPathsAllowNotExist(
 	return imageWithOnlyPaths(image, paths, excludePaths, true)
 }
 
+// ImageByDirSplitImports returns multiple images split by directory.
+//
+// This function does not treat import files differently from non-import files.
+//
+// TODO: rename this and maybe it should be moved to the bufgen package.
+//
+// If strategy is dir, we want the files in file_to_generate inside each
+// CodeGeneratorRequest to be in the same directory.
+//
+// For example, if we have an image with the following files:
+//
+// - a/a.proto -> b/b.proto
+// - b/b.proto -> c/c.proto
+// - b/b.proto -> d/d.proto
+//
+// where a/a.proto and b/b.proto are the non-imports, and c/c.proto and and d/d.proto are imports.
+//
+// Now, if we have includeImports set to true, we should send 4 CodeGeneratorRequests to each plugin.
+// Each request should have file_to_generate equal to ["x/x.proto"] of length 1, with x being one of a, b, c or d,
+// and its proto_file should include "all files in files_to_generate and everything they import", by contract.
+//
+// If includeImports is set to false, the request with c/c.proto to generate and the one with d/d.proto should not exist,
+// and we should only send 2 requests to the plugin.
+func ImageByDirSplitImports(image Image) ([]ImageForGeneration, error) {
+	dirToImageFilePaths := normalpath.ByDir(
+		slicesext.Map(image.Files(), func(imageFile ImageFile) string {
+			return imageFile.Path()
+		})...,
+	)
+	// we need this to produce a deterministic order of the returned Images
+	dirs := make([]string, 0, len(dirToImageFilePaths))
+	for dir := range dirToImageFilePaths {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	newImages := make([]ImageForGeneration, 0, len(dirToImageFilePaths))
+	for _, dir := range dirs {
+		imageFilePaths, ok := dirToImageFilePaths[dir]
+		if !ok {
+			// this should never happen
+			return nil, syserror.Newf("no dir for %q in dirToImageFilePaths", dir)
+		}
+		imageFilesToGenerate, err := slicesext.MapError(imageFilePaths, func(filePath string) (ImageFile, error) {
+			imageFile := image.GetFile(filePath)
+			if imageFile == nil {
+				return nil, syserror.Newf("expected image file to exist at %q", filePath)
+			}
+			return imageFile, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		newImage, err := getImageForGenerationForFilePaths(image, slicesext.ToStructMap(imageFilePaths), imageFilesToGenerate)
+		if err != nil {
+			return nil, err
+		}
+		newImages = append(newImages, newImage)
+	}
+	return newImages, nil
+}
+
 // ImageByDir returns multiple images that have non-imports split
 // by directory.
 //
@@ -584,7 +719,7 @@ func ImageToFileDescriptorProtos(image Image) []*descriptorpb.FileDescriptorProt
 // If includeWellKnownTypes is set, well-known-type imports are also added as files to generate.
 // includeWellKnownTypes has no effect if includeImports is not set.
 func ImageToCodeGeneratorRequest(
-	image Image,
+	image ImageForGeneration,
 	parameter string,
 	compilerVersion *pluginpb.Version,
 	includeImports bool,
@@ -609,13 +744,13 @@ func ImageToCodeGeneratorRequest(
 // If includeWellKnownTypes is set, well-known-type imports are also added as files to generate.
 // includeWellKnownTypes has no effect if includeImports is not set.
 func ImagesToCodeGeneratorRequests(
-	images []Image,
+	images []ImageForGeneration,
 	parameter string,
 	compilerVersion *pluginpb.Version,
 	includeImports bool,
 	includeWellKnownTypes bool,
 ) ([]*pluginpb.CodeGeneratorRequest, error) {
-	requests := make([]*pluginpb.CodeGeneratorRequest, len(images))
+	requests := make([]*pluginpb.CodeGeneratorRequest, 0, len(images))
 	// alreadyUsedPaths is a map of paths that have already been added to an image.
 	//
 	// We track this if includeImports is set, so that when we find an import, we can
@@ -647,9 +782,9 @@ func ImagesToCodeGeneratorRequests(
 			}
 		}
 	}
-	for i, image := range images {
+	for _, image := range images {
 		var err error
-		requests[i], err = imageToCodeGeneratorRequest(
+		request, err := imageToCodeGeneratorRequest(
 			image,
 			parameter,
 			compilerVersion,
@@ -661,6 +796,10 @@ func ImagesToCodeGeneratorRequests(
 		if err != nil {
 			return nil, err
 		}
+		if len(request.FileToGenerate) == 0 {
+			continue
+		}
+		requests = append(requests, request)
 	}
 	return requests, nil
 }

--- a/private/bufpkg/bufimage/bufimagetesting/bufimagetesting_test.go
+++ b/private/bufpkg/bufimage/bufimagetesting/bufimagetesting_test.go
@@ -510,7 +510,7 @@ func TestBasic(t *testing.T) {
 			testProtoImageFileToFileDescriptorProto(protoImageFileOutlandishDirectoryName),
 		},
 	}
-	actualRequest, err := bufimage.ImageToCodeGeneratorRequest(image, "foo", nil, false, false)
+	actualRequest, err := bufimage.ImageToCodeGeneratorRequest(bufimage.NewImageForGenerationFromImageSimple(image), "foo", nil, false, false)
 	require.NoError(t, err)
 	diff = cmp.Diff(
 		codeGeneratorRequest,
@@ -520,7 +520,7 @@ func TestBasic(t *testing.T) {
 	require.Empty(t, diff)
 
 	// verify that includeWellKnownTypes is a no-op if includeImports is false
-	actualRequest, err = bufimage.ImageToCodeGeneratorRequest(image, "foo", nil, false, true)
+	actualRequest, err = bufimage.ImageToCodeGeneratorRequest(bufimage.NewImageForGenerationFromImageSimple(image), "foo", nil, false, true)
 	require.NoError(t, err)
 	diff = cmp.Diff(
 		codeGeneratorRequest,
@@ -558,7 +558,7 @@ func TestBasic(t *testing.T) {
 			testProtoImageFileToFileDescriptorProto(protoImageFileOutlandishDirectoryName),
 		},
 	}
-	actualRequest, err = bufimage.ImageToCodeGeneratorRequest(image, "foo", nil, true, false)
+	actualRequest, err = bufimage.ImageToCodeGeneratorRequest(bufimage.NewImageForGenerationFromImageSimple(image), "foo", nil, true, false)
 	require.NoError(t, err)
 	diff = cmp.Diff(
 		codeGeneratorRequestIncludeImports,
@@ -611,7 +611,7 @@ func TestBasic(t *testing.T) {
 			testProtoImageFileToFileDescriptorProto(protoImageFileOutlandishDirectoryName),
 		},
 	}
-	actualRequest, err = bufimage.ImageToCodeGeneratorRequest(image, "foo", nil, true, true)
+	actualRequest, err = bufimage.ImageToCodeGeneratorRequest(bufimage.NewImageForGenerationFromImageSimple(image), "foo", nil, true, true)
 	require.NoError(t, err)
 	diff = cmp.Diff(
 		codeGeneratorRequestIncludeImportsAndWellKnownTypes,
@@ -704,7 +704,7 @@ func TestBasic(t *testing.T) {
 			},
 		},
 	}
-	requestsFromImages, err := bufimage.ImagesToCodeGeneratorRequests(imagesByDir, "foo", nil, false, false)
+	requestsFromImages, err := bufimage.ImagesToCodeGeneratorRequests(slicesext.Map(imagesByDir, bufimage.NewImageForGenerationFromImageSimple), "foo", nil, false, false)
 	require.NoError(t, err)
 	require.Equal(t, len(codeGeneratorRequests), len(requestsFromImages))
 	for i := range codeGeneratorRequests {
@@ -764,7 +764,7 @@ func TestBasic(t *testing.T) {
 			},
 		},
 	}
-	requestsFromImages, err = bufimage.ImagesToCodeGeneratorRequests(imagesByDir, "foo", nil, true, false)
+	requestsFromImages, err = bufimage.ImagesToCodeGeneratorRequests(slicesext.Map(imagesByDir, bufimage.NewImageForGenerationFromImageSimple), "foo", nil, true, false)
 	require.NoError(t, err)
 	require.Equal(t, len(codeGeneratorRequestsIncludeImports), len(requestsFromImages))
 	for i := range codeGeneratorRequestsIncludeImports {

--- a/private/bufpkg/bufimage/util.go
+++ b/private/bufpkg/bufimage/util.go
@@ -275,6 +275,66 @@ func addFileWithImports(
 	return accumulator
 }
 
+func getImageForGenerationForFilePaths(
+	image Image,
+	generationPaths map[string]struct{},
+	generationImageFiles []ImageFile,
+) (ImageForGeneration, error) {
+	var imageFiles []ImageFile
+	seenPaths := make(map[string]struct{})
+	for _, nonImportImageFile := range generationImageFiles {
+		imageFiles = addFileForGenerationWithImports(
+			imageFiles,
+			image,
+			generationPaths,
+			seenPaths,
+			nonImportImageFile,
+		)
+	}
+	imageWithPaths, err := NewImage(imageFiles)
+	if err != nil {
+		return nil, err
+	}
+	return newImageForGeneration(imageWithPaths, generationPaths), nil
+}
+
+// largely copied from addFileWithImports
+//
+// returns accumulated files in correct order
+func addFileForGenerationWithImports(
+	accumulator []ImageFile,
+	image Image,
+	nonImportPaths map[string]struct{},
+	seenPaths map[string]struct{},
+	imageFile ImageFile,
+) []ImageFile {
+	path := imageFile.Path()
+	// if seen already, skip
+	if _, ok := seenPaths[path]; ok {
+		return accumulator
+	}
+	seenPaths[path] = struct{}{}
+
+	// then, add imports first, for proper ordering
+	for _, importPath := range imageFile.FileDescriptorProto().GetDependency() {
+		if importFile := image.GetFile(importPath); importFile != nil {
+			accumulator = addFileForGenerationWithImports(
+				accumulator,
+				image,
+				nonImportPaths,
+				seenPaths,
+				importFile,
+			)
+		}
+	}
+
+	accumulator = append(
+		accumulator,
+		imageFile,
+	)
+	return accumulator
+}
+
 func checkExcludePathsExistInImage(image Image, excludeFileOrDirPaths []string) error {
 	for _, excludeFileOrDirPath := range excludeFileOrDirPaths {
 		var foundPath bool
@@ -413,7 +473,7 @@ func stripBufExtensionField(unknownFields protoreflect.RawFields) protoreflect.R
 }
 
 func imageToCodeGeneratorRequest(
-	image Image,
+	image ImageForGeneration,
 	parameter string,
 	compilerVersion *pluginpb.Version,
 	includeImports bool,
@@ -455,12 +515,15 @@ func imageToCodeGeneratorRequest(
 }
 
 func isFileToGenerate(
-	imageFile ImageFile,
+	imageFile ImageFileForGeneration,
 	alreadyUsedPaths map[string]struct{},
 	nonImportPaths map[string]struct{},
 	includeImports bool,
 	includeWellKnownTypes bool,
 ) bool {
+	if !imageFile.ToGenerate() {
+		return false
+	}
 	path := imageFile.Path()
 	if !imageFile.IsImport() {
 		if alreadyUsedPaths != nil {


### PR DESCRIPTION
This is still WIP, but it seems to work with the base case.

TODOs:
* testing
* cleanup the code
* there are still places (`*_test.go` and `.../alpha/protoc/plugin.go`) that call `ImageByDir`, they should stop calling it.

Note, this cannot be achieved by simply removing the import check [here](https://github.com/bufbuild/buf/blob/429c3acea420a3e3577494860a3fb0f47806d899/private/bufpkg/bufimage/bufimage.go#L527), because the split images will conflate `IsImport` with _whether we want to generate a file if permitted by include-imports_. The latter is introduced to a new type `ImageFileForGeneration`.

Fixes https://github.com/bufbuild/buf/issues/3056