### PR TITLE
Run go fix to remove obsolete build lines

### DIFF
--- a/private/buf/buffetch/ref_parser_unix_test.go
+++ b/private/buf/buffetch/ref_parser_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package buffetch
 

--- a/private/buf/bufprotopluginexec/util_darwin.go
+++ b/private/buf/bufprotopluginexec/util_darwin.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package bufprotopluginexec
 

--- a/private/buf/bufprotopluginexec/util_undarwin.go
+++ b/private/buf/bufprotopluginexec/util_undarwin.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !darwin
-// +build !darwin
 
 package bufprotopluginexec
 

--- a/private/buf/cmd/buf/buf_unix_test.go
+++ b/private/buf/cmd/buf/buf_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package buf
 

--- a/private/buf/cmd/buf/command/alpha/protoc/const_unix.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/const_unix.go
@@ -15,7 +15,6 @@
 // Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package protoc
 

--- a/private/buf/cmd/buf/command/alpha/protoc/const_windows.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/const_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package protoc
 

--- a/private/buf/cmd/buf/command/alpha/protoc/flags_unix.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/flags_unix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package protoc
 

--- a/private/buf/cmd/buf/command/alpha/protoc/flags_windows.go
+++ b/private/buf/cmd/buf/command/alpha/protoc/flags_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package protoc
 

--- a/private/buf/cmd/buf/command/generate/generate_unix_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package generate
 

--- a/private/buf/cmd/buf/command/generate/generate_windows_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_windows_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package generate
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/client.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/client.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !darwin
-// +build !darwin
 
 package registrylogin
 

--- a/private/buf/cmd/buf/command/registry/registrylogin/client_darwin.go
+++ b/private/buf/cmd/buf/command/registry/registrylogin/client_darwin.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package registrylogin
 

--- a/private/buf/cmd/buf/workspace_unix_test.go
+++ b/private/buf/cmd/buf/workspace_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package buf
 

--- a/private/buf/cmd/buf/workspace_windows_test.go
+++ b/private/buf/cmd/buf/workspace_windows_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package buf
 

--- a/private/bufpkg/bufimage/bufimagefuzz/bufimagefuzz_unix_test.go
+++ b/private/bufpkg/bufimage/bufimagefuzz/bufimagefuzz_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package bufimagefuzz
 

--- a/private/bufpkg/bufimage/build_image_unix_test.go
+++ b/private/bufpkg/bufimage/build_image_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package bufimage_test
 

--- a/private/pkg/app/app_unix.go
+++ b/private/pkg/app/app_unix.go
@@ -21,7 +21,6 @@
 // We still only officially support linux and darwin for buf as a whole.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package app
 

--- a/private/pkg/app/app_windows.go
+++ b/private/pkg/app/app_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package app
 

--- a/private/pkg/app/appext/name_container_unix_test.go
+++ b/private/pkg/app/appext/name_container_unix_test.go
@@ -15,7 +15,6 @@
 // Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package appext
 

--- a/private/pkg/filepathext/filepathext_unix_test.go
+++ b/private/pkg/filepathext/filepathext_unix_test.go
@@ -15,7 +15,6 @@
 // Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package filepathext
 

--- a/private/pkg/netrc/netrc_unix.go
+++ b/private/pkg/netrc/netrc_unix.go
@@ -15,7 +15,6 @@
 // Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package netrc
 

--- a/private/pkg/netrc/netrc_unix_test.go
+++ b/private/pkg/netrc/netrc_unix_test.go
@@ -15,7 +15,6 @@
 // Matching the unix-like build tags in the Golang source i.e. https://github.com/golang/go/blob/912f0750472dd4f674b69ca1616bfaf377af1805/src/os/file_unix.go#L6
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package netrc
 

--- a/private/pkg/netrc/netrc_windows.go
+++ b/private/pkg/netrc/netrc_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package netrc
 

--- a/private/pkg/normalpath/normalpath_unix.go
+++ b/private/pkg/normalpath/normalpath_unix.go
@@ -16,7 +16,6 @@
 // on "path/filepath", i.e. https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/path/filepath/path_unix.go;l=5-6
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package normalpath
 

--- a/private/pkg/normalpath/normalpath_unix_test.go
+++ b/private/pkg/normalpath/normalpath_unix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package normalpath
 

--- a/private/pkg/normalpath/normalpath_windows.go
+++ b/private/pkg/normalpath/normalpath_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package normalpath
 

--- a/private/pkg/normalpath/normalpath_windows_test.go
+++ b/private/pkg/normalpath/normalpath_windows_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package normalpath
 

--- a/private/pkg/prototesting/prototesting_unix.go
+++ b/private/pkg/prototesting/prototesting_unix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd js,wasm linux netbsd openbsd solaris
 
 package prototesting
 

--- a/private/pkg/prototesting/prototesting_windows.go
+++ b/private/pkg/prototesting/prototesting_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package prototesting
 


### PR DESCRIPTION
The old format build lines are obsolete since Go 1.18 and are removed by running `go fix ./...`.