### PR TITLE
Flatten normalpath EqualsOrContainsPath check

### DIFF
--- a/private/pkg/normalpath/normalpath_unix.go
+++ b/private/pkg/normalpath/normalpath_unix.go
@@ -100,22 +100,10 @@ func MapAllEqualOrContainingPathMap(m map[string]struct{}, path string, pathType
 		return nil
 	}
 
-	pathRoot := stringOSPathSeparator
-	if pathType == Relative {
-		pathRoot = "."
-	}
-
 	n := make(map[string]struct{})
-	if _, ok := m[pathRoot]; ok {
-		// also covers if path == separator.
-		n[pathRoot] = struct{}{}
-	}
 	for potentialMatch := range m {
-		for curPath := path; curPath != pathRoot; curPath = Dir(curPath) {
-			if potentialMatch == curPath {
-				n[potentialMatch] = struct{}{}
-				break
-			}
+		if EqualsOrContainsPath(potentialMatch, path, pathType) {
+			n[potentialMatch] = struct{}{}
 		}
 	}
 	return n

--- a/private/pkg/normalpath/normalpath_unix.go
+++ b/private/pkg/normalpath/normalpath_unix.go
@@ -53,18 +53,12 @@ func EqualsOrContainsPath(value string, path string, pathType PathType) bool {
 		pathRoot = "."
 	}
 
-	if value == pathRoot {
-		return true
-	}
-
-	// Walk up the path and compare at each directory level until there is a
-	// match or the path reaches its root (either `/` or `.`).
-	for curPath := path; curPath != pathRoot; curPath = Dir(curPath) {
-		if value == curPath {
-			return true
-		}
-	}
-	return false
+	// If the value is the root, it contains everything.
+	return value == pathRoot ||
+		// If the value is the path, it contains itself.
+		value == path ||
+		// If the value is a directory and the path is in the directory.
+		strings.HasPrefix(path, value+stringOSPathSeparator)
 }
 
 // MapHasEqualOrContainingPath returns true if the path matches any file or directory in the map.

--- a/private/pkg/normalpath/normalpath_unix_test.go
+++ b/private/pkg/normalpath/normalpath_unix_test.go
@@ -319,6 +319,23 @@ func TestEqualsOrContainsPath(t *testing.T) {
 	testEqualsOrContainsPath(t, true, "b", "b/a/c")
 }
 
+func BenchmarkEqualsOrContainsPath(b *testing.B) {
+	b.Run("Short", func(b *testing.B) {
+		var ok bool
+		for i := 0; i < b.N; i++ {
+			ok = EqualsOrContainsPath("a/b/c", "a/b/c/d", Relative)
+		}
+		assert.True(b, ok)
+	})
+	b.Run("Long", func(b *testing.B) {
+		var ok bool
+		for i := 0; i < b.N; i++ {
+			ok = EqualsOrContainsPath("a/b/c", "a/b/c/d/e/f/g/h/i/j", Relative)
+		}
+		assert.True(b, ok)
+	})
+}
+
 func testEqualsOrContainsPath(t *testing.T, expected bool, value string, path string) {
 	assert.Equal(t, expected, EqualsOrContainsPath(value, path, Relative), fmt.Sprintf("%s %s", value, path))
 }


### PR DESCRIPTION
This is a small optimization around the `EqualsOrContainsPath` method. It's called repeatedly over a filesystem when walking and using mappers or matchers. The check is now constant time for a given length. Added a micro benchmark to showcase on unix. Didn't adjust the windows method as theres some changes needed for volume handling.
```
                             │    sec/op     │    sec/op     vs base                 │
EqualsOrContainsPath/Short-8    45.36n ± ∞ ¹   15.56n ± ∞ ¹        ~ (p=1.000 n=1) ²
EqualsOrContainsPath/Long-8    458.20n ± ∞ ¹   15.56n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                         144.2n         15.56n        -89.21%
```