### PR TITLE
Fix flaky zip archive test

### DIFF
--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/osext"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/bufbuild/buf/private/pkg/slicesext"
+	"github.com/bufbuild/buf/private/pkg/storage"
 	"github.com/bufbuild/buf/private/pkg/storage/storagearchive"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/stretchr/testify/require"
@@ -1686,19 +1687,12 @@ func createZipFromDir(t *testing.T, rootPath string, archiveName string) string 
 		storageos.ReadWriteBucketWithSymlinksIfSupported(),
 	)
 	require.NoError(t, err)
-
-	zipCloser, err := zipBucket.Put(
+	require.NoError(t, storage.PutPath(
 		context.Background(),
+		zipBucket,
 		archiveName,
-	)
-	require.NoError(t, err)
-	t.Cleanup(
-		func() {
-			require.NoError(t, zipCloser.Close())
-		},
-	)
-	_, err = zipCloser.Write(buffer.Bytes())
-	require.NoError(t, err)
+		buffer.Bytes(),
+	))
 	return zipDir
 }
 


### PR DESCRIPTION
Eagerly close the file by using `storage.PutPath`. The logic on `t.Cleanup` looks correct but we don't need to hold the file open for the entire test.

```
--- FAIL: TestWorkspaceNestedArchive (6.49s)
    testing.go:1232: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestWorkspaceNestedArchive931609167\006\testdata\workspace\success\v2\nested\archive.zip: The process cannot access the file because it is being used by another process.
```