### PR TITLE
Fix outdated comment

### DIFF
--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -414,7 +414,7 @@ func validateLabelFlagValues(flags *flags) error {
 	return nil
 }
 
-// We do not allow users to set --source-control-url, --create-default-label, and --label
+// We do not allow users to set --tag, --branch, and --draft
 // flags if the --git-metadata flag is set.
 func validateGitMetadataFlags(flags *flags) error {
 	if flags.GitMetadata {


### PR DESCRIPTION
This comment is out of sync with the implementation.

Do we also need to check short flag names separately (like `-t`) or is that already handled?