### PR TITLE
Fix annotation for FIELD_NOT_REQUIRED rule

### DIFF
--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/lint.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/lint.go
@@ -408,6 +408,7 @@ func handleLintFieldNotRequired(
 			field.NameLocation(),
 			nil,
 			`Field named %q should not be required.`,
+			field.Name(),
 		)
 	}
 	return nil


### PR DESCRIPTION
The annotation for `FIELD_NOT_REQUIRED` did not
pass in the field name.