### PR TITLE
Drop go.uber.org/atomic in favor of sync/atomic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/tetratelabs/wazero v1.8.1
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0
-	go.uber.org/atomic v1.11.0
 	go.uber.org/zap v1.27.0
 	go.uber.org/zap/exp v0.3.0
 	golang.org/x/crypto v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,6 @@ go.opentelemetry.io/otel/trace v1.31.0 h1:ffjsj1aRouKewfr85U2aGagJ46+MvodynlQ1HY
 go.opentelemetry.io/otel/trace v1.31.0/go.mod h1:TXZkRk7SM2ZQLtR6eoAWQFIHPvzQ06FJAsO1tJg480A=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=

--- a/private/buf/bufcurl/verbose_transport.go
+++ b/private/buf/bufcurl/verbose_transport.go
@@ -24,10 +24,10 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"connectrpc.com/connect"
 	"github.com/bufbuild/buf/private/pkg/verbose"
-	"go.uber.org/atomic"
 )
 
 type skipUploadFinishedMessageKey struct{}

--- a/private/pkg/storage/limit.go
+++ b/private/pkg/storage/limit.go
@@ -16,8 +16,7 @@ package storage
 
 import (
 	"context"
-
-	"go.uber.org/atomic"
+	"sync/atomic"
 )
 
 // LimitWriteBucket returns a [WriteBucket] that writes to [writeBucket]
@@ -42,7 +41,6 @@ type limitedWriteBucket struct {
 func newLimitedWriteBucket(bucket WriteBucket, limit int64) *limitedWriteBucket {
 	return &limitedWriteBucket{
 		WriteBucket: bucket,
-		currentSize: atomic.NewInt64(0),
 		limit:       limit,
 	}
 }
@@ -78,7 +76,7 @@ func (o *limitedWriteObjectCloser) Write(p []byte) (int, error) {
 	writeSize := int64(len(p))
 	newBucketSize := o.bucketSize.Add(writeSize)
 	if newBucketSize > o.limit {
-		o.bucketSize.Sub(writeSize)
+		o.bucketSize.Add(-writeSize)
 		return 0, &errWriteLimitReached{
 			Limit:       o.limit,
 			ExceedingBy: newBucketSize - o.limit,
@@ -86,7 +84,7 @@ func (o *limitedWriteObjectCloser) Write(p []byte) (int, error) {
 	}
 	writtenSize, err := o.WriteObjectCloser.Write(p)
 	if int64(writtenSize) < writeSize {
-		o.bucketSize.Sub(writeSize - int64(writtenSize))
+		o.bucketSize.Add(-(writeSize - int64(writtenSize)))
 	}
 	return writtenSize, err
 }

--- a/private/pkg/storage/limit.go
+++ b/private/pkg/storage/limit.go
@@ -41,6 +41,7 @@ type limitedWriteBucket struct {
 func newLimitedWriteBucket(bucket WriteBucket, limit int64) *limitedWriteBucket {
 	return &limitedWriteBucket{
 		WriteBucket: bucket,
+		currentSize: &atomic.Int64{},
 		limit:       limit,
 	}
 }

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bufbuild/buf/private/pkg/slicesext"
@@ -38,7 +39,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/tmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 const (

--- a/private/pkg/thread/thread_test.go
+++ b/private/pkg/thread/thread_test.go
@@ -16,10 +16,10 @@ package thread
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func TestParallelizeWithImmediateCancellation(t *testing.T) {
@@ -35,7 +35,7 @@ func TestParallelizeWithImmediateCancellation(t *testing.T) {
 		)
 		for i := 0; i < jobsToExecute; i++ {
 			jobs = append(jobs, func(_ context.Context) error {
-				executed.Inc()
+				executed.Add(1)
 				return nil
 			})
 		}
@@ -49,7 +49,7 @@ func TestParallelizeWithImmediateCancellation(t *testing.T) {
 		var jobs []func(context.Context) error
 		for i := 0; i < 10; i++ {
 			jobs = append(jobs, func(_ context.Context) error {
-				executed.Inc()
+				executed.Add(1)
 				return nil
 			})
 		}


### PR DESCRIPTION
The primitives in sync/atomic are not as good as those in uber/atomic; happy to drop this.