### PR TITLE
Fix buf registry modules listing help output

### DIFF
--- a/private/buf/cmd/buf/command/registry/module/modulecommit/modulecommitlist/modulecommitlist.go
+++ b/private/buf/cmd/buf/command/registry/module/modulecommit/modulecommitlist/modulecommitlist.go
@@ -261,7 +261,7 @@ func nextPageCommand(container appext.Container, flags *flags, nextPageToken str
 	if nextPageToken == "" {
 		return ""
 	}
-	command := fmt.Sprintf("buf registry commit list %s", container.Arg(0))
+	command := fmt.Sprintf("buf registry module commit list %s", container.Arg(0))
 	if flags.PageSize != defaultPageSize {
 		command = fmt.Sprintf("%s --%s %d", command, pageSizeFlagName, flags.PageSize)
 	}

--- a/private/buf/cmd/buf/command/registry/module/modulelabel/modulelabellist/modulelabellist.go
+++ b/private/buf/cmd/buf/command/registry/module/modulelabel/modulelabellist/modulelabellist.go
@@ -172,7 +172,7 @@ func nextPageCommand(container appext.Container, flags *flags, nextPageToken str
 	if nextPageToken == "" {
 		return ""
 	}
-	command := fmt.Sprintf("buf registry label list %s", container.Arg(0))
+	command := fmt.Sprintf("buf registry module label list %s", container.Arg(0))
 	if flags.ArchiveStatus != bufcli.DefaultArchiveStatus {
 		command = fmt.Sprintf("%s --%s %s", command, archiveStatusName, flags.ArchiveStatus)
 	}


### PR DESCRIPTION
This fixes the output of `buf registry module commit list` and `buf registry module label list` to return the non-deprecated command when outputting the help docs.