### PR TITLE
Fix shared module read bucket for proto file refs and include_package_files

### DIFF
--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -543,6 +543,12 @@ func (b *moduleReadBucket) getIsTargetFileForPathUncached(ctx context.Context, p
 		// We've now deferred having to get fastscan.Results as much as we can.
 		protoFileTargetFastscanResult, err := b.getFastscanResultForPath(ctx, b.protoFileTargetPath)
 		if err != nil {
+			// In the case where multiple modules may have shared module roots through the includes key
+			// in the module configs, the protoFileTargetPath may not exist in the target module.
+			// In that case, we just return false.
+			if errors.Is(err, fs.ErrNotExist) {
+				return false, nil
+			}
 			return false, err
 		}
 		if protoFileTargetFastscanResult.PackageName == "" {


### PR DESCRIPTION
In the case where multiple modules have shared module roots
due to the `includes` key in the module configuration, when using
a proto file ref with the `includes_package_files` option (https://buf.build/docs/reference/inputs/?#protofile)
the proto file ref may not exist in the module. We need to check for
that and skip accordingly.