### PR TITLE
Fix unused dependencies on type filters for buf generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `buf convert` to allow for zero length for `binpb`, `txtpb`, and `yaml` formats.
 - Fix use of deprecated flag `--include-types` for `buf generate`.
+- Fix type filter with unused image dependencies for `buf generate`.
 
 ## [v1.50.1] - 2025-03-10
 

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -244,7 +244,6 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 		if !ok {
 			continue
 		}
-		includedFiles = append(includedFiles, imageFile)
 		imageFileDescriptor := imageFile.FileDescriptorProto()
 
 		importsRequired := closure.imports[imageFile.Path()]
@@ -365,6 +364,20 @@ func ImageFilteredByTypesWithOptions(image bufimage.Image, types []string, opts 
 			}
 			imageFileDescriptor.SourceCodeInfo.Location = imageFileDescriptor.SourceCodeInfo.Location[:i]
 		}
+		imageFile, err = bufimage.NewImageFile(
+			imageFileDescriptor,
+			imageFile.FullName(),
+			imageFile.CommitID(),
+			imageFile.ExternalPath(),
+			imageFile.LocalPath(),
+			imageFile.IsImport(),
+			imageFile.IsSyntaxUnspecified(),
+			nil, // There are no unused dependencies.
+		)
+		if err != nil {
+			return nil, err
+		}
+		includedFiles = append(includedFiles, imageFile)
 	}
 	return bufimage.NewImage(includedFiles)
 }

--- a/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/a.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package a;
+import "b.proto";
+import "c.proto";
+message A{
+	b.B b = 1;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/a.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/a.txtar
@@ -1,0 +1,12 @@
+-- a.proto --
+syntax = "proto3";
+package a;
+import "b.proto";
+message A {
+  b.B b = 1;
+}
+-- b.proto --
+syntax = "proto3";
+package b;
+message B {
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/ab.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/ab.txtar
@@ -1,0 +1,5 @@
+-- a.proto --
+syntax = "proto3";
+package a;
+message A {
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/b.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/b.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package b;
+import "c.proto";
+message B {}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/c.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/unuseddeps/c.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+package c;
+message C {}


### PR DESCRIPTION
This fixes unused dependencies when a type filter is applied for `buf generate`. The unused deps are validated when unmarshalling an image [here](https://github.com/bufbuild/buf/blob/37b5a2a496a2279aa03507be64cba00193644a1e/private/bufpkg/bufimage/validate.go#L44-L46). For a filtered image there are no unused deps as all unused are pruned. Test have been updated to capture the validation.

The fix has also been applied in #3624 .