### PR TITLE
Allow use of pre-compiled descriptors as dependencies/inputs for an image

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,7 +174,7 @@ issues:
     - linters:
         - containedctx
       # we actually want to embed a context here
-      path: private/bufpkg/bufimage/parser_accessor_handler.go
+      path: private/bufpkg/bufimage/file_resolver.go
     - linters:
         - containedctx
       # we actually want to embed a context here

--- a/private/bufpkg/bufimage/bufimage.go
+++ b/private/bufpkg/bufimage/bufimage.go
@@ -280,6 +280,7 @@ func BuildImage(
 		moduleReadBucket,
 		buildImageOptions.excludeSourceCodeInfo,
 		buildImageOptions.noParallelism,
+		buildImageOptions.compiledDeps,
 	)
 }
 
@@ -301,6 +302,18 @@ func WithExcludeSourceCodeInfo() BuildImageOption {
 func WithNoParallelism() BuildImageOption {
 	return func(buildImageOptions *buildImageOptions) {
 		buildImageOptions.noParallelism = true
+	}
+}
+
+// WithCompiledDependency allows the caller to supply already-compiled
+// descriptors that can be used, in lieu of source, to resolve imports
+// in the image that is being built.
+func WithCompiledDependency(dep *descriptorpb.FileDescriptorProto) BuildImageOption {
+	return func(buildImageOptions *buildImageOptions) {
+		if buildImageOptions.compiledDeps == nil {
+			buildImageOptions.compiledDeps = map[string]*descriptorpb.FileDescriptorProto{}
+		}
+		buildImageOptions.compiledDeps[dep.GetName()] = dep
 	}
 }
 


### PR DESCRIPTION
This is needed to work with CSR clients, which may provide elements of the schema in the form of a descriptor proto instead of source. So we need something like this to be able to compile the provided schema, coupled with sources for other files/references.

DM me in Slack if you need more context.
cc @pkwarren 