### PR TITLE
Fix relative targetpath bug

### DIFF
--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -636,7 +636,12 @@ func getReadWriteBucketForOS(
 	}
 	fsRootTargetPaths := make([]string, len(targetPaths))
 	for i, targetPath := range targetPaths {
-		_, fsRootTargetPath, err := fsRootAndFSRelPathForPath(targetPath)
+		resolvedTargetPath := targetPath
+		if !filepath.IsAbs(targetPath) {
+			resolvedTargetPath = fsRoot + fsRootInputSubDirPath + "/" + targetPath
+		}
+
+		_, fsRootTargetPath, err := fsRootAndFSRelPathForPath(resolvedTargetPath)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
# Bug Fix: Path Resolution for Local File System Imports

TL;DR
- Before: When using local files, you were building paths starting from where the command was run
- After: Now you build paths starting from where the files are imported from, just like we already do with git
- The fix: You explicitly resolve the target path using the import path as the base directory

The key change was making sure we use the import location as our "starting point" when figuring out where to put files, regardless of whether we're importing from local files or git.

## Issue
The export command was failing for local filesystem imports while working correctly for git imports. When using local filesystem imports, relative output paths were incorrectly resolved, causing errors when trying to export to paths outside the context directory.

For example, this local filesystem import failed:
```
export -o apivendor --exclude-imports ../local-vendor-protos --path package/project/common
```
With error:
```
Failure: ../cur_dir/package/project/common: is outside the context directory
```

While the equivalent git import worked as expected:
```
export -o apivendor --exclude-imports ssh://git/local-vendor-protos.git --path package/project/common
```

## Root Cause
The path resolution logic for local filesystem imports was not implementing the same correct behavior as git imports. Local filesystem imports were incorrectly using the current directory as the base for resolving relative paths.

## Fix
Updated the local filesystem path resolution logic to match the correct behavior already implemented in git imports. The path is now properly resolved as `../apivendor/package/project/common` for both import types.

