### PR TITLE
Fix warning from Docker build

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.24-alpine3.21 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.24-alpine3.21 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Fixes the following Docker warning:
- https://docs.docker.com/go/dockerfile/rule/from-as-casing/