### PR TITLE
Include remote for invalid token errors

### DIFF
--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -206,7 +206,7 @@ func inner(
 		}
 		// We don't want to use the default error from wrapError here if the error
 		// an unauthenticated error.
-		return errors.New("invalid token provided")
+		return fmt.Errorf("invalid token provided for %s", remote)
 	}
 	user := resp.Msg.User
 	if user == nil {


### PR DESCRIPTION
To aid debugging include the remote in the error response for invalid tokens. This helps debug cases where the user didn't set the correct domain. 