### PR TITLE
Clean up godoc comments

### DIFF
--- a/private/buf/bufcli/cache.go
+++ b/private/buf/bufcli/cache.go
@@ -281,7 +281,7 @@ func newPluginDataProvider(
 	if err != nil {
 		return nil, err
 	}
-	delegateModuleDataProvider := bufpluginapi.NewPluingDataProvider(
+	delegateModuleDataProvider := bufpluginapi.NewPluginDataProvider(
 		container.Logger(),
 		pluginClientProvider,
 	)

--- a/private/buf/bufcli/flags_args.go
+++ b/private/buf/bufcli/flags_args.go
@@ -179,7 +179,7 @@ func BindArchiveStatus(flagSet *pflag.FlagSet, addr *string, flagName string) {
 	)
 }
 
-// Binds a string pointer flag, which indicates flag presence, i.e. `--flag ""` is not the same as not passing the flag.
+// BindStringPointer binds a string pointer flag, which indicates flag presence, i.e. `--flag ""` is not the same as not passing the flag.
 //
 // This is useful for buf registry organization/module update, where we only modify the fields specified.
 //

--- a/private/buf/buffetch/buffetch.go
+++ b/private/buf/buffetch/buffetch.go
@@ -71,7 +71,7 @@ var (
 	//
 	// This does not include deprecated formats.
 	SourceOrModuleFormatsString = stringutil.SliceToString(sourceOrModuleFormatsNotDeprecated)
-	// DirOrProtoFileFormats is the string representation of all dir or proto file formats.
+	// DirOrProtoFileFormatsString is the string representation of all dir or proto file formats.
 	//
 	// This does not include deprecated formats.
 	DirOrProtoFileFormatsString = stringutil.SliceToString(dirOrProtoFileFormats)
@@ -146,7 +146,7 @@ type ProtoFileRef interface {
 	SourceRef
 	DirOrProtoFileRef
 	ProtoFilePath() string
-	// True if the FileScheme is Stdio, Stdout, Stdin, or Null.
+	// IsDevPath returns true if the FileScheme is Stdio, Stdout, Stdin, or Null.
 	IsDevPath() bool
 	IncludePackageFiles() bool
 	internalProtoFileRef() internal.ProtoFileRef
@@ -167,7 +167,7 @@ type MessageRefParser interface {
 type SourceRefParser interface {
 	// GetSourceRef gets the reference for the source file.
 	GetSourceRef(ctx context.Context, value string) (SourceRef, error)
-	// GetSourceRef gets the reference for the source file.
+	// GetSourceRefForInputConfig gets the reference for the source file.
 	GetSourceRefForInputConfig(
 		ctx context.Context,
 		inputConfig bufconfig.InputConfig,
@@ -233,8 +233,8 @@ type RefParser interface {
 	DirRefParser
 	SourceOrModuleRefParser
 
-	// TODO FUTURE: should this be renamed to GetRefForString?
 	// GetRef gets the reference for the message file, source bucket, or module.
+	// TODO FUTURE: should this be renamed to GetRefForString?
 	GetRef(ctx context.Context, value string) (Ref, error)
 	// GetRefForInputConfig gets the reference for the message file, source bucket, or module.
 	GetRefForInputConfig(ctx context.Context, inputConfig bufconfig.InputConfig) (Ref, error)
@@ -328,7 +328,7 @@ type SourceReader interface {
 // GetReadBucketCloserOption is an option for a GetSourceReadBucketCloser call.
 type GetReadBucketCloserOption func(*getReadBucketCloserOptions)
 
-// GetReadBucketCloserCopyToInMemory says to copy the returned ReadBucketCloser to an
+// GetReadBucketCloserWithCopyToInMemory says to copy the returned ReadBucketCloser to an
 // in-memory ReadBucketCloser. This can be a performance optimization at the expense of memory.
 func GetReadBucketCloserWithCopyToInMemory() GetReadBucketCloserOption {
 	return func(getReadBucketCloserOptions *getReadBucketCloserOptions) {

--- a/private/buf/buffetch/internal/internal.go
+++ b/private/buf/buffetch/internal/internal.go
@@ -511,7 +511,7 @@ type ProtoFileWriter interface {
 	) (io.WriteCloser, error)
 }
 
-// NewProtoWriter returns a new ProtoWriter.
+// NewProtoFileWriter returns a new ProtoFileWriter.
 func NewProtoFileWriter(
 	logger *slog.Logger,
 ) ProtoFileWriter {
@@ -820,7 +820,7 @@ func WithGetFileKeepFileCompression() GetFileOption {
 // GetReadBucketCloserOption is a GetReadBucketCloser option.
 type GetReadBucketCloserOption func(*getReadBucketCloserOptions)
 
-// WithGetBucketCopyToInMemory says to copy the returned ReadBucketCloser to an
+// WithGetReadBucketCloserCopyToInMemory says to copy the returned ReadBucketCloser to an
 // in-memory ReadBucket. This can be a performance optimization at the expense of memory.
 func WithGetReadBucketCloserCopyToInMemory() GetReadBucketCloserOption {
 	return func(getReadBucketCloserOptions *getReadBucketCloserOptions) {

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -175,7 +175,7 @@ func (f *file) Update(ctx context.Context, version int32, text string) {
 	f.hasText = true
 }
 
-// FetchSettings refreshes configuration settings for this file.
+// RefreshSettings refreshes configuration settings for this file.
 //
 // This only needs to happen when the file is open or when the client signals
 // that configuration settings have changed.

--- a/private/buf/buflsp/report.go
+++ b/private/buf/buflsp/report.go
@@ -37,7 +37,7 @@ func (r *report) Error(err reporter.ErrorWithPos) error {
 	return nil
 }
 
-// Error implements reporter.Handler for *diagnostics.
+// Warning implements reporter.Handler for *diagnostics.
 func (r *report) Warning(err reporter.ErrorWithPos) {
 	r.diagnostics = append(r.diagnostics, newDiagnostic(err, true))
 

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -216,7 +216,7 @@ func (s *server) DidOpen(
 	return nil
 }
 
-// DidOpen is called whenever the client opens a document. This is our signal to parse
+// DidChange is called whenever the client opens a document. This is our signal to parse
 // the file.
 func (s *server) DidChange(
 	ctx context.Context,
@@ -320,8 +320,7 @@ func (s *server) Formatting(
 	}, nil
 }
 
-// DidOpen is called whenever the client opens a document. This is our signal to parse
-// the file.
+// DidClose is called whenever the client closes a document.
 func (s *server) DidClose(
 	ctx context.Context,
 	params *protocol.DidCloseTextDocumentParams,
@@ -332,7 +331,7 @@ func (s *server) DidClose(
 
 // -- Language functionality methods.
 
-// Definition is the entry point for hover inlays.
+// Hover is the entry point for hover inlays.
 func (s *server) Hover(
 	ctx context.Context,
 	params *protocol.HoverParams,

--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -149,7 +149,7 @@ func (s *symbol) ReferencePath() (path []string, absolute bool) {
 	return
 }
 
-// Resolve attempts to resolve an unresolved reference across fileManager.
+// ResolveCrossFile attempts to resolve an unresolved reference across fileManager.
 func (s *symbol) ResolveCrossFile(ctx context.Context) {
 	switch kind := s.kind.(type) {
 	case *definition:

--- a/private/buf/bufworkspace/option.go
+++ b/private/buf/bufworkspace/option.go
@@ -29,7 +29,7 @@ type WorkspaceModuleKeyOption interface {
 	applyToWorkspaceModuleKeyConfig(*workspaceModuleKeyConfig)
 }
 
-// WorkspaceOption is an option for a new Workspace created by either a Bucket or ModuleKey.
+// WorkspaceBucketAndModuleKeyOption is an option for a new Workspace created by either a Bucket or ModuleKey.
 type WorkspaceBucketAndModuleKeyOption interface {
 	WorkspaceBucketOption
 	WorkspaceModuleKeyOption
@@ -89,7 +89,7 @@ func WithTargetPaths(targetPaths []string, targetExcludePaths []string) Workspac
 // This flag will only work if no buf.work.yaml is detected, and the buf.yaml is a v1beta1
 // buf.yaml, v1 buf.yaml, or no buf.yaml. This flag will not work if a buf.work.yaml is
 // detected, or a v2 buf.yaml is detected.
-
+//
 // If used with NewWorkspaceForModuleKey, this has no effect on the build,
 // i.e. excludes are not respected, and the module name is ignored. This matches old behavior.
 //

--- a/private/buf/bufworkspace/workspace_dep_manager_provider.go
+++ b/private/buf/bufworkspace/workspace_dep_manager_provider.go
@@ -25,7 +25,7 @@ import (
 
 // WorkspaceDepManagerProvider provides WorkspaceDepManagers.
 type WorkspaceDepManagerProvider interface {
-	// GetWorkspaceDepManagerForBucket returns a new WorkspaceDepManager for the given Bucket.
+	// GetWorkspaceDepManager returns a new WorkspaceDepManager for the given Bucket.
 	//
 	// If the workspace is not updateable, an error is returned.
 	//
@@ -34,7 +34,7 @@ type WorkspaceDepManagerProvider interface {
 	//
 	// Otherwise, this builds a Workspace with a single module at the TargetSubDirPath (which may be "."), ignoring buf.work.yamls.
 	// Directories with buf.work.yamls cannot be directly targeted.
-
+	//
 	// Note this is the same logic as if WithIgnoreAndDisallowV1BufWorkYAMLs is applied with WorkspaceProvider!! If you want an equivalent
 	// Workspace, you need to use this option!
 	//

--- a/private/buf/cmd/buf/command/beta/internal/internal.go
+++ b/private/buf/cmd/buf/command/beta/internal/internal.go
@@ -25,7 +25,7 @@ import (
 	"pluginrpc.com/pluginrpc"
 )
 
-// NewPluginCommand returns a new Command.
+// NewCommand returns a new Command.
 func NewCommand(
 	name string,
 	builder appext.SubCommandBuilder,

--- a/private/buf/cmd/buf/command/dep/internal/internal.go
+++ b/private/buf/cmd/buf/command/dep/internal/internal.go
@@ -29,7 +29,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/syserror"
 )
 
-// ModuleKeysAndTransitiveDepModuleKeysForModuleKeys gets the ModuleKeys for the
+// ModuleKeysAndTransitiveDepModuleKeysForModuleRefs gets the ModuleKeys for the
 // ModuleRefs, and all the transitive dependencies.
 func ModuleKeysAndTransitiveDepModuleKeysForModuleRefs(
 	ctx context.Context,

--- a/private/bufpkg/bufanalysis/bufanalysis.go
+++ b/private/bufpkg/bufanalysis/bufanalysis.go
@@ -200,7 +200,7 @@ func NewFileAnnotationSet(fileAnnotations ...FileAnnotation) FileAnnotationSet {
 	return newFileAnnotationSet(fileAnnotations)
 }
 
-// PrintFileAnnotations prints the file annotations separated by newlines.
+// PrintFileAnnotationSet prints the file annotations separated by newlines.
 func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSet, formatString string) error {
 	format, err := ParseFormat(formatString)
 	if err != nil {

--- a/private/bufpkg/bufcheck/bufcheck.go
+++ b/private/bufpkg/bufcheck/bufcheck.go
@@ -65,7 +65,7 @@ type Rule interface {
 	// BufcheckCategories returns the Rule's Categories.
 	BufcheckCategories() []Category
 
-	// Plugin returns the name of the plugin that created this Rule.
+	// PluginName returns the name of the plugin that created this Rule.
 	//
 	// Names are freeform.
 	//
@@ -82,7 +82,7 @@ type Rule interface {
 type Category interface {
 	check.Category
 
-	// Plugin returns the name of the plugin that created this Category.
+	// PluginName returns the name of the plugin that created this Category.
 	//
 	// Names are freeform.
 	//

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverbuild/bufcheckserverbuild.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverbuild/bufcheckserverbuild.go
@@ -179,7 +179,7 @@ var (
 			},
 		),
 	}
-	// FieldSameLabelV1Beta1RuleBuilder is a rule spec builder.
+	// BreakingFieldSameLabelV1Beta1RuleSpecBuilder is a rule spec builder.
 	BreakingFieldSameLabelV1Beta1RuleSpecBuilder = &bufcheckserverutil.RuleSpecBuilder{
 		ID:             "FIELD_SAME_LABEL",
 		Purpose:        "Checks that fields have the same labels in a given message.",
@@ -373,7 +373,7 @@ var (
 		Type:    check.RuleTypeBreaking,
 		Handler: bufcheckserverhandle.HandleBreakingFileSameJavaGenericServices,
 	}
-	// BreakingFileSamePyGenericServicesRuleBuilder is a rule spec builder.
+	// BreakingFileSamePyGenericServicesRuleSpecBuilder is a rule spec builder.
 	BreakingFileSamePyGenericServicesRuleSpecBuilder = &bufcheckserverutil.RuleSpecBuilder{
 		ID:      "FILE_SAME_PY_GENERIC_SERVICES",
 		Purpose: "Checks that files have the same value for the py_generic_services option.",

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/breaking.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/breaking.go
@@ -130,7 +130,7 @@ func handleBreakingExtensionNoDelete(
 	return nil
 }
 
-// HandleBreakingFileDelete is a check function.
+// HandleBreakingFileNoDelete is a check function.
 var HandleBreakingFileNoDelete = bufcheckserverutil.NewRuleHandler(handleBreakingFileNoDelete)
 
 func handleBreakingFileNoDelete(
@@ -1164,7 +1164,7 @@ func handleBreakingFileSameJavaPackage(
 	)
 }
 
-// HandleBreakingfileSameObjcClassPrefix is a check function.
+// HandleBreakingFileSameObjcClassPrefix is a check function.
 var HandleBreakingFileSameObjcClassPrefix = bufcheckserverutil.NewBreakingFilePairRuleHandler(handleBreakingFileSameObjcClassPrefix)
 
 func handleBreakingFileSameObjcClassPrefix(

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverutil/lint.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverutil/lint.go
@@ -113,7 +113,7 @@ func NewLintDirPathToFilesRuleHandler(
 	)
 }
 
-// NewLintFilesRuleHandler returns a new check.RuleHandler for the given function.
+// NewLintFileRuleHandler returns a new check.RuleHandler for the given function.
 //
 // The function will be called for each File in the request.
 //

--- a/private/bufpkg/bufcheck/internal/bufcheckopt/bufcheckopt.go
+++ b/private/bufpkg/bufcheck/internal/bufcheckopt/bufcheckopt.go
@@ -140,7 +140,7 @@ func GetServiceSuffix(options option.Options) (string, error) {
 	return defaultServiceSuffix, nil
 }
 
-// CommentExcludes are lines of comments that should be excluded for the COMMENT.* Rules.
+// GetCommentExcludes are lines of comments that should be excluded for the COMMENT.* Rules.
 //
 // If a comment line starts with one of these excludes, it is not considered an actual comment.
 //

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -83,7 +83,7 @@ func GetBufGenYAMLFileForPrefix(
 	return getFileForPrefix(ctx, bucket, prefix, bufGenYAMLFileNames, bufGenYAMLFileNameToSupportedFileVersions, readBufGenYAMLFile)
 }
 
-// GetBufGenYAMLFileForPrefix gets the buf.gen.yaml file version at the given bucket prefix.
+// GetBufGenYAMLFileVersionForPrefix gets the buf.gen.yaml file version at the given bucket prefix.
 //
 // The buf.gen.yaml file will be attempted to be read at prefix/buf.gen.yaml.
 func GetBufGenYAMLFileVersionForPrefix(

--- a/private/bufpkg/bufconfig/buf_work_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_work_yaml_file.go
@@ -91,7 +91,7 @@ func GetBufWorkYAMLFileForPrefix(
 	return getFileForPrefix(ctx, bucket, prefix, bufWorkYAMLFileNames, bufWorkYAMLFileNameToSupportedFileVersions, readBufWorkYAMLFile)
 }
 
-// GetBufWorkYAMLFileForPrefix gets the buf.work.yaml file version at the given bucket prefix.
+// GetBufWorkYAMLFileVersionForPrefix gets the buf.work.yaml file version at the given bucket prefix.
 //
 // The buf.work.yaml file will be attempted to be read at prefix/buf.work.yaml.
 func GetBufWorkYAMLFileVersionForPrefix(

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -194,7 +194,7 @@ func GetBufYAMLFileForOverride(override string) (BufYAMLFile, error) {
 	return readFile(bytes.NewReader(data), fileName, readBufYAMLFile)
 }
 
-// GetBufYAMLFileForOverride get the buf.yaml file for either the usually-flag-based override,
+// GetBufYAMLFileForPrefixOrOverride get the buf.yaml file for either the usually-flag-based override,
 // or if the override is not set, falls back to the prefix.
 func GetBufYAMLFileForPrefixOrOverride(
 	ctx context.Context,
@@ -208,7 +208,7 @@ func GetBufYAMLFileForPrefixOrOverride(
 	return GetBufYAMLFileForPrefix(ctx, bucket, prefix)
 }
 
-// GetBufYAMLFileForPrefix gets the buf.yaml file version at the given bucket prefix.
+// GetBufYAMLFileVersionForPrefix gets the buf.yaml file version at the given bucket prefix.
 //
 // The buf.yaml file will be attempted to be read at prefix/buf.yaml.
 func GetBufYAMLFileVersionForPrefix(

--- a/private/bufpkg/bufconfig/check_config.go
+++ b/private/bufpkg/bufconfig/check_config.go
@@ -124,7 +124,7 @@ func NewEnabledCheckConfig(
 	)
 }
 
-// NewEnabledCheckConfig returns a new enabled CheckConfig for only the use IDs and categories.
+// NewEnabledCheckConfigForUseIDsAndCategories returns a new enabled CheckConfig for only the use IDs and categories.
 func NewEnabledCheckConfigForUseIDsAndCategories(
 	fileVersion FileVersion,
 	use []string,

--- a/private/bufpkg/bufconfig/file_version.go
+++ b/private/bufpkg/bufconfig/file_version.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// FileVersionV1Beta represents v1beta1 files.
+	// FileVersionV1Beta1 represents v1beta1 files.
 	FileVersionV1Beta1 FileVersion = iota + 1
 	// FileVersionV1 represents v1 files.
 	FileVersionV1

--- a/private/bufpkg/bufconfig/generate_managed_config.go
+++ b/private/bufpkg/bufconfig/generate_managed_config.go
@@ -125,13 +125,13 @@ type ManagedOverrideRule interface {
 	isManagedOverrideRule()
 }
 
-// NewFieldOptionOverrideRule returns a new ManagedOverrideRule for a file option.
+// NewManagedOverrideRuleForFileOption returns a new ManagedOverrideRule for a file option.
 func NewManagedOverrideRuleForFileOption(
 	path string,
 	moduleFullName string,
 	fileOption FileOption,
 	value interface{},
-) (*managedOverrideRule, error) {
+) (ManagedOverrideRule, error) {
 	return newFileOptionManagedOverrideRule(
 		path,
 		moduleFullName,

--- a/private/bufpkg/bufmodule/bufmodulestore/commit_store.go
+++ b/private/bufpkg/bufmodule/bufmodulestore/commit_store.go
@@ -54,7 +54,7 @@ type CommitStore interface {
 		notFoundCommitKeys []bufmodule.CommitKey,
 		err error,
 	)
-	// Put puts the Commits to the store.
+	// PutCommits puts the Commits to the store.
 	PutCommits(ctx context.Context, commits []bufmodule.Commit) error
 }
 

--- a/private/bufpkg/bufmodule/bufmodulestore/module_data_store.go
+++ b/private/bufpkg/bufmodule/bufmodulestore/module_data_store.go
@@ -57,9 +57,9 @@ type ModuleDatasResult interface {
 	isModuleDatasResult()
 }
 
-// ModuleStore reads and writes ModulesDatas.
+// ModuleDataStore reads and writes ModulesDatas.
 type ModuleDataStore interface {
-	// GetModuleDatasForModuleKey gets the ModuleDatas from the store for the ModuleKeys.
+	// GetModuleDatasForModuleKeys gets the ModuleDatas from the store for the ModuleKeys.
 	//
 	// Returns the found ModuleDatas, and the input ModuleKeys that were not found, each
 	// ordered by the order of the input ModuleKeys.
@@ -69,7 +69,7 @@ type ModuleDataStore interface {
 		err error,
 	)
 
-	// Put puts the ModuleDatas to the store.
+	// PutModuleDatas puts the ModuleDatas to the store.
 	PutModuleDatas(ctx context.Context, moduleDatas []bufmodule.ModuleData) error
 }
 

--- a/private/bufpkg/bufmodule/file_type.go
+++ b/private/bufpkg/bufmodule/file_type.go
@@ -68,7 +68,7 @@ func ParseFileType(s string) (FileType, error) {
 	return c, nil
 }
 
-// FileType returns the FileType for the given path.
+// FileTypeForPath returns the FileType for the given path.
 //
 // Returns error if the path cannot be classified as a FileType, that is if it is not a
 // .proto file, license file, or documentation file.

--- a/private/bufpkg/bufmodule/module_set_builder.go
+++ b/private/bufpkg/bufmodule/module_set_builder.go
@@ -89,7 +89,6 @@ type ModuleSetBuilder interface {
 	//
 	// Remote modules are rarely targets. However, if we are reading a ModuleSet from a
 	// ModuleProvider for example with a buf build buf.build/foo/bar call, then this
-
 	// specific Module will be targeted, while its dependencies will not be.
 	//
 	// Returns the same ModuleSetBuilder.
@@ -168,7 +167,7 @@ func LocalModuleWithFullName(moduleFullName bufparse.FullName) LocalModuleOption
 	}
 }
 
-// LocalModuleWithFullName returns a new LocalModuleOption that adds the given FullName and CommitID
+// LocalModuleWithFullNameAndCommitID returns a new LocalModuleOption that adds the given FullName and CommitID
 // to the result Module.
 func LocalModuleWithFullNameAndCommitID(moduleFullName bufparse.FullName, commitID uuid.UUID) LocalModuleOption {
 	return func(localModuleOptions *localModuleOptions) {

--- a/private/bufpkg/bufmodule/module_visibility.go
+++ b/private/bufpkg/bufmodule/module_visibility.go
@@ -21,7 +21,7 @@ import (
 const (
 	// ModuleVisibilityPublic says the Module is public on the registry.
 	ModuleVisibilityPublic = iota + 1
-	// ModuleVisibilityPublic says the Module is private on the registry.
+	// ModuleVisibilityPrivate says the Module is private on the registry.
 	ModuleVisibilityPrivate
 )
 

--- a/private/bufpkg/bufparse/full_name.go
+++ b/private/bufpkg/bufparse/full_name.go
@@ -89,7 +89,7 @@ type HasFullName interface {
 	FullName() FullName
 }
 
-// FullNameStringToValue maps the values that implement HasFullName to a map
+// FullNameStringToUniqueValue maps the values that implement HasFullName to a map
 // from FullName string to the unique value that has this FullName.
 //
 // If any value has a nil FullName, this value is not added to the map. Therefore,

--- a/private/bufpkg/bufplugin/bufpluginapi/plugin_data_provider.go
+++ b/private/bufpkg/bufplugin/bufpluginapi/plugin_data_provider.go
@@ -34,7 +34,7 @@ import (
 // NewPluginDataProvider returns a new PluginDataProvider for the given API client.
 //
 // A warning is printed to the logger if a given Plugin is deprecated.
-func NewPluingDataProvider(
+func NewPluginDataProvider(
 	logger *slog.Logger,
 	clientProvider interface {
 		bufregistryapiplugin.V1Beta1DownloadServiceClientProvider

--- a/private/bufpkg/bufplugin/bufpluginstore/module_data_store.go
+++ b/private/bufpkg/bufplugin/bufpluginstore/module_data_store.go
@@ -26,9 +26,9 @@ import (
 	"github.com/bufbuild/buf/private/pkg/uuidutil"
 )
 
-// PluginStore reads and writes PluginsDatas.
+// PluginDataStore reads and writes PluginsDatas.
 type PluginDataStore interface {
-	// GetPluginDatasForPluginKey gets the PluginDatas from the store for the PluginKeys.
+	// GetPluginDatasForPluginKeys gets the PluginDatas from the store for the PluginKeys.
 	//
 	// Returns the found PluginDatas, and the input PluginKeys that were not found, each
 	// ordered by the order of the input PluginKeys.
@@ -37,7 +37,7 @@ type PluginDataStore interface {
 		notFoundPluginKeys []bufplugin.PluginKey,
 		err error,
 	)
-	// Put puts the PluginDatas to the store.
+	// PutPluginDatas puts the PluginDatas to the store.
 	PutPluginDatas(ctx context.Context, moduleDatas []bufplugin.PluginData) error
 }
 

--- a/private/bufpkg/bufplugin/plugin_visibility.go
+++ b/private/bufpkg/bufplugin/plugin_visibility.go
@@ -21,7 +21,7 @@ import (
 const (
 	// PluginVisibilityPublic says the Plugin is public on the registry.
 	PluginVisibilityPublic = iota + 1
-	// PluginVisibilityPublic says the Plugin is private on the registry.
+	// PluginVisibilityPrivate says the Plugin is private on the registry.
 	PluginVisibilityPrivate
 )
 

--- a/private/bufpkg/bufprotocompile/bufprotocompile.go
+++ b/private/bufpkg/bufprotocompile/bufprotocompile.go
@@ -92,7 +92,7 @@ func FileAnnotationForErrorWithPos(
 	), nil
 }
 
-// FileAnnotationSetForErrorWithPos returns new FileAnnotations for the ErrorsWithPos.
+// FileAnnotationSetForErrorsWithPos returns new FileAnnotations for the ErrorsWithPos.
 //
 // This special-cases fs.PathErrors if there is FileInfo information. We know that if there
 // is FileInfo information, and there is a fs.PathError, this can only happen due to import

--- a/private/bufpkg/bufprotosource/bufprotosource.go
+++ b/private/bufpkg/bufprotosource/bufprotosource.go
@@ -241,8 +241,8 @@ type FileInfo interface {
 	// Never empty. Falls back to Path if there is not an external path.
 	//
 	// Example:
-	//	 Assume we had the input path /foo/bar which is a local directory.
-
+	//
+	// Assume we had the input path /foo/bar which is a local directory.
 	//   Path: one/one.proto
 	//   RootDirPath: proto
 	//   ExternalPath: /foo/bar/proto/one/one.proto

--- a/private/pkg/app/appcmd/positional_args.go
+++ b/private/pkg/app/appcmd/positional_args.go
@@ -48,7 +48,7 @@ func RangeArgs(minimum int, maximum int) PositionalArgs {
 	return newPositionalArgs(cobra.RangeArgs(minimum, maximum))
 }
 
-// PostionalArgs matches cobra.PositionalArgs so that importers of appcmd do
+// PositionalArgs matches cobra.PositionalArgs so that importers of appcmd do
 // not need to reference cobra (and shouldn't).
 type PositionalArgs interface {
 	cobra() cobra.PositionalArgs

--- a/private/pkg/bandeps/bandeps.go
+++ b/private/pkg/bandeps/bandeps.go
@@ -52,7 +52,7 @@ type ExternalConfig struct {
 	Bans []ExternalBanConfig `json:"bans,omitempty" yaml:"bans,omitempty"`
 }
 
-// ExternalConfig is an external ban configuration.
+// ExternalBanConfig is an external ban configuration.
 type ExternalBanConfig struct {
 	// Packages are the package expressions to get dependencies for.
 	Packages ExternalPackageConfig `json:"packages,omitempty" yaml:"packages,omitempty"`

--- a/private/pkg/cert/certclient/util.go
+++ b/private/pkg/cert/certclient/util.go
@@ -46,7 +46,7 @@ func WithRootCertFilePaths(rootCertFilePaths ...string) TLSOption {
 	}
 }
 
-// NewClientTLScreates a new tls.Config from a root certificate files.
+// NewClientTLS creates a new tls.Config from a root certificate files.
 func NewClientTLS(options ...TLSOption) (*tls.Config, error) {
 	opts := &tlsOptions{}
 	for _, opt := range options {

--- a/private/pkg/dag/comparable_graph.go
+++ b/private/pkg/dag/comparable_graph.go
@@ -68,7 +68,7 @@ func (g *ComparableGraph[Value]) NumNodes() int {
 	return g.Graph().NumNodes()
 }
 
-// NumNodes returns the number of edges in the graph.
+// NumEdges returns the number of edges in the graph.
 func (g *ComparableGraph[Value]) NumEdges() int {
 	return g.Graph().NumEdges()
 }

--- a/private/pkg/dag/graph.go
+++ b/private/pkg/dag/graph.go
@@ -89,7 +89,7 @@ func (g *Graph[Key, Value]) NumNodes() int {
 	return len(g.keys)
 }
 
-// NumNodes returns the number of edges in the graph.
+// NumEdges returns the number of edges in the graph.
 func (g *Graph[Key, Value]) NumEdges() int {
 	if err := g.checkInit(); err != nil {
 		return 0

--- a/private/pkg/diff/diff.go
+++ b/private/pkg/diff/diff.go
@@ -72,7 +72,7 @@ func DiffWithSuppressCommands() DiffOption {
 	}
 }
 
-// DiffWithSuppressCommands returns a new DiffOption that suppresses printing of timestamps.
+// DiffWithSuppressTimestamps returns a new DiffOption that suppresses printing of timestamps.
 func DiffWithSuppressTimestamps() DiffOption {
 	return func(diffOptions *diffOptions) {
 		diffOptions.suppressTimestamps = true

--- a/private/pkg/oauth2/device.go
+++ b/private/pkg/oauth2/device.go
@@ -58,7 +58,7 @@ type DeviceRegistrationRequest struct {
 	ClientName string `json:"client_name"`
 }
 
-// Device describes a successful OpenID Connect Dynamic Client Registration 1.0 response
+// DeviceRegistrationResponse describes a successful OpenID Connect Dynamic Client Registration 1.0 response
 // for dynamic client registration.
 type DeviceRegistrationResponse struct {
 	// ClientID is the unique client identifier.

--- a/private/pkg/protogenutil/protogenutil.go
+++ b/private/pkg/protogenutil/protogenutil.go
@@ -248,7 +248,7 @@ type NamedHelper interface {
 		goPackageFileSet *GoPackageFileSet,
 		pluginName string,
 	) (protogen.GoImportPath, error)
-	// NewGlobalImportPath gets the helper GoImportPath for the pluginName.
+	// NewGlobalGoImportPath gets the helper GoImportPath for the pluginName.
 	NewGlobalGoImportPath(
 		pluginName string,
 	) (protogen.GoImportPath, error)

--- a/private/pkg/shake256/shake256.go
+++ b/private/pkg/shake256/shake256.go
@@ -37,7 +37,7 @@ func NewDigest(value []byte) (Digest, error) {
 	return newDigest(value)
 }
 
-// NewDigest returns a new Digest for the content read from the Reader.
+// NewDigestForContent returns a new Digest for the content read from the Reader.
 func NewDigestForContent(reader io.Reader) (Digest, error) {
 	shakeHash := sha3.NewShake256()
 	// TODO FUTURE: remove in the future, this should have no effect

--- a/private/pkg/slicesext/slicesext.go
+++ b/private/pkg/slicesext/slicesext.go
@@ -120,7 +120,7 @@ func Reduce[T1, T2 any](s []T1, f func(T2, T1) T2, initialValue T2) T2 {
 	return value
 }
 
-// Reduce reduces the slice.
+// ReduceError reduces the slice.
 //
 // Returns error the first time f returns error.
 func ReduceError[T1, T2 any](s []T1, f func(T2, T1) (T2, error), initialValue T2) (T2, error) {
@@ -327,7 +327,7 @@ func ToUniqueIndexedValuesMapError[K comparable, V any](values []V, f func(V) (K
 	return ToUniqueValuesMapError(ToIndexed(values), func(indexedV Indexed[V]) (K, error) { return f(indexedV.Value) })
 }
 
-// IndexedToSortedValues takes the indexed values and returns them as values.
+// IndexedToValues takes the indexed values and returns them as values.
 func IndexedToValues[T any](s []Indexed[T]) []T {
 	return Map(s, func(indexedT Indexed[T]) T { return indexedT.Value })
 }
@@ -356,7 +356,7 @@ func MapKeysToSlice[K comparable, V any](m map[K]V) []K {
 	return s
 }
 
-// MapValuesToSlice converts the map's values to a sorted slice.
+// MapValuesToSortedSlice converts the map's values to a sorted slice.
 //
 // Duplicate values will be added. This should generally be used
 // in cases where you know there is a 1-1 mapping from K to V.
@@ -427,7 +427,7 @@ func Deduplicate[V comparable](s []V) []V {
 	return result
 }
 
-// Deduplicate returns the unique values of s when transformed with f.
+// DeduplicateAny returns the unique values of s when transformed with f.
 //
 // Earlier occurrences of a value are returned and later occurrences are dropped.
 func DeduplicateAny[K comparable, V any](s []V, f func(V) K) []V {

--- a/private/pkg/storage/diff.go
+++ b/private/pkg/storage/diff.go
@@ -35,7 +35,7 @@ func DiffWithSuppressCommands() DiffOption {
 	}
 }
 
-// DiffWithSuppressCommands returns a new DiffOption that suppresses printing of timestamps.
+// DiffWithSuppressTimestamps returns a new DiffOption that suppresses printing of timestamps.
 func DiffWithSuppressTimestamps() DiffOption {
 	return func(diffOptions *diffOptions) {
 		diffOptions.suppressTimestamps = true

--- a/private/pkg/storage/mapper.go
+++ b/private/pkg/storage/mapper.go
@@ -22,7 +22,7 @@ import (
 //
 // This will cause a Bucket to operate as if the Mapper has all paths mapped.
 type Mapper interface {
-	// Map maps the path to the full path.
+	// MapPath maps the path to the full path.
 	//
 	// The path is expected to be normalized and validated.
 	// The returned path is expected to be normalized and validated.

--- a/private/pkg/zapapp/zapapp.go
+++ b/private/pkg/zapapp/zapapp.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// NewCoreForFlagValues returns a new Core for the given level and format strings.
+// NewCore returns a new Core for the given level and format strings.
 func NewCore(writer io.Writer, logLevel appext.LogLevel, logFormat appext.LogFormat) (zapcore.Core, error) {
 	level, err := getLevel(logLevel)
 	if err != nil {


### PR DESCRIPTION
Update godoc comments to start with the exported name. Fix a typo in plugin data manager.