### PR TITLE
CI trigger test runs on pull requests events

### DIFF
--- a/.github/workflows/buf-binary-size.yaml
+++ b/.github/workflows/buf-binary-size.yaml
@@ -1,5 +1,9 @@
 name: binary-size
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: ci
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all

--- a/.github/workflows/previous.yaml
+++ b/.github/workflows/previous.yaml
@@ -1,5 +1,9 @@
 name: previous
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,5 +1,9 @@
 name: windows
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all


### PR DESCRIPTION
This changes CI tests to trigger on [pull requests events](https://github.com/bufbuild/buf/pull/new/ed/ciOnPREvents), or when pushed to main. This has the following benefits:
- tests are run on the merged state of the target branch so can capture conflicting changes earlier
- forks from third party contributors will now have tests run as part of the PR workflow
- on merge, changes will still be tested on main