### PR TITLE
Fix git checkout for relative HEAD refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix git input handling of relative HEAD refs without branch names.
 
 ## [v1.38.0] - 2024-08-22
 

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -142,6 +142,7 @@ func (c *cloner) CloneToBucket(
 	// First, try to fetch the fetchRef directly. If the ref is not found, we
 	// will try to fetch the fallback ref with a depth to allow resolving partial
 	// refs locally. If the fetch fails, we will return an error.
+	var usedFallback bool
 	fetchRef, fallbackRef, checkoutRef := getRefspecsForName(options.Name)
 	buffer.Reset()
 	if err := c.runner.Run(
@@ -160,9 +161,10 @@ func (c *cloner) CloneToBucket(
 		command.RunWithDir(baseDir.AbsPath()),
 	); err != nil {
 		// If the ref fetch failed, without a fallback, return the error.
-		if fallbackRef == "" || !strings.Contains(buffer.String(), "couldn't find remote ref") {
+		if fallbackRef == "" {
 			return newGitCommandError(err, buffer)
 		}
+		usedFallback = true
 		// Failed to fetch the ref directly, try to fetch the fallback ref.
 		buffer.Reset()
 		if err := c.runner.Run(
@@ -197,7 +199,9 @@ func (c *cloner) CloneToBucket(
 	); err != nil {
 		return newGitCommandError(err, buffer)
 	}
-	if checkoutRef != "" {
+	// Should checkout if the fallback was used or if the checkout ref is different
+	// from the fetch ref.
+	if checkoutRef != "" && (usedFallback || checkoutRef != fetchRef) {
 		buffer.Reset()
 		if err := c.runner.Run(
 			ctx,
@@ -354,7 +358,7 @@ func getRefspecsForName(gitName Name) (fetchRef string, fallbackRef string, chec
 	} else if checkout != "" && checkout != "HEAD" {
 		// If a checkout ref is specified, we fetch the ref directly.
 		// We fallback to fetching the HEAD to resolve partial refs.
-		return checkout, "HEAD", ""
+		return checkout, "HEAD", checkout
 	}
 	return "HEAD", "", ""
 }

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -358,6 +358,7 @@ func getRefspecsForName(gitName Name) (fetchRef string, fallbackRef string, chec
 	} else if checkout != "" && checkout != "HEAD" {
 		// If a checkout ref is specified, we fetch the ref directly.
 		// We fallback to fetching the HEAD to resolve partial refs.
+		// We checkout the ref after the fetch if the fallback was used.
 		return checkout, "HEAD", checkout
 	}
 	return "HEAD", "", ""

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -164,8 +164,8 @@ func (c *cloner) CloneToBucket(
 		if fallbackRef == "" {
 			return newGitCommandError(err, buffer)
 		}
-		usedFallback = true
 		// Failed to fetch the ref directly, try to fetch the fallback ref.
+		usedFallback = true
 		buffer.Reset()
 		if err := c.runner.Run(
 			ctx,

--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -189,7 +189,7 @@ func TestGitCloner(t *testing.T) {
 		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
 
-	t.Run("HEAD", func(t *testing.T) {
+	t.Run("ref=HEAD", func(t *testing.T) {
 		t.Parallel()
 		readBucket := readBucketForName(ctx, t, runner, workDir, 1, NewRefName("HEAD"), false)
 
@@ -199,7 +199,7 @@ func TestGitCloner(t *testing.T) {
 		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
-	t.Run("HEAD~", func(t *testing.T) {
+	t.Run("ref=HEAD~", func(t *testing.T) {
 		t.Parallel()
 		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName("HEAD~"), false)
 
@@ -209,9 +209,29 @@ func TestGitCloner(t *testing.T) {
 		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
-	t.Run("HEAD~1", func(t *testing.T) {
+	t.Run("ref=HEAD~1", func(t *testing.T) {
 		t.Parallel()
 		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName("HEAD~1"), false)
+
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
+		require.NoError(t, err)
+		assert.Equal(t, "// commit 1", string(content))
+		_, err = readBucket.Stat(ctx, "nonexistent")
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+	t.Run("ref=HEAD^", func(t *testing.T) {
+		t.Parallel()
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName("HEAD^"), false)
+
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
+		require.NoError(t, err)
+		assert.Equal(t, "// commit 1", string(content))
+		_, err = readBucket.Stat(ctx, "nonexistent")
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+	t.Run("ref=HEAD^1", func(t *testing.T) {
+		t.Parallel()
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName("HEAD^1"), false)
 
 		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
 		require.NoError(t, err)

--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -199,6 +199,26 @@ func TestGitCloner(t *testing.T) {
 		_, err = readBucket.Stat(ctx, "nonexistent")
 		assert.True(t, errors.Is(err, fs.ErrNotExist))
 	})
+	t.Run("HEAD~", func(t *testing.T) {
+		t.Parallel()
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName("HEAD~"), false)
+
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
+		require.NoError(t, err)
+		assert.Equal(t, "// commit 1", string(content))
+		_, err = readBucket.Stat(ctx, "nonexistent")
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+	t.Run("HEAD~1", func(t *testing.T) {
+		t.Parallel()
+		readBucket := readBucketForName(ctx, t, runner, workDir, 2, NewRefName("HEAD~1"), false)
+
+		content, err := storage.ReadPath(ctx, readBucket, "test.proto")
+		require.NoError(t, err)
+		assert.Equal(t, "// commit 1", string(content))
+		_, err = readBucket.Stat(ctx, "nonexistent")
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
 
 	t.Run("commit-local", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Annotated tag [fix](https://github.com/bufbuild/buf/pull/3198) caused a regression on `ref=HEAD~` and similar git refs. We need to be more lenient with error handling to try the fallback checkout, before finally resolving the checkout. 

Fixes https://github.com/bufbuild/buf/issues/3265