### PR TITLE
Fix parse plugin references for hosts with ports

### DIFF
--- a/private/bufpkg/bufremoteplugin/bufremotepluginref/bufremotepluginref.go
+++ b/private/bufpkg/bufremoteplugin/bufremotepluginref/bufremotepluginref.go
@@ -145,10 +145,11 @@ func newInvalidPluginIdentityStringError(s string) error {
 }
 
 func parsePluginReference(reference string, revision int) (PluginReference, error) {
-	name, version, ok := strings.Cut(reference, ":")
-	if !ok {
+	index := strings.LastIndex(reference, ":")
+	if index == -1 {
 		return nil, fmt.Errorf("plugin references must be specified as \"<name>:<version>\" strings")
 	}
+	name, version := reference[:index], reference[index+1:]
 	identity, err := PluginIdentityForString(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The version suffix should be parsed from the last ':' present in the string to avoid splitting the string on the address of the BSR. For example the value '0.0.0.0:60156/protocolbuffers/go:v1.33.0' is a valid plugin reference.