### PR TITLE
Remove all dynamic purpose strings based on configuration

### DIFF
--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -556,14 +556,14 @@ RPC_PASCAL_CASE                   BASIC, DEFAULT           Checks that RPCs are 
 SERVICE_PASCAL_CASE               BASIC, DEFAULT           Checks that services are PascalCase.
 SYNTAX_SPECIFIED                  BASIC, DEFAULT           Checks that all files have a syntax specified.
 ENUM_VALUE_PREFIX                 DEFAULT                  Checks that enum values are prefixed with ENUM_NAME_UPPER_SNAKE_CASE.
-ENUM_ZERO_VALUE_SUFFIX            DEFAULT                  Checks that enum zero values are suffixed with _UNSPECIFIED (suffix is configurable).
+ENUM_ZERO_VALUE_SUFFIX            DEFAULT                  Checks that enum zero values have a consistent suffix (configurable, default suffix is "_UNSPECIFIED").
 FILE_LOWER_SNAKE_CASE             DEFAULT                  Checks that filenames are lower_snake_case.
 PACKAGE_VERSION_SUFFIX            DEFAULT                  Checks that the last component of all packages is a version of the form v\d+, v\d+test.*, v\d+(alpha|beta)\d+, or v\d+p\d+(alpha|beta)\d+, where numbers are >=1.
 PROTOVALIDATE                     DEFAULT                  Checks that protovalidate rules are valid and all CEL expressions compile.
 RPC_REQUEST_RESPONSE_UNIQUE       DEFAULT                  Checks that RPC request and response types are only used in one RPC (configurable).
 RPC_REQUEST_STANDARD_NAME         DEFAULT                  Checks that RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable).
 RPC_RESPONSE_STANDARD_NAME        DEFAULT                  Checks that RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable).
-SERVICE_SUFFIX                    DEFAULT                  Checks that services are suffixed with Service (suffix is configurable).
+SERVICE_SUFFIX                    DEFAULT                  Checks that services have a consistent suffix (configurable, default suffix is "Service").
 COMMENT_ENUM                      COMMENTS                 Checks that enums have non-empty comments.
 COMMENT_ENUM_VALUE                COMMENTS                 Checks that enum values have non-empty comments.
 COMMENT_FIELD                     COMMENTS                 Checks that fields have non-empty comments.
@@ -632,13 +632,13 @@ PACKAGE_LOWER_SNAKE_CASE          BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Ch
 RPC_PASCAL_CASE                   BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that RPCs are PascalCase.
 SERVICE_PASCAL_CASE               BASIC, DEFAULT, STYLE_BASIC, STYLE_DEFAULT  Checks that services are PascalCase.
 ENUM_VALUE_PREFIX                 DEFAULT, STYLE_DEFAULT                      Checks that enum values are prefixed with ENUM_NAME_UPPER_SNAKE_CASE.
-ENUM_ZERO_VALUE_SUFFIX            DEFAULT, STYLE_DEFAULT                      Checks that enum zero values are suffixed with _UNSPECIFIED (suffix is configurable).
+ENUM_ZERO_VALUE_SUFFIX            DEFAULT, STYLE_DEFAULT                      Checks that enum zero values have a consistent suffix (configurable, default suffix is "_UNSPECIFIED").
 FILE_LOWER_SNAKE_CASE             DEFAULT, STYLE_DEFAULT                      Checks that filenames are lower_snake_case.
 PACKAGE_VERSION_SUFFIX            DEFAULT, STYLE_DEFAULT                      Checks that the last component of all packages is a version of the form v\d+, v\d+test.*, v\d+(alpha|beta)\d+, or v\d+p\d+(alpha|beta)\d+, where numbers are >=1.
 RPC_REQUEST_RESPONSE_UNIQUE       DEFAULT, STYLE_DEFAULT                      Checks that RPC request and response types are only used in one RPC (configurable).
 RPC_REQUEST_STANDARD_NAME         DEFAULT, STYLE_DEFAULT                      Checks that RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable).
 RPC_RESPONSE_STANDARD_NAME        DEFAULT, STYLE_DEFAULT                      Checks that RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable).
-SERVICE_SUFFIX                    DEFAULT, STYLE_DEFAULT                      Checks that services are suffixed with Service (suffix is configurable).
+SERVICE_SUFFIX                    DEFAULT, STYLE_DEFAULT                      Checks that services have a consistent suffix (configurable, default suffix is "Service").
 COMMENT_ENUM                      COMMENTS                                    Checks that enums have non-empty comments.
 COMMENT_ENUM_VALUE                COMMENTS                                    Checks that enum values have non-empty comments.
 COMMENT_FIELD                     COMMENTS                                    Checks that fields have non-empty comments.
@@ -694,14 +694,14 @@ RPC_PASCAL_CASE                   BASIC, DEFAULT           Checks that RPCs are 
 SERVICE_PASCAL_CASE               BASIC, DEFAULT           Checks that services are PascalCase.
 SYNTAX_SPECIFIED                  BASIC, DEFAULT           Checks that all files have a syntax specified.
 ENUM_VALUE_PREFIX                 DEFAULT                  Checks that enum values are prefixed with ENUM_NAME_UPPER_SNAKE_CASE.
-ENUM_ZERO_VALUE_SUFFIX            DEFAULT                  Checks that enum zero values are suffixed with _UNSPECIFIED (suffix is configurable).
+ENUM_ZERO_VALUE_SUFFIX            DEFAULT                  Checks that enum zero values have a consistent suffix (configurable, default suffix is "_UNSPECIFIED").
 FILE_LOWER_SNAKE_CASE             DEFAULT                  Checks that filenames are lower_snake_case.
 PACKAGE_VERSION_SUFFIX            DEFAULT                  Checks that the last component of all packages is a version of the form v\d+, v\d+test.*, v\d+(alpha|beta)\d+, or v\d+p\d+(alpha|beta)\d+, where numbers are >=1.
 PROTOVALIDATE                     DEFAULT                  Checks that protovalidate rules are valid and all CEL expressions compile.
 RPC_REQUEST_RESPONSE_UNIQUE       DEFAULT                  Checks that RPC request and response types are only used in one RPC (configurable).
 RPC_REQUEST_STANDARD_NAME         DEFAULT                  Checks that RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable).
 RPC_RESPONSE_STANDARD_NAME        DEFAULT                  Checks that RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable).
-SERVICE_SUFFIX                    DEFAULT                  Checks that services are suffixed with Service (suffix is configurable).
+SERVICE_SUFFIX                    DEFAULT                  Checks that services have a consistent suffix (configurable, default suffix is "Service").
 COMMENT_ENUM                      COMMENTS                 Checks that enums have non-empty comments.
 COMMENT_ENUM_VALUE                COMMENTS                 Checks that enum values have non-empty comments.
 COMMENT_FIELD                     COMMENTS                 Checks that fields have non-empty comments.

--- a/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
@@ -106,9 +106,7 @@ var (
 	// EnumZeroValueSuffixRuleBuilder is a rule builder.
 	EnumZeroValueSuffixRuleBuilder = internal.NewRuleBuilder(
 		"ENUM_ZERO_VALUE_SUFFIX",
-		func(configBuilder internal.ConfigBuilder) (string, error) {
-			return `enum zero values have a consistent suffix (configurable, default suffix is "_UNSPECIFIED")`, nil
-		},
+		`enum zero values have a consistent suffix (configurable, default suffix is "_UNSPECIFIED")`,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.EnumZeroValueSuffix == "" {
 				return nil, errors.New("enum_zero_value_suffix is empty")
@@ -277,9 +275,7 @@ var (
 	// RPCRequestResponseUniqueRuleBuilder is a rule builder.
 	RPCRequestResponseUniqueRuleBuilder = internal.NewRuleBuilder(
 		"RPC_REQUEST_RESPONSE_UNIQUE",
-		func(configBuilder internal.ConfigBuilder) (string, error) {
-			return "RPC request and response types are only used in one RPC (configurable)", nil
-		},
+		"RPC request and response types are only used in one RPC (configurable)",
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCRequestResponseUnique(
@@ -296,9 +292,7 @@ var (
 	// RPCRequestStandardNameRuleBuilder is a rule builder.
 	RPCRequestStandardNameRuleBuilder = internal.NewRuleBuilder(
 		"RPC_REQUEST_STANDARD_NAME",
-		func(configBuilder internal.ConfigBuilder) (string, error) {
-			return "RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable)", nil
-		},
+		"RPC request type names are RPCNameRequest or ServiceNameRPCNameRequest (configurable)",
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCRequestStandardName(
@@ -313,9 +307,7 @@ var (
 	// RPCResponseStandardNameRuleBuilder is a rule builder.
 	RPCResponseStandardNameRuleBuilder = internal.NewRuleBuilder(
 		"RPC_RESPONSE_STANDARD_NAME",
-		func(configBuilder internal.ConfigBuilder) (string, error) {
-			return "RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable)", nil
-		},
+		"RPC response type names are RPCNameResponse or ServiceNameRPCNameResponse (configurable)",
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			return internal.CheckFunc(func(id string, ignoreFunc internal.IgnoreFunc, _ []bufprotosource.File, files []bufprotosource.File) ([]bufanalysis.FileAnnotation, error) {
 				return buflintcheck.CheckRPCResponseStandardName(
@@ -336,9 +328,7 @@ var (
 	// ServiceSuffixRuleBuilder is a rule builder.
 	ServiceSuffixRuleBuilder = internal.NewRuleBuilder(
 		"SERVICE_SUFFIX",
-		func(configBuilder internal.ConfigBuilder) (string, error) {
-			return `services have a consistent suffix (configurable, default suffix is "Service")`, nil
-		},
+		`services have a consistent suffix (configurable, default suffix is "Service")`,
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.ServiceSuffix == "" {
 				return nil, errors.New("service_suffix is empty")

--- a/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
+++ b/private/bufpkg/bufcheck/buflint/internal/buflintbuild/buflintbuild.go
@@ -107,10 +107,7 @@ var (
 	EnumZeroValueSuffixRuleBuilder = internal.NewRuleBuilder(
 		"ENUM_ZERO_VALUE_SUFFIX",
 		func(configBuilder internal.ConfigBuilder) (string, error) {
-			if configBuilder.EnumZeroValueSuffix == "" {
-				return "", errors.New("enum_zero_value_suffix is empty")
-			}
-			return "enum zero values are suffixed with " + configBuilder.EnumZeroValueSuffix + " (suffix is configurable)", nil
+			return `enum zero values have a consistent suffix (configurable, default suffix is "_UNSPECIFIED")`, nil
 		},
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.EnumZeroValueSuffix == "" {
@@ -340,10 +337,7 @@ var (
 	ServiceSuffixRuleBuilder = internal.NewRuleBuilder(
 		"SERVICE_SUFFIX",
 		func(configBuilder internal.ConfigBuilder) (string, error) {
-			if configBuilder.ServiceSuffix == "" {
-				return "", errors.New("service_suffix is empty")
-			}
-			return "services are suffixed with " + configBuilder.ServiceSuffix + " (suffix is configurable)", nil
+			return `services have a consistent suffix (configurable, default suffix is "Service")`, nil
 		},
 		func(configBuilder internal.ConfigBuilder) (internal.CheckFunc, error) {
 			if configBuilder.ServiceSuffix == "" {

--- a/private/bufpkg/bufcheck/internal/rule_builder.go
+++ b/private/bufpkg/bufcheck/internal/rule_builder.go
@@ -22,7 +22,7 @@ import (
 // RuleBuilder is a rule builder.
 type RuleBuilder struct {
 	id             string
-	newPurpose     func(ConfigBuilder) (string, error)
+	purpose        string
 	deprecated     bool
 	replacementIDs []string
 	newCheck       func(ConfigBuilder) (CheckFunc, error)
@@ -31,12 +31,12 @@ type RuleBuilder struct {
 // NewRuleBuilder returns a new undeprecated RuleBuilder.
 func NewRuleBuilder(
 	id string,
-	newPurpose func(ConfigBuilder) (string, error),
+	purpose string,
 	newCheck func(ConfigBuilder) (CheckFunc, error),
 ) *RuleBuilder {
 	return &RuleBuilder{
 		id:             id,
-		newPurpose:     newPurpose,
+		purpose:        purpose,
 		deprecated:     false,
 		replacementIDs: nil,
 		newCheck:       newCheck,
@@ -52,7 +52,7 @@ func NewNopRuleBuilder(
 ) *RuleBuilder {
 	return NewRuleBuilder(
 		id,
-		newNopPurpose(purpose),
+		purpose,
 		newNopCheckFunc(checkFunc),
 	)
 }
@@ -67,7 +67,7 @@ func NewDeprecatedRuleBuilder(
 ) *RuleBuilder {
 	return &RuleBuilder{
 		id:             id,
-		newPurpose:     newNopPurpose(purpose),
+		purpose:        purpose,
 		deprecated:     true,
 		replacementIDs: replacementIDs,
 		newCheck:       newNopCheckFunc(newNopCheck),
@@ -81,10 +81,6 @@ func NewDeprecatedRuleBuilder(
 //
 // Categories is an actual copy from the ruleBuilder.
 func (c *RuleBuilder) NewRule(configBuilder ConfigBuilder, categories []string) (*Rule, error) {
-	purpose, err := c.newPurpose(configBuilder)
-	if err != nil {
-		return nil, err
-	}
 	check, err := c.newCheck(configBuilder)
 	if err != nil {
 		return nil, err
@@ -92,7 +88,7 @@ func (c *RuleBuilder) NewRule(configBuilder ConfigBuilder, categories []string) 
 	return newRule(
 		c.id,
 		categories,
-		purpose,
+		c.purpose,
 		c.deprecated,
 		c.replacementIDs,
 		check,
@@ -112,12 +108,6 @@ func (c *RuleBuilder) Deprecated() bool {
 // ReplacementIDs returns the replacement IDs.
 func (c *RuleBuilder) ReplacementIDs() []string {
 	return c.replacementIDs
-}
-
-func newNopPurpose(purpose string) func(ConfigBuilder) (string, error) {
-	return func(ConfigBuilder) (string, error) {
-		return purpose, nil
-	}
 }
 
 func newNopCheckFunc(


### PR DESCRIPTION
We have allowed the purpose strings for rules to be based on configuration. However, for our 100+ rules, we only used this in two places, and both of those places don't really need it. Making purpose strings static can result in the new plugin API being massively simplified.