### PR TITLE
Chore remove lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,13 +48,13 @@ linters:
     - bidichk
     - bodyclose
     - containedctx
+    - copyloopvar
     # - contextcheck
     - decorder
     # - depguard
     - dogsled
     - errcheck
     - exhaustruct
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - gci

--- a/buf.yaml
+++ b/buf.yaml
@@ -4,7 +4,7 @@ modules:
     name: buf.build/bufbuild/buf
 lint:
   use:
-    - DEFAULT
+    - STANDARD
     - UNARY_RPC
   disallow_comment_ignores: true
 breaking:

--- a/private/buf/bufformat/bufformat.go
+++ b/private/buf/bufformat/bufformat.go
@@ -49,7 +49,6 @@ func FormatBucket(ctx context.Context, bucket storage.ReadBucket) (_ storage.Rea
 	}
 	jobs := make([]func(context.Context) error, len(paths))
 	for i, path := range paths {
-		path := path
 		jobs[i] = func(ctx context.Context) (retErr error) {
 			readObjectCloser, err := bucket.Get(ctx, path)
 			if err != nil {

--- a/private/buf/bufgen/generator.go
+++ b/private/buf/bufgen/generator.go
@@ -253,8 +253,6 @@ func (g *generator) execPlugins(
 	}
 	// Batch for each remote.
 	for remote, indexedPluginConfigs := range remotePluginConfigTable {
-		remote := remote
-		indexedPluginConfigs := indexedPluginConfigs
 		if len(indexedPluginConfigs) > 0 {
 			jobs = append(jobs, func(ctx context.Context) error {
 				results, err := g.execRemotePluginsV2(

--- a/private/buf/buflsp/symbol_test.go
+++ b/private/buf/buflsp/symbol_test.go
@@ -92,7 +92,6 @@ func TestCommentToMarkdown(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, test.expected, commentToMarkdown(test.input))

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1345,7 +1345,6 @@ func TestCheckLsBreakingRulesFromConfigExceptDeprecated(t *testing.T) {
 	t.Parallel()
 
 	for _, version := range bufconfig.AllFileVersions {
-		version := version
 		t.Run(version.String(), func(t *testing.T) {
 			t.Parallel()
 			// Do not need any custom lint/breaking plugins here.
@@ -1384,7 +1383,6 @@ func TestCheckLsBreakingRulesFromConfigExceptDeprecated(t *testing.T) {
 			require.NoError(t, err)
 
 			for deprecatedRule := range deprecations {
-				deprecatedRule := deprecatedRule
 				t.Run(deprecatedRule, func(t *testing.T) {
 					t.Parallel()
 					ids := getRuleIDsFromLsBreaking(t, version.String(), []string{"PACKAGE"}, []string{deprecatedRule})

--- a/private/buf/cmd/buf/command/alpha/protoc/flags_test.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/flags_test.go
@@ -589,7 +589,6 @@ func TestParseFlags(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		name := fmt.Sprintf("%d", i)
-		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			env, err := testParseFlags(name, testCase.Args)

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/field_default_test.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/field_default_test.go
@@ -55,7 +55,6 @@ func TestDefaultsEqual(t *testing.T) {
 		},
 	}
 	for name, vals := range values {
-		name, vals := name, vals
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			for _, val := range vals {

--- a/private/bufpkg/bufcheck/multi_client.go
+++ b/private/bufpkg/bufcheck/multi_client.go
@@ -61,7 +61,6 @@ func (c *multiClient) Check(ctx context.Context, request check.Request) ([]*anno
 	var jobs []func(context.Context) error
 	var lock sync.Mutex
 	for i, delegate := range c.checkClientSpecs {
-		delegate := delegate
 		// This is all ruleIDs for this client.
 		allDelegateRuleIDs := chunkedRuleIDs[i]
 		// This is the specific requested ruleIDs for this client

--- a/private/bufpkg/bufconfig/buf_lock_file.go
+++ b/private/bufpkg/bufconfig/buf_lock_file.go
@@ -301,7 +301,6 @@ func readBufLockFile(
 		}
 		depModuleKeys := make([]bufmodule.ModuleKey, len(externalBufLockFile.Deps))
 		for i, dep := range externalBufLockFile.Deps {
-			dep := dep
 			if dep.Remote == "" {
 				return nil, errors.New("remote missing")
 			}
@@ -355,7 +354,6 @@ func readBufLockFile(
 		}
 		depModuleKeys := make([]bufmodule.ModuleKey, len(externalBufLockFile.Deps))
 		for i, dep := range externalBufLockFile.Deps {
-			dep := dep
 			if dep.Name == "" {
 				return nil, errors.New("no module name specified")
 			}
@@ -391,7 +389,6 @@ func readBufLockFile(
 		}
 		remotePluginKeys := make([]bufplugin.PluginKey, len(externalBufLockFile.Plugins))
 		for i, plugin := range externalBufLockFile.Plugins {
-			plugin := plugin
 			if plugin.Name == "" {
 				return nil, errors.New("no plugin name specified")
 			}

--- a/private/bufpkg/bufconfig/buf_work_yaml_file_test.go
+++ b/private/bufpkg/bufconfig/buf_work_yaml_file_test.go
@@ -82,7 +82,6 @@ directories:
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
 			t.Parallel()
 			readBucket, err := storagemem.NewReadBucket(
@@ -130,7 +129,6 @@ func TestNewBufWorkYAMLFile(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
 			t.Parallel()
 			bufWorkYAMLFile, err := NewBufWorkYAMLFile(testcase.version, testcase.dirPaths)
@@ -189,7 +187,6 @@ func TestNewWorkYAMLFileFail(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
 			t.Parallel()
 			_, err := NewBufWorkYAMLFile(testcase.version, testcase.dirPaths)

--- a/private/bufpkg/bufconfig/generate_config_test.go
+++ b/private/bufpkg/bufconfig/generate_config_test.go
@@ -688,7 +688,6 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
 			t.Parallel()
 			parsedConfig, err := newGenerateConfigFromExternalFileV1(testcase.externalConfig)
@@ -764,7 +763,6 @@ func TestParseConfigFromExternalV1Fail(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
 			t.Parallel()
 			_, err := newGenerateConfigFromExternalFileV1(testcase.externalConfig)

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -150,9 +150,7 @@ func TestModifyImage(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		for _, includeSourceInfo := range []bool{true, false} {
-			includeSourceInfo := includeSourceInfo
 			t.Run(testcase.description, func(t *testing.T) {
 				t.Parallel()
 				image := testGetImageFromDirs(t, testcase.dirPathToFullName, includeSourceInfo)
@@ -550,10 +548,8 @@ func TestModifyImageFile(
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		for _, includeSourceInfo := range []bool{true, false} {
 			// TODO FUTURE: we are only testing sweep here, no need to test both include and exclude source info
-			includeSourceInfo := includeSourceInfo
 			t.Run(testcase.description, func(t *testing.T) {
 				t.Parallel()
 				image := testGetImageFromDirs(t, testcase.dirPathToFullName, includeSourceInfo)
@@ -744,7 +740,6 @@ func TestGetStringOverrideFromConfig(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.description, func(t *testing.T) {
 			t.Parallel()
 			override, err := stringOverrideFromConfig(

--- a/private/bufpkg/bufmodule/bufmoduleapi/module_key_provider.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/module_key_provider.go
@@ -108,7 +108,6 @@ func (a *moduleKeyProvider) getIndexedModuleKeysForRegistryAndIndexedModuleRefs(
 	}
 	indexedModuleKeys := make([]slicesext.Indexed[bufmodule.ModuleKey], len(indexedModuleRefs))
 	for i, universalProtoCommit := range universalProtoCommits {
-		universalProtoCommit := universalProtoCommit
 		commitID, err := uuidutil.FromDashless(universalProtoCommit.ID)
 		if err != nil {
 			return nil, err

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -335,7 +335,6 @@ func (a *uploader) Upload(
 	}
 	commits := make([]bufmodule.Commit, len(universalProtoCommits))
 	for i, universalProtoCommit := range universalProtoCommits {
-		universalProtoCommit := universalProtoCommit
 		// This is how we get the FullName without calling the ModuleService or OwnerService.
 		//
 		// We've maintained ordering throughout this function, so we can do this.

--- a/private/bufpkg/bufprotoplugin/generator.go
+++ b/private/bufpkg/bufprotoplugin/generator.go
@@ -55,7 +55,6 @@ func (g *generator) Generate(
 	)
 	jobs := make([]func(context.Context) error, len(codeGeneratorRequests))
 	for i, codeGeneratorRequest := range codeGeneratorRequests {
-		codeGeneratorRequest := codeGeneratorRequest
 		jobs[i] = func(ctx context.Context) error {
 			protopluginRequest, err := protoplugin.NewRequest(codeGeneratorRequest)
 			if err != nil {

--- a/private/bufpkg/bufprotosource/files.go
+++ b/private/bufpkg/bufprotosource/files.go
@@ -56,7 +56,6 @@ func newFiles[F InputFile](
 	jobs := make([]func(context.Context) error, len(chunks))
 	var lock sync.Mutex
 	for i, indexedInputFileChunk := range chunks {
-		indexedInputFileChunk := indexedInputFileChunk
 		jobs[i] = func(ctx context.Context) error {
 			iIndexedFiles := make([]slicesext.Indexed[File], 0, len(indexedInputFileChunk))
 			for _, indexedInputFile := range indexedInputFileChunk {

--- a/private/bufpkg/bufremoteplugin/bufremotepluginref/bufremotepluginref_test.go
+++ b/private/bufpkg/bufremoteplugin/bufremotepluginref/bufremotepluginref_test.go
@@ -69,7 +69,6 @@ func TestPluginIdentityForStringError(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.Name, func(t *testing.T) {
 			t.Parallel()
 			_, err := PluginIdentityForString(testCase.Input)

--- a/private/pkg/bandeps/checker.go
+++ b/private/pkg/bandeps/checker.go
@@ -116,7 +116,6 @@ func (c *checker) populateState(ctx context.Context, state *state, externalConfi
 	var lock sync.Mutex
 	var jobs []func(context.Context) error
 	for _, packageExpression := range depPackageExpressions {
-		packageExpression := packageExpression
 		jobs = append(
 			jobs,
 			func(ctx context.Context) error {
@@ -132,7 +131,6 @@ func (c *checker) populateState(ctx context.Context, state *state, externalConfi
 		)
 	}
 	for _, packageExpression := range packageExpressions {
-		packageExpression := packageExpression
 		jobs = append(
 			jobs,
 			func(ctx context.Context) error {
@@ -147,7 +145,6 @@ func (c *checker) populateState(ctx context.Context, state *state, externalConfi
 
 	jobs = make([]func(context.Context) error, 0)
 	for pkg := range depPackages {
-		pkg := pkg
 		jobs = append(
 			jobs,
 			func(ctx context.Context) error {

--- a/private/pkg/oauth2/client_test.go
+++ b/private/pkg/oauth2/client_test.go
@@ -91,7 +91,6 @@ func TestRegisterDevice(t *testing.T) {
 		err: fmt.Errorf("oauth2: %w: 501 not implemented", errors.ErrUnsupported),
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -156,7 +155,6 @@ func TestAuthorizeDevice(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -263,7 +261,6 @@ func TestAccessDeviceToken(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/private/pkg/storage/copy.go
+++ b/private/pkg/storage/copy.go
@@ -144,7 +144,6 @@ func copyPaths(
 	var count atomic.Int64
 	jobs := make([]func(context.Context) error, len(paths))
 	for i, path := range paths {
-		path := path
 		jobs[i] = func(ctx context.Context) error {
 			if err := copyPath(ctx, from, path, to, path, copyExternalAndLocalPaths, atomicOpt); err != nil {
 				return err

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -183,7 +183,6 @@ func RunTestSuite(
 		".",
 		"./",
 	} {
-		prefix := prefix
 		t.Run(fmt.Sprintf("root-%q", prefix), func(t *testing.T) {
 			t.Parallel()
 			readBucket, _ := newReadBucket(t, oneDirPath, defaultProvider)
@@ -905,7 +904,6 @@ func RunTestSuite(
 			},
 		},
 	} {
-		testCase := testCase
 		if testCase.stripComponentCount == 0 {
 			t.Run(fmt.Sprintf("copy-%s", testCase.name), func(t *testing.T) {
 				t.Parallel()


### PR DESCRIPTION
This removes the lint warnings. Buf changed DEFAULT to STANDARD. Golangci-lint remove deprecated exportloopref for copyloopvar in Go v1.22+. Fixed up lint issues.