### PR TITLE
Re-order docker tags to correct image version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,6 @@ jobs:
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
           flavor: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,10 +107,10 @@ jobs:
             bufbuild/buf
           tags: |
             type=edge,branch=main
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
           flavor: |
             latest=auto
       - name: docker-build-push


### PR DESCRIPTION
The first tag appears to be used as the
`org.opencontainers.image.version`, so re-order the tags so the full version comes first for release builds.