### PR TITLE
Add Set type to slicesext

### DIFF
--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -1107,10 +1107,10 @@ func (c *controller) warnUnconfiguredTransitiveImports(
 	if err != nil {
 		return err
 	}
-	configuredModuleFullNameStringMap := slicesext.ToStructMap(configuredModuleFullNameStrings)
+	configuredModuleFullNameStringSet := slicesext.ToSet(configuredModuleFullNameStrings)
 	for _, localModule := range bufmodule.ModuleSetLocalModules(workspace) {
 		if moduleFullName := localModule.ModuleFullName(); moduleFullName != nil {
-			configuredModuleFullNameStringMap[moduleFullName.String()] = struct{}{}
+			configuredModuleFullNameStringSet.Add(moduleFullName.String())
 		}
 	}
 
@@ -1138,7 +1138,7 @@ func (c *controller) warnUnconfiguredTransitiveImports(
 				// The import was from a local unnamed Module in the Workspace.
 				continue
 			}
-			if _, ok := configuredModuleFullNameStringMap[moduleFullNameString]; !ok {
+			if !configuredModuleFullNameStringSet.Contains(moduleFullNameString) {
 				c.logger.Sugar().Warnf(
 					`File %q imports %q, which is not in your workspace or in the dependencies declared in your buf.yaml, but is found in transitive dependency %q.
 Declare %q in the deps key in your buf.yaml.`,

--- a/private/buf/bufmigrate/migrator.go
+++ b/private/buf/bufmigrate/migrator.go
@@ -746,21 +746,13 @@ func equivalentCheckConfigInV2(
 		return simplyTranslatedCheckConfig, nil
 	}
 	// Otherwise, find what's missing and what's extra.
-	expectedIDsMap := slicesext.ToStructMap(expectedIDs)
-	simplyTranslatedIDsMap := slicesext.ToStructMap(simplyTranslatedIDs)
 	missingIDs := slicesext.Filter(
 		expectedIDs,
-		func(expectedID string) bool {
-			_, ok := simplyTranslatedIDsMap[expectedID]
-			return !ok
-		},
+		slicesext.ToSet(simplyTranslatedIDs).Contains,
 	)
 	extraIDs := slicesext.Filter(
 		simplyTranslatedIDs,
-		func(simplyTranslatedID string) bool {
-			_, ok := expectedIDsMap[simplyTranslatedID]
-			return !ok
-		},
+		slicesext.ToSet(expectedIDs).Contains,
 	)
 	return bufconfig.NewEnabledCheckConfig(
 		bufconfig.FileVersionV2,

--- a/private/buf/bufstudioagent/bufstudioagent.go
+++ b/private/buf/bufstudioagent/bufstudioagent.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"net/http"
 
+	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
 )
@@ -28,7 +29,7 @@ func NewHandler(
 	logger *zap.Logger,
 	origin string,
 	tlsClientConfig *tls.Config,
-	disallowedHeaders map[string]struct{},
+	disallowedHeaders slicesext.Set[string],
 	forwardHeaders map[string]string,
 	privateNetwork bool,
 ) http.Handler {

--- a/private/buf/bufworkspace/malformed_dep.go
+++ b/private/buf/bufworkspace/malformed_dep.go
@@ -54,7 +54,7 @@ type MalformedDep interface {
 
 // MalformedDepsForWorkspace gets the MalformedDeps for the workspace.
 func MalformedDepsForWorkspace(workspace Workspace) ([]MalformedDep, error) {
-	localModuleFullNameStringMap := slicesext.ToStructMapOmitEmpty(
+	localModuleFullNameStringSet := slicesext.ToSetOmitEmpty(
 		slicesext.Map(
 			bufmodule.ModuleSetLocalModules(workspace),
 			func(module bufmodule.Module) string {
@@ -97,7 +97,7 @@ func MalformedDepsForWorkspace(workspace Workspace) ([]MalformedDep, error) {
 	}
 	var malformedDeps []MalformedDep
 	for moduleFullNameString, configuredDepModuleRef := range moduleFullNameStringToConfiguredDepModuleRef {
-		_, isLocalModule := localModuleFullNameStringMap[moduleFullNameString]
+		isLocalModule := localModuleFullNameStringSet.Contains(moduleFullNameString)
 		_, isRemoteDep := moduleFullNameStringToRemoteDep[moduleFullNameString]
 		if !isRemoteDep && !isLocalModule {
 			// The module was in buf.yaml deps, but was not in the remote dep list after

--- a/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
+++ b/private/buf/cmd/buf/command/beta/studioagent/studioagent.go
@@ -183,7 +183,7 @@ func run(
 		container.Logger(),
 		flags.Origin,
 		clientTLSConfig,
-		slicesext.ToStructMap(flags.DisallowedHeaders),
+		slicesext.ToSet(flags.DisallowedHeaders),
 		flags.ForwardHeaders,
 		flags.PrivateNetwork,
 	)

--- a/private/buf/cmd/buf/command/format/format.go
+++ b/private/buf/cmd/buf/command/format/format.go
@@ -354,13 +354,13 @@ func run(
 		}
 	}
 	if flags.Write {
-		changedPathSet := slicesext.ToStructMap(changedPaths)
+		changedPathSet := slicesext.ToSet(changedPaths)
 		return storage.WalkReadObjects(
 			ctx,
 			formattedReadBucket,
 			"",
 			func(readObject storage.ReadObject) error {
-				if _, ok := changedPathSet[readObject.Path()]; !ok {
+				if changedPathSet.Contains(readObject.Path()) {
 					// no change, nothing to re-write
 					return nil
 				}

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -814,7 +814,7 @@ func getRootToExcludes(roots []string, fullExcludes []string) (map[string][]stri
 	}
 
 	// Verify that all excludes are within a root.
-	rootMap := slicesext.ToStructMap(roots)
+	rootMap := slicesext.ToSet(roots)
 	for _, fullExclude := range fullExcludes {
 		switch matchingRoots := normalpath.MapAllEqualOrContainingPaths(rootMap, fullExclude, normalpath.Relative); len(matchingRoots) {
 		case 0:

--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -268,7 +268,7 @@ type moduleReadBucket struct {
 // module cannot be assumed to be functional yet.
 // Do not call any functions on module.
 func newModuleReadBucketForModule(
-	ctx context.Context,
+	_ context.Context,
 	// This function must already be filtered to include only module files and must be sync.OnceValues wrapped!
 	syncOnceValuesGetBucketWithStorageMatcherApplied func() (storage.ReadBucket, error),
 	module Module,
@@ -288,8 +288,8 @@ func newModuleReadBucketForModule(
 		getBucket:            syncOnceValuesGetBucketWithStorageMatcherApplied,
 		module:               module,
 		targetPaths:          targetPaths,
-		targetPathMap:        slicesext.ToStructMap(targetPaths),
-		targetExcludePathMap: slicesext.ToStructMap(targetExcludePaths),
+		targetPathMap:        slicesext.ToSet(targetPaths),
+		targetExcludePathMap: slicesext.ToSet(targetExcludePaths),
 		protoFileTargetPath:  protoFileTargetPath,
 		includePackageFiles:  includePackageFiles,
 	}, nil
@@ -690,7 +690,7 @@ func newFilteredModuleReadBucket(
 	delegate ModuleReadBucket,
 	fileTypes []FileType,
 ) *filteredModuleReadBucket {
-	fileTypeMap := slicesext.ToStructMap(fileTypes)
+	fileTypeMap := slicesext.ToSet(fileTypes)
 	_, containsFileTypeProto := fileTypeMap[FileTypeProto]
 	return &filteredModuleReadBucket{
 		delegate:              delegate,

--- a/private/bufpkg/bufmodule/module_set.go
+++ b/private/bufpkg/bufmodule/module_set.go
@@ -325,7 +325,7 @@ func (m *moduleSet) WithTargetOpaqueIDs(opaqueIDs ...string) (ModuleSet, error) 
 	if len(opaqueIDs) == 0 {
 		return nil, errors.New("at least one Module must be targeted")
 	}
-	opaqueIDMap := slicesext.ToStructMap(opaqueIDs)
+	opaqueIDMap := slicesext.ToSet(opaqueIDs)
 	modules := make([]Module, len(m.modules))
 	for i, module := range m.modules {
 		_, isTarget := opaqueIDMap[module.OpaqueID()]

--- a/private/bufpkg/bufmodule/paths.go
+++ b/private/bufpkg/bufmodule/paths.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	docFilePathMap = slicesext.ToStructMap(orderedDocFilePaths)
+	docFilePathMap = slicesext.ToSet(orderedDocFilePaths)
 }
 
 func getDocFilePathForStorageReadBucket(ctx context.Context, bucket storage.ReadBucket) string {

--- a/private/pkg/bandeps/state.go
+++ b/private/pkg/bandeps/state.go
@@ -159,7 +159,7 @@ func (s *state) packagesForPackageExpressionUncached(
 	if err != nil {
 		return nil, err
 	}
-	return slicesext.ToStructMap(getNonEmptyLines(string(data))), nil
+	return slicesext.ToSet(getNonEmptyLines(string(data))), nil
 }
 
 func (s *state) depsForPackage(
@@ -214,7 +214,7 @@ func (s *state) depsForPackageUncached(
 	if err != nil {
 		return nil, err
 	}
-	return slicesext.ToStructMap(getNonEmptyLines(string(data))), nil
+	return slicesext.ToSet(getNonEmptyLines(string(data))), nil
 }
 
 type packagesResult struct {

--- a/private/pkg/git/lister.go
+++ b/private/pkg/git/lister.go
@@ -82,10 +82,10 @@ func (l *lister) ListFilesAndUnstagedFiles(
 
 // stringSliceExcept returns all elements in source that are not in except.
 func stringSliceExcept(source []string, except []string) []string {
-	exceptMap := slicesext.ToStructMap(except)
+	exceptSet := slicesext.ToSet(except)
 	result := make([]string, 0, len(source))
 	for _, s := range source {
-		if _, ok := exceptMap[s]; !ok {
+		if !exceptSet.Contains(s) {
 			result = append(result, s)
 		}
 	}

--- a/private/pkg/normalpath/normalpath_unix_test.go
+++ b/private/pkg/normalpath/normalpath_unix_test.go
@@ -339,8 +339,8 @@ func TestMapHasEqualOrContainingPath(t *testing.T) {
 }
 
 func testMapHasEqualOrContainingPath(t *testing.T, expected bool, path string, keys ...string) {
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapHasEqualOrContainingPath(keyMap, path, Relative), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapHasEqualOrContainingPath(keySet, path, Relative), fmt.Sprintf("%s %v", path, keys))
 }
 
 func TestMapAllEqualOrContainingPaths(t *testing.T) {
@@ -364,8 +364,8 @@ func testMapAllEqualOrContainingPaths(t *testing.T, expected []string, path stri
 		expected = make([]string, 0)
 	}
 	sort.Strings(expected)
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keyMap, path, Relative), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keySet, path, Relative), fmt.Sprintf("%s %v", path, keys))
 }
 
 func TestContainsPathAbs(t *testing.T) {
@@ -421,8 +421,8 @@ func TestMapHasEqualOrContainingPathAbs(t *testing.T) {
 }
 
 func testMapHasEqualOrContainingPathAbs(t *testing.T, expected bool, path string, keys ...string) {
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapHasEqualOrContainingPath(keyMap, path, Absolute), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapHasEqualOrContainingPath(keySet, path, Absolute), fmt.Sprintf("%s %v", path, keys))
 }
 
 func TestMapAllEqualOrContainingPathsAbs(t *testing.T) {
@@ -446,6 +446,6 @@ func testMapAllEqualOrContainingPathsAbs(t *testing.T, expected []string, path s
 		expected = make([]string, 0)
 	}
 	sort.Strings(expected)
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keyMap, path, Absolute), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keySet, path, Absolute), fmt.Sprintf("%s %v", path, keys))
 }

--- a/private/pkg/normalpath/normalpath_windows_test.go
+++ b/private/pkg/normalpath/normalpath_windows_test.go
@@ -362,8 +362,8 @@ func TestMapHasEqualOrContainingPath(t *testing.T) {
 }
 
 func testMapHasEqualOrContainingPath(t *testing.T, expected bool, path string, keys ...string) {
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapHasEqualOrContainingPath(keyMap, path, Relative), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapHasEqualOrContainingPath(keySet, path, Relative), fmt.Sprintf("%s %v", path, keys))
 }
 
 func TestMapAllEqualOrContainingPaths(t *testing.T) {
@@ -386,8 +386,8 @@ func testMapAllEqualOrContainingPaths(t *testing.T, expected []string, path stri
 		expected = make([]string, 0)
 	}
 	sort.Strings(expected)
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keyMap, path, Relative), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keySet, path, Relative), fmt.Sprintf("%s %v", path, keys))
 }
 
 func TestContainsPathAbs(t *testing.T) {
@@ -497,8 +497,8 @@ func TestMapHasEqualOrContainingPathAbs(t *testing.T) {
 }
 
 func testMapHasEqualOrContainingPathAbs(t *testing.T, expected bool, path string, keys ...string) {
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapHasEqualOrContainingPath(keyMap, path, Absolute), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapHasEqualOrContainingPath(keySet, path, Absolute), fmt.Sprintf("%s %v", path, keys))
 }
 
 func TestMapAllEqualOrContainingPathsAbs(t *testing.T) {
@@ -527,6 +527,6 @@ func testMapAllEqualOrContainingPathsAbs(t *testing.T, expected []string, path s
 		expected = make([]string, 0)
 	}
 	sort.Strings(expected)
-	keyMap := slicesext.ToStructMap(keys)
-	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keyMap, path, Absolute), fmt.Sprintf("%s %v", path, keys))
+	keySet := slicesext.ToSet(keys)
+	assert.Equal(t, expected, MapAllEqualOrContainingPaths(keySet, path, Absolute), fmt.Sprintf("%s %v", path, keys))
 }

--- a/private/pkg/stringutil/stringutil.go
+++ b/private/pkg/stringutil/stringutil.go
@@ -60,7 +60,7 @@ func SplitTrimLinesNoEmpty(output string) []string {
 //
 // Strings with only spaces are considered empty.
 func SliceToUniqueSortedSliceFilterEmptyStrings(s []string) []string {
-	m := slicesext.ToStructMap(s)
+	m := slicesext.ToSet(s)
 	for key := range m {
 		if strings.TrimSpace(key) == "" {
 			delete(m, key)


### PR DESCRIPTION
Adds a new type `Set` that can replace the use of `map[T]struct{}` or be cast to and from to gain the helper methods as needed. Converted the two methods `ToStructMap` and `ToStructMapOmitEmpty` to return the new type, with the respective name change `ToSet` and `ToSetOmitEmpty`. Converted some of the use cases to show usability of the new methods, but not exhaustive. Intended to be initialized with make `make(slicesext.Set[string], size)` to allow setting size or not. `Delete` and `Len` helpers are added for convenience but can simply call the map functions.