### PR TITLE
Update bufimageutil test to protoprint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -287,8 +287,3 @@ issues:
       # trip this off.
       path: private/pkg/oauth2/device.go
       text: "G101:"
-      # TODO: Remove once github.com/jhump/protoreflect is no longer a dependency
-    - linters:
-        - staticcheck
-      path: private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
-      test: "SA1019:"

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/jdx/go-netrc v1.0.0
-	github.com/jhump/protoreflect/v2 v2.0.0-20240901130830-bd8d71d0d99e
+	github.com/jhump/protoreflect/v2 v2.0.0-20240912143647-4b37dd90726f
 	github.com/klauspost/compress v1.17.9
 	github.com/klauspost/pgzip v1.2.6
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -117,5 +117,5 @@ require (
 	golang.org/x/text v0.18.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
-	google.golang.org/grpc v1.66.1 // indirect
+	google.golang.org/grpc v1.66.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/jdx/go-netrc v1.0.0
-	github.com/jhump/protoreflect v1.17.0
+	github.com/jhump/protoreflect/v2 v2.0.0-20240901130830-bd8d71d0d99e
 	github.com/klauspost/compress v1.17.9
 	github.com/klauspost/pgzip v1.2.6
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -82,7 +82,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/pprof v0.0.0-20240910150728-a0b0bb1d4134 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,6 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/cel-go v0.21.0 h1:cl6uW/gxN+Hy50tNYvI691+sXxioCnstFzLp2WO4GCI=
 github.com/google/cel-go v0.21.0/go.mod h1:rHUlWCcBKgyEk+eV03RPdZUekPp6YcJwV0FxuUksYxc=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -159,8 +157,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jdx/go-netrc v1.0.0 h1:QbLMLyCZGj0NA8glAhxUpf1zDg6cxnWgMBbjq40W0gQ=
 github.com/jdx/go-netrc v1.0.0/go.mod h1:Gh9eFQJnoTNIRHXl2j5bJXA1u84hQWJWgGh569zF3v8=
-github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
-github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
+github.com/jhump/protoreflect/v2 v2.0.0-20240901130830-bd8d71d0d99e h1:WGFOx/QSEMrR/q58r6vVyO70/842BrzAK1HOlyq/RVM=
+github.com/jhump/protoreflect/v2 v2.0.0-20240901130830-bd8d71d0d99e/go.mod h1:A481SWa8T4ME2MfyXIZU9nvC7wL1MeLZjYJ+hNfjRIc=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jdx/go-netrc v1.0.0 h1:QbLMLyCZGj0NA8glAhxUpf1zDg6cxnWgMBbjq40W0gQ=
 github.com/jdx/go-netrc v1.0.0/go.mod h1:Gh9eFQJnoTNIRHXl2j5bJXA1u84hQWJWgGh569zF3v8=
-github.com/jhump/protoreflect/v2 v2.0.0-20240901130830-bd8d71d0d99e h1:WGFOx/QSEMrR/q58r6vVyO70/842BrzAK1HOlyq/RVM=
-github.com/jhump/protoreflect/v2 v2.0.0-20240901130830-bd8d71d0d99e/go.mod h1:A481SWa8T4ME2MfyXIZU9nvC7wL1MeLZjYJ+hNfjRIc=
+github.com/jhump/protoreflect/v2 v2.0.0-20240912143647-4b37dd90726f h1:wnVRtYTjzLERxznrJWfRi0y6OBlyfSxzTYIps8CSYU8=
+github.com/jhump/protoreflect/v2 v2.0.0-20240912143647-4b37dd90726f/go.mod h1:D9LBEowZyv8/iSu97FU2zmXG3JxVTmNw21mu63niFzU=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -363,8 +363,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.66.1 h1:hO5qAXR19+/Z44hmvIM4dQFMSYX9XcWsByfoxutBpAM=
-google.golang.org/grpc v1.66.1/go.mod h1:s3/l6xSSCURdVfAnL+TqCNMyTDAGN6+lZeVxnZR128Y=
+google.golang.org/grpc v1.66.2 h1:3QdXkuq3Bkh7w+ywLdLvM56cmGvQHUMZpiCzt6Rqaoo=
+google.golang.org/grpc v1.66.2/go.mod h1:s3/l6xSSCURdVfAnL+TqCNMyTDAGN6+lZeVxnZR128Y=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -184,7 +184,7 @@ func TestTransitivePublic(t *testing.T) {
 	filteredImage, err := ImageFilteredByTypes(image, "c.Baz")
 	require.NoError(t, err)
 
-	_, err = protoencoding.NewWireMarshaler().Marshal(bufimage.ImageToFileDescriptorSet(filteredImage))
+	_, err = protodesc.NewFiles(bufimage.ImageToFileDescriptorSet(filteredImage))
 	require.NoError(t, err)
 }
 
@@ -286,7 +286,7 @@ func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedF
 	}
 	files.RangeFiles(func(fileDescriptor protoreflect.FileDescriptor) bool {
 		fileBuilder := &bytes.Buffer{}
-		require.NoError(t, printer.PrintProtoFile(fileDescriptor, fileBuilder), "expected no error while printing %q", fileDescriptor.Name())
+		require.NoError(t, printer.PrintProtoFile(fileDescriptor, fileBuilder), "expected no error while printing %q", fileDescriptor.Path())
 		archive.Files = append(
 			archive.Files,
 			txtar.File{

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/gofrs/uuid/v5"
-	"github.com/jhump/protoreflect/desc"
-	"github.com/jhump/protoreflect/desc/protoprint"
+	"github.com/jhump/protoreflect/v2/protoprint"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/tools/txtar"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -184,7 +184,7 @@ func TestTransitivePublic(t *testing.T) {
 	filteredImage, err := ImageFilteredByTypes(image, "c.Baz")
 	require.NoError(t, err)
 
-	_, err = desc.CreateFileDescriptorsFromSet(bufimage.ImageToFileDescriptorSet(filteredImage))
+	_, err = protoencoding.NewWireMarshaler().Marshal(bufimage.ImageToFileDescriptorSet(filteredImage))
 	require.NoError(t, err)
 }
 
@@ -276,24 +276,26 @@ func runDiffTest(t *testing.T, testdataDir string, typenames []string, expectedF
 	err = proto.UnmarshalOptions{Resolver: filteredImage.Resolver()}.Unmarshal(data, fileDescriptorSet)
 	require.NoError(t, err)
 
-	reflectDescriptors, err := desc.CreateFileDescriptorsFromSet(fileDescriptorSet)
+	files, err := protodesc.NewFiles(fileDescriptorSet)
 	require.NoError(t, err)
+
 	archive := &txtar.Archive{}
 	printer := protoprint.Printer{
 		SortElements: true,
 		Compact:      true,
 	}
-	for fname, d := range reflectDescriptors {
+	files.RangeFiles(func(fileDescriptor protoreflect.FileDescriptor) bool {
 		fileBuilder := &bytes.Buffer{}
-		require.NoError(t, printer.PrintProtoFile(d, fileBuilder), "expected no error while printing %q", fname)
+		require.NoError(t, printer.PrintProtoFile(fileDescriptor, fileBuilder), "expected no error while printing %q", fileDescriptor.Name())
 		archive.Files = append(
 			archive.Files,
 			txtar.File{
-				Name: fname,
+				Name: fileDescriptor.Path(),
 				Data: fileBuilder.Bytes(),
 			},
 		)
-	}
+		return true
+	})
 	sort.SliceStable(archive.Files, func(i, j int) bool {
 		return archive.Files[i].Name < archive.Files[j].Name
 	})

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/Files.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/Files.txtar
@@ -430,43 +430,43 @@ message UnusedOption {
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional UnusedOption file_bar = 50001;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    UnusedOption file_bar = 50001;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.EnumOptions {
-  optional UsedOption enum_foo = 50000;
-  optional UnusedOption enum_bar = 50001;
-  optional string enum_baz = 50002;
+  UsedOption enum_foo = 50000;
+  UnusedOption enum_bar = 50001;
+  string enum_baz = 50002;
 }
 extend google.protobuf.EnumValueOptions {
-  optional UsedOption enum_value_foo = 50000;
-  optional UnusedOption enum_value_bar = 50001;
-  optional string enum_value_baz = 50002;
+  UsedOption enum_value_foo = 50000;
+  UnusedOption enum_value_bar = 50001;
+  string enum_value_baz = 50002;
 }
 extend google.protobuf.FieldOptions {
-  optional UsedOption field_foo = 50000;
-  optional UnusedOption field_bar = 50001;
-  optional string field_baz = 50002;
+  UsedOption field_foo = 50000;
+  UnusedOption field_bar = 50001;
+  string field_baz = 50002;
 }
 extend google.protobuf.MessageOptions {
-  optional UsedOption message_foo = 50000;
-  optional UnusedOption message_bar = 50001;
-  optional string message_baz = 50002;
+  UsedOption message_foo = 50000;
+  UnusedOption message_bar = 50001;
+  string message_baz = 50002;
 }
 extend google.protobuf.MethodOptions {
-  optional UsedOption method_foo = 50000;
-  optional UnusedOption method_bar = 50001;
-  optional string method_baz = 50002;
+  UsedOption method_foo = 50000;
+  UnusedOption method_bar = 50001;
+  string method_baz = 50002;
 }
 extend google.protobuf.OneofOptions {
-  optional UsedOption oneof_foo = 50000;
-  optional UnusedOption oneof_bar = 50001;
-  optional string oneof_baz = 50002;
+  UsedOption oneof_foo = 50000;
+  UnusedOption oneof_bar = 50001;
+  string oneof_baz = 50002;
 }
 extend google.protobuf.ServiceOptions {
-  optional UsedOption service_foo = 50000;
-  optional UnusedOption service_bar = 50001;
-  optional string service_baz = 50002;
+  UsedOption service_foo = 50000;
+  UnusedOption service_bar = 50001;
+  string service_baz = 50002;
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/all-with-Files.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/all-with-Files.txtar
@@ -479,43 +479,43 @@ message UnusedOption {
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional UnusedOption file_bar = 50001;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    UnusedOption file_bar = 50001;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.EnumOptions {
-  optional UsedOption enum_foo = 50000;
-  optional UnusedOption enum_bar = 50001;
-  optional string enum_baz = 50002;
+  UsedOption enum_foo = 50000;
+  UnusedOption enum_bar = 50001;
+  string enum_baz = 50002;
 }
 extend google.protobuf.EnumValueOptions {
-  optional UsedOption enum_value_foo = 50000;
-  optional UnusedOption enum_value_bar = 50001;
-  optional string enum_value_baz = 50002;
+  UsedOption enum_value_foo = 50000;
+  UnusedOption enum_value_bar = 50001;
+  string enum_value_baz = 50002;
 }
 extend google.protobuf.FieldOptions {
-  optional UsedOption field_foo = 50000;
-  optional UnusedOption field_bar = 50001;
-  optional string field_baz = 50002;
+  UsedOption field_foo = 50000;
+  UnusedOption field_bar = 50001;
+  string field_baz = 50002;
 }
 extend google.protobuf.MessageOptions {
-  optional UsedOption message_foo = 50000;
-  optional UnusedOption message_bar = 50001;
-  optional string message_baz = 50002;
+  UsedOption message_foo = 50000;
+  UnusedOption message_bar = 50001;
+  string message_baz = 50002;
 }
 extend google.protobuf.MethodOptions {
-  optional UsedOption method_foo = 50000;
-  optional UnusedOption method_bar = 50001;
-  optional string method_baz = 50002;
+  UsedOption method_foo = 50000;
+  UnusedOption method_bar = 50001;
+  string method_baz = 50002;
 }
 extend google.protobuf.OneofOptions {
-  optional UsedOption oneof_foo = 50000;
-  optional UnusedOption oneof_bar = 50001;
-  optional string oneof_baz = 50002;
+  UsedOption oneof_foo = 50000;
+  UnusedOption oneof_bar = 50001;
+  string oneof_baz = 50002;
 }
 extend google.protobuf.ServiceOptions {
-  optional UsedOption service_foo = 50000;
-  optional UnusedOption service_bar = 50001;
-  optional string service_baz = 50002;
+  UsedOption service_foo = 50000;
+  UnusedOption service_bar = 50001;
+  string service_baz = 50002;
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/all.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/all.txtar
@@ -334,35 +334,35 @@ import "google/protobuf/descriptor.proto";
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.EnumOptions {
-  optional UsedOption enum_foo = 50000;
-  optional string enum_baz = 50002;
+  UsedOption enum_foo = 50000;
+  string enum_baz = 50002;
 }
 extend google.protobuf.EnumValueOptions {
-  optional UsedOption enum_value_foo = 50000;
-  optional string enum_value_baz = 50002;
+  UsedOption enum_value_foo = 50000;
+  string enum_value_baz = 50002;
 }
 extend google.protobuf.FieldOptions {
-  optional UsedOption field_foo = 50000;
-  optional string field_baz = 50002;
+  UsedOption field_foo = 50000;
+  string field_baz = 50002;
 }
 extend google.protobuf.MessageOptions {
-  optional UsedOption message_foo = 50000;
-  optional string message_baz = 50002;
+  UsedOption message_foo = 50000;
+  string message_baz = 50002;
 }
 extend google.protobuf.MethodOptions {
-  optional UsedOption method_foo = 50000;
-  optional string method_baz = 50002;
+  UsedOption method_foo = 50000;
+  string method_baz = 50002;
 }
 extend google.protobuf.OneofOptions {
-  optional UsedOption oneof_foo = 50000;
-  optional string oneof_baz = 50002;
+  UsedOption oneof_foo = 50000;
+  string oneof_baz = 50002;
 }
 extend google.protobuf.ServiceOptions {
-  optional UsedOption service_foo = 50000;
-  optional string service_baz = 50002;
+  UsedOption service_foo = 50000;
+  string service_baz = 50002;
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.Foo.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.Foo.txtar
@@ -275,19 +275,19 @@ import "google/protobuf/descriptor.proto";
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.FieldOptions {
-  optional UsedOption field_foo = 50000;
-  optional string field_baz = 50002;
+  UsedOption field_foo = 50000;
+  string field_baz = 50002;
 }
 extend google.protobuf.MessageOptions {
-  optional UsedOption message_foo = 50000;
-  optional string message_baz = 50002;
+  UsedOption message_foo = 50000;
+  string message_baz = 50002;
 }
 extend google.protobuf.OneofOptions {
-  optional UsedOption oneof_foo = 50000;
-  optional string oneof_baz = 50002;
+  UsedOption oneof_foo = 50000;
+  string oneof_baz = 50002;
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.FooEnum.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.FooEnum.txtar
@@ -220,15 +220,15 @@ import "google/protobuf/descriptor.proto";
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.EnumOptions {
-  optional UsedOption enum_foo = 50000;
-  optional string enum_baz = 50002;
+  UsedOption enum_foo = 50000;
+  string enum_baz = 50002;
 }
 extend google.protobuf.EnumValueOptions {
-  optional UsedOption enum_value_foo = 50000;
-  optional string enum_value_baz = 50002;
+  UsedOption enum_value_foo = 50000;
+  string enum_value_baz = 50002;
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.FooService.Do.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.FooService.Do.txtar
@@ -199,15 +199,15 @@ import "google/protobuf/descriptor.proto";
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.MethodOptions {
-  optional UsedOption method_foo = 50000;
-  optional string method_baz = 50002;
+  UsedOption method_foo = 50000;
+  string method_baz = 50002;
 }
 extend google.protobuf.ServiceOptions {
-  optional UsedOption service_foo = 50000;
-  optional string service_baz = 50002;
+  UsedOption service_foo = 50000;
+  string service_baz = 50002;
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.FooService.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/options/pkg.FooService.txtar
@@ -203,15 +203,15 @@ import "google/protobuf/descriptor.proto";
 message UsedOption {
   string foo = 1;
   extend google.protobuf.FileOptions {
-    optional UsedOption file_foo = 50000;
-    optional string file_baz = 50002;
+    UsedOption file_foo = 50000;
+    string file_baz = 50002;
   }
 }
 extend google.protobuf.MethodOptions {
-  optional UsedOption method_foo = 50000;
-  optional string method_baz = 50002;
+  UsedOption method_foo = 50000;
+  string method_baz = 50002;
 }
 extend google.protobuf.ServiceOptions {
-  optional UsedOption service_foo = 50000;
-  optional string service_baz = 50002;
+  UsedOption service_foo = 50000;
+  string service_baz = 50002;
 }


### PR DESCRIPTION
Removes the dep on github.com/golang/protobuf. See discussion in #3308.

Closes #3308 