### PR TITLE
Fix typo in buf generate template file

### DIFF
--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -169,7 +169,7 @@ func NewCommand(
       # The accepted field options are:
       #  - jstype
       #
-      # If multple overrides for the same option apply to a file or field,
+      # If multiple overrides for the same option apply to a file or field,
       # the last rule takes effect.
       # Optional.
       override:


### PR DESCRIPTION
Noticed this in `buf generate --help` / on the docs site.