### PR TITLE
Make LSP always publish diagnostics

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -169,7 +169,7 @@ func (f *file) Refresh(ctx context.Context) {
 	progress.Begin(ctx, "Indexing")
 
 	progress.Report(ctx, "Parsing AST", 1.0/6)
-	hasReport := f.RefreshAST(ctx)
+	f.RefreshAST(ctx)
 
 	progress.Report(ctx, "Indexing Imports", 2.0/6)
 	f.IndexImports(ctx)
@@ -179,15 +179,17 @@ func (f *file) Refresh(ctx context.Context) {
 
 	progress.Report(ctx, "Linking Descriptors", 4.0/6)
 	f.BuildImage(ctx)
-	hasReport = f.RunLints(ctx) || hasReport // Avoid short-circuit here.
+	f.RunLints(ctx)
 
 	progress.Report(ctx, "Indexing Symbols", 5.0/6)
 	f.IndexSymbols(ctx)
 
 	progress.Done(ctx)
-	if hasReport {
-		f.PublishDiagnostics(ctx)
-	}
+
+	// NOTE: Diagnostics are published unconditionally. This is necessary even
+	// if we have zero diagnostics, so that the client correctly ticks over from
+	// n > 0 diagnostics to 0 diagnostics.
+	f.PublishDiagnostics(ctx)
 }
 
 // RefreshAST reparses the file and generates diagnostics if necessary.

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -234,8 +234,11 @@ func (f *file) RefreshAST(ctx context.Context) bool {
 func (f *file) PublishDiagnostics(ctx context.Context) {
 	defer slogext.DebugProfile(f.lsp.logger, slog.String("uri", string(f.uri)))()
 
+	// NOTE: We need to avoid sending a JSON null here, so we replace it with
+	// a non-nil empty slice when the diagnostics slice is nil.
+	diagnostics := f.diagnostics
 	if f.diagnostics == nil {
-		return
+		diagnostics = []protocol.Diagnostic{}
 	}
 
 	// Publish the diagnostics. This error is automatically logged by the LSP framework.
@@ -244,7 +247,7 @@ func (f *file) PublishDiagnostics(ctx context.Context) {
 		// NOTE: For some reason, Version is int32 in the document struct, but uint32 here.
 		// This seems like a bug in the LSP protocol package.
 		Version:     uint32(f.version),
-		Diagnostics: f.diagnostics,
+		Diagnostics: diagnostics,
 	})
 }
 


### PR DESCRIPTION
This change makes it so that the LSP publishes diagnostics on refresh regardless of whether there are any diagnostics to publish. This is necessary, because if there are currently N diagnostics displayed for the current file, we need to explicitly set them to zero on some clients, such as VSCode, when the user updates the file to be syntactically/semantically correct.

In other words, not doing this results in red squiggles that don't go away after fixing the issue.