### PR TITLE
Default protoencoding resolver to an empty resolver 

### DIFF
--- a/private/pkg/protoencoding/json_marshaler.go
+++ b/private/pkg/protoencoding/json_marshaler.go
@@ -28,6 +28,9 @@ type jsonMarshaler struct {
 }
 
 func newJSONMarshaler(resolver Resolver, options ...JSONMarshalerOption) Marshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	jsonMarshaler := &jsonMarshaler{
 		resolver: resolver,
 	}

--- a/private/pkg/protoencoding/json_unmarshaler.go
+++ b/private/pkg/protoencoding/json_unmarshaler.go
@@ -25,6 +25,9 @@ type jsonUnmarshaler struct {
 }
 
 func newJSONUnmarshaler(resolver Resolver, options ...JSONUnmarshalerOption) Unmarshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	jsonUnmarshaler := &jsonUnmarshaler{
 		resolver: resolver,
 	}

--- a/private/pkg/protoencoding/protoencoding.go
+++ b/private/pkg/protoencoding/protoencoding.go
@@ -77,7 +77,7 @@ func NewWireMarshaler() Marshaler {
 // NewJSONMarshaler returns a new Marshaler for JSON.
 //
 // This has the potential to be unstable over time.
-// resolver can be nil if unknown and is only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewJSONMarshaler(resolver Resolver, options ...JSONMarshalerOption) Marshaler {
 	return newJSONMarshaler(resolver, options...)
 }
@@ -115,14 +115,14 @@ func JSONMarshalerWithEmitUnpopulated() JSONMarshalerOption {
 
 // NewTxtpbMarshaler returns a new Marshaler for txtpb.
 //
-// resolver can be nil if unknown and is only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewTxtpbMarshaler(resolver Resolver) Marshaler {
 	return newTxtpbMarshaler(resolver)
 }
 
 // NewYAMLMarshaler returns a new Marshaler for YAML.
 //
-// resolver can be nil if unknown and is only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewYAMLMarshaler(resolver Resolver, options ...YAMLMarshalerOption) Marshaler {
 	return newYAMLMarshaler(resolver, options...)
 }
@@ -165,14 +165,14 @@ type Unmarshaler interface {
 
 // NewWireUnmarshaler returns a new Unmarshaler for wire.
 //
-// resolver can be nil if unknown and are only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewWireUnmarshaler(resolver Resolver) Unmarshaler {
 	return newWireUnmarshaler(resolver)
 }
 
 // NewJSONUnmarshaler returns a new Unmarshaler for json.
 //
-// resolver can be nil if unknown and are only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewJSONUnmarshaler(resolver Resolver, options ...JSONUnmarshalerOption) Unmarshaler {
 	return newJSONUnmarshaler(resolver, options...)
 }
@@ -189,7 +189,7 @@ func JSONUnmarshalerWithDisallowUnknown() JSONUnmarshalerOption {
 
 // NewTxtpbUnmarshaler returns a new Unmarshaler for txtpb.
 //
-// resolver can be nil if unknown and are only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewTxtpbUnmarshaler(resolver Resolver) Unmarshaler {
 	return newTxtpbUnmarshaler(resolver)
 }
@@ -212,7 +212,7 @@ func YAMLUnmarshalerWithValidator(validator protoyaml.Validator) YAMLUnmarshaler
 
 // NewYAMLUnmarshaler returns a new Unmarshaler for yaml.
 //
-// resolver can be nil if unknown and are only needed for extensions.
+// If the resolver is nil, EmptyResolver will be used.
 func NewYAMLUnmarshaler(resolver Resolver, options ...YAMLUnmarshalerOption) Unmarshaler {
 	return newYAMLUnmarshaler(resolver, options...)
 }

--- a/private/pkg/protoencoding/txtpb_marshaler.go
+++ b/private/pkg/protoencoding/txtpb_marshaler.go
@@ -24,6 +24,9 @@ type txtpbMarshaler struct {
 }
 
 func newTxtpbMarshaler(resolver Resolver) Marshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	return &txtpbMarshaler{
 		resolver: resolver,
 	}

--- a/private/pkg/protoencoding/txtpb_unmarshaler.go
+++ b/private/pkg/protoencoding/txtpb_unmarshaler.go
@@ -24,6 +24,9 @@ type txtpbUnmarshaler struct {
 }
 
 func newTxtpbUnmarshaler(resolver Resolver) Unmarshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	return &txtpbUnmarshaler{
 		resolver: resolver,
 	}

--- a/private/pkg/protoencoding/wire_unmarshaler.go
+++ b/private/pkg/protoencoding/wire_unmarshaler.go
@@ -23,6 +23,9 @@ type wireUnmarshaler struct {
 }
 
 func newWireUnmarshaler(resolver Resolver) Unmarshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	return &wireUnmarshaler{
 		resolver: resolver,
 	}

--- a/private/pkg/protoencoding/yaml_marshaler.go
+++ b/private/pkg/protoencoding/yaml_marshaler.go
@@ -28,6 +28,9 @@ type yamlMarshaler struct {
 }
 
 func newYAMLMarshaler(resolver Resolver, options ...YAMLMarshalerOption) Marshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	yamlMarshaler := &yamlMarshaler{
 		resolver: resolver,
 	}

--- a/private/pkg/protoencoding/yaml_unmarshaler.go
+++ b/private/pkg/protoencoding/yaml_unmarshaler.go
@@ -26,6 +26,9 @@ type yamlUnmarshaler struct {
 }
 
 func newYAMLUnmarshaler(resolver Resolver, options ...YAMLUnmarshalerOption) Unmarshaler {
+	if resolver == nil {
+		resolver = EmptyResolver
+	}
 	result := &yamlUnmarshaler{
 		resolver: resolver,
 	}


### PR DESCRIPTION
This changes the behaviour of protoencoding to always set a resolver on init, defaulting to the `protoencoding.EmtpyResolver`. Currently, Marshaller and Unmarshallers will default to the `protoregistry.GlobalTypes` if a nil resolver is set. To keep the same behaviour the caller must pass in the GlobalTypes explicitly.