### PR TITLE
LSP: Fix diagnostics not being published

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -311,6 +311,9 @@ func (f *file) Refresh(ctx context.Context) {
 		f.BuildImages(ctx)
 		f.RunLints(ctx)
 		f.RunBreaking(ctx)
+
+		// Ensure diagnostics are published after checks are run.
+		f.PublishDiagnostics(ctx)
 	}()
 
 	progress.Report(ctx, "Indexing Symbols", 5.0/6)


### PR DESCRIPTION
Language Server runs checks (lint, breaking) in a go routine which may not finish before diagnostics are published.

Add a PublishDiagnostics at the end of the go routine to ensure diagnostics are published.