### PR TITLE
Document registry logout argument

### DIFF
--- a/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/registrylogin.go
@@ -53,9 +53,9 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		Use:   name + " <domain>",
+		Use:   name + " [domain]",
 		Short: `Log in to the Buf Schema Registry`,
-		Long:  fmt.Sprintf(`This command will open a browser to complete the login process. Use the flags --%s or --%s to complete an alternative login flow. The token is saved to your %s file. The <domain> argument will default to buf.build if not specified.`, promptFlagName, tokenStdinFlagName, netrc.Filename),
+		Long:  fmt.Sprintf(`This command will open a browser to complete the login process. Use the flags --%s or --%s to complete an alternative login flow. The token is saved to your %s file. The [domain] argument will default to %s if not specified.`, promptFlagName, tokenStdinFlagName, netrc.Filename, bufconnect.DefaultRemote),
 		Args:  appcmd.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appext.Container) error {

--- a/private/buf/cmd/buf/command/registry/registrylogout/registrylogout.go
+++ b/private/buf/cmd/buf/command/registry/registrylogout/registrylogout.go
@@ -33,11 +33,9 @@ func NewCommand(
 ) *appcmd.Command {
 	flags := newFlags()
 	return &appcmd.Command{
-		// Not documenting the first arg (remote) as this is just for testing for now.
-		// TODO: Update when we have self-hosted.
-		Use:   name,
+		Use:   name + " [domain]",
 		Short: `Log out of the Buf Schema Registry`,
-		Long:  fmt.Sprintf(`This command removes any BSR credentials from your %s file`, netrc.Filename),
+		Long:  fmt.Sprintf(`This command removes any BSR credentials from your %s file. The [domain] argument will default to %s if not specified.`, netrc.Filename, bufconnect.DefaultRemote),
 		Args:  appcmd.MaximumNArgs(1),
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appext.Container) error {


### PR DESCRIPTION
Update `buf registry logout` to document the domain optional argument, which if specified will log out of a specific BSR instance.