### PR TITLE
Parse docker image digest from Status if Aux not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `STABLE_PACKAGE_NO_IMPORT_UNSTABLE` lint rule which disallows files from stable packages
   to import files from unstable packages.
+- Fix plugin push failures when pushing an image built with containerd image store.
 
 ## [v1.36.0] - 2024-08-06
 

--- a/private/bufpkg/bufremoteplugin/bufremoteplugindocker/docker.go
+++ b/private/bufpkg/bufremoteplugin/bufremoteplugindocker/docker.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,13 @@ const (
 	// Example: User-Agent = [docker/20.10.21 go/go1.18.7 git-commit/3056208 kernel/5.15.49-linuxkit os/linux arch/arm64 UpstreamClient(buf-cli-1.11.0)]
 	BufUpstreamClientUserAgentPrefix = "buf-cli-"
 )
+
+// imageDigestRe is a regular expression for extracting the image digest from the output of a docker
+// push command. It is tightly coupled to the string representation because the stream response
+// itself is not very well defined.
+//
+// https://github.com/moby/moby/blob/1c282d1f1b90ff188a1b46f48548ac3151ca2ddf/daemon/containerd/image_push.go#L130
+var imageDigestRe = regexp.MustCompile(`digest:\s*(\S+)`)
 
 // Client is a small abstraction over a Docker API client, providing the basic APIs we need to build plugins.
 // It ensures that we pass the appropriate parameters to build images (i.e. platform 'linux/amd64').
@@ -183,12 +191,7 @@ func (d *dockerAPIClient) Push(ctx context.Context, image string, auth *Registry
 			if message.Error != nil {
 				return nil, message.Error
 			}
-			if message.Aux != nil {
-				var pushResult types.PushResult
-				if err := json.Unmarshal(*message.Aux, &pushResult); err == nil {
-					imageDigest = pushResult.Digest
-				}
-			}
+			imageDigest = getImageDigestFromMessage(message)
 		}
 	}
 	if err := pushScanner.Err(); err != nil {
@@ -197,7 +200,24 @@ func (d *dockerAPIClient) Push(ctx context.Context, image string, auth *Registry
 	if len(imageDigest) == 0 {
 		return nil, fmt.Errorf("failed to determine image digest after push")
 	}
+	d.logger.Debug("docker image digest", zap.String("imageDigest", imageDigest))
 	return &PushResponse{Digest: imageDigest}, nil
+}
+
+func getImageDigestFromMessage(message jsonmessage.JSONMessage) string {
+	if message.Aux != nil {
+		var pushResult types.PushResult
+		if err := json.Unmarshal(*message.Aux, &pushResult); err == nil {
+			return pushResult.Digest
+		}
+	}
+	// If the message has no aux field, we fall back to parsing the status field.
+	if message.Status != "" {
+		if match := imageDigestRe.FindStringSubmatch(message.Status); len(match) > 1 {
+			return match[1]
+		}
+	}
+	return ""
 }
 
 func (d *dockerAPIClient) Delete(ctx context.Context, image string) (*DeleteResponse, error) {

--- a/private/bufpkg/bufremoteplugin/bufremoteplugindocker/docker_test.go
+++ b/private/bufpkg/bufremoteplugin/bufremoteplugindocker/docker_test.go
@@ -103,6 +103,32 @@ func TestMain(m *testing.M) {
 	}
 }
 
+func TestGetImageDigestFromMessage(t *testing.T) {
+	t.Parallel()
+	assertImageDigestFromStatusString(t,
+		"v1.4.0: digest: sha256:83189bf0fa178c5947af0bcfcf8b9e955c67bf13c4bea0eee145fbfc3e8398d8 size: 855",
+		"sha256:83189bf0fa178c5947af0bcfcf8b9e955c67bf13c4bea0eee145fbfc3e8398d8",
+	)
+	assertImageDigestFromStatusString(t,
+		"v1.4.0: digest: sha512:4b230b5e4e3518cf1f16e0a5d3293245cd6f27df350aed72c9eb59fc4b5b5ef764cb0aaea201ea70eab68ca7388533384c4d0e690eaba7f2cd7a0e8939db986f size: 855", "sha512:4b230b5e4e3518cf1f16e0a5d3293245cd6f27df350aed72c9eb59fc4b5b5ef764cb0aaea201ea70eab68ca7388533384c4d0e690eaba7f2cd7a0e8939db986f",
+	)
+	assertImageDigestFromStatusString(t,
+		"digest: sha256:83189bf0fa178c5947af0bcfcf8b9e955c67bf13c4bea0eee145fbfc3e8398d8",
+		"sha256:83189bf0fa178c5947af0bcfcf8b9e955c67bf13c4bea0eee145fbfc3e8398d8",
+	)
+	// malformed, missing "digest:"
+	assertImageDigestFromStatusString(t,
+		"sha256:83189bf0fa178c5947af0bcfcf8b9e955c67bf13c4bea0eee145fbfc3e8398d8",
+		"",
+	)
+}
+
+func assertImageDigestFromStatusString(t *testing.T, status string, expectedDigest string) {
+	t.Helper()
+	digest := getImageDigestFromMessage(jsonmessage.JSONMessage{Status: status})
+	assert.Equal(t, expectedDigest, digest)
+}
+
 func createClient(t testing.TB, options ...ClientOption) Client {
 	t.Helper()
 	logger, err := zap.NewDevelopment()


### PR DESCRIPTION
This PR adds logic to retrieve the docker image digest from the status field following a successful push. There are some cases where the `Aux` field is not used, and instead, we have to parse it out of the `Status` field.

I've mentioned it in the comment, but adding it here for brevity, the string we're parsing from is:

https://github.com/moby/moby/blob/1c282d1f1b90ff188a1b46f48548ac3151ca2ddf/daemon/containerd/image_push.go#L126-L133

For a bit more context, I've opened an issue upstream https://github.com/moby/moby/issues/48331, but afaics there isn't a better way.

Without this change, I was getting failures pushing a plugin against images built with [containerd image store](https://docs.docker.com/desktop/containerd/) feature enabled. The plugin was pushed, but we failed to parse out the final image digest.

> Failure: failed to determine image digest after push