### PR TITLE
Remove CI for Go 1.21

### DIFF
--- a/.github/workflows/previous.yaml
+++ b/.github/workflows/previous.yaml
@@ -9,7 +9,7 @@ jobs:
   test-previous:
     strategy:
       matrix:
-        go-version: ['1.21.x', '1.22.x']
+        go-version: ['1.22.x']
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
We are up to Go 1.22 now. As of Go 1.21, we no longer need to go back three versions, and we went to 1.22 a while back.