### PR TITLE
Fix comment ignore with trailing comment not recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix issue with `buf lint` where comment ignores in the shape of `// buf:lint:ignore <RULE_ID> <extra comment>`
+  are not recognized due to the extra comment.
 
 ## [v1.40.0] - 2024-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Fix issue with `buf lint` where comment ignores in the shape of `// buf:lint:ignore <RULE_ID> <extra comment>`
-  are not recognized due to the extra comment.
+  were not recognized due to the extra comment.
 
 ## [v1.40.0] - 2024-09-04
 

--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -491,13 +491,14 @@ func ignoreLocation(
 }
 
 // checkCommentLineForCheckIgnore checks that the comment line starts with the configured
-// comment ignore prefix, a number of spaces (at least one), the ruleID of the check.
+// comment ignore prefix, a space and the ruleID of the check.
 //
-// All of the following comments ignore SERVICE_PASCAL_CASE and this rule only:
+// All of the following comments are valid, ignoring SERVICE_PASCAL_CASE and this rule only:
 //
 //	// buf:lint:ignore SERVICE_PASCAL_CASE, SERVICE_SUFFIX
 //	// buf:lint:ignore SERVICE_PASCAL_CASE
-//	// buf:lint:ignore SERVICE_PASCAL_CASE   some other comment
+//	// buf:lint:ignore SERVICE_PASCAL_CASEsome other comment
+//	// buf:lint:ignore SERVICE_PASCAL_CASE some other comment
 //
 // While the following is invalid and a nop
 //

--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -495,7 +495,7 @@ func ignoreLocation(
 //
 // All of the following comments are valid, ignoring SERVICE_PASCAL_CASE and this rule only:
 //
-//	// buf:lint:ignore SERVICE_PASCAL_CASE, SERVICE_SUFFIX
+//	// buf:lint:ignore SERVICE_PASCAL_CASE, SERVICE_SUFFIX (only SERVICE_PASCAL_CASE is ignored)
 //	// buf:lint:ignore SERVICE_PASCAL_CASE
 //	// buf:lint:ignore SERVICE_PASCAL_CASEsome other comment
 //	// buf:lint:ignore SERVICE_PASCAL_CASE some other comment

--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -494,27 +494,24 @@ func ignoreLocation(
 }
 
 // checkCommentLineForCheckIgnore checks that the comment line starts with the configured
-// comment ignore prefix, and the rest of the string is the ruleID of the check.
+// comment ignore prefix, a number of spaces (at least one), the ruleID of the check.
 //
-// We currently do not support multiple rules per comment ignore:
+// All of the following comments ignore SERVICE_PASCAL_CASE and this rule only:
 //
-//	Invalid:
-//		// buf:lint:ignore SERVICE_SUFFIX, SERVICE_PASCAL_CASE
+//	// buf:lint:ignore SERVICE_PASCAL_CASE, SERVICE_SUFFIX
+//	// buf:lint:ignore SERVICE_PASCAL_CASE
+//	// buf:lint:ignore SERVICE_PASCAL_CASE   some other comment
 //
-//	Valid:
-//		// buf:lint:ignore SERVICE_SUFFIX
-//		// buf:lint:ignore SERVICE_PASCAL_CASE
+// While the following is invalid and a nop
+//
+//	// buf:lint:ignoreSERVICE_PASCAL_CASE
 func checkCommentLineForCheckIgnore(
 	commentLine string,
 	commentIgnorePrefix string,
 	ruleID string,
 ) bool {
-	if after, ok := strings.CutPrefix(commentLine, commentIgnorePrefix); ok {
-		if strings.TrimSpace(after) == ruleID {
-			return true
-		}
-	}
-	return false
+	fullIgnorePrefix := commentIgnorePrefix + " " + ruleID
+	return strings.HasPrefix(commentLine, fullIgnorePrefix)
 }
 
 type lintOptions struct {

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -1188,6 +1188,14 @@ func TestCommentIgnoresOnlyRule(t *testing.T) {
 	)
 }
 
+func TestCommentIgnoresWithTrailingComment(t *testing.T) {
+	t.Parallel()
+	testLint(
+		t,
+		"comment_ignores_with_trailing_comment",
+	)
+}
+
 func TestRunLintCustomPlugins(t *testing.T) {
 	t.Parallel()
 	testLint(

--- a/private/bufpkg/bufcheck/testdata/lint/comment_ignores_with_trailing_comment/a.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/comment_ignores_with_trailing_comment/a.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+
+// buf:lint:ignore PACKAGE_DIRECTORY_MATCH trailing comment after the ignore comment is also OK
+package a;

--- a/private/bufpkg/bufcheck/testdata/lint/comment_ignores_with_trailing_comment/buf.yaml
+++ b/private/bufpkg/bufcheck/testdata/lint/comment_ignores_with_trailing_comment/buf.yaml
@@ -1,0 +1,4 @@
+version: v2
+lint:
+  use:
+    - PACKAGE_DIRECTORY_MATCH


### PR DESCRIPTION
This fixes the problem where comment ignores with a trailing comment is not recognized as a comment ignore:

```
// buf:lint:ignore PACKAGE_DIRECTORY_MATCH some comment ...
```