### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Add `buf registry plugin {create,delete,info,update}` commands to manage BSR plugins.
 - Breaking analysis support for `buf beta lsp`.
 - Fix bug when using the `--type` flag filter for `buf build` where import ordering is not
-  determinisitic.
+  deterministic.
 - Add `buf plugin push` command to push a plugin to the Buf Schema Registry. 
   Only WebAssembly check plugins are supported at this time.
 - Add `buf plugin update` and `buf plugin prune` command to manage plugins in the `buf.lock`
@@ -855,7 +855,7 @@ curl -sSL https://github.com/bufbuild/buf/releases/download/v0.57.0/protoc-gen-b
 ## [v0.56.0] - 2021-09-08
 
 - Cascade `ENUM_ZERO_VALUE_SUFFIX` comment ignores from the enum level.
-- Fix issue where `buf genarate --output` was not being respected in 0.55.0.
+- Fix issue where `buf generate --output` was not being respected in 0.55.0.
 
 ## [v0.55.0] - 2021-09-07
 
@@ -863,7 +863,7 @@ curl -sSL https://github.com/bufbuild/buf/releases/download/v0.57.0/protoc-gen-b
 - Support `BUF_TOKEN` for authentication. `buf` will now look for a token in the `BUF_TOKEN` environment variable, falling back to `.netrc` as set via `buf login`.
 - Add support for using remote plugins with local source files.
 - Add per-file overrides for managed mode.
-- Fix issue with the module cache where multiple simulataneous downloads would result in a temporarily-corrupted cache.
+- Fix issue with the module cache where multiple simultaneous downloads would result in a temporarily-corrupted cache.
 - Hide verbose messaing behind the `--verbose` (`-v`) flag.
 - Add `--debug` flag to print out debug logging.
 

--- a/private/buf/bufcli/flags_args.go
+++ b/private/buf/bufcli/flags_args.go
@@ -42,8 +42,8 @@ const (
 )
 
 var (
-	// allVisibiltyStrings are the possible options that a user can set the visibility flag with.
-	allVisibiltyStrings = []string{
+	// allVisibilityStrings are the possible options that a user can set the visibility flag with.
+	allVisibilityStrings = []string{
 		publicVisibility,
 		privateVisibility,
 	}
@@ -153,7 +153,7 @@ func BindVisibility(flagSet *pflag.FlagSet, addr *string, flagName string, empty
 		addr,
 		flagName,
 		defaultVisibility,
-		fmt.Sprintf(`The module's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The module's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibilityStrings)),
 	)
 }
 
@@ -164,7 +164,7 @@ func BindCreateVisibility(flagSet *pflag.FlagSet, addr *string, flagName string,
 		addr,
 		flagName,
 		privateVisibility,
-		fmt.Sprintf(`The module's visibility setting, if created. Can only be set with --%s. Must be one of %s`, createFlagName, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The module's visibility setting, if created. Can only be set with --%s. Must be one of %s`, createFlagName, stringutil.SliceToString(allVisibilityStrings)),
 	)
 }
 

--- a/private/buf/bufctl/option.go
+++ b/private/buf/bufctl/option.go
@@ -87,7 +87,7 @@ func WithImageAsFileDescriptorSet(imageAsFileDescriptorSet bool) FunctionOption 
 // If used with an image or module ref, this has no effect on the build, i.e. excludes are
 // not respected, and the module name is ignored. This matches old behavior.
 //
-// This implements the soon-to-be-deprected --config flag.
+// This implements the soon-to-be-deprecated --config flag.
 //
 // See bufconfig.GetBufYAMLFileForPrefixOrOverride for more details.
 //

--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -100,7 +100,7 @@ type MessageRef interface {
 	MessageEncoding() MessageEncoding
 	// Path returns the path of the file.
 	//
-	// May be used for items such as YAML unmarshaling errors.
+	// May be used for items such as YAML unmarshalling errors.
 	Path() string
 	// UseProtoNames only applies for MessageEncodingYAML at this time.
 	UseProtoNames() bool

--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -410,7 +410,7 @@ type BucketExtender interface {
 	// SubDirPath is the subdir within the Bucket of the actual asset.
 	//
 	// This will be set if a terminate file was found. If so, the actual Bucket will be
-	// the directory that contained this terminate file, and the subDirPath will be the sub-direftory of
+	// the directory that contained this terminate file, and the subDirPath will be the sub-directory of
 	// the actual asset relative to the terminate file.
 	SubDirPath() string
 }

--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -672,7 +672,7 @@ func getReadWriteBucketForOS(
 	// osRootBucketTargeting returns the information on whether or not a controlling
 	// workspace was found based on the inputDirPath.
 	//
-	// *** CONTROLLING WOKRSPACE FOUND ***
+	// *** CONTROLLING WORKSPACE FOUND ***
 	//
 	// In the case where a controlling workspace is found, we want to create a new bucket
 	// for the controlling workspace.
@@ -687,11 +687,11 @@ func getReadWriteBucketForOS(
 	//
 	// We do not need to remap the input dir, target paths, and target exclude paths
 	// returned by buftarget.BucketTargeting, because they are already relative to the
-	// controlling workpsace.
+	// controlling workspace.
 	//
-	// *** CONTROLLING WOKRSPACE NOT FOUND ***
+	// *** CONTROLLING WORKSPACE NOT FOUND ***
 	//
-	// In the case where a controlling workpsace is not found, we have three outcomes for
+	// In the case where a controlling workspace is not found, we have three outcomes for
 	// creating a new bucket.
 	// If the inputDirPath is an absolute path, we want to use an absolute path to the input
 	// path:

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -154,7 +154,7 @@ func (f *formatter) Indent(nextNode ast.Node) {
 // WriteString writes the given element to the generated output.
 //
 // This will not write indentation or newlines. Use P if you
-// want to emit identation or newlines.
+// want to emit indentation or newlines.
 func (f *formatter) WriteString(elem string) {
 	if f.pendingSpace {
 		f.pendingSpace = false
@@ -886,7 +886,7 @@ func (f *formatter) writeField(fieldNode *ast.FieldNode) {
 		// If a label was not written, the multiline comments will be
 		// attached to the type.
 		if compoundIdentNode, ok := fieldNode.FldType.(*ast.CompoundIdentNode); ok {
-			f.writeCompountIdentForFieldName(compoundIdentNode)
+			f.writeCompoundIdentForFieldName(compoundIdentNode)
 		} else {
 			f.writeStart(fieldNode.FldType)
 		}
@@ -1500,7 +1500,7 @@ func (f *formatter) writeCompoundIdent(compoundIdentNode *ast.CompoundIdentNode)
 	}
 }
 
-// writeCompountIdentForFieldName writes a compound identifier, but handles comments
+// writeCompoundIdentForFieldName writes a compound identifier, but handles comments
 // specially for field names.
 //
 // For example,
@@ -1509,7 +1509,7 @@ func (f *formatter) writeCompoundIdent(compoundIdentNode *ast.CompoundIdentNode)
 //	  // These are comments attached to bar.
 //	  bar.v1.Bar bar = 1;
 //	}
-func (f *formatter) writeCompountIdentForFieldName(compoundIdentNode *ast.CompoundIdentNode) {
+func (f *formatter) writeCompoundIdentForFieldName(compoundIdentNode *ast.CompoundIdentNode) {
 	if compoundIdentNode.LeadingDot != nil {
 		f.writeStart(compoundIdentNode.LeadingDot)
 	}

--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -88,7 +88,7 @@ func testFormatNoDiff(t *testing.T, path string) {
 				func(formattedFile storage.ReadObject) error {
 					expectedPath := formattedFile.Path()
 					t.Run(expectedPath, func(t *testing.T) {
-						// The expecetd format result is the golden file. If
+						// The expected format result is the golden file. If
 						// this file IS a golden file, it is expected to not
 						// change.
 						if !strings.HasSuffix(expectedPath, ".golden.proto") {

--- a/private/buf/bufgen/bufgen.go
+++ b/private/buf/bufgen/bufgen.go
@@ -39,7 +39,7 @@ const (
 	StrategyAll Strategy = 2
 )
 
-// Strategy is a generation stategy.
+// Strategy is a generation strategy.
 type Strategy int
 
 // ParseStrategy parses the Strategy.

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -93,15 +93,15 @@ func (s *server) Initialize(
 
 	// The LSP protocol library doesn't actually provide SemanticTokensOptions
 	// correctly.
-	type SematicTokensLegend struct {
+	type SemanticTokensLegend struct {
 		TokenTypes     []string `json:"tokenTypes"`
 		TokenModifiers []string `json:"tokenModifiers"`
 	}
 	type SemanticTokensOptions struct {
 		protocol.WorkDoneProgressOptions
 
-		Legend SematicTokensLegend `json:"legend"`
-		Full   bool                `json:"full"`
+		Legend SemanticTokensLegend `json:"legend"`
+		Full   bool                 `json:"full"`
 	}
 
 	return &protocol.InitializeResult{
@@ -125,7 +125,7 @@ func (s *server) Initialize(
 			HoverProvider:              true,
 			SemanticTokensProvider: &SemanticTokensOptions{
 				WorkDoneProgressOptions: protocol.WorkDoneProgressOptions{WorkDoneProgress: true},
-				Legend: SematicTokensLegend{
+				Legend: SemanticTokensLegend{
 					TokenTypes:     semanticTypeLegend,
 					TokenModifiers: semanticModifierLegend,
 				},

--- a/private/buf/bufmigrate/bufmigrate.go
+++ b/private/buf/bufmigrate/bufmigrate.go
@@ -43,7 +43,7 @@ type Migrator interface {
 	//     regardless whether these module directories are specified in moduleDirPaths. Same
 	//     behavior with multiple workspaces. For example, if workspace foo has directories
 	//     bar and baz, then specifying foo, foo + bar and foo + bar + baz are the same.
-	//   - If a workspace is specfied, and modules not from this workspace are specified, the
+	//   - If a workspace is specified, and modules not from this workspace are specified, the
 	//     buf.yaml will contain all directories from the workspace, as well as the module
 	//     directories specified.
 	//   - If only module directories are specified, then the buf.yaml will contain exactly

--- a/private/buf/bufmigrate/migrate_builder.go
+++ b/private/buf/bufmigrate/migrate_builder.go
@@ -228,7 +228,7 @@ func (m *migrateBuilder) addModule(ctx context.Context, moduleDirPath string) (r
 	}
 	bufYAMLFilePath := normalpath.Join(moduleDirPath, objectData.Name())
 	// If this module is already visited, we don't add it for a second time. It's
-	// possbile to visit the same module directory twice when the user specifies both
+	// possible to visit the same module directory twice when the user specifies both
 	// a workspace and a module in this workspace.
 	if _, ok := m.pathsToDelete[bufYAMLFilePath]; ok {
 		return nil

--- a/private/buf/bufmigrate/migrator.go
+++ b/private/buf/bufmigrate/migrator.go
@@ -336,7 +336,7 @@ func (m *migrator) buildBufYAMLAndBufLockFiles(
 		// If a declared dependency also shows up in the workspace, it's not a dependency.
 		//
 		// We are only removing lock entries that are in the workspace. A lock entry
-		// could be for an indirect dependenceny not listed in deps in any buf.yaml.
+		// could be for an indirect dependency not listed in deps in any buf.yaml.
 		if _, ok := migrateBuilder.moduleFullNameStringToParentPath[moduleFullName]; ok {
 			continue
 		}

--- a/private/buf/buftarget/bucket_targeting.go
+++ b/private/buf/buftarget/bucket_targeting.go
@@ -25,13 +25,13 @@ import (
 // BucketTargeting provides targeting information for the bucket based on any controlling
 // workspaces that have been found.
 type BucketTargeting interface {
-	// ControllingWorkpsace returns the information for the controlling workspace, if one was
+	// ControllingWorkspace returns the information for the controlling workspace, if one was
 	// found. If not found, then this will be nil.
 	ControllingWorkspace() ControllingWorkspace
 	// SubDirPath returns the input directory relative to the controlling workspace, if one
 	// was found, otherwise it is relative to the root of the bucket
 	SubDirPath() string
-	// TargetPaths returns the target paths relative to the controlling workpsace, if one was
+	// TargetPaths returns the target paths relative to the controlling workspace, if one was
 	// found, otherwise it is relative to the root of the bucket.
 	TargetPaths() []string
 	// TargetExcludePaths returns the target exclude paths relative to the controlling

--- a/private/buf/buftarget/terminate.go
+++ b/private/buf/buftarget/terminate.go
@@ -45,7 +45,7 @@ func TerminateAtControllingWorkspace(
 }
 
 // TerminateAtV1Module is a special terminate func that returns a controlling workspace with
-// a v1 module confiugration if found at the given prefix.
+// a v1 module configuration if found at the given prefix.
 func TerminateAtV1Module(
 	ctx context.Context,
 	bucket storage.ReadBucket,

--- a/private/buf/bufwkt/cmd/wkt-go-data/main.go
+++ b/private/buf/bufwkt/cmd/wkt-go-data/main.go
@@ -205,7 +205,7 @@ func getProtosourceFiles(
 	if err != nil {
 		var fileAnnotationSet bufanalysis.FileAnnotationSet
 		if errors.As(err, &fileAnnotationSet) {
-			// stderr since we do output to stdouot
+			// stderr since we do output to stdout
 			if err := bufanalysis.PrintFileAnnotationSet(
 				container.Stderr(),
 				fileAnnotationSet,

--- a/private/buf/bufworkspace/option.go
+++ b/private/buf/bufworkspace/option.go
@@ -93,7 +93,7 @@ func WithTargetPaths(targetPaths []string, targetExcludePaths []string) Workspac
 // If used with NewWorkspaceForModuleKey, this has no effect on the build,
 // i.e. excludes are not respected, and the module name is ignored. This matches old behavior.
 //
-// This implements the deprected --config flag.
+// This implements the deprecated --config flag.
 //
 // See bufconfig.GetBufYAMLFileForPrefixOrOverride for more details.
 //

--- a/private/buf/bufworkspace/workspace.go
+++ b/private/buf/bufworkspace/workspace.go
@@ -60,7 +60,7 @@ type Workspace interface {
 	//
 	// However, this would mean that Workspace would not inherit ModuleSet, as we'd
 	// want to create GetWorkspaceModule.* functions instead of GetModule.* functions,
-	// and then provide a WorkpaceToModuleSet global function. This seems messier in
+	// and then provide a WorkspaceToModuleSet global function. This seems messier in
 	// practice than having users call GetLintConfigForOpaqueID(module.OpaqueID())
 	// in the situations where they need configuration.
 	GetLintConfigForOpaqueID(opaqueID string) bufconfig.LintConfig

--- a/private/buf/bufworkspace/workspace_dep_manager.go
+++ b/private/buf/bufworkspace/workspace_dep_manager.go
@@ -40,7 +40,7 @@ import (
 type WorkspaceDepManager interface {
 	// BufLockFileDigestType returns the DigestType that the buf.lock file expects.
 	BufLockFileDigestType() bufmodule.DigestType
-	// ExisingBufLockFileDepModuleKeys returns the ModuleKeys from the buf.lock file.
+	// ExistingBufLockFileDepModuleKeys returns the ModuleKeys from the buf.lock file.
 	ExistingBufLockFileDepModuleKeys(ctx context.Context) ([]bufmodule.ModuleKey, error)
 	// ExistingBufLockFileRemotePluginKeys returns the PluginKeys from the buf.lock file.
 	ExistingBufLockFileRemotePluginKeys(ctx context.Context) ([]bufplugin.PluginKey, error)

--- a/private/buf/bufworkspace/workspace_dep_manager_provider.go
+++ b/private/buf/bufworkspace/workspace_dep_manager_provider.go
@@ -32,7 +32,7 @@ type WorkspaceDepManagerProvider interface {
 	// If the underlying bucket has a v2 buf.yaml at the root, this builds a WorkspaceDepManager for this buf.yaml,
 	// using TargetSubDirPath for targeting.
 	//
-	// Otherwise, this builds a Workspace with a single module at the TargetSubDirPath (which may be "."), igoring buf.work.yamls.
+	// Otherwise, this builds a Workspace with a single module at the TargetSubDirPath (which may be "."), ignoring buf.work.yamls.
 	// Directories with buf.work.yamls cannot be directly targeted.
 
 	// Note this is the same logic as if WithIgnoreAndDisallowV1BufWorkYAMLs is applied with WorkspaceProvider!! If you want an equivalent

--- a/private/buf/bufworkspace/workspace_targeting.go
+++ b/private/buf/bufworkspace/workspace_targeting.go
@@ -194,7 +194,7 @@ func v2WorkspaceTargeting(
 	bufYAMLFile bufconfig.BufYAMLFile,
 	// If true and if a workspace module does not have a license/doc at its moduleDirPath,
 	// use the license/doc respectively at the workspace root for this module.
-	useWorkspaceLicenseDocIfNotFoundAtMoudle bool,
+	useWorkspaceLicenseDocIfNotFoundAtModule bool,
 ) (*workspaceTargeting, error) {
 	// We keep track of if any module was tentatively targeted, and then actually targeted via
 	// the paths flags. We use this pre-building of the ModuleSet to see if the --path and
@@ -231,7 +231,7 @@ func v2WorkspaceTargeting(
 		isTentativelyTargetModule := normalpath.EqualsOrContainsPath(bucketTargeting.SubDirPath(), moduleDirPath, normalpath.Relative)
 		// We ignore this check for proto file refs, since the input is considered the directory
 		// of the proto file reference, which is unlikely to contain a module in its entirety.
-		// In the future, it would be nice to handle this more elegently.
+		// In the future, it would be nice to handle this more elegantly.
 		if config.protoFileTargetPath != "" {
 			isTentativelyTargetModule = true
 		}
@@ -246,7 +246,7 @@ func v2WorkspaceTargeting(
 			moduleDirPath,
 			moduleConfig,
 			isTentativelyTargetModule,
-			useWorkspaceLicenseDocIfNotFoundAtMoudle,
+			useWorkspaceLicenseDocIfNotFoundAtModule,
 		)
 		if err != nil {
 			return nil, err
@@ -338,7 +338,7 @@ func v1WorkspaceTargeting(
 		isTentativelyTargetModule := normalpath.EqualsOrContainsPath(bucketTargeting.SubDirPath(), moduleDirPath, normalpath.Relative)
 		// We ignore this check for proto file refs, since the input is considered the directory
 		// of the proto file reference, which is unlikely to contain a module in its entirety.
-		// In the future, it would be nice to handle this more elegently.
+		// In the future, it would be nice to handle this more elegantly.
 		if config.protoFileTargetPath != "" {
 			isTentativelyTargetModule = true
 		}
@@ -569,7 +569,7 @@ func getMappedModuleBucketAndModuleTargeting(
 	isTargetModule bool,
 	// If true and if a workspace module does not have a license/doc at its moduleDirPath,
 	// use the license/doc respectively at the workspace root for this module.
-	useWorkspaceLicenseDocIfNotFoundAtMoudle bool,
+	useWorkspaceLicenseDocIfNotFoundAtModule bool,
 ) (storage.ReadBucket, *moduleTargeting, error) {
 	moduleBucket := storage.MapReadBucket(
 		workspaceBucket,
@@ -645,7 +645,7 @@ func getMappedModuleBucketAndModuleTargeting(
 	if err != nil {
 		return nil, nil, err
 	}
-	if useWorkspaceLicenseDocIfNotFoundAtMoudle {
+	if useWorkspaceLicenseDocIfNotFoundAtModule {
 		isModuleDocBucketEmpty, err := storage.IsEmpty(ctx, docStorageReadBucket, "")
 		if err != nil {
 			return nil, nil, err
@@ -838,7 +838,7 @@ func bucketIDsForModuleConfigsV2(moduleConfigs []bufconfig.ModuleConfig) []strin
 	// make sure each local module has a unique BucketID, which means we cannot use their DirPaths as
 	// BucketIDs directly. Instead, we append an index (1-indexed) to each DirPath to deduplicate, and
 	// each module's bucketID becomes "<path>[index]", except for the first one does not need the index
-	// and its bucketID is stil "<path>".
+	// and its bucketID is still "<path>".
 	// As an example, bucketIDs are shown for modules in the buf.yaml below:
 	// ...
 	// modules:

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -61,7 +61,7 @@ const (
 	privateVisibility = "private"
 )
 
-var allVisibiltyStrings = []string{
+var allVisibilityStrings = []string{
 	publicVisibility,
 	privateVisibility,
 }
@@ -122,7 +122,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Visibility,
 		visibilityFlagName,
 		"",
-		fmt.Sprintf(`The plugin's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibiltyStrings)),
+		fmt.Sprintf(`The plugin's visibility setting. Must be one of %s`, stringutil.SliceToString(allVisibilityStrings)),
 	)
 	_ = appcmd.MarkFlagRequired(flagSet, visibilityFlagName)
 }
@@ -536,7 +536,7 @@ func visibilityFlagToVisibility(visibility string) (registryv1alpha1.CuratedPlug
 	case privateVisibility:
 		return registryv1alpha1.CuratedPluginVisibility_CURATED_PLUGIN_VISIBILITY_PRIVATE, nil
 	default:
-		return 0, fmt.Errorf("invalid visibility: %s, expected one of %s", visibility, stringutil.SliceToString(allVisibiltyStrings))
+		return 0, fmt.Errorf("invalid visibility: %s, expected one of %s", visibility, stringutil.SliceToString(allVisibilityStrings))
 	}
 }
 

--- a/private/buf/cmd/buf/command/dep/internal/internal.go
+++ b/private/buf/cmd/buf/command/dep/internal/internal.go
@@ -113,7 +113,7 @@ func Prune(
 	return workspaceDepManager.UpdateBufLockFile(ctx, depModuleKeys, existingRemotePluginKeys)
 }
 
-// LogUnusedConfiugredDepsForWorkspace takes a workspace and logs the unused configured
+// LogUnusedConfiguredDepsForWorkspace takes a workspace and logs the unused configured
 // dependencies as warnings to the user.
 func LogUnusedConfiguredDepsForWorkspace(
 	workspace bufworkspace.Workspace,

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -1023,7 +1023,7 @@ func testRunStdoutStderr(t *testing.T, stdin io.Reader, expectedExitCode int, ex
 					appext.BuilderWithInterceptor(
 						// TODO FUTURE: use the real interceptor. Currently in buf.go, NewBuilder receives appflag.BuilderWithInterceptor(newErrorInterceptor()).
 						// However we cannot depend on newErrorInterceptor because it would create an import cycle, not to mention it needs to be exported first.
-						// This can depend on newErroInterceptor when it's moved to a separate package and made public.
+						// This can depend on newErrorInterceptor when it's moved to a separate package and made public.
 						func(next func(context.Context, appext.Container) error) func(context.Context, appext.Container) error {
 							return func(ctx context.Context, container appext.Container) error {
 								err := next(ctx, container)

--- a/private/buf/cmd/buf/command/plugin/pluginprune/pluginprune.go
+++ b/private/buf/cmd/buf/command/plugin/pluginprune/pluginprune.go
@@ -91,7 +91,7 @@ func prune(
 	}
 	var prunedBufLockPluginKeys []bufplugin.PluginKey
 	for _, existingRemotePluginKey := range existingRemotePluginKeys {
-		// Check if an existing plugin key from the buf.lock is confiugred in the buf.yaml.
+		// Check if an existing plugin key from the buf.lock is configured in the buf.yaml.
 		if _, ok := bufYAMLRemotePluginNames[existingRemotePluginKey.FullName().String()]; ok {
 			// If yes, then we keep it for the updated buf.lock.
 			prunedBufLockPluginKeys = append(prunedBufLockPluginKeys, existingRemotePluginKey)

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -241,13 +241,13 @@ func run(
 		}
 	}
 	if flags.Create {
-		createModuleVisiblity, err := bufmodule.ParseModuleVisibility(flags.CreateVisibility)
+		createModuleVisibility, err := bufmodule.ParseModuleVisibility(flags.CreateVisibility)
 		if err != nil {
 			return err
 		}
 		uploadOptions = append(
 			uploadOptions,
-			bufmodule.UploadWithCreateIfNotExist(createModuleVisiblity, flags.CreateDefaultLabel),
+			bufmodule.UploadWithCreateIfNotExist(createModuleVisibility, flags.CreateDefaultLabel),
 		)
 	}
 	if flags.SourceControlURL != "" {

--- a/private/buf/cmd/buf/command/registry/module/modulecreate/modulecreate.go
+++ b/private/buf/cmd/buf/command/registry/module/modulecreate/modulecreate.go
@@ -61,7 +61,7 @@ func NewCommand(
 type flags struct {
 	Format       string
 	Visibility   string
-	DefautlLabel string
+	DefaultLabel string
 }
 
 func newFlags() *flags {
@@ -77,7 +77,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		fmt.Sprintf(`The output format to use. Must be one of %s`, bufprint.AllFormatsString),
 	)
 	flagSet.StringVar(
-		&f.DefautlLabel,
+		&f.DefaultLabel,
 		defaultLabeFlagName,
 		defaultDefaultLabel,
 		"The default label name of the module",
@@ -120,7 +120,7 @@ func run(
 						},
 						Name:             moduleFullName.Name(),
 						Visibility:       visibility,
-						DefaultLabelName: flags.DefautlLabel,
+						DefaultLabelName: flags.DefaultLabel,
 					},
 				},
 			},

--- a/private/buf/cmd/buf/command/registry/module/modulelabel/modulelabellist/modulelabellist.go
+++ b/private/buf/cmd/buf/command/registry/module/modulelabel/modulelabellist/modulelabellist.go
@@ -110,7 +110,7 @@ func run(
 	if err != nil {
 		return appcmd.WrapInvalidArgumentError(err)
 	}
-	archiveStatusFitler, err := bufcli.ArchiveStatusFlagToModuleArchiveStatusFilter(flags.ArchiveStatus)
+	archiveStatusFilter, err := bufcli.ArchiveStatusFlagToModuleArchiveStatusFilter(flags.ArchiveStatus)
 	if err != nil {
 		return appcmd.WrapInvalidArgumentError(err)
 	}
@@ -147,7 +147,7 @@ func run(
 					},
 				},
 				Order:         order,
-				ArchiveFilter: archiveStatusFitler,
+				ArchiveFilter: archiveStatusFilter,
 			},
 		),
 	)

--- a/private/buf/cmd/buf/command/registry/plugin/plugincreate/plugincreate.go
+++ b/private/buf/cmd/buf/command/registry/plugin/plugincreate/plugincreate.go
@@ -71,7 +71,7 @@ func NewCommand(
 type flags struct {
 	Format       string
 	Visibility   string
-	DefautlLabel string
+	DefaultLabel string
 	Type         string
 }
 
@@ -88,7 +88,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		fmt.Sprintf(`The output format to use. Must be one of %s`, bufprint.AllFormatsString),
 	)
 	flagSet.StringVar(
-		&f.DefautlLabel,
+		&f.DefaultLabel,
 		defaultLabeFlagName,
 		defaultDefaultLabel,
 		"The default label name of the module",

--- a/private/buf/cmd/buf/command/registry/plugin/pluginlabel/pluginlabellist/pluginlabellist.go
+++ b/private/buf/cmd/buf/command/registry/plugin/pluginlabel/pluginlabellist/pluginlabellist.go
@@ -110,7 +110,7 @@ func run(
 	if err != nil {
 		return appcmd.WrapInvalidArgumentError(err)
 	}
-	archiveStatusFitler, err := bufcli.ArchiveStatusFlagToPluginArchiveStatusFilter(flags.ArchiveStatus)
+	archiveStatusFilter, err := bufcli.ArchiveStatusFlagToPluginArchiveStatusFilter(flags.ArchiveStatus)
 	if err != nil {
 		return appcmd.WrapInvalidArgumentError(err)
 	}
@@ -147,7 +147,7 @@ func run(
 					},
 				},
 				Order:         order,
-				ArchiveFilter: archiveStatusFitler,
+				ArchiveFilter: archiveStatusFilter,
 			},
 		),
 	)

--- a/private/buf/cmd/buf/workspace_test.go
+++ b/private/buf/cmd/buf/workspace_test.go
@@ -1288,7 +1288,7 @@ func TestWorkspaceJumpContextFail(t *testing.T) {
 
 func TestWorkspaceDirOverlapFail(t *testing.T) {
 	t.Parallel()
-	// The buf.work.yaml file cannot specify overlapping diretories.
+	// The buf.work.yaml file cannot specify overlapping directories.
 	testRunStdoutStderrNoWarn(
 		t,
 		nil,
@@ -1611,7 +1611,7 @@ func TestWorkspaceWithInvalidArchiveAbsolutePathFail(t *testing.T) {
 	)
 }
 
-func TestWorkspaceWithTargettingModuleCommonParentDir(t *testing.T) {
+func TestWorkspaceWithTargetingModuleCommonParentDir(t *testing.T) {
 	workspaceDir := filepath.Join("testdata", "workspace", "success", "shared_parent_dir")
 	requireBuildOutputFilePaths(
 		t,

--- a/private/bufpkg/bufcas/digest.go
+++ b/private/bufpkg/bufcas/digest.go
@@ -156,7 +156,7 @@ func DigestWithDigestType(digestType DigestType) DigestOption {
 // ParseDigest parses a Digest from its string representation.
 //
 // A Digest string is of the form typeString:hexValue.
-// The string is expected to be non-empty, If not, an error is treutned.
+// The string is expected to be non-empty, If not, an error is returned.
 //
 // This reverses Digest.String().
 //

--- a/private/bufpkg/bufcheck/bufcheck.go
+++ b/private/bufpkg/bufcheck/bufcheck.go
@@ -256,7 +256,7 @@ func PrintRulesWithJSON() PrintRulesOption {
 	}
 }
 
-// PrintRulesWithDeprecated returns a new PrintRulesOption that resullts in deprecated rules  being printed.
+// PrintRulesWithDeprecated returns a new PrintRulesOption that results in deprecated rules  being printed.
 func PrintRulesWithDeprecated() PrintRulesOption {
 	return func(printRulesOptions *printRulesOptions) {
 		printRulesOptions.includeDeprecated = true

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverbuild/bufcheckserverbuild.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverbuild/bufcheckserverbuild.go
@@ -255,7 +255,7 @@ var (
 		Type:    check.RuleTypeBreaking,
 		Handler: bufcheckserverhandle.HandleBreakingFileNoDelete,
 	}
-	// BreakingFileSameCsharpNamesapceRuleSpecBuilder is a rule spec builder.
+	// BreakingFileSameCsharpNamespaceRuleSpecBuilder is a rule spec builder.
 	BreakingFileSameCsharpNamespaceRuleSpecBuilder = &bufcheckserverutil.RuleSpecBuilder{
 		ID:      "FILE_SAME_CSHARP_NAMESPACE",
 		Purpose: "Checks that files have the same value for the csharp_namespace option.",

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/buflintvalidate.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/buflintvalidate.go
@@ -22,7 +22,7 @@ import (
 )
 
 // https://buf.build/bufbuild/protovalidate/docs/v0.5.1:buf.validate#buf.validate.MessageConstraints
-const disabledFieldNumberInMesageConstraints = 1
+const disabledFieldNumberInMessageConstraints = 1
 
 // CheckMessage validates that all rules on the message are valid, and any CEL expressions compile.
 // It also checks all predefined rule extensions on the messages.
@@ -39,7 +39,7 @@ func CheckMessage(
 	if messageConstraints.GetDisabled() && len(messageConstraints.GetCel()) > 0 {
 		addAnnotationFunc(
 			message,
-			message.OptionExtensionLocation(validate.E_Message, disabledFieldNumberInMesageConstraints),
+			message.OptionExtensionLocation(validate.E_Message, disabledFieldNumberInMessageConstraints),
 			nil,
 			"Message %q has (buf.validate.message).disabled, therefore other rules in (buf.validate.message) are not applied and should be removed.",
 			message.Name(),

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
@@ -889,7 +889,7 @@ func checkExampleValues(
 					exampleValue,
 				)
 			default:
-				return syserror.Newf("expected key or value as sythetic field name for map entry's field name, got %q", fieldDescriptor.Name())
+				return syserror.Newf("expected key or value as synthetic field name for map entry's field name, got %q", fieldDescriptor.Name())
 			}
 			messageToValidate.Set(parentMapFieldDescriptor, protoreflect.ValueOfMap(mapEntry))
 		case fieldDescriptor.Enum() != nil:

--- a/private/bufpkg/bufcheck/internal/bufcheckopt/bufcheckopt.go
+++ b/private/bufpkg/bufcheck/internal/bufcheckopt/bufcheckopt.go
@@ -54,7 +54,7 @@ type OptionsSpec struct {
 	// Right now, this should just be []string{"buf:lint:ignore"}, however we do this as a proper option
 	// to maintain the client/server split we want; the server (ie the Rules) should not have the lint comment
 	// ignore strings as part of their logic, all lint comment ignore logic is a client-side concern. However,
-	// it is concievable that a COMMENT.* Rule might want to say "I don't want to consider this generic
+	// it is conceivable that a COMMENT.* Rule might want to say "I don't want to consider this generic
 	// line to be a comment", which is exclusive of the lint comment ignore logic. We could even potentially
 	// give users the ability to configure things to ignore as part of their buf.yaml configuration. So,
 	// this feels OK to expose here.

--- a/private/bufpkg/bufcheck/internal/cmd/buf-plugin-suffix/main.go
+++ b/private/bufpkg/bufcheck/internal/cmd/buf-plugin-suffix/main.go
@@ -141,7 +141,7 @@ func main() {
 				},
 				{
 					ID:      categoryAttributesSuffixesID,
-					Purpose: "Check that all fields and enum values have valid suffixes and messages and enums with specific suffixes have no chnage.",
+					Purpose: "Check that all fields and enum values have valid suffixes and messages and enums with specific suffixes have no change.",
 				},
 			},
 		},

--- a/private/bufpkg/bufcheck/rules_config.go
+++ b/private/bufpkg/bufcheck/rules_config.go
@@ -103,7 +103,7 @@ type rulesConfig struct {
 	// The Rule IDs will be sorted.
 	// This will only contain RuleIDs of the given RuleType.
 	// There will be no empty key for plugin name (which means the Rule is builtin), that is
-	// builtin rules are not accounted for as unusued.
+	// builtin rules are not accounted for as unused.
 	//
 	// This can be used for warning messages.
 	UnusedPluginNameToRuleIDs map[string][]string
@@ -128,7 +128,7 @@ func newRulesConfig(
 	if len(allRulesForType) == 0 {
 		// This can happen with i.e. disable_builtin pretty easily.
 		//
-		// We return here so that we can do some syserror checking below for expecations
+		// We return here so that we can do some syserror checking below for expectations
 		// that certain variables are non-empty at certain points.
 		return &rulesConfig{
 			RuleType:                ruleType,
@@ -411,7 +411,7 @@ func warnReferencedDeprecatedIDsForIDType(
 	The concept of a default rule has been introduced. A default rule is a rule that will be run
 	if no rules are explicitly configured in your buf.yaml. Run buf config ls-lint-rules or
 	buf config ls-breaking-rules to see which rules are defaults. With this introduction, having a category
-	also named DEFAULT is confusing, as while it happpens that all the rules in the DEFAULT category
+	also named DEFAULT is confusing, as while it happens that all the rules in the DEFAULT category
 	are also default rules, the name has become overloaded.
 `
 		}

--- a/private/bufpkg/bufcheck/runner_provider.go
+++ b/private/bufpkg/bufcheck/runner_provider.go
@@ -129,7 +129,7 @@ func (r *remoteWasmPluginRunner) loadRunnerOnce(ctx context.Context) (pluginrpc.
 		runner, err := r.loadRunner(ctx)
 		if err != nil {
 			// The error isn't stored to avoid ctx cancellation issues. On the next call,
-			// the runner will be reloaded instead of returning the erorr.
+			// the runner will be reloaded instead of returning the error.
 			return nil, err
 		}
 		r.runner = runner

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/map.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/map.proto
@@ -33,7 +33,7 @@ message MapTest {
     // key has type int64
     (buf.validate.field).map.keys.string.min_len = 1
   ];
-  map<int64, google.protobuf.Duration> value_type_mistmatch = 7 [
+  map<int64, google.protobuf.Duration> value_type_mismatch = 7 [
     (buf.validate.field).map.min_pairs = 1,
     // value has type Duration
     (buf.validate.field).map.values.string.min_len = 1

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/string.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/string.proto
@@ -138,7 +138,7 @@ message StringTest {
     (buf.validate.field).string.not_contains = "bar"
   ];
   // this is valid: for example, "foo_" contains "foo" without containing "bar_foo".
-  string not_contains_conatins_prefix = 31 [
+  string not_contains_contains_prefix = 31 [
     (buf.validate.field).string.not_contains = "bar_foo",
     (buf.validate.field).string.prefix = "foo"
   ];

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -280,7 +280,7 @@ type externalBufGenYAMLFileV1Beta1 struct {
 	Options externalGenerateManagedConfigV1Beta1  `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
-// externalGeneratePluginConfigV1Beta1 represents a single plugin conifg in a v1beta1 buf.gen.yaml file.
+// externalGeneratePluginConfigV1Beta1 represents a single plugin config in a v1beta1 buf.gen.yaml file.
 type externalGeneratePluginConfigV1Beta1 struct {
 	Name     string      `json:"name,omitempty" yaml:"name,omitempty"`
 	Out      string      `json:"out,omitempty" yaml:"out,omitempty"`
@@ -538,7 +538,7 @@ type externalManagedDisableConfigV2 struct {
 
 // externalManagedOverrideConfigV2 represents an override rule in managed mode in a v2 buf.gen.yaml file.
 type externalManagedOverrideConfigV2 struct {
-	// Exactly one of FileOpion and FieldOption must be set.
+	// Exactly one of FileOption and FieldOption must be set.
 	FileOption  string `json:"file_option,omitempty" yaml:"file_option,omitempty"`
 	FieldOption string `json:"field_option,omitempty" yaml:"field_option,omitempty"`
 	Module      string `json:"module,omitempty" yaml:"module,omitempty"`

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -1282,7 +1282,7 @@ type externalBufYAMLFileV2 struct {
 	Plugins  []externalBufYAMLFilePluginV2          `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 }
 
-// externalBufYAMLFileModuleV2 represents a single module configuation within a v2 buf.yaml file.
+// externalBufYAMLFileModuleV2 represents a single module configuration within a v2 buf.yaml file.
 type externalBufYAMLFileModuleV2 struct {
 	Path     string                                 `json:"path,omitempty" yaml:"path,omitempty"`
 	Name     string                                 `json:"name,omitempty" yaml:"name,omitempty"`
@@ -1292,7 +1292,7 @@ type externalBufYAMLFileModuleV2 struct {
 	Breaking externalBufYAMLFileBreakingV1Beta1V1V2 `json:"breaking,omitempty" yaml:"breaking,omitempty"`
 }
 
-// externalBufYAMLFileBuildV1Beta1V1 represents build configuation within a v1 or
+// externalBufYAMLFileBuildV1Beta1V1 represents build configuration within a v1 or
 // v1beta1 buf.yaml file, which have the same shape except for roots.
 type externalBufYAMLFileBuildV1Beta1V1 struct {
 	// Roots are only valid in v1beta! Validate that this is not set for v1.
@@ -1300,7 +1300,7 @@ type externalBufYAMLFileBuildV1Beta1V1 struct {
 	Excludes []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
 }
 
-// externalBufYAMLFileLintV1Beta1V1 represents lint configuation within a v1beta1 or v1
+// externalBufYAMLFileLintV1Beta1V1 represents lint configuration within a v1beta1 or v1
 // buf.yaml file, which have the same shape.
 //
 // Note that the lint and breaking ids/categories DID change between versions, make
@@ -1338,7 +1338,7 @@ func (el externalBufYAMLFileLintV1Beta1V1) isEmpty() bool {
 		!el.DisableBuiltin
 }
 
-// externalBufYAMLFileLintV2 represents lint configuation within a  v2 buf.yaml file.
+// externalBufYAMLFileLintV2 represents lint configuration within a  v2 buf.yaml file.
 //
 // Note that the lint and breaking ids/categories DID change between versions, make
 // sure to deal with this when parsing what to set as defaults, or how to interpret categories.
@@ -1372,7 +1372,7 @@ func (el externalBufYAMLFileLintV2) isEmpty() bool {
 		!el.DisableBuiltin
 }
 
-// externalBufYAMLFileBreakingV1Beta1V1V2 represents breaking configuation within a v1beta1, v1,
+// externalBufYAMLFileBreakingV1Beta1V1V2 represents breaking configuration within a v1beta1, v1,
 // or v2 buf.yaml file, which have the same shape.
 //
 // Note that the lint and breaking ids/categories DID change between versions, make

--- a/private/bufpkg/bufconfig/generate_managed_config.go
+++ b/private/bufpkg/bufconfig/generate_managed_config.go
@@ -60,7 +60,7 @@ func NewGenerateManagedConfig(
 // A ManagedDisableRule is guaranteed to specify at least one of the two aspects.
 // i.e. At least one of Path, FullName, FieldName, FileOption and
 // FieldOption is not empty. A rule can disable all options for certain files/fields,
-// disable certains options for all files/fields, or disable certain options for
+// disable certain options for all files/fields, or disable certain options for
 // certain files/fields. To disable all options for all files/fields, turn off managed mode.
 type ManagedDisableRule interface {
 	// Path returns the file path, relative to its module, to disable managed mode for.
@@ -74,7 +74,7 @@ type ManagedDisableRule interface {
 	// FileOption returns the file option to disable managed mode for. This is
 	// guaranteed to be empty if FieldName is not empty.
 	FileOption() FileOption
-	// FieldOption returns the field option to disalbe managed mode for.
+	// FieldOption returns the field option to disable managed mode for.
 	FieldOption() FieldOption
 
 	isManagedDisableRule()

--- a/private/bufpkg/bufconfig/generate_plugin_config.go
+++ b/private/bufpkg/bufconfig/generate_plugin_config.go
@@ -330,7 +330,7 @@ func newGeneratePluginConfigFromExternalV1(
 			externalConfig.Revision,
 		)
 	}
-	// At this point the plugin must be local, regardless whehter it's specified
+	// At this point the plugin must be local, regardless whether it's specified
 	// by key 'plugin' or 'name'.
 	if len(path) > 0 {
 		return newLocalGeneratePluginConfig(

--- a/private/bufpkg/bufconnect/static_token_provider.go
+++ b/private/bufpkg/bufconnect/static_token_provider.go
@@ -106,7 +106,7 @@ func newMultipleTokenProvider(tokens []string, isFromEnvVar bool) (*multipleToke
 			return nil, fmt.Errorf("invalid token: %s, token cannot contain special character `,`", token)
 		}
 		if _, ok := addressToToken[split[1]]; ok {
-			return nil, fmt.Errorf("invalid token: %s, repeated remote adddress: %s", token, split[1])
+			return nil, fmt.Errorf("invalid token: %s, repeated remote address: %s", token, split[1])
 		}
 		addressToToken[split[1]] = split[0]
 	}

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify.go
@@ -41,7 +41,7 @@ func Modify(
 			modifyJavaPackage,
 			modifyJavaStringCheckUtf8,
 			modifyObjcClassPrefix,
-			modifyOptmizeFor,
+			modifyOptimizeFor,
 			modifyPhpMetadataNamespace,
 			modifyPhpNamespace,
 			modifyRubyPackage,
@@ -205,8 +205,8 @@ func ModifyJavaStringCheckUtf8(
 	)
 }
 
-// ModifyOptmizeFor modifies the optimize_for file option.
-func ModifyOptmizeFor(
+// ModifyOptimizeFor modifies the optimize_for file option.
+func ModifyOptimizeFor(
 	image bufimage.Image,
 	config bufconfig.GenerateManagedConfig,
 	options ...ModifyOption,
@@ -214,7 +214,7 @@ func ModifyOptmizeFor(
 	return modifyImageForSingleOption(
 		image,
 		config,
-		modifyOptmizeFor,
+		modifyOptimizeFor,
 		options...,
 	)
 }

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -94,7 +94,7 @@ func TestModifyImage(t *testing.T) {
 					JavaPackage:        proto.String("com.foo.empty"),
 					// JavaStringCheckUtf8 is not modified by default
 					ObjcClassPrefix: proto.String("FEX"),
-					// OptimizeFor tries to modifiy this value to SPEED, which is already the default
+					// OptimizeFor tries to modify this value to SPEED, which is already the default
 					// Empty is a keyword in php
 					PhpMetadataNamespace: proto.String(`Foo\Empty_\GPBMetadata`),
 					PhpNamespace:         proto.String(`Foo\Empty_`),
@@ -106,7 +106,7 @@ func TestModifyImage(t *testing.T) {
 					JavaMultipleFiles:  proto.Bool(true),
 					JavaOuterClassname: proto.String("WithoutPackageProto"),
 					// JavaStringCheckUtf8 is not modified by default
-					// OptimizeFor tries to modifiy this value to SPEED, which is already the default
+					// OptimizeFor tries to modify this value to SPEED, which is already the default
 				},
 				"bar_all/with_package.proto": {
 					CcEnableArenas:       proto.Bool(true),

--- a/private/bufpkg/bufimage/bufimagemodify/file_option.go
+++ b/private/bufpkg/bufimage/bufimagemodify/file_option.go
@@ -449,7 +449,7 @@ func modifyJavaStringCheckUtf8(
 	)
 }
 
-func modifyOptmizeFor(
+func modifyOptimizeFor(
 	sweeper internal.MarkSweeper,
 	imageFile bufimage.ImageFile,
 	config bufconfig.GenerateManagedConfig,

--- a/private/bufpkg/bufimage/build_image_test.go
+++ b/private/bufpkg/bufimage/build_image_test.go
@@ -342,7 +342,7 @@ func TestModuleTargetFiles(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	testTagetImageFiles := func(t *testing.T, want []string, opaqueID ...string) {
+	testTargetImageFiles := func(t *testing.T, want []string, opaqueID ...string) {
 		targetModuleSet := moduleSet
 		if len(opaqueID) > 0 {
 			var err error
@@ -357,11 +357,11 @@ func TestModuleTargetFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, want, testGetImageFilePaths(image))
 	}
-	testTagetImageFiles(t, []string{"a.proto", "b.proto", "c.proto"})
-	testTagetImageFiles(t, []string{"a.proto", "b.proto", "c.proto"}, "buf.build/foo/a")
-	testTagetImageFiles(t, []string{"b.proto", "c.proto"}, "buf.build/foo/b")
-	testTagetImageFiles(t, []string{"c.proto"}, "buf.build/foo/c")
-	testTagetImageFiles(t, []string{"b.proto", "c.proto"}, "buf.build/foo/b", "buf.build/foo/c")
+	testTargetImageFiles(t, []string{"a.proto", "b.proto", "c.proto"})
+	testTargetImageFiles(t, []string{"a.proto", "b.proto", "c.proto"}, "buf.build/foo/a")
+	testTargetImageFiles(t, []string{"b.proto", "c.proto"}, "buf.build/foo/b")
+	testTargetImageFiles(t, []string{"c.proto"}, "buf.build/foo/c")
+	testTargetImageFiles(t, []string{"b.proto", "c.proto"}, "buf.build/foo/b", "buf.build/foo/c")
 }
 
 func testCompare(t *testing.T, relDirPath string) {

--- a/private/bufpkg/bufmodule/added_module.go
+++ b/private/bufpkg/bufmodule/added_module.go
@@ -370,7 +370,7 @@ func getUniqueSortedAddedModulesByOpaqueID(
 }
 
 // selectAddedModuleForOpaqueID selects the single addedModule that should be used for a list
-// of addedModules that all have ths same OpaqueID.
+// of addedModules that all have the same OpaqueID.
 //
 // Note from earlier, not deleting:
 //

--- a/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/uploader.go
@@ -264,7 +264,7 @@ func (a *uploader) Upload(
 
 	// A sorted slice of unique registries for the RemoteDeps.
 	remoteDepRegistries := slicesext.MapKeysToSortedSlice(
-		// A map from registry to RemoteDeps for that reigsry.
+		// A map from registry to RemoteDeps for that registry.
 		slicesext.ToValuesMap(
 			remoteDeps,
 			func(remoteDep bufmodule.RemoteDep) string {

--- a/private/bufpkg/bufmodule/bufmodulecache/base_provider.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/base_provider.go
@@ -82,7 +82,7 @@ func (p *baseProvider[K, V]) getValuesForKeys(ctx context.Context, keys []K) ([]
 	}
 	// We are getting the values again so that we retrieve the values from the cache directly.
 	// This matters for ie ModuleDatas where the storage.Bucket attached will have local paths
-	// instead of empty local paths if read from the cache. We documment NewModuleDataProvider
+	// instead of empty local paths if read from the cache. We document NewModuleDataProvider
 	// to return a ModuleDataProvider that will always have local paths for returned storage.Buckets,
 	// if the cache is an on-disk cache.
 	var delegateNotFoundKeys []K

--- a/private/bufpkg/bufmodule/commit.go
+++ b/private/bufpkg/bufmodule/commit.go
@@ -77,7 +77,7 @@ func newCommit(
 		// We need to preserve this, as if we do not, the new value for moduleKey
 		// will end up recursively calling itself when moduleKey.Digest() is called
 		// in the anonymous function. We could just extract moduleKeyDigestFunc := moduleKey.Digest
-		// and call that, but we make a variable to reference the original ModuleKey just for constency.
+		// and call that, but we make a variable to reference the original ModuleKey just for consistency.
 		originalModuleKey := moduleKey
 		moduleKey = newModuleKeyNoValidate(
 			originalModuleKey.FullName(),

--- a/private/bufpkg/bufmodule/file_type.go
+++ b/private/bufpkg/bufmodule/file_type.go
@@ -74,7 +74,7 @@ func ParseFileType(s string) (FileType, error) {
 // .proto file, license file, or documentation file.
 //
 // Note that license and documentation files must be at the root, and cannot be in subdirectories. That is,
-// subdir/LICENSE will not be classified as a FileTypeLicnese, but LICENSE will be.
+// subdir/LICENSE will not be classified as a FileTypeLicense, but LICENSE will be.
 func FileTypeForPath(path string) (FileType, error) {
 	if normalpath.Ext(path) == ".proto" {
 		return FileTypeProto, nil

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -152,12 +152,12 @@ type Module interface {
 	// Modules are either local or remote.
 	//
 	// A local Module is one which was built from sources from the "local context", such
-	// a Workspace containing Modules, or a ModuleNode in a CreateCommiteRequest. Local
+	// a Workspace containing Modules, or a ModuleNode in a CreateCommitRequest. Local
 	// Modules are important for understanding what Modules to push, and what modules to
 	// check declared dependencies for unused dependencies.
 	//
 	// A remote Module is one which was not contained in the local context, such as
-	// dependencies specified in a buf.lock (with no correspoding Module in the Workspace),
+	// dependencies specified in a buf.lock (with no corresponding Module in the Workspace),
 	// or a DepNode in a CreateCommitRequest with no corresponding ModuleNode.
 	//
 	// Remote Modules will always have FullNames.

--- a/private/bufpkg/bufmodule/module_dep.go
+++ b/private/bufpkg/bufmodule/module_dep.go
@@ -35,7 +35,7 @@ type ModuleDep interface {
 
 	// Parent returns the Module that this ModuleDep is a dependency of.
 	//
-	// Note this is not recursive - this points ot the top-level Module that dependencies
+	// Note this is not recursive - this points of the top-level Module that dependencies
 	// were created for. That is, if a -> b -> c, then a will have ModuleDeps b and c, both
 	// of which have a as a parent.
 	Parent() Module

--- a/private/bufpkg/bufmodule/module_read_bucket.go
+++ b/private/bufpkg/bufmodule/module_read_bucket.go
@@ -362,7 +362,7 @@ func (b *moduleReadBucket) WalkFileInfos(
 	if !walkFileInfosOptions.onlyTargetFiles {
 		// We only want to call trackModule if we are walking all the files, not just
 		// the target files. By not calling trackModule outside of this if statement,
-		// we will not produce NoProtoFilesErrors, per the documention on trackModule.
+		// we will not produce NoProtoFilesErrors, per the documentation on trackModule.
 		protoFileTracker.trackModule(b.module)
 		if err := bucket.Walk(
 			ctx,

--- a/private/bufpkg/bufmodule/module_set.go
+++ b/private/bufpkg/bufmodule/module_set.go
@@ -188,7 +188,7 @@ func ModuleSetTargetOpaqueIDs(moduleSet ModuleSet) []string {
 	return modulesOpaqueIDs(ModuleSetTargetModules(moduleSet))
 }
 
-// ModuleSetNonTargetOpaqueIDs is a conenience function that returns a slice of the OpaqueIDs of the
+// ModuleSetNonTargetOpaqueIDs is a convenience function that returns a slice of the OpaqueIDs of the
 // non-target Modules in the ModuleSet.
 //
 // Sorted.
@@ -196,7 +196,7 @@ func ModuleSetNonTargetOpaqueIDs(moduleSet ModuleSet) []string {
 	return modulesOpaqueIDs(ModuleSetNonTargetModules(moduleSet))
 }
 
-// ModuleSetLocalOpaqueIDs is a conenience function that returns a slice of the OpaqueIDs of the
+// ModuleSetLocalOpaqueIDs is a convenience function that returns a slice of the OpaqueIDs of the
 // local Modules in the ModuleSet.
 //
 // Sorted.
@@ -204,7 +204,7 @@ func ModuleSetLocalOpaqueIDs(moduleSet ModuleSet) []string {
 	return modulesOpaqueIDs(ModuleSetLocalModules(moduleSet))
 }
 
-// ModuleSetRemoteOpaqueIDs is a conenience function that returns a slice of the OpaqueIDs of the
+// ModuleSetRemoteOpaqueIDs is a convenience function that returns a slice of the OpaqueIDs of the
 // remote Modules in the ModuleSet.
 //
 // Sorted.

--- a/private/bufpkg/bufmodule/module_set_builder.go
+++ b/private/bufpkg/bufmodule/module_set_builder.go
@@ -44,12 +44,12 @@ var (
 // Modules are also either local or remote.
 //
 // A local Module is one which was built from sources from the "local context", such
-// a Workspace containing Modules, or a ModuleNode in a CreateCommiteRequest. Local
+// a Workspace containing Modules, or a ModuleNode in a CreateCommitRequest. Local
 // Modules are important for understanding what Modules to push, and what modules to
 // check declared dependencies for unused dependencies.
 //
 // A remote Module is one which was not contained in the local context, such as
-// dependencies specified in a buf.lock (with no correspoding Module in the Workspace),
+// dependencies specified in a buf.lock (with no corresponding Module in the Workspace),
 // or a DepNode in a CreateCommitRequest with no corresponding ModuleNode. A module
 // retrieved from a ModuleDataProvider via a ModuleKey is always remote.
 type ModuleSetBuilder interface {

--- a/private/bufpkg/bufmodule/uploader.go
+++ b/private/bufpkg/bufmodule/uploader.go
@@ -100,7 +100,7 @@ type UploadOptions interface {
 	// Will always be present if CreateIfNotExist() is true.
 	CreateModuleVisibility() ModuleVisibility
 	// CreateDefaultLabel returns the default label to create Modules with. If this is an
-	// emptry string, then the Modules will be created with default label "main".
+	// empty string, then the Modules will be created with default label "main".
 	CreateDefaultLabel() string
 	// Tags returns unique and sorted set of tags to be added as labels.
 	// Tags are set using the `--tag` flag when calling `buf push`, and represent labels

--- a/private/bufpkg/bufparse/ref.go
+++ b/private/bufpkg/bufparse/ref.go
@@ -38,7 +38,7 @@ type Ref interface {
 	isRef()
 }
 
-// NewRef returns a new Ref for the given compoonents.
+// NewRef returns a new Ref for the given components.
 func NewRef(
 	registry string,
 	owner string,

--- a/private/bufpkg/bufplugin/plugin_data.go
+++ b/private/bufpkg/bufplugin/plugin_data.go
@@ -29,7 +29,7 @@ import (
 //
 // Tamper-proofing is done as part of every function.
 type PluginData interface {
-	// PluginKey used to downoad this PluginData.
+	// PluginKey used to download this PluginData.
 	//
 	// The Digest from this PluginKey is used for tamper-proofing. It will be checked
 	// against the actual data downloaded before Data() returns.

--- a/private/bufpkg/bufplugin/plugin_key.go
+++ b/private/bufpkg/bufplugin/plugin_key.go
@@ -60,7 +60,7 @@ type PluginKey interface {
 // NewPluginKey returns a new PluginKey.
 //
 // The Digest will be loaded lazily if needed. Note this means that NewPluginKey does
-// *not* validate the digest. If you need to validate the digset, call Digest() and evaluate
+// *not* validate the digest. If you need to validate the digest, call Digest() and evaluate
 // the returned error.
 func NewPluginKey(
 	pluginFullName bufparse.FullName,

--- a/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer.go
+++ b/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer.go
@@ -126,7 +126,7 @@ func (w *responseWriter) Close() error {
 			// whereas others aren't.
 			//
 			// Regardless, we stop at the first error so that
-			// we don't unncessarily write more results.
+			// we don't unnecessarily write more results.
 			return err
 		}
 	}

--- a/private/bufpkg/bufprotoplugin/response_writer.go
+++ b/private/bufpkg/bufprotoplugin/response_writer.go
@@ -68,7 +68,7 @@ func (h *responseWriter) WriteResponse(
 	return nil
 }
 
-// applyInsertionPoint inserts the content of the given file at the insertion point that it specfiies.
+// applyInsertionPoint inserts the content of the given file at the insertion point that it specifies.
 // For more details on insertion points, see the following:
 //
 // https://github.com/protocolbuffers/protobuf/blob/f5bdd7cd56aa86612e166706ed8ef139db06edf2/src/google/protobuf/compiler/plugin.proto#L135-L171

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/doc.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/doc.pb.go
@@ -1094,7 +1094,7 @@ func (b0 GetPackageDocumentationRequest_builder) Build() *GetPackageDocumentatio
 	return m0
 }
 
-// GetPackageDocumentationReponse returns the documentation for the requested package.
+// GetPackageDocumentationResponse returns the documentation for the requested package.
 type GetPackageDocumentationResponse struct {
 	state                           protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_PackageDocumentation *PackageDocumentation  `protobuf:"bytes,1,opt,name=package_documentation,json=packageDocumentation,proto3" json:"package_documentation,omitempty"`
@@ -3546,7 +3546,7 @@ type Field_builder struct {
 	// It contains all the metadata for the import.
 	ImportModuleRef *ImportModuleRef
 	// Extendee is the name of the type that is being ext if the field is an extension.
-	// This is an empty string for fields that are not extenions.
+	// This is an empty string for fields that are not extensions.
 	Extendee string
 	// All options that are present on the field. This is a super-set of
 	// field_options and uses a dynamic representation so it can also

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/schema.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/schema.pb.go
@@ -781,7 +781,7 @@ func (x *JSONOutputOptions) SetIncludeDefaults(v bool) {
 type JSONOutputOptions_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// Enum fields will be emitted as numeric values. If false (the dafault), enum
+	// Enum fields will be emitted as numeric values. If false (the default), enum
 	// fields are emitted as strings that are the enum values' names.
 	UseEnumNumbers bool
 	// Includes fields that have their default values. This applies only to fields

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/user.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/user.pb.go
@@ -502,7 +502,7 @@ func (x *UserPluginPreference) SetSelectedPlugins(v []string) {
 type UserPluginPreference_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// The language that the user has indicidated as their preferred language for plugins.
+	// The language that the user has indicated as their preferred language for plugins.
 	SelectedLanguage PluginLanguage
 	// A list of plugin names selected by the user.
 	SelectedPlugins []string

--- a/private/pkg/app/app.go
+++ b/private/pkg/app/app.go
@@ -108,7 +108,7 @@ func NewStdoutContainer(writer io.Writer) StdoutContainer {
 	return newStdoutContainer(writer)
 }
 
-// NewStdoutContainerForOS returns a new StdoutContainer for the operatoutg system.
+// NewStdoutContainerForOS returns a new StdoutContainer for the operating system.
 func NewStdoutContainerForOS() StdoutContainer {
 	return newStdoutContainer(os.Stdout)
 }
@@ -126,7 +126,7 @@ func NewStderrContainer(writer io.Writer) StderrContainer {
 	return newStderrContainer(writer)
 }
 
-// NewStderrContainerForOS returns a new StderrContainer for the operaterrg system.
+// NewStderrContainerForOS returns a new StderrContainer for the operating system.
 func NewStderrContainerForOS() StderrContainer {
 	return newStderrContainer(os.Stderr)
 }

--- a/private/pkg/bandeps/bandeps.go
+++ b/private/pkg/bandeps/bandeps.go
@@ -47,12 +47,12 @@ type Violation interface {
 	key() string
 }
 
-// ExternalConfig is an external configuation.
+// ExternalConfig is an external configuration.
 type ExternalConfig struct {
 	Bans []ExternalBanConfig `json:"bans,omitempty" yaml:"bans,omitempty"`
 }
 
-// ExternalConfig is an external ban configuation.
+// ExternalConfig is an external ban configuration.
 type ExternalBanConfig struct {
 	// Packages are the package expressions to get dependencies for.
 	Packages ExternalPackageConfig `json:"packages,omitempty" yaml:"packages,omitempty"`

--- a/private/pkg/git/git.go
+++ b/private/pkg/git/git.go
@@ -37,7 +37,7 @@ const (
 	gitCommand      = "git"
 	tagsPrefix      = "refs/tags/"
 	headsPrefix     = "refs/heads/"
-	psuedoRefSuffix = "^{}"
+	pseudoRefSuffix = "^{}"
 )
 
 var (
@@ -341,7 +341,7 @@ func GetRefsForGitCommitAndRemote(
 			ref = strings.TrimSpace(ref)
 			if tag, isTag := strings.CutPrefix(ref, tagsPrefix); isTag {
 				// Remove the ^{} suffix for pseudo-ref tags
-				tag, _ = strings.CutSuffix(tag, psuedoRefSuffix)
+				tag, _ = strings.CutSuffix(tag, pseudoRefSuffix)
 				refs = append(refs, tag)
 				continue
 			}

--- a/private/pkg/indent/indent.go
+++ b/private/pkg/indent/indent.go
@@ -36,7 +36,7 @@ type Printer interface {
 	In()
 	// Out unindents by one.
 	Out()
-	// String gets the resulting string represntation.
+	// String gets the resulting string representation.
 	//
 	// Returns error if there was an error during printing.
 	String() (string, error)

--- a/private/pkg/normalpath/normalpath.go
+++ b/private/pkg/normalpath/normalpath.go
@@ -349,7 +349,7 @@ func ValidatePathComponents(components ...string) error {
 	return nil
 }
 
-// ValidatePathsNormalizedValidatedUnique validates the file or diretory paths are normalized
+// ValidatePathsNormalizedValidatedUnique validates the file or directory paths are normalized
 // and validated, and not duplicated.
 func ValidatePathsNormalizedValidatedUnique(paths []string) error {
 	pathMap := make(map[string]struct{}, len(paths))

--- a/private/pkg/oauth2/device.go
+++ b/private/pkg/oauth2/device.go
@@ -58,7 +58,7 @@ type DeviceRegistrationRequest struct {
 	ClientName string `json:"client_name"`
 }
 
-// Devic describes a successful OpenID Connect Dynamic Client Registration 1.0 response
+// Device describes a successful OpenID Connect Dynamic Client Registration 1.0 response
 // for dynamic client registration.
 type DeviceRegistrationResponse struct {
 	// ClientID is the unique client identifier.
@@ -161,7 +161,7 @@ type DeviceAccessTokenResponse struct {
 	TokenType string `json:"token_type"`
 	// ExpiresIn is the lifetime in seconds of the access token.
 	ExpiresIn int `json:"expires_in,omitempty"`
-	// RefreshToken may be used to obtain new access tokens using the same authoization
+	// RefreshToken may be used to obtain new access tokens using the same authorization
 	// grant. May be empty.
 	RefreshToken string `json:"refresh_token,omitempty"`
 	// Scope is the scope of the access token as described in RFC 6749 Section 3.3.

--- a/private/pkg/protogenutil/protogenutil.go
+++ b/private/pkg/protogenutil/protogenutil.go
@@ -231,7 +231,7 @@ func (g *GoPackageFileSet) Services() []*protogen.Service {
 // NamedHelper is a helper to deal with named golang plugins.
 //
 // Named plugins should be named in the form protoc-gen-go-foobar, where the plugin
-// name is consiered to be "foobar". The plugin name must be lowercase.
+// name is considered to be "foobar". The plugin name must be lowercase.
 type NamedHelper interface {
 	// NewGoPackageName gets the helper GoPackageName for the pluginName.
 	NewGoPackageName(

--- a/private/pkg/protosourcepath/message.go
+++ b/private/pkg/protosourcepath/message.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	messageNameTypeTag                 = int32(1)
-	mesasgeFieldsTypeTag               = int32(2)
+	messageFieldsTypeTag               = int32(2)
 	nestedMessagesTypeTag              = int32(3)
 	nestedEnumsTypeTag                 = int32(4)
 	messageOneOfsTypeTag               = int32(8)
@@ -77,7 +77,7 @@ func message(token int32, fullSourcePath protoreflect.SourcePath, index int, _ b
 	case messageNameTypeTag:
 		// The path for message name has already been added, can terminate here immediately.
 		return nil, nil, nil
-	case mesasgeFieldsTypeTag:
+	case messageFieldsTypeTag:
 		// We check to make sure that the length of the source path contains at least the current
 		// token and an index. This is because all source paths for fields are expected
 		// to have indices.

--- a/private/pkg/protosourcepath/service.go
+++ b/private/pkg/protosourcepath/service.go
@@ -53,7 +53,7 @@ func services(
 func service(token int32, fullSourcePath protoreflect.SourcePath, index int, _ bool) (state, []protoreflect.SourcePath, error) {
 	switch token {
 	case serviceNameTypeTag:
-		// The path for service name has already been added, can termiante here immediately.
+		// The path for service name has already been added, can terminate here immediately.
 		return nil, nil, nil
 	case serviceMethodsTypeTag:
 		// We check to make sure that the length of the source path contains at least the current

--- a/private/pkg/protoversion/protoversion.go
+++ b/private/pkg/protoversion/protoversion.go
@@ -92,7 +92,7 @@ func NewPackageVersionForPackage(pkg string, options ...PackageVersionOption) (P
 	return newPackageVersionForPackage(pkg, options...)
 }
 
-// NewPackageVersionForCompoonent returns the PackageVersion for the package component.
+// NewPackageVersionForComponent returns the PackageVersion for the package component.
 //
 // Returns false if the component is not a package version per the specifications.
 // That is, the component "v1beta1" will return true, while the component "foo" will return false.

--- a/private/pkg/storage/map.go
+++ b/private/pkg/storage/map.go
@@ -316,17 +316,17 @@ func replaceReadObjectCloserPath(readObjectCloser ReadObjectCloser, path string)
 }
 
 func replaceWriteObjectCloserExternalAndLocalPathsNotSupported(writeObjectCloser WriteObjectCloser) WriteObjectCloser {
-	return writeObjectCloserExternalAndLocalPathsNotSuppoted{writeObjectCloser}
+	return writeObjectCloserExternalAndLocalPathsNotSupported{writeObjectCloser}
 }
 
-type writeObjectCloserExternalAndLocalPathsNotSuppoted struct {
+type writeObjectCloserExternalAndLocalPathsNotSupported struct {
 	io.WriteCloser
 }
 
-func (writeObjectCloserExternalAndLocalPathsNotSuppoted) SetExternalPath(string) error {
+func (writeObjectCloserExternalAndLocalPathsNotSupported) SetExternalPath(string) error {
 	return ErrSetExternalPathUnsupported
 }
 
-func (writeObjectCloserExternalAndLocalPathsNotSuppoted) SetLocalPath(string) error {
+func (writeObjectCloserExternalAndLocalPathsNotSupported) SetLocalPath(string) error {
 	return ErrSetLocalPathUnsupported
 }

--- a/private/pkg/storage/storageutil/storageutil.go
+++ b/private/pkg/storage/storageutil/storageutil.go
@@ -25,7 +25,7 @@ import (
 
 // ObjectInfo is an embeddable ObjectInfo.
 //
-// This is intentially static and should not be modifiable.
+// This is intentionally static and should not be modifiable.
 // If constructing an object, do not use an ObjectInfo to build it.
 type ObjectInfo struct {
 	path         string

--- a/private/pkg/storage/util.go
+++ b/private/pkg/storage/util.go
@@ -28,7 +28,7 @@ var errIsNotEmpty = errors.New("__is_not_empty__")
 
 // ReadPath is analogous to os.ReadFile.
 //
-// Returns an error that fufills IsNotExist if the path does not exist.
+// Returns an error that fulfills IsNotExist if the path does not exist.
 func ReadPath(ctx context.Context, readBucket ReadBucket, path string) (_ []byte, retErr error) {
 	readObject, err := readBucket.Get(ctx, path)
 	if err != nil {

--- a/private/pkg/syserror/syserror.go
+++ b/private/pkg/syserror/syserror.go
@@ -15,7 +15,7 @@
 // Package syserror handles "system errors".
 //
 // A system error is an error that should never actually happen, and should be
-// propogated to the user as a bug in the codebase. System errors are generally
+// propagated to the user as a bug in the codebase. System errors are generally
 // defensive-programming assertions that we want to check for in our codebase.
 //
 // If a system error occurs, you may want to send a specialized help that says

--- a/private/pkg/thread/thread.go
+++ b/private/pkg/thread/thread.go
@@ -26,7 +26,7 @@ var (
 	globalLock        sync.RWMutex
 )
 
-// Parallelism returns the current parellism.
+// Parallelism returns the current parallelism.
 //
 // This defaults to the number of CPUs.
 func Parallelism() int {

--- a/private/pkg/wasm/runtime.go
+++ b/private/pkg/wasm/runtime.go
@@ -46,7 +46,7 @@ func newRuntime(ctx context.Context, options ...RuntimeOption) (*runtime, error)
 	}
 	// The maximum memory size is limited to 4 GiB. Sizes less than the page
 	// size (64 KiB) are truncated. memoryLimitPages is guaranteed to be
-	// below 2^16 as the maxium uint32 value is 2^32 - 1.
+	// below 2^16 as the maximum uint32 value is 2^32 - 1.
 	// NOTE: The option represented as a uint32 restricts the max number of
 	// pages to 2^16-1, one less the the actual max value of 2^16. But this
 	// is a nicer API then specifying the max number of pages directly.

--- a/proto/buf/alpha/registry/v1alpha1/authn.proto
+++ b/proto/buf/alpha/registry/v1alpha1/authn.proto
@@ -18,7 +18,7 @@ package buf.alpha.registry.v1alpha1;
 
 import "buf/alpha/registry/v1alpha1/user.proto";
 
-// AuthnService supplies authenication helpers.
+// AuthnService supplies authentication helpers.
 service AuthnService {
   // GetCurrentUser gets information associated with the current user.
   //

--- a/proto/buf/alpha/registry/v1alpha1/doc.proto
+++ b/proto/buf/alpha/registry/v1alpha1/doc.proto
@@ -150,7 +150,7 @@ message GetPackageDocumentationRequest {
   string package_name = 4;
 }
 
-// GetPackageDocumentationReponse returns the documentation for the requested package.
+// GetPackageDocumentationResponse returns the documentation for the requested package.
 message GetPackageDocumentationResponse {
   PackageDocumentation package_documentation = 1;
 }
@@ -406,7 +406,7 @@ message Field {
   // It contains all the metadata for the import.
   ImportModuleRef import_module_ref = 8;
   // Extendee is the name of the type that is being ext if the field is an extension.
-  // This is an empty string for fields that are not extenions.
+  // This is an empty string for fields that are not extensions.
   string extendee = 9;
   // All options that are present on the field. This is a super-set of
   // field_options and uses a dynamic representation so it can also

--- a/proto/buf/alpha/registry/v1alpha1/schema.proto
+++ b/proto/buf/alpha/registry/v1alpha1/schema.proto
@@ -149,7 +149,7 @@ enum Format {
 message BinaryOutputOptions {}
 
 message JSONOutputOptions {
-  // Enum fields will be emitted as numeric values. If false (the dafault), enum
+  // Enum fields will be emitted as numeric values. If false (the default), enum
   // fields are emitted as strings that are the enum values' names.
   bool use_enum_numbers = 3;
   // Includes fields that have their default values. This applies only to fields

--- a/proto/buf/alpha/registry/v1alpha1/user.proto
+++ b/proto/buf/alpha/registry/v1alpha1/user.proto
@@ -61,7 +61,7 @@ message OrganizationUser {
 message UserPluginPreference {
   reserved 1;
   reserved "user_id";
-  // The language that the user has indicidated as their preferred language for plugins.
+  // The language that the user has indicated as their preferred language for plugins.
   PluginLanguage selected_language = 2;
   // A list of plugin names selected by the user.
   repeated string selected_plugins = 3;


### PR DESCRIPTION
Fix all typos found with the help of https://github.com/crate-ci/typos, also added a `_typos.yaml` with appropriate exclusions. 

If you like this, the typos check can also be added to GH Actions with: https://github.com/crate-ci/typos/blob/master/docs/github-action.md