### PR TITLE
Fix path handling on windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/tetratelabs/wazero v1.9.0
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0
+	go.lsp.dev/uri v0.3.0
 	go.uber.org/zap v1.27.0
 	go.uber.org/zap/exp v0.3.0
 	golang.org/x/crypto v0.36.0
@@ -105,7 +106,6 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	go.lsp.dev/pkg v0.0.0-20210717090340-384b27a52fb2 // indirect
-	go.lsp.dev/uri v0.3.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -569,15 +569,15 @@ func (f *file) newFileOpener() fileOpener {
 	}
 
 	return func(path string) (io.ReadCloser, error) {
-		var newUri protocol.URI
+		var newURI protocol.URI
 		fileInfo, ok := f.importablePathToObject[path]
 		if ok {
-			newUri = uri.File(fileInfo.LocalPath())
+			newURI = uri.File(fileInfo.LocalPath())
 		} else {
-			newUri = uri.File(path)
+			newURI = uri.File(path)
 		}
 
-		if file := f.Manager().Get(newUri); file != nil {
+		if file := f.Manager().Get(newURI); file != nil {
 			return ioext.CompositeReadCloser(strings.NewReader(file.text), ioext.NopCloser), nil
 		} else if !ok {
 			return nil, os.ErrNotExist

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -42,6 +42,7 @@ import (
 	"github.com/bufbuild/protocompile/parser"
 	"github.com/bufbuild/protocompile/reporter"
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 )
 
 const (
@@ -518,7 +519,7 @@ func (f *file) IndexImports(ctx context.Context) {
 		if fileInfo.LocalPath() == f.uri.Filename() {
 			imported = f
 		} else {
-			imported = f.Manager().Open(ctx, protocol.URI("file://"+fileInfo.LocalPath()))
+			imported = f.Manager().Open(ctx, uri.File(fileInfo.LocalPath()))
 		}
 
 		imported.objectInfo = fileInfo
@@ -528,7 +529,7 @@ func (f *file) IndexImports(ctx context.Context) {
 	// descriptor.proto is always implicitly imported.
 	if _, ok := f.importToFile[descriptorPath]; !ok {
 		descriptorFile := importable[descriptorPath]
-		descriptorURI := protocol.URI("file://" + descriptorFile.LocalPath())
+		descriptorURI := uri.File(descriptorFile.LocalPath())
 		if f.uri == descriptorURI {
 			f.importToFile[descriptorPath] = f
 		} else {
@@ -568,15 +569,15 @@ func (f *file) newFileOpener() fileOpener {
 	}
 
 	return func(path string) (io.ReadCloser, error) {
-		var uri protocol.URI
+		var newUri protocol.URI
 		fileInfo, ok := f.importablePathToObject[path]
 		if ok {
-			uri = protocol.URI("file://" + fileInfo.LocalPath())
+			newUri = uri.File(fileInfo.LocalPath())
 		} else {
-			uri = protocol.URI("file://" + path)
+			newUri = uri.File(path)
 		}
 
-		if file := f.Manager().Get(uri); file != nil {
+		if file := f.Manager().Get(newUri); file != nil {
 			return ioext.CompositeReadCloser(strings.NewReader(file.text), ioext.NopCloser), nil
 		} else if !ok {
 			return nil, os.ErrNotExist


### PR DESCRIPTION
Ensure go.lsp.dev/uri is used for path handling to correctly handle paths cross-platform e.g. windows.

Closes #3699.