### PR TITLE
Update thread.ParallelizeWithCancel to thread.ParallelizeWithCancelOnFailure that no longer takes a context.CancelFunc

### DIFF
--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -295,12 +295,10 @@ func (g *generator) execPlugins(
 	//      out: gen/proto
 	//    - name: insertion-point-writer
 	//      out: gen/proto
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	if err := thread.Parallelize(
 		ctx,
 		jobs,
-		thread.ParallelizeWithCancel(cancel),
+		thread.ParallelizeWithCancelOnFailure(),
 	); err != nil {
 		if errs := multierr.Errors(err); len(errs) > 0 {
 			return nil, errs[0]

--- a/private/bufpkg/bufprotoplugin/generator.go
+++ b/private/bufpkg/bufprotoplugin/generator.go
@@ -72,9 +72,7 @@ func (g *generator) Generate(
 			)
 		}
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	if err := thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancel(cancel)); err != nil {
+	if err := thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancelOnFailure()); err != nil {
 		return nil, err
 	}
 	codeGeneratorResponse, err := protopluginResponseWriter.ToCodeGeneratorResponse()

--- a/private/pkg/bandeps/checker.go
+++ b/private/pkg/bandeps/checker.go
@@ -144,9 +144,7 @@ func (c *checker) populateState(ctx context.Context, state *state, externalConfi
 			},
 		)
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	if err := thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancel(cancel)); err != nil {
+	if err := thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancelOnFailure()); err != nil {
 		return err
 	}
 
@@ -161,5 +159,5 @@ func (c *checker) populateState(ctx context.Context, state *state, externalConfi
 			},
 		)
 	}
-	return thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancel(cancel))
+	return thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancelOnFailure())
 }


### PR DESCRIPTION
`thread.ParallelizeWithCancel` would call a provided `context.CancelFunc` if any given job failed. However:

- All we wanted to do was make sure a cancel was sent to `ctx` on any job failure.
- Every time we called `thread.ParallelizeWithCancel`, we created the `CancelFunc` right before it:

```go
// This is every call we made.
ctx, cancel := context.WithCancel(ctx)
defer cancel()
return thread.Parallelize(ctx, jobs, thread.ParallelizeWithCancel(cancel))
```

This was confusing and unnecessary - all we need to do is create a `CancelFunc` within `Parallelize` if we want this behavior.

This PR updates the option to do just this, along with a rename in line with this behavior.