### PR TITLE
Use ordered set for imports to iterate deterministically when filtering an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `buf registry plugin {create,delete,info,update}` commands to manage BSR plugins.
 - Breaking analysis support for `buf beta lsp`.
+- Fix bug when using the `--type` flag filter for `buf build` where import ordering is not
+  determinisitic.
 
 ## [v1.47.2] - 2024-11-14
 

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -1034,20 +1034,17 @@ func (o *orderedImports) index(path string) int {
 // then this is a no-op.
 func (o *orderedImports) add(path string) {
 	if _, ok := o.pathToIndex[path]; !ok {
-		o.paths = append(o.paths, path)
 		o.pathToIndex[path] = len(o.paths)
+		o.paths = append(o.paths, path)
 	}
 }
 
-// delete removes a key from the index map of ordered imports. Note that the path is not removed
-// from the paths list. If you want to iterate through the paths, use keys() to get all
-// non-deleted keys.
-func (o *orderedImports) delete(path string) error {
-	if _, ok := o.pathToIndex[path]; ok {
-		delete(o.pathToIndex, path)
-		return nil
-	}
-	return fmt.Errorf("no import found for: %s", path)
+// delete removes a key from the index map of ordered imports. If a non-existent path is
+// set for deletion, then this is a no-op.
+// Note that the path is not removed from the paths list. If you want to iterate through
+// the paths, use keys() to get all non-deleted keys.
+func (o *orderedImports) delete(path string) {
+	delete(o.pathToIndex, path)
 }
 
 // keys provides all non-deleted keys from the ordered imports.
@@ -1061,6 +1058,7 @@ func (o *orderedImports) keys() []string {
 	return keys
 }
 
+// newOrderedImports creates a new orderedImports structure.
 func newOrderedImports() *orderedImports {
 	return &orderedImports{
 		pathToIndex: map[string]int{},

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -1016,6 +1016,13 @@ type orderedImports struct {
 	paths       []string
 }
 
+// newOrderedImports creates a new orderedImports structure.
+func newOrderedImports() *orderedImports {
+	return &orderedImports{
+		pathToIndex: map[string]int{},
+	}
+}
+
 // index returns the index for a given path. If the path does not exist in index map, -1
 // is returned and should be considered deleted.
 func (o *orderedImports) index(path string) int {
@@ -1051,11 +1058,4 @@ func (o *orderedImports) keys() []string {
 		}
 	}
 	return keys
-}
-
-// newOrderedImports creates a new orderedImports structure.
-func newOrderedImports() *orderedImports {
-	return &orderedImports{
-		pathToIndex: map[string]int{},
-	}
 }

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -266,17 +266,28 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 		// the file's WeakDependency field.
 		indexFromTo := make(map[int32]int32)
 		indexTo := 0
+		// Only handle imports and dependencies if there are any.
 		for indexFrom, importPath := range imageFileDescriptor.GetDependency() {
 			path := append(basePath, int32(indexFrom))
-			if _, ok := importsRequired[importPath]; ok {
-				sourcePathRemapper.markMoved(path, int32(indexTo))
-				indexFromTo[int32(indexFrom)] = int32(indexTo)
-				imageFileDescriptor.Dependency[indexTo] = importPath
-				indexTo++
-				// markDeleted them as we go, so we know which ones weren't in the list
-				delete(importsRequired, importPath)
-			} else {
+			// If there are no required imports, we mark this as deleted.
+			if importsRequired == nil {
 				sourcePathRemapper.markDeleted(path)
+			} else {
+				// Otherwise, we check if the import path exists among required imports. If yes, we
+				// move and then delete from required imports as we go.
+				if i := importsRequired.index(importPath); i != -1 {
+					sourcePathRemapper.markMoved(path, int32(indexTo))
+					indexFromTo[int32(indexFrom)] = int32(indexTo)
+					imageFileDescriptor.Dependency[indexTo] = importPath
+					indexTo++
+					// delete them as we go, so we know which ones weren't in the list
+					if err := importsRequired.delete(importPath); err != nil {
+						return nil, err
+					}
+				} else {
+					// Path did not exist in required imports, we mark as deleted.
+					sourcePathRemapper.markDeleted(path)
+				}
 			}
 		}
 		imageFileDescriptor.Dependency = imageFileDescriptor.Dependency[:indexTo]
@@ -284,9 +295,10 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 		// Add any other imports (which may not have been in the list because
 		// they were picked up via a public import). The filtered files will not
 		// use public imports.
-		for importPath := range importsRequired {
-			imageFileDescriptor.Dependency = append(imageFileDescriptor.Dependency, importPath)
+		if importsRequired != nil {
+			imageFileDescriptor.Dependency = append(imageFileDescriptor.Dependency, importsRequired.keys()...)
 		}
+
 		imageFileDescriptor.PublicDependency = nil
 		sourcePathRemapper.markDeleted([]int32{filePublicDependencyTag})
 
@@ -458,9 +470,9 @@ type transitiveClosure struct {
 	// entire package being included). The above fields are used to filter the
 	// contents of files. But files named in this set will not be filtered.
 	completeFiles map[string]struct{}
-	// The set of imports for each file. This allows for re-writing imports
+	// The ordered set of imports for each file. This allows for re-writing imports
 	// for files whose contents have been pruned.
-	imports map[string]map[string]struct{}
+	imports map[string]*orderedImports
 }
 
 type closureInclusionMode int
@@ -485,7 +497,7 @@ func newTransitiveClosure() *transitiveClosure {
 		elements:      map[namedDescriptor]closureInclusionMode{},
 		files:         map[string]struct{}{},
 		completeFiles: map[string]struct{}{},
-		imports:       map[string]map[string]struct{}{},
+		imports:       map[string]*orderedImports{},
 	}
 }
 
@@ -495,10 +507,10 @@ func (t *transitiveClosure) addImport(fromPath, toPath string) {
 	}
 	imps := t.imports[fromPath]
 	if imps == nil {
-		imps = map[string]struct{}{}
+		imps = newOrderedImports()
 		t.imports[fromPath] = imps
 	}
-	imps[toPath] = struct{}{}
+	imps.add(toPath)
 }
 
 func (t *transitiveClosure) addFile(file string, imageIndex *imageIndex, opts *imageFilterOptions) error {
@@ -999,4 +1011,58 @@ func stripSourceRetentionOptionsFromFile(imageFile bufimage.ImageFile) (bufimage
 		imageFile.IsSyntaxUnspecified(),
 		imageFile.UnusedDependencyIndexes(),
 	)
+}
+
+// orderedImports is a structure to maintain an ordered set of imports. This is needed
+// because we want to be able to iterate through imports in a deterministic way when filtering
+// the image.
+type orderedImports struct {
+	pathToIndex map[string]int
+	paths       []string
+}
+
+// index returns the index for a given path. If the path does not exist in index map, -1
+// is returned and should be considered deleted.
+func (o *orderedImports) index(path string) int {
+	if index, ok := o.pathToIndex[path]; ok {
+		return index
+	}
+	return -1
+}
+
+// add appends a path to the paths list and the index in the map. If a key already exists,
+// then this is a no-op.
+func (o *orderedImports) add(path string) {
+	if _, ok := o.pathToIndex[path]; !ok {
+		o.paths = append(o.paths, path)
+		o.pathToIndex[path] = len(o.paths)
+	}
+}
+
+// delete removes a key from the index map of ordered imports. Note that the path is not removed
+// from the paths list. If you want to iterate through the paths, use keys() to get all
+// non-deleted keys.
+func (o *orderedImports) delete(path string) error {
+	if _, ok := o.pathToIndex[path]; ok {
+		delete(o.pathToIndex, path)
+		return nil
+	}
+	return fmt.Errorf("no import found for: %s", path)
+}
+
+// keys provides all non-deleted keys from the ordered imports.
+func (o *orderedImports) keys() []string {
+	keys := make([]string, 0, len(o.pathToIndex))
+	for _, path := range o.paths {
+		if _, ok := o.pathToIndex[path]; ok {
+			keys = append(keys, path)
+		}
+	}
+	return keys
+}
+
+func newOrderedImports() *orderedImports {
+	return &orderedImports{
+		pathToIndex: map[string]int{},
+	}
 }

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -281,9 +281,7 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 					imageFileDescriptor.Dependency[indexTo] = importPath
 					indexTo++
 					// delete them as we go, so we know which ones weren't in the list
-					if err := importsRequired.delete(importPath); err != nil {
-						return nil, err
-					}
+					importsRequired.delete(importPath)
 				} else {
 					// Path did not exist in required imports, we mark as deleted.
 					sourcePathRemapper.markDeleted(path)


### PR DESCRIPTION
Prior to this change, we used a map to keep track of imports
when filtering an image based on type. This resulted in a bug
where iterating through the imports was non-deterministic, and
resulted in non-deterministic images.
This change uses an ordered set for imports instead of a map.

Fixes #3506