### PR TITLE
Omit stack trace from error level logs

### DIFF
--- a/private/pkg/slogapp/slogapp.go
+++ b/private/pkg/slogapp/slogapp.go
@@ -35,5 +35,5 @@ func NewLogger(writer io.Writer, logLevel appext.LogLevel, logFormat appext.LogF
 	if err != nil {
 		return nil, err
 	}
-	return slog.New(zapslog.NewHandler(core)), nil
+	return slog.New(zapslog.NewHandler(core, zapslog.AddStacktraceAt(slog.LevelError+1))), nil
 }

--- a/private/pkg/slogapp/slogapp_test.go
+++ b/private/pkg/slogapp/slogapp_test.go
@@ -1,0 +1,37 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slogapp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoStack(t *testing.T) {
+	t.Parallel()
+	var sb strings.Builder
+	logger, err := NewLogger(&sb, appext.LogLevelInfo, appext.LogFormatJSON)
+	require.NoError(t, err)
+	logger.Error("boom")
+	var logFields map[string]any
+	err = json.Unmarshal([]byte(sb.String()), &logFields)
+	require.NoError(t, err)
+	assert.NotContains(t, logFields, "stacktrace")
+}


### PR DESCRIPTION
As part of the migration to slog, stack traces are now computed and included in logs at `slog.LevelError` and above. Update the `zapslog` handler to pass `slog.LevelError+1` as the level at which stack traces should be included, which should better match the previous behavior of buf when using zap.

In prior releases of buf before the migration to slog, `zaputil.NewLogger` called `zap.New` without passing the `zap.AddStacktrace` option, which meant that the `addStackAt` level defaulted to `zapcore.FatalLevel + 1` (disabling the inclusion of stack traces in logs).