### PR TITLE
Improve support for docker plugins built with containerd image store

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -456,11 +456,11 @@ func getImageIDAndDigestFromReference(
 
 	switch {
 	case desc.MediaType.IsIndex():
-		index, err := desc.ImageIndex()
+		imageIndex, err := desc.ImageIndex()
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get image index: %w", err)
 		}
-		indexManifest, err := index.IndexManifest()
+		indexManifest, err := imageIndex.IndexManifest()
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get image manifests: %w", err)
 		}
@@ -475,19 +475,19 @@ func getImageIDAndDigestFromReference(
 				break
 			}
 		}
-		repoName, _, ok := strings.Cut(ref.Name(), "@")
+		refNameWithoutDigest, _, ok := strings.Cut(ref.Name(), "@")
 		if !ok {
-			return "", "", fmt.Errorf("could not resolve repository name from %q", ref.Name())
+			return "", "", fmt.Errorf("failed to parse reference name %q", ref)
 		}
-		repo, err := name.NewRepository(repoName)
+		repository, err := name.NewRepository(refNameWithoutDigest)
 		if err != nil {
-			return "", "", err
+			return "", "", fmt.Errorf("failed to construct repository %q: %w", refNameWithoutDigest, err)
 		}
 		// We resolved the image index to an image manifest digest, we can now call this function
 		// again to resolve the image manifest digest to an image config digest.
 		return getImageIDAndDigestFromReference(
 			ctx,
-			repo.Digest(manifest.Digest.String()),
+			repository.Digest(manifest.Digest.String()),
 			options...,
 		)
 	case desc.MediaType.IsImage():


### PR DESCRIPTION
This PR adds support for pushing docker images built with the [containerd image store](https://docs.docker.com/desktop/containerd/) feature enabled. Specifically, we need to handle [image index](https://github.com/opencontainers/image-spec/blob/v1.1.0/image-index.md) digests.

Without these changes users trying to push plugins might run into the following error (in the case an image already exists in the registry):

> Failure: no child with platform linux/amd64 in index {registry}/asdf/go-json@sha256:4830ada11bc5df2123086fbc85af7ac9555db7c7095b0ea982cf372aa9a0c84f

This is because in [`getImageIDAndDigestFromReference`](https://github.com/bufbuild/buf/blob/b029c1f2151dff3f08c848c3e797a4c248840e57/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go#L437-L440) we were only checking for the image manifest, and if we hit an image index digest it wouldn't resolve, hence the "no child" error.

The intended behavior is to see the following:

```
INFO    plugin already exists   {"name": "{registry}/asdf/go-json", "digest": "sha256:10a3c5683995cc5f69ef341ab23841df04c76b0822367c884ca42cfc04ec9041"}
Owner  Name     Version  Revision
asdf   go-json  v1.4.0   1
```

Related to https://github.com/bufbuild/buf/pull/3239