### PR TITLE
Parse app config strictly by default

### DIFF
--- a/private/pkg/app/appext/appext.go
+++ b/private/pkg/app/appext/appext.go
@@ -174,6 +174,25 @@ func ReadConfig(container NameContainer, value interface{}) error {
 	return nil
 }
 
+// ReadConfigNonStrict reads the configuration from the YAML configuration file config.yaml
+// in the configuration directory, ignoring any unknown properties.
+//
+// If the file does not exist, this is a no-op.
+// The value should be a pointer to unmarshal into.
+func ReadConfigNonStrict(container NameContainer, value interface{}) error {
+	configFilePath := filepath.Join(container.ConfigDirPath(), configFileName)
+	data, err := os.ReadFile(configFilePath)
+	if !errors.Is(err, os.ErrNotExist) {
+		if err != nil {
+			return fmt.Errorf("could not read %s configuration file at %s: %w", container.AppName(), configFilePath, err)
+		}
+		if err := encoding.UnmarshalYAMLNonStrict(data, value); err != nil {
+			return fmt.Errorf("invalid %s configuration file: %w", container.AppName(), err)
+		}
+	}
+	return nil
+}
+
 // ReadSecret returns the contents of the file at path
 // filepath.Join(container.ConfigDirPath(), secretRelDirPath, name).
 func ReadSecret(container NameContainer, name string) (string, error) {

--- a/private/pkg/app/appext/appext.go
+++ b/private/pkg/app/appext/appext.go
@@ -167,7 +167,7 @@ func ReadConfig(container NameContainer, value interface{}) error {
 		if err != nil {
 			return fmt.Errorf("could not read %s configuration file at %s: %w", container.AppName(), configFilePath, err)
 		}
-		if err := encoding.UnmarshalYAMLNonStrict(data, value); err != nil {
+		if err := encoding.UnmarshalYAMLStrict(data, value); err != nil {
 			return fmt.Errorf("invalid %s configuration file: %w", container.AppName(), err)
 		}
 	}


### PR DESCRIPTION
In #3376 we switched `ReadConfig` from `UnmarshalYAMLStrict` to `UnmarshalYAMLNonStrict`. This was to enable a use case in an internal application. This PR switches `ReadConfig` back to `UnmarshalYAMLStrict` and adds `ReadConfigNonStrict` to enable the non-strict use case. The internal application will document why it needs the non-strict property.

I verified that nothing in the CLI needs non-strict parsing, everything is using the CLI's `NameContainer` and reads `bufapp.Config`.