### PR TITLE
Fix source-control-url with buf plugin push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fix `buf plugin push --label` to allow pushing a plugin with a label.
 - Add `--digest-changes-only` flag to `buf registry {module,plugin} commit list` to filter
   out commits that have no digest changes.
+- Fix `buf plugin push --source-control-url` to allow pushing a plugin with the source 
+  control url.
 
 ## [v1.48.0] - 2024-12-19
 

--- a/private/buf/cmd/buf/command/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/plugin/pluginpush/pluginpush.go
@@ -190,6 +190,9 @@ func upload(
 	if len(flags.Labels) > 0 {
 		options = append(options, bufplugin.UploadWithLabels(flags.Labels...))
 	}
+	if flags.SourceControlURL != "" {
+		options = append(options, bufplugin.UploadWithSourceControlURL(flags.SourceControlURL))
+	}
 	commits, err := uploader.Upload(ctx, []bufplugin.Plugin{plugin}, options...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the command `buf plugin push` flag `--source-control-url` to allow setting parameter.