### PR TITLE
Introducing Buf Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Docker](https://img.shields.io/docker/pulls/bufbuild/buf)](https://hub.docker.com/r/bufbuild/buf)
 [![Homebrew](https://img.shields.io/homebrew/v/buf)](https://github.com/bufbuild/homebrew-buf)
 [![Slack](https://img.shields.io/badge/slack-buf-%23e01563)][badges_slack]
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Buf%20Guru-006BFF)](https://gurubase.io/g/buf)
 
 <a name="features"></a>
 The [`buf`][buf] CLI is the best tool for working with [Protocol Buffers][protobuf]. It provides:


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Buf Guru](https://gurubase.io/g/buf) to Gurubase. Buf Guru uses the data from this repo and data from the [docs](https://buf.build/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Buf Guru", which highlights that Buf now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Buf Guru in Gurubase, just let me know that's totally fine.
