### PR TITLE
Fix labels with buf plugin push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix `buf plugin push --label` to allow pushing a plugin with a label.
 
 ## [v1.48.0] - 2024-12-19
 

--- a/private/buf/cmd/buf/command/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/plugin/pluginpush/pluginpush.go
@@ -187,6 +187,9 @@ func upload(
 			createPluginType,
 		))
 	}
+	if len(flags.Labels) > 0 {
+		options = append(options, bufplugin.UploadWithLabels(flags.Labels...))
+	}
 	commits, err := uploader.Upload(ctx, []bufplugin.Plugin{plugin}, options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the command `buf plugin push` flag `--label` to allow specifying additional labels.