### PR TITLE
Add `clean` key to `buf generate` long description

### DIFF
--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -68,6 +68,10 @@ func NewCommand(
     # The valid values are v1beta1, v1 and v2.
     # Required.
     version: v2
+    # When clean is set to true, ddelete the directories, zip files, and/or jar files specified in the
+    # "out" field for all plugins before running code generation. Defaults to false.
+    # Optional.
+    clean: true
     # The plugins to run.
     # Required.
     plugins:

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -68,7 +68,7 @@ func NewCommand(
     # The valid values are v1beta1, v1 and v2.
     # Required.
     version: v2
-    # When clean is set to true, ddelete the directories, zip files, and/or jar files specified in the
+    # When clean is set to true, delete the directories, zip files, and/or jar files specified in the
     # "out" field for all plugins before running code generation. Defaults to false.
     # Optional.
     clean: true


### PR DESCRIPTION
This adds the `clean` key to the example `buf.gen.yaml` in
the `buf generate` command long description.