### PR TITLE
Run bufcheck WithPlugins option

### DIFF
--- a/private/buf/bufmigrate/migrator.go
+++ b/private/buf/bufmigrate/migrator.go
@@ -28,7 +28,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/normalpath"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
@@ -713,7 +712,7 @@ func equivalentCheckConfigInV2(
 ) (bufconfig.CheckConfig, error) {
 	// No need for custom lint/breaking plugins since there's no plugins to migrate from <=v1.
 	// TODO: If we ever need v3, then we will have to deal with this.
-	client, err := bufcheck.NewClient(logger, tracer, pluginrpcutil.NewRunnerProvider(runner))
+	client, err := bufcheck.NewClient(logger, tracer)
 	if err != nil {
 		return nil, err
 	}

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -38,9 +38,7 @@ import (
 	imagev1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/image/v1"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd/appcmdtesting"
-	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/osext"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/storage/storagetesting"
@@ -1350,7 +1348,7 @@ func TestCheckLsBreakingRulesFromConfigExceptDeprecated(t *testing.T) {
 		t.Run(version.String(), func(t *testing.T) {
 			t.Parallel()
 			// Do not need any custom lint/breaking plugins here.
-			client, err := bufcheck.NewClient(zap.NewNop(), tracing.NopTracer, pluginrpcutil.NewRunnerProvider(command.NewRunner()))
+			client, err := bufcheck.NewClient(zap.NewNop(), tracing.NopTracer)
 			require.NoError(t, err)
 			allRules, err := client.AllRules(context.Background(), check.RuleTypeBreaking, version)
 			require.NoError(t, err)

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -28,7 +28,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
 	"github.com/bufbuild/buf/private/pkg/command"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/bufbuild/buf/private/pkg/tracing"
@@ -210,12 +209,16 @@ func run(
 	tracer := tracing.NewTracer(container.Tracer())
 	var allFileAnnotations []bufanalysis.FileAnnotation
 	for i, imageWithConfig := range imageWithConfigs {
-		client, err := bufcheck.NewClient(container.Logger(), tracer, pluginrpcutil.NewRunnerProvider(command.NewRunner()), bufcheck.ClientWithStderr(container.Stderr()))
+		client, err := bufcheck.NewClient(container.Logger(), tracer, bufcheck.ClientWithStderr(container.Stderr()))
+		if err != nil {
+			return err
+		}
+		plugins, err := bufcheck.NewPluginsForRunner(command.NewRunner(), imageWithConfig.PluginConfigs()...)
 		if err != nil {
 			return err
 		}
 		breakingOptions := []bufcheck.BreakingOption{
-			bufcheck.WithPluginConfigs(imageWithConfig.PluginConfigs()...),
+			bufcheck.WithPlugins(plugins...),
 		}
 		if flags.ExcludeImports {
 			breakingOptions = append(breakingOptions, bufcheck.BreakingWithExcludeImports())

--- a/private/buf/cmd/buf/command/mod/internal/internal.go
+++ b/private/buf/cmd/buf/command/mod/internal/internal.go
@@ -26,8 +26,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
-	"github.com/bufbuild/buf/private/pkg/command"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/bufbuild/buf/private/pkg/syserror"
@@ -176,7 +174,7 @@ func lsRun(
 	}
 	// BufYAMLFiles <=v1 never had plugins.
 	tracer := tracing.NewTracer(container.Tracer())
-	client, err := bufcheck.NewClient(container.Logger(), tracer, pluginrpcutil.NewRunnerProvider(command.NewRunner()), bufcheck.ClientWithStderr(container.Stderr()))
+	client, err := bufcheck.NewClient(container.Logger(), tracer, bufcheck.ClientWithStderr(container.Stderr()))
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/protoc-gen-buf-breaking/breaking.go
+++ b/private/buf/cmd/protoc-gen-buf-breaking/breaking.go
@@ -28,9 +28,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/encoding"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/buf/private/pkg/tracing"
@@ -126,7 +124,7 @@ func handle(
 	}
 	// The protoc plugins do not support custom lint/breaking change plugins for now.
 	tracer := tracing.NewTracer(container.Tracer())
-	client, err := bufcheck.NewClient(container.Logger(), tracer, pluginrpcutil.NewRunnerProvider(command.NewRunner()), bufcheck.ClientWithStderr(pluginEnv.Stderr))
+	client, err := bufcheck.NewClient(container.Logger(), tracer, bufcheck.ClientWithStderr(pluginEnv.Stderr))
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/protoc-gen-buf-lint/lint.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint.go
@@ -27,9 +27,7 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufcheck"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
-	"github.com/bufbuild/buf/private/pkg/command"
 	"github.com/bufbuild/buf/private/pkg/encoding"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/buf/private/pkg/tracing"
@@ -101,7 +99,7 @@ func handle(
 	}
 	// The protoc plugins do not support custom lint/breaking change plugins for now.
 	tracer := tracing.NewTracer(container.Tracer())
-	client, err := bufcheck.NewClient(container.Logger(), tracer, pluginrpcutil.NewRunnerProvider(command.NewRunner()), bufcheck.ClientWithStderr(pluginEnv.Stderr))
+	client, err := bufcheck.NewClient(container.Logger(), tracer, bufcheck.ClientWithStderr(pluginEnv.Stderr))
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
 	"github.com/bufbuild/buf/private/bufpkg/bufmodule"
 	"github.com/bufbuild/buf/private/pkg/command"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/stretchr/testify/assert"
@@ -1294,13 +1293,15 @@ func testLintWithOptions(
 
 	lintConfig := workspace.GetLintConfigForOpaqueID(opaqueID)
 	require.NotNil(t, lintConfig)
-	client, err := bufcheck.NewClient(zap.NewNop(), tracing.NopTracer, pluginrpcutil.NewRunnerProvider(command.NewRunner()))
+	plugins, err := bufcheck.NewPluginsForRunner(command.NewRunner(), workspace.PluginConfigs()...)
+	require.NoError(t, err)
+	client, err := bufcheck.NewClient(zap.NewNop(), tracing.NopTracer)
 	require.NoError(t, err)
 	err = client.Lint(
 		ctx,
 		lintConfig,
 		image,
-		bufcheck.WithPluginConfigs(workspace.PluginConfigs()...),
+		bufcheck.WithPlugins(plugins...),
 		bufcheck.WithPluginsEnabled(),
 	)
 	if len(expectedFileAnnotations) == 0 {

--- a/private/bufpkg/bufcheck/multi_client_test.go
+++ b/private/bufpkg/bufcheck/multi_client_test.go
@@ -24,7 +24,6 @@ import (
 	"buf.build/go/bufplugin/check/checkutil"
 	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"github.com/bufbuild/buf/private/pkg/command"
-	"github.com/bufbuild/buf/private/pkg/pluginrpcutil"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/bufbuild/buf/private/pkg/tracing"
@@ -185,7 +184,6 @@ func TestMultiClientCannotHaveOverlappingRulesWithBuiltIn(t *testing.T) {
 	client, err := newClient(
 		zaptest.NewLogger(t),
 		tracing.NopTracer,
-		pluginrpcutil.NewRunnerProvider(command.NewRunner()),
 	)
 	require.NoError(t, err)
 	duplicateBuiltInRulePluginConfig, err := bufconfig.NewLocalPluginConfig(
@@ -197,11 +195,12 @@ func TestMultiClientCannotHaveOverlappingRulesWithBuiltIn(t *testing.T) {
 	emptyOptions, err := check.NewOptions(nil)
 	require.NoError(t, err)
 
+	plugins, err := NewPluginsForRunner(command.NewRunner(), duplicateBuiltInRulePluginConfig)
+	require.NoError(t, err)
+
 	multiClient, err := client.getMultiClient(
 		bufconfig.FileVersionV2,
-		[]bufconfig.PluginConfig{
-			duplicateBuiltInRulePluginConfig,
-		},
+		plugins,
 		false,
 		emptyOptions,
 	)
@@ -279,7 +278,6 @@ func TestMultiClientCannotHaveOverlappingCategoriesWithBuiltIn(t *testing.T) {
 	client, err := newClient(
 		zaptest.NewLogger(t),
 		tracing.NopTracer,
-		pluginrpcutil.NewRunnerProvider(command.NewRunner()),
 	)
 	require.NoError(t, err)
 	duplicateBuiltInRulePluginConfig, err := bufconfig.NewLocalPluginConfig(
@@ -291,11 +289,12 @@ func TestMultiClientCannotHaveOverlappingCategoriesWithBuiltIn(t *testing.T) {
 	emptyOptions, err := check.NewOptions(nil)
 	require.NoError(t, err)
 
+	plugins, err := NewPluginsForRunner(command.NewRunner(), duplicateBuiltInRulePluginConfig)
+	require.NoError(t, err)
+
 	multiClient, err := client.getMultiClient(
 		bufconfig.FileVersionV2,
-		[]bufconfig.PluginConfig{
-			duplicateBuiltInRulePluginConfig,
-		},
+		plugins,
 		false,
 		emptyOptions,
 	)

--- a/private/bufpkg/bufcheck/plugin.go
+++ b/private/bufpkg/bufcheck/plugin.go
@@ -12,14 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pluginrpcutil
+package bufcheck
 
 import (
-	"github.com/bufbuild/buf/private/pkg/command"
+	"github.com/bufbuild/buf/private/bufpkg/bufconfig"
 	"pluginrpc.com/pluginrpc"
 )
 
-// NewRunner returns a new pluginrpc.Runner for the command.Runner and program name.
-func NewRunner(delegate command.Runner, programName string, programArgs ...string) pluginrpc.Runner {
-	return newRunner(delegate, programName, programArgs...)
+type plugin struct {
+	pluginrpc.Runner
+
+	pluginConfig bufconfig.PluginConfig
+}
+
+func newPlugin(
+	pluginConfig bufconfig.PluginConfig,
+	runner pluginrpc.Runner,
+) *plugin {
+	return &plugin{
+		Runner:       runner,
+		pluginConfig: pluginConfig,
+	}
+}
+
+func (p *plugin) Config() bufconfig.PluginConfig {
+	return p.pluginConfig
 }


### PR DESCRIPTION
Moves the `bufconfig.PluginConfig` to be provided with the `pluginrpc.Runner` as a `bufcheck.Plugin`. This allows for setting the runner based on the configuration of the plugin. Removes the default runner as this is now provided when invoking a bufcheck check using the new `WithPlugins` client function option that replaces `WithPluginConfigs`. `RunnerProvider` is removed. A helper `NewPluginsForRunner` is provided to map local plugins to a `command.Runner`. 