### PR TITLE
Add validation for verification URI in registry login

### DIFF
--- a/private/pkg/oauth2/client.go
+++ b/private/pkg/oauth2/client.go
@@ -254,7 +254,7 @@ func validateDeviceAuthorizationResponse(deviceAuthorizationResponse DeviceAutho
 func validateURIScheme(rawURI string) error {
 	parsed, err := url.Parse(rawURI)
 	if err != nil {
-		return err
+		return fmt.Errorf("oauth2: invalid verification URI, %s: %w", rawURI, err)
 	}
 	if parsed.Scheme != "https" && parsed.Scheme != "http" {
 		return fmt.Errorf("oauth2: invalid verification URI scheme, %q, received: %s", parsed.Scheme, parsed)

--- a/private/pkg/oauth2/client.go
+++ b/private/pkg/oauth2/client.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -124,6 +125,9 @@ func (c *Client) AuthorizeDevice(
 	}
 	if code := response.StatusCode; code != http.StatusOK {
 		return nil, fmt.Errorf("oauth2: invalid status: %v", code)
+	}
+	if err := validateDeviceAuthorizationResponse(payload.DeviceAuthorizationResponse); err != nil {
+		return nil, err
 	}
 	return &payload.DeviceAuthorizationResponse, nil
 }
@@ -234,6 +238,26 @@ func parseJSONResponse(response *http.Response, payload any) error {
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return fmt.Errorf("oauth2: failed to unmarshal response: %w: %s", err, body)
+	}
+	return nil
+}
+
+func validateDeviceAuthorizationResponse(deviceAuthorizationResponse DeviceAuthorizationResponse) error {
+	// Validate that the verification URI with and without the code
+	// are valid web URLs, and not a file system URI, for example.
+	if err := validateURIScheme(deviceAuthorizationResponse.VerificationURI); err != nil {
+		return err
+	}
+	return validateURIScheme(deviceAuthorizationResponse.VerificationURIComplete)
+}
+
+func validateURIScheme(rawURI string) error {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("oauth2: invalid verification URI scheme, %q, received: %s", parsed.Scheme, parsed)
 	}
 	return nil
 }

--- a/private/pkg/oauth2/client_test.go
+++ b/private/pkg/oauth2/client_test.go
@@ -153,39 +153,55 @@ func TestAuthorizeDevice(t *testing.T) {
 			ErrorCode:        ErrorCodeInvalidRequest,
 			ErrorDescription: "invalid request",
 		},
-	},
-		{
-			name: "invalid_device_uri",
-			input: &DeviceAuthorizationRequest{
-				ClientID:     "clientID",
-				ClientSecret: "clientSecret",
-			},
-			transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
-				testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
-				return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"file:///path/to/file.ext","verification_uri_complete":"file:///path/to/file.ext?code=userCode","expires_in":10,"interval":5}`), nil
-			},
-			err: fmt.Errorf(
-				`oauth2: invalid verification URI scheme, %q, received: %s`,
-				"file",
-				"file:///path/to/file.ext",
-			),
+	}, {
+		name: "http_device_uri",
+		input: &DeviceAuthorizationRequest{
+			ClientID:     "clientID",
+			ClientSecret: "clientSecret",
 		},
-		{
-			name: "invalid_device_uri_complete",
-			input: &DeviceAuthorizationRequest{
-				ClientID:     "clientID",
-				ClientSecret: "clientSecret",
-			},
-			transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
-				testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
-				return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"https://example.com","verification_uri_complete":"file:///path/to/file.ext?code=userCode","expires_in":10,"interval":5}`), nil
-			},
-			err: fmt.Errorf(
-				`oauth2: invalid verification URI scheme, %q, received: %s`,
-				"file",
-				"file:///path/to/file.ext?code=userCode",
-			),
-		}}
+		transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
+			testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
+			return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"http://example.com","verification_uri_complete":"http://example.com?code=userCode","expires_in":10,"interval":5}`), nil
+		},
+		output: &DeviceAuthorizationResponse{
+			DeviceCode:              "deviceCode",
+			UserCode:                "userCode",
+			VerificationURI:         "http://example.com",
+			VerificationURIComplete: "http://example.com?code=userCode",
+			ExpiresIn:               10,
+			Interval:                5,
+		},
+	}, {
+		name: "invalid_device_uri",
+		input: &DeviceAuthorizationRequest{
+			ClientID:     "clientID",
+			ClientSecret: "clientSecret",
+		},
+		transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
+			testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
+			return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"file:///path/to/file.ext","verification_uri_complete":"file:///path/to/file.ext?code=userCode","expires_in":10,"interval":5}`), nil
+		},
+		err: fmt.Errorf(
+			`oauth2: invalid verification URI scheme, %q, received: %s`,
+			"file",
+			"file:///path/to/file.ext",
+		),
+	}, {
+		name: "invalid_device_uri_complete",
+		input: &DeviceAuthorizationRequest{
+			ClientID:     "clientID",
+			ClientSecret: "clientSecret",
+		},
+		transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
+			testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
+			return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"https://example.com","verification_uri_complete":"file:///path/to/file.ext?code=userCode","expires_in":10,"interval":5}`), nil
+		},
+		err: fmt.Errorf(
+			`oauth2: invalid verification URI scheme, %q, received: %s`,
+			"file",
+			"file:///path/to/file.ext?code=userCode",
+		),
+	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/private/pkg/oauth2/client_test.go
+++ b/private/pkg/oauth2/client_test.go
@@ -153,7 +153,39 @@ func TestAuthorizeDevice(t *testing.T) {
 			ErrorCode:        ErrorCodeInvalidRequest,
 			ErrorDescription: "invalid request",
 		},
-	}}
+	},
+		{
+			name: "invalid_device_uri",
+			input: &DeviceAuthorizationRequest{
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
+				testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
+				return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"file:///path/to/file.ext","verification_uri_complete":"file:///path/to/file.ext?code=userCode","expires_in":10,"interval":5}`), nil
+			},
+			err: fmt.Errorf(
+				`oauth2: invalid verification URI scheme, %q, received: %s`,
+				"file",
+				"file:///path/to/file.ext",
+			),
+		},
+		{
+			name: "invalid_device_uri_complete",
+			input: &DeviceAuthorizationRequest{
+				ClientID:     "clientID",
+				ClientSecret: "clientSecret",
+			},
+			transport: func(t *testing.T, r *http.Request) (*http.Response, error) {
+				testAssertFormRequest(t, r, url.Values{"client_id": {"clientID"}, "client_secret": {"clientSecret"}})
+				return testNewJSONResponse(t, http.StatusOK, `{"device_code":"deviceCode","user_code":"userCode","verification_uri":"https://example.com","verification_uri_complete":"file:///path/to/file.ext?code=userCode","expires_in":10,"interval":5}`), nil
+			},
+			err: fmt.Errorf(
+				`oauth2: invalid verification URI scheme, %q, received: %s`,
+				"file",
+				"file:///path/to/file.ext?code=userCode",
+			),
+		}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This adds validation to ensure that the URL scheme
returned from the oauth handler is only `http`/`https`.