### PR TITLE
Allow webpages to have an empty config

### DIFF
--- a/private/bufpkg/bufcobra/bufcobra.go
+++ b/private/bufpkg/bufcobra/bufcobra.go
@@ -77,7 +77,6 @@ func run(
 	if err != nil {
 		return err
 	}
-
 	excludes := slicesext.ToStructMap(config.ExcludeCommands)
 	for _, command := range cobraCommand.Commands() {
 		if _, ok := excludes[command.CommandPath()]; ok {

--- a/private/bufpkg/bufcobra/config.go
+++ b/private/bufpkg/bufcobra/config.go
@@ -46,8 +46,9 @@ type config struct {
 }
 
 func readConfigFromFile(path string) (*config, error) {
+	var webpagesConfig config
 	if path == "" {
-		return nil, nil
+		return &webpagesConfig, nil
 	}
 	file, err := os.Open(path)
 	if err != nil {
@@ -57,7 +58,6 @@ func readConfigFromFile(path string) (*config, error) {
 	if err != nil {
 		return nil, err
 	}
-	var webpagesConfig config
 	if err := yaml.Unmarshal(data, &webpagesConfig); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For the `buf` CLI, we always have a config, but this might not
be true, and therefore we should allow generating with no config.