### PR TITLE
Add registry plugin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add `buf registry plugin {create,delete,info,update}` commands to manage BSR plugins.
 
 ## [v1.47.0] - 2024-11-13
 

--- a/private/buf/bufcli/errors.go
+++ b/private/buf/bufcli/errors.go
@@ -54,6 +54,12 @@ func NewLabelNameAlreadyExistsError(name string) error {
 	return fmt.Errorf("a label named %q already exists", name)
 }
 
+// NewPluginNameAlreadyExistsError informs the user that a plugin
+// with that name already exists.
+func NewPluginNameAlreadyExistsError(name string) error {
+	return fmt.Errorf("a plugin named %q already exists", name)
+}
+
 // NewOrganizationNotFoundError informs the user that an organization with
 // that name does not exist.
 func NewOrganizationNotFoundError(name string) error {
@@ -86,6 +92,12 @@ func NewLabelNotFoundError(ref bufparse.Ref) error {
 // that identifier does not exist.
 func NewTokenNotFoundError(tokenID string) error {
 	return fmt.Errorf("a token with ID %q does not exist", tokenID)
+}
+
+// NewPluginNotFoundError informs the user that a plugin with
+// that name does not exist.
+func NewPluginNotFoundError(name string) error {
+	return fmt.Errorf("a plugin named %q does not exist", name)
 }
 
 // NewInvalidRemoteError informs the user that the given remote is invalid.

--- a/private/buf/bufcli/flags_args.go
+++ b/private/buf/bufcli/flags_args.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	modulev1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1"
+	pluginv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1"
 	"github.com/bufbuild/buf/private/buf/buffetch"
 	"github.com/bufbuild/buf/private/pkg/app"
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
@@ -297,6 +298,21 @@ func VisibilityFlagToVisibilityAllowUnspecified(visibility string) (modulev1.Mod
 		return modulev1.ModuleVisibility_MODULE_VISIBILITY_PRIVATE, nil
 	case "":
 		return modulev1.ModuleVisibility_MODULE_VISIBILITY_UNSPECIFIED, nil
+	default:
+		return 0, fmt.Errorf("invalid visibility: %s", visibility)
+	}
+}
+
+// VisibilityFlagToPluginVisibilityAllowUnspecified parses the given string as a pluginv1.PluginVisibility
+// where an empty string will be parsed as unspecified.
+func VisibilityFlagToPluginVisibilityAllowUnspecified(visibility string) (pluginv1beta1.PluginVisibility, error) {
+	switch visibility {
+	case publicVisibility:
+		return pluginv1beta1.PluginVisibility_PLUGIN_VISIBILITY_PUBLIC, nil
+	case privateVisibility:
+		return pluginv1beta1.PluginVisibility_PLUGIN_VISIBILITY_PRIVATE, nil
+	case "":
+		return pluginv1beta1.PluginVisibility_PLUGIN_VISIBILITY_UNSPECIFIED, nil
 	default:
 		return 0, fmt.Errorf("invalid visibility: %s", visibility)
 	}

--- a/private/buf/bufprint/bufprint.go
+++ b/private/buf/bufprint/bufprint.go
@@ -27,6 +27,7 @@ import (
 
 	modulev1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1"
 	ownerv1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1"
+	pluginv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1"
 	"github.com/bufbuild/buf/private/bufpkg/bufparse"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/protoencoding"
@@ -248,6 +249,18 @@ func NewOrganizationEntity(organization *ownerv1.Organization, remote string) En
 	}
 }
 
+// NewPluginEntity returns a new plugin entity to print.
+func NewPluginEntity(plugin *pluginv1beta1.Plugin, pluginFullName bufparse.FullName) Entity {
+	return outputPlugin{
+		ID:         plugin.Id,
+		Remote:     pluginFullName.Registry(),
+		Owner:      pluginFullName.Owner(),
+		Name:       pluginFullName.Name(),
+		FullName:   pluginFullName.String(),
+		CreateTime: plugin.CreateTime.AsTime(),
+	}
+}
+
 // NewUserEntity returns a new user entity to print.
 func NewUserEntity(user *registryv1alpha1.User) Entity {
 	return outputUser{
@@ -464,6 +477,19 @@ type outputOrganization struct {
 
 func (o outputOrganization) fullName() string {
 	return o.FullName
+}
+
+type outputPlugin struct {
+	ID         string    `json:"id,omitempty"`
+	Remote     string    `json:"remote,omitempty"`
+	Owner      string    `json:"owner,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	FullName   string    `json:"-" bufprint:"Name"`
+	CreateTime time.Time `json:"create_time,omitempty" bufprint:"Create Time"`
+}
+
+func (m outputPlugin) fullName() string {
+	return m.FullName
 }
 
 type outputUser struct {

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -35,8 +35,8 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/bufpluginv2"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/lsp"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/price"
-	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete"
-	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush"
+	betaplugindelete "github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/plugindelete"
+	betapluginpush "github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookcreate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhookdelete"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/beta/registry/webhook/webhooklist"
@@ -81,6 +81,10 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/organization/organizationdelete"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/organization/organizationinfo"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/organization/organizationupdate"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/plugin/plugincreate"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/plugin/plugindelete"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/plugin/plugininfo"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/plugin/pluginupdate"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/registrycc"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/registrylogin"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/registrylogout"
@@ -252,6 +256,16 @@ func NewRootCommand(name string) *appcmd.Command {
 							moduleupdate.NewCommand("update", builder),
 						},
 					},
+					{
+						Use:   "plugin",
+						Short: "Manage BSR plugins",
+						SubCommands: []*appcmd.Command{
+							plugincreate.NewCommand("create", builder),
+							plugininfo.NewCommand("info", builder),
+							plugindelete.NewCommand("delete", builder),
+							pluginupdate.NewCommand("update", builder),
+						},
+					},
 				},
 			},
 			{
@@ -282,8 +296,8 @@ func NewRootCommand(name string) *appcmd.Command {
 								Use:   "plugin",
 								Short: "Manage plugins on the Buf Schema Registry",
 								SubCommands: []*appcmd.Command{
-									pluginpush.NewCommand("push", builder),
-									plugindelete.NewCommand("delete", builder),
+									betapluginpush.NewCommand("push", builder),
+									betaplugindelete.NewCommand("delete", builder),
 								},
 							},
 						},

--- a/private/buf/cmd/buf/command/registry/plugin/plugincreate/plugincreate.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugincreate/plugincreate.go
@@ -1,0 +1,185 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugincreate
+
+import (
+	"context"
+	"fmt"
+
+	ownerv1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1"
+	pluginv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/buf/bufprint"
+	"github.com/bufbuild/buf/private/bufpkg/bufparse"
+	"github.com/bufbuild/buf/private/bufpkg/bufregistryapi/bufregistryapiplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/bufbuild/buf/private/pkg/stringutil"
+	"github.com/bufbuild/buf/private/pkg/syserror"
+	"github.com/spf13/pflag"
+)
+
+const (
+	formatFlagName      = "format"
+	visibilityFlagName  = "visibility"
+	defaultLabeFlagName = "default-label-name"
+	typeFlagName        = "type"
+
+	defaultDefaultLabel = "main"
+
+	pluginTypeCheck = "check"
+)
+
+var (
+	allPluginTypeStrings = []string{
+		pluginTypeCheck,
+	}
+)
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <remote/owner/plugin>",
+		Short: "Create a BSR plugin",
+		Args:  appcmd.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	Format       string
+	Visibility   string
+	DefautlLabel string
+	Type         string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	bufcli.BindVisibility(flagSet, &f.Visibility, visibilityFlagName, false)
+	flagSet.StringVar(
+		&f.Format,
+		formatFlagName,
+		bufprint.FormatText.String(),
+		fmt.Sprintf(`The output format to use. Must be one of %s`, bufprint.AllFormatsString),
+	)
+	flagSet.StringVar(
+		&f.DefautlLabel,
+		defaultLabeFlagName,
+		defaultDefaultLabel,
+		"The default label name of the module",
+	)
+	flagSet.StringVar(
+		&f.Type,
+		typeFlagName,
+		"",
+		fmt.Sprintf(
+			"The type of the plugin. Must be one of %s",
+			stringutil.SliceToString(allPluginTypeStrings),
+		),
+	)
+	_ = appcmd.MarkFlagRequired(flagSet, typeFlagName)
+}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	pluginFullName, err := bufparse.ParseFullName(container.Arg(0))
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	visibility, err := bufcli.VisibilityFlagToPluginVisibilityAllowUnspecified(flags.Visibility)
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	format, err := bufprint.ParseFormat(flags.Format)
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	pluginType, err := typeFlagToPluginType(flags.Type)
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
+	if err != nil {
+		return err
+	}
+	pluginServiceClient := bufregistryapiplugin.NewClientProvider(clientConfig).
+		V1Beta1PluginServiceClient(pluginFullName.Registry())
+
+	pluginResponse, err := pluginServiceClient.CreatePlugins(ctx, connect.NewRequest(
+		&pluginv1beta1.CreatePluginsRequest{
+			Values: []*pluginv1beta1.CreatePluginsRequest_Value{
+				{
+					OwnerRef: &ownerv1.OwnerRef{
+						Value: &ownerv1.OwnerRef_Name{
+							Name: pluginFullName.Owner(),
+						},
+					},
+					Name:       pluginFullName.Name(),
+					Visibility: visibility,
+					Type:       pluginType,
+				},
+			},
+		},
+	))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeAlreadyExists {
+			return bufcli.NewPluginNameAlreadyExistsError(pluginFullName.String())
+		}
+		return err
+	}
+	plugins := pluginResponse.Msg.Plugins
+	if len(plugins) != 1 {
+		return syserror.Newf("unexpected number of plugins returned from server: %d", len(plugins))
+	}
+	if format == bufprint.FormatText {
+		_, err = fmt.Fprintf(container.Stdout(), "Created %s.\n", pluginFullName)
+		if err != nil {
+			return syserror.Wrap(err)
+		}
+		return nil
+	}
+	return bufprint.PrintNames(
+		container.Stdout(),
+		format,
+		bufprint.NewPluginEntity(plugins[0], pluginFullName),
+	)
+}
+
+// typeFlagToPluginType parses the given string as a pluginv1.PluginType.
+func typeFlagToPluginType(pluginType string) (pluginv1beta1.PluginType, error) {
+	switch pluginType {
+	case pluginTypeCheck:
+		return pluginv1beta1.PluginType_PLUGIN_TYPE_CHECK, nil
+	default:
+		return 0, fmt.Errorf("invalid plugin type: %s", pluginType)
+	}
+}

--- a/private/buf/cmd/buf/command/registry/plugin/plugincreate/usage.gen.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugincreate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package plugincreate
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/registry/plugin/plugindelete/plugindelete.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugindelete/plugindelete.go
@@ -1,0 +1,114 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugindelete
+
+import (
+	"context"
+	"fmt"
+
+	pluginv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/bufpkg/bufparse"
+	"github.com/bufbuild/buf/private/bufpkg/bufregistryapi/bufregistryapiplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/bufbuild/buf/private/pkg/syserror"
+	"github.com/spf13/pflag"
+)
+
+const forceFlagName = "force"
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <remote/owner/plugin>",
+		Short: "Delete a BSR plugin",
+		Args:  appcmd.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	Force bool
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(
+		&f.Force,
+		forceFlagName,
+		false,
+		"Force deletion without confirming. Use with caution",
+	)
+}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	pluginFullName, err := bufparse.ParseFullName(container.Arg(0))
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	if !flags.Force {
+		if err := bufcli.PromptUserForDelete(container, "entity", pluginFullName.Name()); err != nil {
+			return err
+		}
+	}
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
+	if err != nil {
+		return err
+	}
+	pluginServiceClient := bufregistryapiplugin.NewClientProvider(clientConfig).
+		V1Beta1PluginServiceClient(pluginFullName.Registry())
+
+	if _, err := pluginServiceClient.DeletePlugins(ctx, connect.NewRequest(
+		&pluginv1beta1.DeletePluginsRequest{
+			PluginRefs: []*pluginv1beta1.PluginRef{
+				{
+					Value: &pluginv1beta1.PluginRef_Name_{
+						Name: &pluginv1beta1.PluginRef_Name{
+							Owner:  pluginFullName.Owner(),
+							Plugin: pluginFullName.Name(),
+						},
+					},
+				},
+			},
+		},
+	)); err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			return bufcli.NewPluginNotFoundError(container.Arg(0))
+		}
+		return err
+	}
+	if _, err := fmt.Fprintf(container.Stdout(), "Deleted %s.\n", pluginFullName); err != nil {
+		return syserror.Wrap(err)
+	}
+	return nil
+}

--- a/private/buf/cmd/buf/command/registry/plugin/plugindelete/usage.gen.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugindelete/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package plugindelete
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/registry/plugin/plugininfo/plugininfo.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugininfo/plugininfo.go
@@ -1,0 +1,121 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugininfo
+
+import (
+	"context"
+	"fmt"
+
+	pluginv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
+	"github.com/bufbuild/buf/private/buf/bufprint"
+	"github.com/bufbuild/buf/private/bufpkg/bufparse"
+	"github.com/bufbuild/buf/private/bufpkg/bufregistryapi/bufregistryapiplugin"
+	"github.com/bufbuild/buf/private/pkg/app/appcmd"
+	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"github.com/bufbuild/buf/private/pkg/syserror"
+	"github.com/spf13/pflag"
+)
+
+const formatFlagName = "format"
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " <remote/owner/plugin>",
+		Short: "Get a BSR plugin",
+		Args:  appcmd.ExactArgs(1),
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	Format string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.Format,
+		formatFlagName,
+		bufprint.FormatText.String(),
+		fmt.Sprintf(`The output format to use. Must be one of %s`, bufprint.AllFormatsString),
+	)
+}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	pluginFullName, err := bufparse.ParseFullName(container.Arg(0))
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	format, err := bufprint.ParseFormat(flags.Format)
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
+	if err != nil {
+		return err
+	}
+	pluginServiceClient := bufregistryapiplugin.NewClientProvider(clientConfig).
+		V1Beta1PluginServiceClient(pluginFullName.Registry())
+
+	pluginsResponse, err := pluginServiceClient.GetPlugins(ctx, connect.NewRequest(
+		&pluginv1beta1.GetPluginsRequest{
+			PluginRefs: []*pluginv1beta1.PluginRef{
+				{
+					Value: &pluginv1beta1.PluginRef_Name_{
+						Name: &pluginv1beta1.PluginRef_Name{
+							Owner:  pluginFullName.Owner(),
+							Plugin: pluginFullName.Name(),
+						},
+					},
+				},
+			},
+		},
+	))
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			return bufcli.NewPluginNotFoundError(container.Arg(0))
+		}
+		return err
+	}
+	plugins := pluginsResponse.Msg.Plugins
+	if len(plugins) != 1 {
+		return syserror.Newf("unexpected number of plugins returned from server: %d", len(plugins))
+	}
+	return bufprint.PrintEntity(
+		container.Stdout(),
+		format,
+		bufprint.NewPluginEntity(plugins[0], pluginFullName),
+	)
+}

--- a/private/buf/cmd/buf/command/registry/plugin/plugininfo/usage.gen.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugininfo/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package plugininfo
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/buf/cmd/buf/command/registry/plugin/pluginupdate/usage.gen.go
+++ b/private/buf/cmd/buf/command/registry/plugin/pluginupdate/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package pluginupdate
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This adds new plugin registry commands to get, create, delete and update plugins in the BSR. These commands are used for the upcoming check plugins.

The trimmed output from `buf registry plugin --help`:
```
Manage BSR plugins

Usage:
  buf registry plugin [flags]
  buf registry plugin [command]

Available Commands:
  create      Create a BSR plugin
  delete      Delete a BSR plugin
  info        Get a BSR plugin
  update      Update BSR plugin settings
```