### PR TITLE
Do not set err to unwrapped connectErr in error interceptor

### DIFF
--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -471,7 +471,6 @@ func wrapError(err error) error {
 			}
 			return errors.New(msg)
 		}
-		err = connectErr.Unwrap()
 	}
 
 	sysError, isSysError := syserror.As(err)


### PR DESCRIPTION
This PR removes setting `err = connectErr.Unwrap()` from our
error interceptor after the `connectErr` checks. The reason for this
is that this could create some lossiness with `err`. For example, when
using `thread.ParallelizeWithCancelOnFailure`, the errors are appended
together with `errors.Join`:

https://github.com/bufbuild/buf/blob/7321103f28e0668a434e8370c8bfe4aa9dd2a62b/private/pkg/thread/thread.go#L128

When we call `errors.As(err, connectErr)` in the error interceptor, this matches
the first error in the error tree, in this case the context cancellation, and sets that
as the underlying error. So, when `connectErr.Unwrap()` is called, only the context
cancellation error is returned, and the rest of `err` is lost.