### PR TITLE
Fix deprecated include types flag for buf generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix `buf convert` to allow for zero length for `binpb`, `txtpb`, and `yaml` formats.
+- Fix use of deprecated flag `--include-types` for `buf generate`.
 
 ## [v1.50.1] - 2025-03-10
 

--- a/private/buf/cmd/buf/command/generate/generate.go
+++ b/private/buf/cmd/buf/command/generate/generate.go
@@ -516,7 +516,7 @@ func run(
 		flags.Config,
 		flags.Paths,
 		flags.ExcludePaths,
-		flags.Types,
+		append(flags.Types, flags.TypesDeprecated...),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes the flag `--include-types` for `buf generate`. This is a deprecated flag, replaced by `--type`. Currently this flag won't be applied. The behavior now allows for mixing of flag types, for example the following includes all 3 types:
```bash
buf generate --type=pkg.Foo --include-types=pkg.Bar --type=pkg.Baz
```