### PR TITLE
Add `default_label_name` to JSON output of `buf registry module info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add `default_label_name`, which provides the name of the default label of a module to
+  the JSON output for `buf registry module info`.
 
 ## [v1.44.0] - 2024-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 
-- Add `default_label_name`, which provides the name of the default label of a module to
-  the JSON output for `buf registry module info`.
+- Update `buf registry module info --format=json` to add `default_label_name, which provides the name
+  of the default label of a module.
 
 ## [v1.44.0] - 2024-10-03
 

--- a/private/buf/bufprint/bufprint.go
+++ b/private/buf/bufprint/bufprint.go
@@ -226,13 +226,14 @@ func NewCommitEntity(commit *modulev1.Commit, moduleFullName bufmodule.ModuleFul
 // NewModuleEntity returns a new module entity to print.
 func NewModuleEntity(module *modulev1.Module, moduleFullName bufmodule.ModuleFullName) Entity {
 	return outputModule{
-		ID:         module.Id,
-		Remote:     moduleFullName.Registry(),
-		Owner:      moduleFullName.Owner(),
-		Name:       moduleFullName.Name(),
-		FullName:   moduleFullName.String(),
-		CreateTime: module.CreateTime.AsTime(),
-		State:      module.State.String(),
+		ID:               module.Id,
+		Remote:           moduleFullName.Registry(),
+		Owner:            moduleFullName.Owner(),
+		Name:             moduleFullName.Name(),
+		FullName:         moduleFullName.String(),
+		CreateTime:       module.CreateTime.AsTime(),
+		State:            module.State.String(),
+		DefaultLabelName: module.GetDefaultLabelName(),
 	}
 }
 
@@ -430,13 +431,14 @@ func (c outputCommit) fullName() string {
 }
 
 type outputModule struct {
-	ID         string    `json:"id,omitempty"`
-	Remote     string    `json:"remote,omitempty"`
-	Owner      string    `json:"owner,omitempty"`
-	Name       string    `json:"name,omitempty"`
-	FullName   string    `json:"-" bufprint:"Name"`
-	CreateTime time.Time `json:"create_time,omitempty" bufprint:"Create Time"`
-	State      string    `json:"state,omitempty"`
+	ID               string    `json:"id,omitempty"`
+	Remote           string    `json:"remote,omitempty"`
+	Owner            string    `json:"owner,omitempty"`
+	Name             string    `json:"name,omitempty"`
+	FullName         string    `json:"-" bufprint:"Name"`
+	CreateTime       time.Time `json:"create_time,omitempty" bufprint:"Create Time"`
+	State            string    `json:"state,omitempty"`
+	DefaultLabelName string    `json:"default_label_name,omitempty"`
 }
 
 func (m outputModule) fullName() string {


### PR DESCRIPTION
This adds information for the default label name of a module
to the JSON output of `buf registry module info`. The text output
remains unchanged.

```
$ buf registry module info buf.build/bufbuild/registry
Name                         Create Time
buf.build/bufbuild/registry  2023-10-27T20:23:20Z

$ buf registry module info buf.build/bufbuild/registry --format json | jq .
{
  "id": "11bdb5abfb544d54b2a3b7a354a07112",
  "remote": "buf.build",
  "owner": "bufbuild",
  "name": "registry",
  "create_time": "2023-10-27T20:23:20.396779Z",
  "state": "MODULE_STATE_ACTIVE",
  "default_label_name": "main"
}

```