### PR TITLE
Improve LSP diagnostic info

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -614,7 +614,7 @@ func (f *file) RunLints(ctx context.Context) bool {
 			},
 			Code:     annotation.Type(),
 			Severity: protocol.DiagnosticSeverityError,
-			Source:   "buf lint",
+			Source:   serverName,
 			Message:  annotation.Message(),
 		})
 	}

--- a/private/buf/buflsp/report.go
+++ b/private/buf/buflsp/report.go
@@ -17,8 +17,6 @@
 package buflsp
 
 import (
-	"fmt"
-
 	"github.com/bufbuild/protocompile/linker"
 	"github.com/bufbuild/protocompile/parser"
 	"github.com/bufbuild/protocompile/reporter"
@@ -79,7 +77,8 @@ func newDiagnostic(err reporter.ErrorWithPos, isWarning bool) protocol.Diagnosti
 		// essentially a bug that will result in worse diagnostics until fixed.
 		Range:    protocol.Range{Start: pos, End: pos},
 		Severity: protocol.DiagnosticSeverityError,
-		Message:  fmt.Sprintf("%s:%d:%d: %s", err.GetPosition().Filename, err.GetPosition().Line, err.GetPosition().Col, err.Unwrap().Error()),
+		Message:  err.Unwrap().Error(),
+		Source:   "buf",
 	}
 
 	if isWarning {

--- a/private/buf/buflsp/report.go
+++ b/private/buf/buflsp/report.go
@@ -78,7 +78,7 @@ func newDiagnostic(err reporter.ErrorWithPos, isWarning bool) protocol.Diagnosti
 		Range:    protocol.Range{Start: pos, End: pos},
 		Severity: protocol.DiagnosticSeverityError,
 		Message:  err.Unwrap().Error(),
-		Source:   "buf",
+		Source:   serverName,
 	}
 
 	if isWarning {

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -29,6 +29,10 @@ import (
 )
 
 const (
+	serverName = "buf-lsp"
+)
+
+const (
 	semanticTypeType = iota
 	semanticTypeStruct
 	semanticTypeVariable
@@ -82,7 +86,7 @@ func (s *server) Initialize(
 		return nil, err
 	}
 
-	info := &protocol.ServerInfo{Name: "buf-lsp"}
+	info := &protocol.ServerInfo{Name: serverName}
 	if buildInfo, ok := debug.ReadBuildInfo(); ok {
 		info.Version = buildInfo.Main.Version
 	}


### PR DESCRIPTION
This removes the extraneous information from the diagnostic report (filename, line, column), which is already included in the range.

It also adds a hard-coded `buf` as the source of the diagnostic.

Before:

<img width="793" alt="image" src="https://github.com/user-attachments/assets/e9b11afe-6bf6-4c56-afdf-f1cf30df2400">

After:

<img width="595" alt="image" src="https://github.com/user-attachments/assets/bd0646eb-bdd6-4e93-b482-8630c8e3aaaf">
