### PR TITLE
Add short-circuit to multi read bucket in overlay mode

### DIFF
--- a/private/pkg/storage/multi.go
+++ b/private/pkg/storage/multi.go
@@ -79,7 +79,9 @@ func (m *multiReadBucket) Get(ctx context.Context, path string) (ReadObjectClose
 	if m.overlay {
 		// If overlay is enabled, attempt a Get operation against the first bucket. If the file is
 		// found, we avoid the potentially expensive Stat call.
-		if readObjectCloser, err := m.delegates[0].Get(ctx, path); err == nil && readObjectCloser != nil {
+		if readObjectCloser, err := m.delegates[0].Get(ctx, path); err != nil && !IsNotExist(err) {
+			return nil, err
+		} else if readObjectCloser != nil {
 			return readObjectCloser, nil
 		}
 	}

--- a/private/pkg/storage/multi.go
+++ b/private/pkg/storage/multi.go
@@ -85,6 +85,7 @@ func (m *multiReadBucket) Get(ctx context.Context, path string) (ReadObjectClose
 			if !errors.Is(err, fs.ErrNotExist) {
 				return nil, err
 			}
+			// Fallthrough to expensive logic to check every delegate.
 		} else {
 			// If we did find a ReadObjectCloser, return it, otherwise do the expensive logic to
 			// check every delegate.


### PR DESCRIPTION
Small optimization for `multiReadBucket`. The goal is to avoid a `Stat` call when overlay is enabled and the file is found.