### PR TITLE
Replace `golang.org/x/exp` with stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	go.uber.org/zap v1.27.0
 	go.uber.org/zap/exp v0.3.0
 	golang.org/x/crypto v0.32.0
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/mod v0.22.0
 	golang.org/x/net v0.34.0
 	golang.org/x/sync v0.10.0
@@ -122,6 +121,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250124145028-65684f501c47 // indirect

--- a/private/buf/bufwkt/cmd/wkt-go-data/main.go
+++ b/private/buf/bufwkt/cmd/wkt-go-data/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -24,8 +25,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/constraints"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufanalysis"
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
@@ -400,7 +399,7 @@ type keyValPair[K any, V any] struct {
 	val V
 }
 
-func sortedPairs[K constraints.Ordered, V any](m map[K]V) []keyValPair[K, V] {
+func sortedPairs[K cmp.Ordered, V any](m map[K]V) []keyValPair[K, V] {
 	ret := make([]keyValPair[K, V], 0, len(m))
 	for key := range m {
 		ret = append(ret, keyValPair[K, V]{key: key, val: m[key]})

--- a/private/bufpkg/bufimage/bufimagemodify/internal/field_options_trie.go
+++ b/private/bufpkg/bufimage/bufimagemodify/internal/field_options_trie.go
@@ -15,9 +15,8 @@
 package internal
 
 import (
+	"slices"
 	"sort"
-
-	"golang.org/x/exp/slices"
 )
 
 // fieldOptionsTrie stores paths to FieldOptions (tag 8 of a FieldDescriptorProto).


### PR DESCRIPTION
The experimental functions in `golang.org/x/exp` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#slices
Reference: https://go.dev/doc/go1.21#cmp