### PR TITLE
Cache doc and license storage buckets

### DIFF
--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -557,10 +557,18 @@ func getMappedModuleBucketAndModuleTargeting(
 			),
 		)
 	}
+	docStorageReadBucket, err := bufmodule.GetDocStorageReadBucket(ctx, moduleBucket)
+	if err != nil {
+		return nil, nil, err
+	}
+	licenseStorageReadBucket, err := bufmodule.GetLicenseStorageReadBucket(ctx, moduleBucket)
+	if err != nil {
+		return nil, nil, err
+	}
 	rootBuckets = append(
 		rootBuckets,
-		bufmodule.GetDocStorageReadBucket(ctx, moduleBucket),
-		bufmodule.GetLicenseStorageReadBucket(moduleBucket),
+		docStorageReadBucket,
+		licenseStorageReadBucket,
 	)
 	mappedModuleBucket := storage.MultiReadBucket(rootBuckets...)
 	moduleTargeting, err := newModuleTargeting(

--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -231,17 +231,17 @@ func GetLicenseFile(ctx context.Context, moduleReadBucket ModuleReadBucket) (Fil
 // This is needed for i.e. using RootToExcludes in NewWorkspaceForBucket.
 func GetDocStorageReadBucket(ctx context.Context, bucket storage.ReadBucket) (storage.ReadBucket, error) {
 	// Store the documentation file in a new memory bucket for performance reasons.
-	path := getDocFilePathForStorageReadBucket(ctx, bucket)
-	if path == "" {
+	docFilePath := getDocFilePathForStorageReadBucket(ctx, bucket)
+	if docFilePath == "" {
 		return storage.MultiReadBucket(), nil // nop bucket
 	}
-	content, err := storage.ReadPath(ctx, bucket, path)
+	content, err := storage.ReadPath(ctx, bucket, docFilePath)
 	if err != nil {
 		return nil, err
 	}
 	return storagemem.NewReadBucket(
 		map[string][]byte{
-			path: content,
+			docFilePath: content,
 		},
 	)
 }

--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -26,6 +26,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/normalpath"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/storage"
+	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/buf/private/pkg/syserror"
 	"github.com/bufbuild/protocompile/parser/fastscan"
 	"go.uber.org/multierr"
@@ -228,20 +229,39 @@ func GetLicenseFile(ctx context.Context, moduleReadBucket ModuleReadBucket) (Fil
 // GetDocStorageReadBucket gets a storage.ReadBucket that just contains the documentation file(s).
 //
 // This is needed for i.e. using RootToExcludes in NewWorkspaceForBucket.
-func GetDocStorageReadBucket(ctx context.Context, bucket storage.ReadBucket) storage.ReadBucket {
-	return storage.MapReadBucket(
-		bucket,
-		storage.MatchPathEqual(getDocFilePathForStorageReadBucket(ctx, bucket)),
+func GetDocStorageReadBucket(ctx context.Context, bucket storage.ReadBucket) (storage.ReadBucket, error) {
+	// Store the documentation file in a new memory bucket for performance reasons.
+	path := getDocFilePathForStorageReadBucket(ctx, bucket)
+	if path == "" {
+		return storage.MultiReadBucket(), nil // nop bucket
+	}
+	content, err := storage.ReadPath(ctx, bucket, path)
+	if err != nil {
+		return nil, err
+	}
+	return storagemem.NewReadBucket(
+		map[string][]byte{
+			path: content,
+		},
 	)
 }
 
 // GetLicenseStorageReadBucket gets a storage.ReadBucket that just contains the license file(s).
 //
 // This is needed for i.e. using RootToExcludes in NewWorkspaceForBucket.
-func GetLicenseStorageReadBucket(bucket storage.ReadBucket) storage.ReadBucket {
-	return storage.MapReadBucket(
-		bucket,
-		storage.MatchPathEqual(licenseFilePath),
+func GetLicenseStorageReadBucket(ctx context.Context, bucket storage.ReadBucket) (storage.ReadBucket, error) {
+	// Store the license file in a new memory bucket for performance reasons.
+	content, err := storage.ReadPath(ctx, bucket, licenseFilePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return storage.MultiReadBucket(), nil // nop bucket
+		}
+		return nil, err
+	}
+	return storagemem.NewReadBucket(
+		map[string][]byte{
+			licenseFilePath: content,
+		},
 	)
 }
 


### PR DESCRIPTION
For large repositories, buckets can be slow to iterate over. Use memory backed buckets to reduce file access for both doc and license files. This can speed up builds by up to 2/3 on large repositories by avoiding iterating over os storage buckets. As an example running build of a single proto file in a large workspace of 96k files takes 1.60s with `v1.36.0`, 1.06s with `v1.31.0` and 0.56s with this change.

This is a simpler approach to #3230 but can be used in conjunction with it.