### PR TITLE
Chore fix make upgrade go version

### DIFF
--- a/.github/workflows/make-upgrade.yaml
+++ b/.github/workflows/make-upgrade.yaml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app_token.outputs.token }}
+      - name: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+          cache: false
       - name: Set up Git name and email
         run: |
           git config user.name 'github-actions[bot]'


### PR DESCRIPTION
Routine make upgrades are failing. See https://github.com/bufbuild/buf/actions/runs/10665104712/job/29621728404 . Looks related to the golangci-lint go version. Force go version to be 1.23, avoid caching of deps to avoid poising caches on upgrades.