### PR TITLE
Improve lsp hover definition comment formatting

### DIFF
--- a/private/buf/buflsp/symbol_test.go
+++ b/private/buf/buflsp/symbol_test.go
@@ -1,0 +1,58 @@
+package buflsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_formatComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Single-line comment",
+			input:    "// This is a single-line comment",
+			expected: " This is a single-line comment",
+		},
+		{
+			name:     "Multi-line comment",
+			input:    "/*\n This is a\n multi-line comment\n */",
+			expected: "This is a\nmulti-line comment",
+		},
+		{
+			name:     "Multi-line comment with mixed indentation",
+			input:    "/*\n  * First line\n  * - Second line\n  *   - Third line\n */",
+			expected: "First line\n- Second line\n  - Third line",
+		},
+		{
+			name:     "Multi-line comment with JavaDoc convention",
+			input:    "/** This is a\n   * multi-line comment\n   * with multi-asterisks */",
+			expected: "This is a\nmulti-line comment\nwith multi-asterisks",
+		},
+		{
+			name:     "Single-line multi-line comment",
+			input:    "/* Single-line multi-line comment */",
+			expected: "Single-line multi-line comment",
+		},
+		{
+			name:     "Empty comment",
+			input:    "/**/",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := formatComment(tt.input)
+			if result != tt.expected {
+				assert.Equal(t, tt.input, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a new `formatComment` function to enhance the formatting of comments displayed in hover definitions. The implementation handles both single-line and multi-line comments, ensuring proper formatting while maintaining Markdown compatibility.

## Before
<img width="700" alt="screenshot2" src="https://github.com/user-attachments/assets/f42a2d7e-9cad-4a75-9da4-4990a7d0aefc">

As shown above, hover definitions currently display unnecessary asterisks from the proto file's comment syntax, making the documentation harder to read.

## After

<img width="700" alt="screenshot1" src="https://github.com/user-attachments/assets/b2aac87c-6c21-497a-86ec-cc71e73c8046">


The new implementation removes the redundant asterisks while preserving the comment's structure, resulting in cleaner and more readable documentation in hover definitions.