### PR TITLE
Remove extraneous deps within bufprotosource

### DIFF
--- a/private/buf/bufwkt/cmd/wkt-go-data/main.go
+++ b/private/buf/bufwkt/cmd/wkt-go-data/main.go
@@ -214,7 +214,7 @@ func getProtosourceFiles(
 		}
 		return nil, err
 	}
-	return bufprotosource.NewFiles(ctx, image)
+	return bufprotosource.NewFiles(ctx, image.Files(), image.Resolver())
 }
 
 func getGolangFileData(

--- a/private/bufpkg/bufcheck/bufbreaking/handler.go
+++ b/private/bufpkg/bufcheck/bufbreaking/handler.go
@@ -53,11 +53,11 @@ func (h *handler) Check(
 	if config.Disabled() {
 		return nil
 	}
-	previousFiles, err := bufprotosource.NewFiles(ctx, previousImage)
+	previousFiles, err := bufprotosource.NewFiles(ctx, previousImage.Files(), previousImage.Resolver())
 	if err != nil {
 		return err
 	}
-	files, err := bufprotosource.NewFiles(ctx, image)
+	files, err := bufprotosource.NewFiles(ctx, image.Files(), image.Resolver())
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufcheck/buflint/handler.go
+++ b/private/bufpkg/bufcheck/buflint/handler.go
@@ -56,7 +56,7 @@ func (h *handler) Check(
 	if config.Disabled() {
 		return nil
 	}
-	files, err := bufprotosource.NewFiles(ctx, image)
+	files, err := bufprotosource.NewFiles(ctx, image.Files(), image.Resolver())
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufimage/build_image_test.go
+++ b/private/bufpkg/bufimage/build_image_test.go
@@ -213,7 +213,7 @@ func TestGoogleapis(t *testing.T) {
 
 	assert.Equal(t, buftesting.NumGoogleapisFilesWithImports, len(image.Files()))
 	// basic check to make sure there is no error at this scale
-	_, err = bufprotosource.NewFiles(context.Background(), image)
+	_, err = bufprotosource.NewFiles(context.Background(), image.Files(), image.Resolver())
 	assert.NoError(t, err)
 }
 

--- a/private/bufpkg/bufprotosource/bufprotosource.go
+++ b/private/bufpkg/bufprotosource/bufprotosource.go
@@ -525,6 +525,7 @@ type Method interface {
 	IdempotencyLevelLocation() Location
 }
 
+// InputFile is a file used as input when building Files.
 type InputFile interface {
 	FileInfo
 

--- a/private/bufpkg/bufprotosource/bufprotosource.go
+++ b/private/bufpkg/bufprotosource/bufprotosource.go
@@ -29,8 +29,10 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
+	"github.com/gofrs/uuid/v5"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -240,6 +242,18 @@ type FileInfo interface {
 	//   RootDirPath: proto
 	//   ExternalPath: /foo/bar/proto/one/one.proto
 	ExternalPath() string
+	// ModuleFullName is the module that this file came from.
+	//
+	// Note this *can* be nil if we did not build from a named module.
+	// All code must assume this can be nil.
+	// Note that nil checking should work since the backing type is always a pointer.
+	ModuleFullName() bufmodule.ModuleFullName
+	// CommitID is the commit for the module that this file came from.
+	//
+	// This will only be set if ModuleFullName is set, but may not be set
+	// even if ModuleFullName is set, that is commit is optional information
+	// even if we know what module this file came from.
+	CommitID() uuid.UUID
 	// IsImport returns true if this file is an import.
 	IsImport() bool
 }

--- a/private/bufpkg/bufprotosource/bufprotosource_test.go
+++ b/private/bufpkg/bufprotosource/bufprotosource_test.go
@@ -35,7 +35,7 @@ func TestNewFiles(t *testing.T) {
 		bufmodule.ModuleSetToModuleReadBucketWithOnlyProtoFiles(moduleSet),
 	)
 	require.NoError(t, err)
-	files, err := NewFiles(context.Background(), image)
+	files, err := NewFiles(context.Background(), image.Files(), image.Resolver())
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 	file := files[0]

--- a/private/bufpkg/bufprotosource/file.go
+++ b/private/bufpkg/bufprotosource/file.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"google.golang.org/protobuf/reflect/protodesc"
@@ -228,19 +227,19 @@ func (f *file) SyntaxLocation() Location {
 
 // does not validation of the fileDescriptorProto - this is assumed to be done elsewhere
 // does no duplicate checking by name - could just have maps ie importToFileImport, enumNameToEnum, etc
-func newFile(imageFile bufimage.ImageFile, resolver protodesc.Resolver) (*file, error) {
-	locationStore := newLocationStore(imageFile.FileDescriptorProto().GetSourceCodeInfo().GetLocation())
+func newFile(inputFile InputFile, resolver protodesc.Resolver) (*file, error) {
+	locationStore := newLocationStore(inputFile.FileDescriptorProto().GetSourceCodeInfo().GetLocation())
 	f := &file{
-		FileInfo:       imageFile,
+		FileInfo:       inputFile,
 		resolver:       resolver,
-		fileDescriptor: imageFile.FileDescriptorProto(),
+		fileDescriptor: inputFile.FileDescriptorProto(),
 		optionExtensionDescriptor: newOptionExtensionDescriptor(
-			imageFile.FileDescriptorProto().GetOptions(),
+			inputFile.FileDescriptorProto().GetOptions(),
 			[]int32{8},
 			locationStore,
 			50,
 		),
-		edition: imageFile.FileDescriptorProto().GetEdition(),
+		edition: inputFile.FileDescriptorProto().GetEdition(),
 	}
 	descriptor := newDescriptor(
 		f,
@@ -248,7 +247,7 @@ func newFile(imageFile bufimage.ImageFile, resolver protodesc.Resolver) (*file, 
 	)
 	f.descriptor = descriptor
 
-	if imageFile.IsSyntaxUnspecified() {
+	if inputFile.IsSyntaxUnspecified() {
 		// if the syntax is "proto2", protoc and buf will not set the syntax
 		// field even if it was explicitly set, this is why we have
 		// IsSyntaxUnspecified
@@ -297,7 +296,7 @@ func newFile(imageFile bufimage.ImageFile, resolver protodesc.Resolver) (*file, 
 		}
 		fileImport.setIsWeak()
 	}
-	for _, dependencyIndex := range imageFile.UnusedDependencyIndexes() {
+	for _, dependencyIndex := range inputFile.UnusedDependencyIndexes() {
 		if int(dependencyIndex) < 0 || len(f.fileImports) <= int(dependencyIndex) {
 			return nil, fmt.Errorf("got dependency index of %d but length of imports is %d", dependencyIndex, len(f.fileImports))
 		}


### PR DESCRIPTION
This narrows the scope required to build `[]File` from `bufimage.Image` to [F InputFile]([]InputFile)`, where `InputFile` is a new, minimal interface with only the items that `bufprotosource` needs.

Note that this will result in a breakage in three locations in core, but just `s/image/image.Files(), image.Resolver()/` in those three `NewFiles` calls and all should work.