### PR TITLE
Add debug logging interceptor for RPC logs

### DIFF
--- a/private/buf/bufcli/connectclient_config.go
+++ b/private/buf/bufcli/connectclient_config.go
@@ -81,6 +81,7 @@ func newConnectClientConfigWithOptions(container appext.Container, opts ...conne
 				bufconnect.NewAugmentedConnectErrorInterceptor(),
 				bufconnect.NewSetCLIVersionInterceptor(Version),
 				bufconnect.NewCLIWarningInterceptor(container),
+				bufconnect.NewDebugLoggingInterceptor(container),
 				otelconnectInterceptor,
 			},
 		),

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -163,12 +163,7 @@ func NewDebugLoggingInterceptor(container appext.LoggerContainer) connect.UnaryI
 			startTime := time.Now()
 			resp, err := next(ctx, req)
 			duration := time.Since(startTime)
-			var status connect.Code
-			if err != nil {
-				if connectErr := new(connect.Error); errors.As(err, &connectErr) {
-					status = connectErr.Code()
-				}
-			}
+			status = connect.CodeOf(err)
 			var responseSize int
 			if resp != nil && resp.Any() != nil {
 				msg, ok := resp.Any().(proto.Message)

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -163,7 +163,10 @@ func NewDebugLoggingInterceptor(container appext.LoggerContainer) connect.UnaryI
 			startTime := time.Now()
 			resp, err := next(ctx, req)
 			duration := time.Since(startTime)
-			status = connect.CodeOf(err)
+			var status connect.Code
+			if err != nil {
+				status = connect.CodeOf(err)
+			}
 			var responseSize int
 			if resp != nil && resp.Any() != nil {
 				msg, ok := resp.Any().(proto.Message)

--- a/private/bufpkg/bufconnect/interceptors.go
+++ b/private/bufpkg/bufconnect/interceptors.go
@@ -18,10 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -139,4 +143,56 @@ func NewAuthorizationInterceptorProvider(tokenProviders ...TokenProvider) func(s
 		}
 		return interceptor
 	}
+}
+
+// NewDebugLoggingInterceptor returns a new Connect Interceptor that adds debug log
+// statements for each rpc call.
+//
+// The following information is collected for logging: duration, status code, peer name,
+// rpc system, request size, and response size.
+func NewDebugLoggingInterceptor(container appext.LoggerContainer) connect.UnaryInterceptorFunc {
+	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			var requestSize int
+			if req.Any() != nil {
+				msg, ok := req.Any().(proto.Message)
+				if ok {
+					requestSize = proto.Size(msg)
+				}
+			}
+			startTime := time.Now()
+			resp, err := next(ctx, req)
+			duration := time.Since(startTime)
+			var status connect.Code
+			if err != nil {
+				if connectErr := new(connect.Error); errors.As(err, &connectErr) {
+					status = connectErr.Code()
+				}
+			}
+			var responseSize int
+			if resp != nil && resp.Any() != nil {
+				msg, ok := resp.Any().(proto.Message)
+				if ok {
+					responseSize = proto.Size(msg)
+				}
+			}
+			attrs := []slog.Attr{
+				slog.Duration("duration", duration),
+				slog.String("status", status.String()),
+				slog.String("net.peer.name", req.Peer().Addr),
+				slog.String("rpc.system", req.Peer().Protocol),
+				slog.Int("message.sent.uncompressed_size", requestSize),
+				slog.Int("message.received.uncompressed_size", responseSize),
+			}
+			container.Logger().LogAttrs(
+				ctx,
+				slog.LevelDebug,
+				// Remove the leading "/" from Procedure name
+				strings.TrimPrefix(req.Spec().Procedure, "/"),
+				attrs...,
+			)
+			return resp, err
+		}
+	}
+	return interceptor
 }


### PR DESCRIPTION
This adds an interceptor for RPC-level debug logs that were lost
when the tracing instrumentation was removed (#3374).

Fixes #3484