### PR TITLE
Update bufcheck.Rules logic to match upcoming bufplugin Rules

### DIFF
--- a/private/buf/bufcli/rules.go
+++ b/private/buf/bufcli/rules.go
@@ -1,0 +1,45 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufcli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/bufbuild/buf/private/bufpkg/bufcheck"
+)
+
+// AllRuleFormatStrings is all rule format strings.
+var AllRuleFormatStrings = []string{
+	"text",
+	"json",
+}
+
+// PrintRules prints the Rules to the writer given the --format and --include-deprecated flag values.
+func PrintRules(writer io.Writer, rules []bufcheck.Rule, format string, includeDeprecated bool) error {
+	var printRulesOptions []bufcheck.PrintRulesOption
+	switch s := strings.ToLower(strings.TrimSpace(format)); s {
+	case "", "text":
+	case "json":
+		printRulesOptions = append(printRulesOptions, bufcheck.PrintRulesWithJSON())
+	default:
+		return fmt.Errorf("unknown format: %q", s)
+	}
+	if includeDeprecated {
+		printRulesOptions = append(printRulesOptions, bufcheck.PrintRulesWithDeprecated())
+	}
+	return bufcheck.PrintRules(writer, rules, printRulesOptions...)
+}

--- a/private/buf/cmd/buf/command/config/internal/internal.go
+++ b/private/buf/cmd/buf/command/config/internal/internal.go
@@ -118,7 +118,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"text",
 		fmt.Sprintf(
 			"The format to print rules as. Must be one of %s",
-			stringutil.SliceToString(bufcheck.AllRuleFormatStrings),
+			stringutil.SliceToString(bufcli.AllRuleFormatStrings),
 		),
 	)
 	flagSet.StringVar(
@@ -249,7 +249,7 @@ func lsRun(
 			return syserror.Newf("unknown FileVersion: %v", fileVersion)
 		}
 	}
-	return bufcheck.PrintRules(
+	return bufcli.PrintRules(
 		container.Stdout(),
 		rules,
 		flags.Format,

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -116,7 +116,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		"text",
 		fmt.Sprintf(
 			"The format to print rules as. Must be one of %s",
-			stringutil.SliceToString(bufcheck.AllRuleFormatStrings),
+			stringutil.SliceToString(bufcli.AllRuleFormatStrings),
 		),
 	)
 	flagSet.StringVar(
@@ -207,7 +207,7 @@ func lsRun(
 			return syserror.Newf("unknown FileVersion: %v", fileVersion)
 		}
 	}
-	return bufcheck.PrintRules(
+	return bufcli.PrintRules(
 		container.Stdout(),
 		rules,
 		flags.Format,

--- a/private/bufpkg/bufcheck/internal/rule.go
+++ b/private/bufpkg/bufcheck/internal/rule.go
@@ -15,7 +15,6 @@
 package internal
 
 import (
-	"encoding/json"
 	"sort"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
@@ -101,19 +100,6 @@ func (c *Rule) ReplacementIDs() []string {
 	return c.replacementIDs
 }
 
-// MarshalJSON implements Rule.
-func (c *Rule) MarshalJSON() ([]byte, error) {
-	return json.Marshal(ruleJSON{ID: c.id, Categories: c.categories, Purpose: c.purpose})
-}
-
 func (c *Rule) check(ignoreFunc IgnoreFunc, previousFiles []bufprotosource.File, files []bufprotosource.File) (_ []bufanalysis.FileAnnotation, retErr error) {
 	return c.checkFunc(c.ID(), ignoreFunc, previousFiles, files)
-}
-
-type ruleJSON struct {
-	ID           string   `json:"id" yaml:"id"`
-	Categories   []string `json:"categories" yaml:"categories"`
-	Purpose      string   `json:"purpose" yaml:"purpose"`
-	Deprecated   bool     `json:"deprecated" yaml:"deprecated"`
-	Replacements []string `json:"replacements" yaml:"replacements"`
 }


### PR DESCRIPTION
This updates `bufcheck.Rule` to match `bufplugin/check.Rule` by removing `json.Marshaler`. It also cleans up `bufcheck.PrintRules` which was never in style with the rest of the codebase (it was one of the first functions written in bufbuild/buf, and it was done so hastily, without functional options). It also does some separation of concerns by moving flag-specific logic to `bufcli`.