### PR TITLE
Add protoglobal.DisableGlobalFiles

### DIFF
--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -89,11 +89,13 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/bufbuild/buf/private/pkg/protoglobal"
 	"github.com/bufbuild/buf/private/pkg/syserror"
 )
 
 // Main is the entrypoint to the buf CLI.
 func Main(name string) {
+	protoglobal.DisableGlobalFiles()
 	appcmd.Main(context.Background(), NewRootCommand(name))
 }
 

--- a/private/buf/cmd/protoc-gen-buf-breaking/breaking.go
+++ b/private/buf/cmd/protoc-gen-buf-breaking/breaking.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
+	"github.com/bufbuild/buf/private/pkg/protoglobal"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/bufbuild/protoplugin"
 )
@@ -43,6 +44,7 @@ const (
 
 // Main is the main.
 func Main() {
+	protoglobal.DisableGlobalFiles()
 	protoplugin.Main(
 		protoplugin.HandlerFunc(handle),
 		// An `EmptyResolver` is passed to protoplugin for unmarshalling instead of defaulting to

--- a/private/buf/cmd/protoc-gen-buf-lint/lint.go
+++ b/private/buf/cmd/protoc-gen-buf-lint/lint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/encoding"
 	"github.com/bufbuild/buf/private/pkg/protodescriptor"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
+	"github.com/bufbuild/buf/private/pkg/protoglobal"
 	"github.com/bufbuild/buf/private/pkg/tracing"
 	"github.com/bufbuild/protoplugin"
 )
@@ -42,6 +43,7 @@ const (
 
 // Main is the main.
 func Main() {
+	protoglobal.DisableGlobalFiles()
 	protoplugin.Main(
 		protoplugin.HandlerFunc(handle),
 		// An `EmptyResolver` is passed to protoplugin for unmarshalling instead of defaulting to

--- a/private/pkg/protoglobal/protoglobal.go
+++ b/private/pkg/protoglobal/protoglobal.go
@@ -1,0 +1,34 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoglobal
+
+import (
+	"sync"
+
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+var lock sync.Mutex
+
+// DisableGlobalFiles disables protoregistry.GlobalFiles by overwriting it with
+// an empty Files struct.
+//
+// This should not be called in init functions, and should only be called at
+// the start of applications.
+func DisableGlobalFiles() {
+	lock.Lock()
+	protoregistry.GlobalFiles = new(protoregistry.Files)
+	lock.Unlock()
+}

--- a/private/pkg/protoglobal/usage.gen.go
+++ b/private/pkg/protoglobal/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package protoglobal
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
For discussion, primarily with @jhump.

@oliversun9 and @doriable have suggested doing effectively this, as we keep on running into issues with the global registry storing state. We don't want to call in an init function, so that we can make sure this happens after all packages are imported. A brief audit of protobuf-go says that this shouldn't break anything, and that makes sense. Honestly, nothing would make me happier, but this is obviously scary. Thoughts?