### PR TITLE
Fix flaky symlink test on windows

### DIFF
--- a/private/pkg/storage/storageos/storageos_test.go
+++ b/private/pkg/storage/storageos/storageos_test.go
@@ -85,17 +85,13 @@ func TestOS(t *testing.T) {
 		require.NoError(t, err)
 		tempDir = filepath.Join(tempDir, "sym")
 		require.NoError(t, os.Symlink(actualTempDir, tempDir))
-		t.Cleanup(func() {
-			if err := os.Remove(tempDir); err != nil {
-				t.Error(err)
-			}
-		})
 		provider := storageos.NewProvider(storageos.ProviderWithSymlinks())
 		bucket, err := provider.NewReadWriteBucket(tempDir, storageos.ReadWriteBucketWithSymlinksIfSupported())
 		require.NoError(t, err)
 
-		_, err = bucket.Get(ctx, "foo.txt")
+		foo, err := bucket.Get(ctx, "foo.txt")
 		require.NoError(t, err)
+		require.NoError(t, foo.Close())
 
 		// Try reading a file as if foo.txt is a directory.
 		_, err = bucket.Get(ctx, "foo.txt/bar.txt")


### PR DESCRIPTION
Fix flaky test failing to remove all as file is still open. Forces the close on the opened bucket object. Removes the t.Cleanup to allow testing to handle windows closes more gracefully. See https://github.com/golang/go/blob/c208b913954514ac7cab0fa701fba9c89af70392/src/testing/testing.go#L1271

```
--- FAIL: TestOS (0.00s)
    --- FAIL: TestOS/get_non_existent_file_symlink (1.27s)
        testing.go:1232: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestOSget_non_existent_file_symlink229375574\001\foo.txt: The process cannot access the file because it is being used by another proces
```