### PR TITLE
Change Path to SourcePath and reduce protoencoding.Resolver to protodesc.Resolver in bufprotosource

### DIFF
--- a/private/bufpkg/bufprotosource/bufprotosource.go
+++ b/private/bufpkg/bufprotosource/bufprotosource.go
@@ -214,7 +214,7 @@ type Location interface {
 	// NOT a copy. Do not modify.
 	LeadingDetachedComments() []string
 	// NOT a copy. Do not modify.
-	Path() protoreflect.SourcePath
+	SourcePath() protoreflect.SourcePath
 }
 
 // ModuleFullName is a module full name.

--- a/private/bufpkg/bufprotosource/file.go
+++ b/private/bufpkg/bufprotosource/file.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
-	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
+	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -30,7 +30,7 @@ type file struct {
 	descriptor
 	optionExtensionDescriptor
 
-	resolver       protoencoding.Resolver
+	resolver       protodesc.Resolver
 	fileDescriptor protodescriptor.FileDescriptor
 	syntax         Syntax
 	fileImports    []FileImport
@@ -228,7 +228,7 @@ func (f *file) SyntaxLocation() Location {
 
 // does not validation of the fileDescriptorProto - this is assumed to be done elsewhere
 // does no duplicate checking by name - could just have maps ie importToFileImport, enumNameToEnum, etc
-func newFile(imageFile bufimage.ImageFile, resolver protoencoding.Resolver) (*file, error) {
+func newFile(imageFile bufimage.ImageFile, resolver protodesc.Resolver) (*file, error) {
 	locationStore := newLocationStore(imageFile.FileDescriptorProto().GetSourceCodeInfo().GetLocation())
 	f := &file{
 		FileInfo:       imageFile,

--- a/private/bufpkg/bufprotosource/location.go
+++ b/private/bufpkg/bufprotosource/location.go
@@ -95,6 +95,6 @@ func (l *location) LeadingDetachedComments() []string {
 	return l.sourceCodeInfoLocation.LeadingDetachedComments
 }
 
-func (l *location) Path() protoreflect.SourcePath {
+func (l *location) SourcePath() protoreflect.SourcePath {
 	return protoreflect.SourcePath(l.sourceCodeInfoLocation.Path)
 }

--- a/private/bufpkg/bufprotosource/merge_comment_location.go
+++ b/private/bufpkg/bufprotosource/merge_comment_location.go
@@ -67,6 +67,6 @@ func (l *mergeCommentLocation) LeadingDetachedComments() []string {
 	return l.delegate.LeadingDetachedComments()
 }
 
-func (l *mergeCommentLocation) Path() protoreflect.SourcePath {
-	return l.base.Path()
+func (l *mergeCommentLocation) SourcePath() protoreflect.SourcePath {
+	return l.base.SourcePath()
 }


### PR DESCRIPTION
Just some slight changes.

- Name change to make the field clearer.
- `protodesc.Resolver` is all that we need, whereas `protoencoding.Resolver` has a bunch more methods.