### PR TITLE
Use Workspaces for buf config ls rules

### DIFF
--- a/private/buf/bufworkspace/workspace.go
+++ b/private/buf/bufworkspace/workspace.go
@@ -92,6 +92,7 @@ type Workspace interface {
 	// handle v1 vs v2 transparently. Right now, this is only approved to be used in push
 	// when we want to know whether we need to print out only CommitIDs. Any other usages
 	// need to be evaluated.
+	// TODO: Validate the usecase for `buf config ls-lint-rules` and `buf config ls-breaking-rules`.
 	IsV2() bool
 
 	isWorkspace()


### PR DESCRIPTION
This refactors the commands `buf config {ls-lint-rules, ls-breaking-rules}` to utilize Workspaces. Workspaces allow for re-use of the validation for config overrides and provide more information about the source.