### PR TITLE
Cleanup tmp package

### DIFF
--- a/private/buf/bufprotopluginexec/protoc_proxy_handler.go
+++ b/private/buf/bufprotopluginexec/protoc_proxy_handler.go
@@ -109,16 +109,16 @@ func (h *protocProxyHandler) Handle(
 	var tmpFile tmp.File
 	if descriptorFilePath == "" {
 		// since we have no stdin file (i.e. Windows), we're going to have to use a temporary file
-		tmpFile, err = tmp.NewFileWithData(fileDescriptorSetData)
+		tmpFile, err = tmp.NewFile(ctx, bytes.NewReader(fileDescriptorSetData))
 		if err != nil {
 			return err
 		}
 		defer func() {
 			retErr = multierr.Append(retErr, tmpFile.Close())
 		}()
-		descriptorFilePath = tmpFile.AbsPath()
+		descriptorFilePath = tmpFile.Path()
 	}
-	tmpDir, err := tmp.NewDir()
+	tmpDir, err := tmp.NewDir(ctx)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (h *protocProxyHandler) Handle(
 	}()
 	args := slicesext.Concat(h.protocExtraArgs, []string{
 		fmt.Sprintf("--descriptor_set_in=%s", descriptorFilePath),
-		fmt.Sprintf("--%s_out=%s", h.pluginName, tmpDir.AbsPath()),
+		fmt.Sprintf("--%s_out=%s", h.pluginName, tmpDir.Path()),
 	})
 	if getSetExperimentalAllowProto3OptionalFlag(protocVersion) {
 		args = append(
@@ -171,7 +171,7 @@ func (h *protocProxyHandler) Handle(
 	responseWriter.SetFeatureSupportsEditions(descriptorpb.Edition_EDITION_PROTO2, descriptorpb.Edition_EDITION_MAX)
 
 	// no need for symlinks here, and don't want to support
-	readWriteBucket, err := h.storageosProvider.NewReadWriteBucket(tmpDir.AbsPath())
+	readWriteBucket, err := h.storageosProvider.NewReadWriteBucket(tmpDir.Path())
 	if err != nil {
 		return err
 	}

--- a/private/bufpkg/bufimage/bufimagefuzz/bufimagefuzz_unix_test.go
+++ b/private/bufpkg/bufimage/bufimagefuzz/bufimagefuzz_unix_test.go
@@ -104,18 +104,18 @@ func TestCorpus(t *testing.T) {
 //}
 
 func fuzz(ctx context.Context, runner command.Runner, data []byte) (_ *fuzzResult, retErr error) {
-	dir, err := tmp.NewDir()
+	dir, err := tmp.NewDir(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
 		retErr = multierr.Append(retErr, dir.Close())
 	}()
-	if err := untxtar(data, dir.AbsPath()); err != nil {
+	if err := untxtar(data, dir.Path()); err != nil {
 		return nil, err
 	}
 
-	filePaths, err := buftesting.GetProtocFilePathsErr(ctx, dir.AbsPath(), 0)
+	filePaths, err := buftesting.GetProtocFilePathsErr(ctx, dir.Path(), 0)
 	if err != nil {
 		return nil, err
 	}
@@ -123,13 +123,13 @@ func fuzz(ctx context.Context, runner command.Runner, data []byte) (_ *fuzzResul
 	actualProtocFileDescriptorSet, protocErr := prototesting.GetProtocFileDescriptorSet(
 		ctx,
 		runner,
-		[]string{dir.AbsPath()},
+		[]string{dir.Path()},
 		filePaths,
 		false,
 		false,
 	)
 
-	image, bufErr := fuzzBuild(ctx, dir.AbsPath())
+	image, bufErr := fuzzBuild(ctx, dir.Path())
 	return newFuzzResult(
 		runner,
 		bufErr,

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -80,7 +80,7 @@ func (c *cloner) CloneToBucket(
 
 	depthArg := strconv.Itoa(int(depth))
 
-	baseDir, err := tmp.NewDir()
+	baseDir, err := tmp.NewDir(ctx)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (c *cloner) CloneToBucket(
 		command.RunWithArgs("init"),
 		command.RunWithEnv(app.EnvironMap(envContainer)),
 		command.RunWithStderr(buffer),
-		command.RunWithDir(baseDir.AbsPath()),
+		command.RunWithDir(baseDir.Path()),
 	); err != nil {
 		return newGitCommandError(err, buffer)
 	}
@@ -107,7 +107,7 @@ func (c *cloner) CloneToBucket(
 		command.RunWithArgs("remote", "add", "origin", url),
 		command.RunWithEnv(app.EnvironMap(envContainer)),
 		command.RunWithStderr(buffer),
-		command.RunWithDir(baseDir.AbsPath()),
+		command.RunWithDir(baseDir.Path()),
 	); err != nil {
 		return newGitCommandError(err, buffer)
 	}
@@ -148,7 +148,7 @@ func (c *cloner) CloneToBucket(
 		)...),
 		command.RunWithEnv(app.EnvironMap(envContainer)),
 		command.RunWithStderr(buffer),
-		command.RunWithDir(baseDir.AbsPath()),
+		command.RunWithDir(baseDir.Path()),
 	); err != nil {
 		// If the ref fetch failed, without a fallback, return the error.
 		if fallbackRef == "" {
@@ -170,7 +170,7 @@ func (c *cloner) CloneToBucket(
 			)...),
 			command.RunWithEnv(app.EnvironMap(envContainer)),
 			command.RunWithStderr(buffer),
-			command.RunWithDir(baseDir.AbsPath()),
+			command.RunWithDir(baseDir.Path()),
 		); err != nil {
 			return newGitCommandError(err, buffer)
 		}
@@ -185,7 +185,7 @@ func (c *cloner) CloneToBucket(
 		command.RunWithArgs("checkout", "--force", "FETCH_HEAD"),
 		command.RunWithEnv(app.EnvironMap(envContainer)),
 		command.RunWithStderr(buffer),
-		command.RunWithDir(baseDir.AbsPath()),
+		command.RunWithDir(baseDir.Path()),
 	); err != nil {
 		return newGitCommandError(err, buffer)
 	}
@@ -199,7 +199,7 @@ func (c *cloner) CloneToBucket(
 			command.RunWithArgs("checkout", "--force", checkoutRef),
 			command.RunWithEnv(app.EnvironMap(envContainer)),
 			command.RunWithStderr(buffer),
-			command.RunWithDir(baseDir.AbsPath()),
+			command.RunWithDir(baseDir.Path()),
 		); err != nil {
 			return newGitCommandError(err, buffer)
 		}
@@ -222,14 +222,14 @@ func (c *cloner) CloneToBucket(
 			)...),
 			command.RunWithEnv(app.EnvironMap(envContainer)),
 			command.RunWithStderr(buffer),
-			command.RunWithDir(baseDir.AbsPath()),
+			command.RunWithDir(baseDir.Path()),
 		); err != nil {
 			return newGitCommandError(err, buffer)
 		}
 	}
 
 	// we do NOT want to read in symlinks
-	tmpReadWriteBucket, err := c.storageosProvider.NewReadWriteBucket(baseDir.AbsPath())
+	tmpReadWriteBucket, err := c.storageosProvider.NewReadWriteBucket(baseDir.Path())
 	if err != nil {
 		return err
 	}

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -1446,17 +1446,17 @@ func RunTestSuite(
 		require.NoError(t, err)
 		require.False(t, isEmpty)
 
-		tmpDir, err := tmp.NewDir()
+		tmpDir, err := tmp.NewDir(ctx)
 		require.NoError(t, err)
-		readBucket, _ = newReadBucket(t, tmpDir.AbsPath(), defaultProvider)
+		readBucket, _ = newReadBucket(t, tmpDir.Path(), defaultProvider)
 		isEmpty, err = storage.IsEmpty(ctx, readBucket, "")
 		require.NoError(t, err)
 		require.True(t, isEmpty)
-		err = os.WriteFile(filepath.Join(tmpDir.AbsPath(), "foo.txt"), []byte("foo"), 0600)
+		err = os.WriteFile(filepath.Join(tmpDir.Path(), "foo.txt"), []byte("foo"), 0600)
 		require.NoError(t, err)
 		// need to make a new readBucket since the old one won't necessarily have the foo.txt
 		// file in it, ie in-memory buckets
-		readBucket, _ = newReadBucket(t, tmpDir.AbsPath(), defaultProvider)
+		readBucket, _ = newReadBucket(t, tmpDir.Path(), defaultProvider)
 		isEmpty, err = storage.IsEmpty(ctx, readBucket, "")
 		require.NoError(t, err)
 		require.False(t, isEmpty)

--- a/private/pkg/tmp/tmp.go
+++ b/private/pkg/tmp/tmp.go
@@ -98,7 +98,7 @@ func NewDir(ctx context.Context, options ...DirOption) (File, error) {
 	closer := func() error { return os.RemoveAll(absPath) }
 	go func() {
 		<-ctx.Done()
-		closer()
+		_ = closer()
 	}()
 	return newFile(closerFunc(closer), absPath), nil
 }


### PR DESCRIPTION
Makes cleanup rely on context cancellation instead of directly depending on signals. Also does a few other associated cleanups - this was an old package.