### PR TITLE
Fix linting for a test lint plugin

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -287,8 +287,3 @@ issues:
       # trip this off.
       path: private/pkg/oauth2/device.go
       text: "G101:"
-    - linters:
-          - staticcheck
-      # This linter is for testing and calls a deprecated method on purpose.
-      path: private/bufpkg/bufcheck/internal/cmd/buf-plugin-protovalidate-ext/handlers.go
-      text: "deprecated"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -287,3 +287,8 @@ issues:
       # trip this off.
       path: private/pkg/oauth2/device.go
       text: "G101:"
+    - linters:
+          - staticcheck
+      # This linter is for testing and calls a deprecated method on purpose.
+      path: private/bufpkg/bufcheck/internal/cmd/buf-plugin-protovalidate-ext/handlers.go
+      text: "deprecated"

--- a/private/bufpkg/bufcheck/internal/cmd/buf-plugin-protovalidate-ext/handlers.go
+++ b/private/bufpkg/bufcheck/internal/cmd/buf-plugin-protovalidate-ext/handlers.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 
+	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	"github.com/bufbuild/bufplugin-go/check"
 	"github.com/bufbuild/protovalidate-go/resolver"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -34,7 +35,7 @@ func checkFieldNotSkippedNoImport(
 	fieldDescriptor protoreflect.FieldDescriptor,
 ) error {
 	constraints := resolver.DefaultResolver{}.ResolveFieldConstraints(fieldDescriptor)
-	if constraints.GetSkipped() {
+	if constraints.GetIgnore() == validate.Ignore_IGNORE_ALWAYS {
 		skippedRuleName := "(buf.validate.field).skipped"
 		if fieldDescriptor.Cardinality() == protoreflect.Repeated {
 			skippedRuleName = "(buf.validate.field).repeated.items.skipped"
@@ -58,7 +59,7 @@ func checkFieldNotSkipped(
 	fieldDescriptor protoreflect.FieldDescriptor,
 ) error {
 	constraints := resolver.DefaultResolver{}.ResolveFieldConstraints(fieldDescriptor)
-	if constraints.GetSkipped() {
+	if constraints.GetIgnore() == validate.Ignore_IGNORE_ALWAYS {
 		skippedRuleName := "(buf.validate.field).skipped"
 		if fieldDescriptor.Cardinality() == protoreflect.Repeated {
 			skippedRuleName = "(buf.validate.field).repeated.items.skipped"


### PR DESCRIPTION
This fixes the [lint error](https://github.com/bufbuild/buf/actions/runs/10690978756/job/29636516892?pr=3288) of a test plugin calling a deprecate method, `GetSkipped`.