### PR TITLE
Clean up interrupt package

### DIFF
--- a/private/pkg/app/app.go
+++ b/private/pkg/app/app.go
@@ -326,8 +326,11 @@ func Main(ctx context.Context, f func(context.Context, Container) error) {
 // The run will be stopped on interrupt signal.
 // The exit code can be determined using GetExitCode.
 func Run(ctx context.Context, container Container, f func(context.Context, Container) error) error {
-	ctx, cancel := interrupt.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := interrupt.NotifyContext(ctx)
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
 	if err := f(ctx, container); err != nil {
 		printError(container, err)
 		return err

--- a/private/pkg/interrupt/interrupt.go
+++ b/private/pkg/interrupt/interrupt.go
@@ -20,33 +20,10 @@ import (
 	"os/signal"
 )
 
-var signals = append(
-	[]os.Signal{
-		os.Interrupt,
-	},
-	extraSignals...,
-)
+var interruptSignals = append([]os.Signal{os.Interrupt}, extraSignals...)
 
-// WithCancel returns a context that is cancelled if interrupt signals are sent.
-func WithCancel(ctx context.Context) (context.Context, context.CancelFunc) {
-	signalC, closer := NewSignalChannel()
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-signalC
-		closer()
-		cancel()
-	}()
-	return ctx, cancel
-}
-
-// NewSignalChannel returns a new channel for interrupt signals.
-//
-// Call the returned function to cancel sending to this channel.
-func NewSignalChannel() (<-chan os.Signal, func()) {
-	signalC := make(chan os.Signal, 1)
-	signal.Notify(signalC, signals...)
-	return signalC, func() {
-		signal.Stop(signalC)
-		close(signalC)
-	}
+// NotifyContext returns a new [context.Context] from [signal.NotifyContext]
+// with the appropriate interrupt signals.
+func NotifyContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, interruptSignals...)
 }

--- a/private/pkg/interrupt/interrupt_other.go
+++ b/private/pkg/interrupt/interrupt_other.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build windows
-// +build windows
+//go:build !unix
 
 package interrupt
 
@@ -22,7 +21,6 @@ import "os"
 // extraSignals are signals beyond os.Interrupt that we want to be handled
 // as interrupts.
 //
-// For unix-like platforms, this adds syscall.SIGTERM, although this is only
-// tested on darwin and linux, which buf officially supports. Other unix-like
-// platforms should have this as well, however.
+// For unix-like platforms, this adds syscall.SIGTERM. No other signals
+// are added for other platforms.
 var extraSignals = []os.Signal{}

--- a/private/pkg/interrupt/interrupt_unix.go
+++ b/private/pkg/interrupt/interrupt_unix.go
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
-
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
+//go:build unix
 
 package interrupt
 
@@ -27,9 +24,6 @@ import (
 // extraSignals are signals beyond os.Interrupt that we want to be handled
 // as interrupts.
 //
-// For unix-like platforms, this adds syscall.SIGTERM, although this is only
-// tested on darwin and linux, which buf officially supports. Other unix-like
-// platforms should have this as well, however.
-var extraSignals = []os.Signal{
-	syscall.SIGTERM,
-}
+// For unix-like platforms, this adds syscall.SIGTERM. No other signals
+// are added for other platforms.
+var extraSignals = []os.Signal{syscall.SIGTERM}


### PR DESCRIPTION
This standardizes on `signal.NotifyContext` and cleans up the build tags. We still want to additionally handle `syscall.SIGTERM` - it's moderately annoying that the stdlib doesn't provide a platform-specific variable for this.