### PR TITLE
Fix Docker warning

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
   go build -ldflags "-s -w" -trimpath -buildvcs=false -o /go/bin/buf ./cmd/buf
 
-FROM --platform=${TARGETPLATFORM} alpine:3.21.3
+FROM alpine:3.21.3
 
 RUN apk add --update --no-cache \
     ca-certificates \


### PR DESCRIPTION
Fixes the redundant target platform warning:
- https://docs.docker.com/reference/build-checks/redundant-target-platform/