### PR TITLE
Fix b5 module digest calculation with transitive dependencies

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleapi/module_data_provider.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/module_data_provider.go
@@ -125,8 +125,6 @@ func (a *moduleDataProvider) getIndexedModuleDatasForRegistryAndIndexedModuleKey
 	indexedModuleKeys []slicesext.Indexed[bufmodule.ModuleKey],
 	digestType bufmodule.DigestType,
 ) ([]slicesext.Indexed[bufmodule.ModuleData], error) {
-	// This returns the graph with pruned dependencies for the given indexedModuleKeys.
-	// We must resolve the direct and transitive dependencies for each ModuleKey.
 	graph, err := a.graphProvider.GetGraphForModuleKeys(ctx, slicesext.IndexedToValues(indexedModuleKeys))
 	if err != nil {
 		return nil, err
@@ -151,45 +149,61 @@ func (a *moduleDataProvider) getIndexedModuleDatasForRegistryAndIndexedModuleKey
 		return nil, err
 	}
 	indexedModuleDatas := make([]slicesext.Indexed[bufmodule.ModuleData], 0, len(indexedModuleKeys))
-	for _, indexedModuleKey := range indexedModuleKeys {
-		moduleKey := indexedModuleKey.Value
-		// TopoSort will get us both the direct and transitive dependencies for the moduleKey.
-		depModuleKeys, err := graph.TopoSort(bufmodule.ModuleKeyToRegistryCommitID(moduleKey))
-		if err != nil {
-			return nil, err
-		}
-		// Remove the final ModuleKey, this parent.
-		depModuleKeys = depModuleKeys[:len(depModuleKeys)-1]
-		sort.Slice(
-			depModuleKeys,
-			func(i int, j int) bool {
-				return depModuleKeys[i].FullName().String() < depModuleKeys[j].FullName().String()
-			},
-		)
-
-		universalProtoContent, ok := commitIDToUniversalProtoContent[moduleKey.CommitID()]
-		if !ok {
-			// This should never happen.
-			return nil, syserror.Newf("no content returned for commit ID %s", moduleKey.CommitID())
-		}
-		indexedModuleData := slicesext.Indexed[bufmodule.ModuleData]{
-			Value: bufmodule.NewModuleData(
-				ctx,
-				moduleKey,
-				func() (storage.ReadBucket, error) {
-					return universalProtoFilesToBucket(universalProtoContent.Files)
+	if err := graph.WalkNodes(
+		func(
+			moduleKey bufmodule.ModuleKey,
+			_ []bufmodule.ModuleKey,
+			_ []bufmodule.ModuleKey,
+		) error {
+			// TopoSort will get us both the direct and transitive dependencies for the key.
+			//
+			// The outgoing edge list is just the direct dependencies.
+			//
+			// There is definitely a better way to do this in one pass for all commits with
+			// memoization - this is algorithmically bad.
+			depModuleKeys, err := graph.TopoSort(bufmodule.ModuleKeyToRegistryCommitID(moduleKey))
+			if err != nil {
+				return err
+			}
+			depModuleKeys = depModuleKeys[:len(depModuleKeys)-1]
+			sort.Slice(
+				depModuleKeys,
+				func(i int, j int) bool {
+					return depModuleKeys[i].FullName().String() < depModuleKeys[j].FullName().String()
 				},
-				func() ([]bufmodule.ModuleKey, error) { return depModuleKeys, nil },
-				func() (bufmodule.ObjectData, error) {
-					return universalProtoFileToObjectData(universalProtoContent.V1BufYAMLFile)
-				},
-				func() (bufmodule.ObjectData, error) {
-					return universalProtoFileToObjectData(universalProtoContent.V1BufLockFile)
-				},
-			),
-			Index: indexedModuleKey.Index,
-		}
-		indexedModuleDatas = append(indexedModuleDatas, indexedModuleData)
+			)
+			universalProtoContent, ok := commitIDToUniversalProtoContent[moduleKey.CommitID()]
+			if !ok {
+				// We only care to get content for a subset of the graph. If we have something
+				// in the graph without content, we just skip it.
+				return nil
+			}
+			indexedModuleKey, ok := commitIDToIndexedModuleKey[moduleKey.CommitID()]
+			if !ok {
+				return syserror.Newf("could not find indexed ModuleKey for commit ID %q", uuidutil.ToDashless(moduleKey.CommitID()))
+			}
+			indexedModuleData := slicesext.Indexed[bufmodule.ModuleData]{
+				Value: bufmodule.NewModuleData(
+					ctx,
+					moduleKey,
+					func() (storage.ReadBucket, error) {
+						return universalProtoFilesToBucket(universalProtoContent.Files)
+					},
+					func() ([]bufmodule.ModuleKey, error) { return depModuleKeys, nil },
+					func() (bufmodule.ObjectData, error) {
+						return universalProtoFileToObjectData(universalProtoContent.V1BufYAMLFile)
+					},
+					func() (bufmodule.ObjectData, error) {
+						return universalProtoFileToObjectData(universalProtoContent.V1BufLockFile)
+					},
+				),
+				Index: indexedModuleKey.Index,
+			}
+			indexedModuleDatas = append(indexedModuleDatas, indexedModuleData)
+			return nil
+		},
+	); err != nil {
+		return nil, err
 	}
 	return indexedModuleDatas, nil
 }

--- a/private/bufpkg/bufmodule/bufmoduleapi/module_data_provider.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/module_data_provider.go
@@ -126,7 +126,7 @@ func (a *moduleDataProvider) getIndexedModuleDatasForRegistryAndIndexedModuleKey
 	digestType bufmodule.DigestType,
 ) ([]slicesext.Indexed[bufmodule.ModuleData], error) {
 	// This returns the graph with pruned dependencies for the given indexedModuleKeys.
-	// We must resolve the declared dependencies for each ModuleKey.
+	// We must resolve the direct and transitive dependencies for each ModuleKey.
 	graph, err := a.graphProvider.GetGraphForModuleKeys(ctx, slicesext.IndexedToValues(indexedModuleKeys))
 	if err != nil {
 		return nil, err

--- a/private/bufpkg/bufmodule/bufmodulestore/module_data_store.go
+++ b/private/bufpkg/bufmodule/bufmodulestore/module_data_store.go
@@ -262,9 +262,9 @@ func (p *moduleDataStore) getModuleDataForModuleKey(
 	// We don't want to do this lazily (or anything else in this function) as we want to
 	// make sure everything we have is valid before returning so we can auto-correct
 	// the cache if necessary.
-	declaredDepModuleKeys, err := slicesext.MapError(
+	depModuleKeys, err := slicesext.MapError(
 		externalModuleData.Deps,
-		getDeclaredDepModuleKeyForExternalModuleDataDep,
+		getDepModuleKeyForExternalModuleDataDep,
 	)
 	if err != nil {
 		return nil, err
@@ -316,7 +316,7 @@ func (p *moduleDataStore) getModuleDataForModuleKey(
 			), nil
 		},
 		func() ([]bufmodule.ModuleKey, error) {
-			return declaredDepModuleKeys, nil
+			return depModuleKeys, nil
 		},
 		func() (bufmodule.ObjectData, error) {
 			return v1BufYAMLObjectData, nil
@@ -461,7 +461,7 @@ func (p *moduleDataStore) putModuleData(
 		}
 	}
 	// Proceed to writing module data.
-	depModuleKeys, err := moduleData.DeclaredDepModuleKeys()
+	depModuleKeys, err := moduleData.DepModuleKeys()
 	if err != nil {
 		return err
 	}
@@ -653,7 +653,7 @@ func getModuleDataStoreTarPath(moduleKey bufmodule.ModuleKey) (string, error) {
 	), nil
 }
 
-func getDeclaredDepModuleKeyForExternalModuleDataDep(dep externalModuleDataDep) (bufmodule.ModuleKey, error) {
+func getDepModuleKeyForExternalModuleDataDep(dep externalModuleDataDep) (bufmodule.ModuleKey, error) {
 	if dep.Name == "" {
 		return nil, errors.New("no module name specified")
 	}

--- a/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting.go
+++ b/private/bufpkg/bufmodule/bufmoduletesting/bufmoduletesting.go
@@ -311,7 +311,7 @@ func (o *omniProvider) getModuleDataForModuleKey(
 	if err != nil {
 		return nil, err
 	}
-	declaredDepModuleKeys, err := slicesext.MapError(
+	depModuleKeys, err := slicesext.MapError(
 		moduleDeps,
 		func(moduleDep bufmodule.ModuleDep) (bufmodule.ModuleKey, error) {
 			return bufmodule.ModuleToModuleKey(moduleDep, digest.Type())
@@ -327,7 +327,7 @@ func (o *omniProvider) getModuleDataForModuleKey(
 			return bufmodule.ModuleReadBucketToStorageReadBucket(module), nil
 		},
 		func() ([]bufmodule.ModuleKey, error) {
-			return declaredDepModuleKeys, nil
+			return depModuleKeys, nil
 		},
 		func() (bufmodule.ObjectData, error) {
 			return module.V1Beta1OrV1BufYAMLObjectData()

--- a/private/bufpkg/bufmodule/module.go
+++ b/private/bufpkg/bufmodule/module.go
@@ -230,17 +230,17 @@ func ModuleDirectModuleDeps(module Module) ([]ModuleDep, error) {
 type module struct {
 	ModuleReadBucket
 
-	ctx                        context.Context
-	getBucket                  func() (storage.ReadBucket, error)
-	bucketID                   string
-	description                string
-	moduleFullName             bufparse.FullName
-	commitID                   uuid.UUID
-	isTarget                   bool
-	isLocal                    bool
-	getV1BufYAMLObjectData     func() (ObjectData, error)
-	getV1BufLockObjectData     func() (ObjectData, error)
-	getDeclaredDepModuleKeysB5 func() ([]ModuleKey, error)
+	ctx                    context.Context
+	getBucket              func() (storage.ReadBucket, error)
+	bucketID               string
+	description            string
+	moduleFullName         bufparse.FullName
+	commitID               uuid.UUID
+	isTarget               bool
+	isLocal                bool
+	getV1BufYAMLObjectData func() (ObjectData, error)
+	getV1BufLockObjectData func() (ObjectData, error)
+	getDepModuleKeysB5     func() ([]ModuleKey, error)
 
 	moduleSet ModuleSet
 
@@ -261,7 +261,7 @@ func newModule(
 	isLocal bool,
 	getV1BufYAMLObjectData func() (ObjectData, error),
 	getV1BufLockObjectData func() (ObjectData, error),
-	getDeclaredDepModuleKeysB5 func() ([]ModuleKey, error),
+	getDepModuleKeysB5 func() ([]ModuleKey, error),
 	targetPaths []string,
 	targetExcludePaths []string,
 	protoFileTargetPath string,
@@ -304,17 +304,17 @@ func newModule(
 	}
 
 	module := &module{
-		ctx:                        ctx,
-		getBucket:                  syncOnceValuesGetBucketWithStorageMatcherApplied,
-		bucketID:                   bucketID,
-		description:                description,
-		moduleFullName:             moduleFullName,
-		commitID:                   commitID,
-		isTarget:                   isTarget,
-		isLocal:                    isLocal,
-		getV1BufYAMLObjectData:     sync.OnceValues(getV1BufYAMLObjectData),
-		getV1BufLockObjectData:     sync.OnceValues(getV1BufLockObjectData),
-		getDeclaredDepModuleKeysB5: sync.OnceValues(getDeclaredDepModuleKeysB5),
+		ctx:                    ctx,
+		getBucket:              syncOnceValuesGetBucketWithStorageMatcherApplied,
+		bucketID:               bucketID,
+		description:            description,
+		moduleFullName:         moduleFullName,
+		commitID:               commitID,
+		isTarget:               isTarget,
+		isLocal:                isLocal,
+		getV1BufYAMLObjectData: sync.OnceValues(getV1BufYAMLObjectData),
+		getV1BufLockObjectData: sync.OnceValues(getV1BufLockObjectData),
+		getDepModuleKeysB5:     sync.OnceValues(getDepModuleKeysB5),
 	}
 	moduleReadBucket, err := newModuleReadBucketForModule(
 		ctx,
@@ -398,17 +398,17 @@ func (m *module) ModuleSet() ModuleSet {
 func (m *module) withIsTarget(isTarget bool) (Module, error) {
 	// We don't just call newModule directly as we don't want to double sync.OnceValues stuff.
 	newModule := &module{
-		ctx:                        m.ctx,
-		getBucket:                  m.getBucket,
-		bucketID:                   m.bucketID,
-		description:                m.description,
-		moduleFullName:             m.moduleFullName,
-		commitID:                   m.commitID,
-		isTarget:                   isTarget,
-		isLocal:                    m.isLocal,
-		getV1BufYAMLObjectData:     m.getV1BufYAMLObjectData,
-		getV1BufLockObjectData:     m.getV1BufLockObjectData,
-		getDeclaredDepModuleKeysB5: m.getDeclaredDepModuleKeysB5,
+		ctx:                    m.ctx,
+		getBucket:              m.getBucket,
+		bucketID:               m.bucketID,
+		description:            m.description,
+		moduleFullName:         m.moduleFullName,
+		commitID:               m.commitID,
+		isTarget:               isTarget,
+		isLocal:                m.isLocal,
+		getV1BufYAMLObjectData: m.getV1BufYAMLObjectData,
+		getV1BufLockObjectData: m.getV1BufLockObjectData,
+		getDepModuleKeysB5:     m.getDepModuleKeysB5,
 	}
 	moduleReadBucket, ok := m.ModuleReadBucket.(*moduleReadBucket)
 	if !ok {
@@ -452,26 +452,26 @@ func newGetDigestFuncForModuleAndDigestType(module *module, digestType DigestTyp
 			}
 			return getB4Digest(module.ctx, bucket, v1BufYAMLObjectData, v1BufLockObjectData)
 		case DigestTypeB5:
-			// B5 digests are calculated from the Module's content and its declared dependencies.
+			// B5 digests are calculated from the Module's content and its dependencies.
 			//
-			// Declared dependencies are all direct and transitive dependencies of the Module.
-			// For local Modules, the declared dependencies are resolved to the current ModuleSet.
-			// For remote Modules, the declared dependencies are the ModuleKeys of
+			// Dependencies are all direct and transitive dependencies of the Module.
+			// For local Modules, the dependencies are resolved to the current ModuleSet.
+			// For remote Modules, the dependencies are the ModuleKeys of
 			// the direct and transitive dependencies of the Module at the specific commit.
 			//
-			// This is effectively the same. The local Modules have a declared dependency at the current commit,
-			// and the remote Modules have a declared dependency at a specific commit. Pushing up a local Module
+			// This is effectively the same. The local Modules have a dependency at the current commit,
+			// and the remote Modules have a dependency at a specific commit. Pushing up a local Module
 			// as a remote Module will result in the same Digest.
 			//
-			// See the comment on getDeclaredDepModuleKeysB5 for more information.
+			// See the comment on getDepModuleKeysB5 for more information.
 			if !module.isLocal {
-				declaredDepModuleKeys, err := module.getDeclaredDepModuleKeysB5()
+				depModuleKeys, err := module.getDepModuleKeysB5()
 				if err != nil {
 					return nil, err
 				}
-				return getB5DigestForBucketAndDepModuleKeys(module.ctx, bucket, declaredDepModuleKeys)
+				return getB5DigestForBucketAndDepModuleKeys(module.ctx, bucket, depModuleKeys)
 			}
-			// ModuleDeps returns the declared dependent Modules resolved for the target Module in the ModuleSet.
+			// ModuleDeps returns the dependent Modules resolved for the target Module in the ModuleSet.
 			// A local Module will recursively resolve the Digest of other dependent local Modules.
 			// This is done by calling Module.Digest(DigestTypeB5) on each ModuleDep.
 			moduleDeps, err := module.ModuleDeps()

--- a/private/bufpkg/bufmodule/module_data.go
+++ b/private/bufpkg/bufmodule/module_data.go
@@ -152,9 +152,8 @@ func newModuleData(
 					return err
 				}
 				// The B5 digest is calculated based on the dependencies.
-				// Dependencies are not required to be resolved to a Module to calculate the digest.
-				// Each dependent ModuleKey is a reference to a specific commit of a module
-				// that includes the dependencies expected Digest.
+				// The dependencies are not required to be resolved to a Module to calculate this Digest.
+				// Each ModuleKey includes the expected Digest which is validated when loading that dependencies ModuleData, if needed.
 				actualDigest, err = getB5DigestForBucketAndDepModuleKeys(ctx, bucket, depModuleKeys)
 				if err != nil {
 					return err

--- a/private/bufpkg/bufmodule/module_data.go
+++ b/private/bufpkg/bufmodule/module_data.go
@@ -32,7 +32,7 @@ type ModuleData interface {
 	// ModuleKey contains the ModuleKey that was used to download this ModuleData.
 	//
 	// The Digest from this ModuleKey is used for tamper-proofing. It will be checked against
-	// the actual data downloaded before Bucket() or DeclaredDepModuleKeys() returns.
+	// the actual data downloaded before Bucket() or DepModuleKeys() returns.
 	ModuleKey() ModuleKey
 	// Bucket returns a Bucket of the Module's files.
 	//
@@ -40,15 +40,15 @@ type ModuleData interface {
 	//
 	// This bucket will only contain module files - it will be filtered via NewModuleData.
 	Bucket() (storage.ReadBucket, error)
-	// DeclaredDepModuleKeys returns the declared dependencies for this specific Module.
+	// DepModuleKeys returns the dependencies for this specific Module.
 	//
-	// The declared dependencies are the same as that would appear in the buf.lock file.
+	// The dependencies are the same as that would appear in the buf.lock file.
 	// These include all direct and transitive dependencies. A Module constructed
 	// from this ModuleData as the target will require all Modules referenced by
-	// its DeclaredDepModuleKeys to be present in the ModuleSet.
+	// its DepModuleKeys to be present in the ModuleSet.
 	//
 	// This is used for digest calculations. It is not used otherwise.
-	DeclaredDepModuleKeys() ([]ModuleKey, error)
+	DepModuleKeys() ([]ModuleKey, error)
 
 	// V1Beta1OrV1BufYAMLObjectData gets the v1beta1 or v1 buf.yaml ObjectData.
 	//
@@ -68,7 +68,7 @@ type ModuleData interface {
 
 // NewModuleData returns a new ModuleData.
 //
-// getBucket and getDeclaredDepModuleKeys are meant to be lazily-loaded functions where possible.
+// getBucket and getDepModuleKeys are meant to be lazily-loaded functions where possible.
 //
 // It is OK for getBucket to return a bucket that has extra files that are not part of the Module, this
 // bucket will be filtered as part of this function.
@@ -76,7 +76,7 @@ func NewModuleData(
 	ctx context.Context,
 	moduleKey ModuleKey,
 	getBucket func() (storage.ReadBucket, error),
-	getDeclaredDepModuleKeys func() ([]ModuleKey, error),
+	getDepModuleKeys func() ([]ModuleKey, error),
 	getV1BufYAMLObjectData func() (ObjectData, error),
 	getV1BufLockObjectData func() (ObjectData, error),
 ) ModuleData {
@@ -84,7 +84,7 @@ func NewModuleData(
 		ctx,
 		moduleKey,
 		getBucket,
-		getDeclaredDepModuleKeys,
+		getDepModuleKeys,
 		getV1BufYAMLObjectData,
 		getV1BufLockObjectData,
 	)
@@ -93,11 +93,11 @@ func NewModuleData(
 // *** PRIVATE ***
 
 type moduleData struct {
-	moduleKey                ModuleKey
-	getBucket                func() (storage.ReadBucket, error)
-	getDeclaredDepModuleKeys func() ([]ModuleKey, error)
-	getV1BufYAMLObjectData   func() (ObjectData, error)
-	getV1BufLockObjectData   func() (ObjectData, error)
+	moduleKey              ModuleKey
+	getBucket              func() (storage.ReadBucket, error)
+	getDepModuleKeys       func() ([]ModuleKey, error)
+	getV1BufYAMLObjectData func() (ObjectData, error)
+	getV1BufLockObjectData func() (ObjectData, error)
 
 	checkDigest func() error
 }
@@ -106,16 +106,16 @@ func newModuleData(
 	ctx context.Context,
 	moduleKey ModuleKey,
 	getBucket func() (storage.ReadBucket, error),
-	getDeclaredDepModuleKeys func() ([]ModuleKey, error),
+	getDepModuleKeys func() ([]ModuleKey, error),
 	getV1BufYAMLObjectData func() (ObjectData, error),
 	getV1BufLockObjectData func() (ObjectData, error),
 ) *moduleData {
 	moduleData := &moduleData{
-		moduleKey:                moduleKey,
-		getBucket:                getSyncOnceValuesGetBucketWithStorageMatcherApplied(ctx, getBucket),
-		getDeclaredDepModuleKeys: sync.OnceValues(getDeclaredDepModuleKeys),
-		getV1BufYAMLObjectData:   sync.OnceValues(getV1BufYAMLObjectData),
-		getV1BufLockObjectData:   sync.OnceValues(getV1BufLockObjectData),
+		moduleKey:              moduleKey,
+		getBucket:              getSyncOnceValuesGetBucketWithStorageMatcherApplied(ctx, getBucket),
+		getDepModuleKeys:       sync.OnceValues(getDepModuleKeys),
+		getV1BufYAMLObjectData: sync.OnceValues(getV1BufYAMLObjectData),
+		getV1BufLockObjectData: sync.OnceValues(getV1BufLockObjectData),
 	}
 	moduleData.checkDigest = sync.OnceValue(
 		func() error {
@@ -147,15 +147,15 @@ func newModuleData(
 				}
 			case DigestTypeB5:
 				// Call unexported func instead of exported method to avoid deadlocking on checking the digest again.
-				declaredDepModuleKeys, err := moduleData.getDeclaredDepModuleKeys()
+				depModuleKeys, err := moduleData.getDepModuleKeys()
 				if err != nil {
 					return err
 				}
-				// The B5 digest is calculated based on the declared dependencies.
+				// The B5 digest is calculated based on the dependencies.
 				// Dependencies are not required to be resolved to a Module to calculate the digest.
-				// Each declared dependent ModuleKey is a reference to a specific commit of a module
+				// Each dependent ModuleKey is a reference to a specific commit of a module
 				// that includes the dependencies expected Digest.
-				actualDigest, err = getB5DigestForBucketAndDepModuleKeys(ctx, bucket, declaredDepModuleKeys)
+				actualDigest, err = getB5DigestForBucketAndDepModuleKeys(ctx, bucket, depModuleKeys)
 				if err != nil {
 					return err
 				}
@@ -185,18 +185,17 @@ func (m *moduleData) Bucket() (storage.ReadBucket, error) {
 	return m.getBucket()
 }
 
-func (m *moduleData) DeclaredDepModuleKeys() ([]ModuleKey, error) {
-	// Do we need to tamper-proof when getting declared deps? Probably yes - this is
-	// data that could be tampered with.
+func (m *moduleData) DepModuleKeys() ([]ModuleKey, error) {
+	// Do we need to tamper-proof when getting deps? Probably yes - this is data that could be tampered with.
 	//
-	// Note that doing so kills some of our lazy-loading, as we call DeclaredDepModuleKeys
+	// Note that doing so kills some of our lazy-loading, as we call DepModuleKeys
 	// in ModuleSetBuilder right away. However, we still do the lazy-loading here, in the case
 	// where ModuleData is loaded outside of a ModuleSetBuilder and users may defer calling this
 	// function if it is not needed.
 	if err := m.checkDigest(); err != nil {
 		return nil, err
 	}
-	return m.getDeclaredDepModuleKeys()
+	return m.getDepModuleKeys()
 }
 
 func (m *moduleData) V1Beta1OrV1BufYAMLObjectData() (ObjectData, error) {

--- a/private/bufpkg/bufmodule/module_data.go
+++ b/private/bufpkg/bufmodule/module_data.go
@@ -42,12 +42,12 @@ type ModuleData interface {
 	Bucket() (storage.ReadBucket, error)
 	// DepModuleKeys returns the dependencies for this specific Module.
 	//
-	// The dependencies are the same as that would appear in the buf.lock file.
+	// The dependencies are the same as that would appear in the v1 buf.lock file.
 	// These include all direct and transitive dependencies. A Module constructed
 	// from this ModuleData as the target will require all Modules referenced by
 	// its DepModuleKeys to be present in the ModuleSet.
 	//
-	// This is used for digest calculations. It is not used otherwise.
+	// This is used for digest calculations.
 	DepModuleKeys() ([]ModuleKey, error)
 
 	// V1Beta1OrV1BufYAMLObjectData gets the v1beta1 or v1 buf.yaml ObjectData.

--- a/private/bufpkg/bufmodule/module_set_builder.go
+++ b/private/bufpkg/bufmodule/module_set_builder.go
@@ -356,7 +356,7 @@ func (b *moduleSetBuilder) AddLocalModule(
 		func() ([]ModuleKey, error) {
 			// See comment in added_module.go when we construct remote Modules for why
 			// we have this function in the first place.
-			return nil, syserror.Newf("getDeclaredDepModuleKeysB5 should never be called for a local Module")
+			return nil, syserror.Newf("getDepModuleKeysB5 should never be called for a local Module")
 		},
 		localModuleOptions.targetPaths,
 		localModuleOptions.targetExcludePaths,


### PR DESCRIPTION
This fixes the b5 digest calculation for remote Modules when a transitive dependency is no longer a dependency in the parents ModuleSet. The digest calculation on Module.Digest would filter dependencies causing a ModuleData to fail tamper-proofing, as it would not filter it's dependencies. The documentation has been reworded to highlight the error case.

The ModuleData's method `DeclaredDepModuleKeys` has been renamed to `DepModuleKeys`. This clarifies the difference between declared dependencies, those in the `buf.yaml`, and the full dependency list, those in the `buf.lock`. The digest calculation must use the full list of dependencies, not the declared.

This is similar to the fix proposed in #3190 but does not cache the digest calculation in ModuleData for reuse in the Modules digest calculation. A Modules digest will always be calculated locally.