### PR TITLE
Include `gitConfigAuthArgs` on `git checkout` when `filter` is set

### DIFF
--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -181,7 +181,7 @@ func (c *cloner) CloneToBucket(
 		if err := execext.Run(
 			ctx,
 			"git",
-			execext.WithArgs("sparse-checkout", "set", options.SubDir),
+			execext.WithArgs(append(gitConfigAuthArgs, "sparse-checkout", "set", options.SubDir)...),
 			execext.WithEnv(app.Environ(envContainer)),
 			execext.WithStderr(buffer),
 			execext.WithDir(baseDir.Path()),
@@ -196,7 +196,7 @@ func (c *cloner) CloneToBucket(
 	if err := execext.Run(
 		ctx,
 		"git",
-		execext.WithArgs("checkout", "--force", "FETCH_HEAD"),
+		execext.WithArgs(append(gitConfigAuthArgs, "checkout", "--force", "FETCH_HEAD")...),
 		execext.WithEnv(app.Environ(envContainer)),
 		execext.WithStderr(buffer),
 		execext.WithDir(baseDir.Path()),
@@ -210,7 +210,7 @@ func (c *cloner) CloneToBucket(
 		if err := execext.Run(
 			ctx,
 			"git",
-			execext.WithArgs("checkout", "--force", checkoutRef),
+			execext.WithArgs(append(gitConfigAuthArgs, "checkout", "--force", checkoutRef)...),
 			execext.WithEnv(app.Environ(envContainer)),
 			execext.WithStderr(buffer),
 			execext.WithDir(baseDir.Path()),

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -193,18 +193,10 @@ func (c *cloner) CloneToBucket(
 	// Always checkout the FETCH_HEAD to populate the working directory.
 	// This allows for referencing HEAD in checkouts.
 	buffer.Reset()
-
-	// Include auth when using git-filters, so git can pull the required
-	// objects from the origin.
-	checkoutArgs := []string{"checkout", "--force", "FETCH_HEAD"}
-	if options.Filter != "" {
-		checkoutArgs = append(gitConfigAuthArgs, checkoutArgs...)
-	}
-
 	if err := execext.Run(
 		ctx,
 		"git",
-		execext.WithArgs(checkoutArgs...),
+		execext.WithArgs("checkout", "--force", "FETCH_HEAD"),
 		execext.WithEnv(app.Environ(envContainer)),
 		execext.WithStderr(buffer),
 		execext.WithDir(baseDir.Path()),

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -173,34 +173,34 @@ func (c *cloner) CloneToBucket(
 		}
 	}
 
+	checkoutArgs := []string{"checkout", "--force", "FETCH_HEAD"}
+
 	// As a further optimization, if a filter is applied with a subdir, we run
 	// a sparse checkout to reduce the size of the working directory.
 	buffer.Reset()
-	if options.Filter != "" && options.SubDir != "" {
-		// Set the subdir for sparse checkout.
-		if err := execext.Run(
-			ctx,
-			"git",
-			execext.WithArgs("sparse-checkout", "set", options.SubDir),
-			execext.WithEnv(app.Environ(envContainer)),
-			execext.WithStderr(buffer),
-			execext.WithDir(baseDir.Path()),
-		); err != nil {
-			return newGitCommandError(err, buffer)
+	if options.Filter != "" {
+		// Include auth credentials when a git filter is set, so that git can
+		// pull the required objects upon checkout.
+		checkoutArgs = append(gitConfigAuthArgs, checkoutArgs...)
+
+		if options.SubDir != "" {
+			// Set the subdir for sparse checkout.
+			if err := execext.Run(
+				ctx,
+				"git",
+				execext.WithArgs("sparse-checkout", "set", options.SubDir),
+				execext.WithEnv(app.Environ(envContainer)),
+				execext.WithStderr(buffer),
+				execext.WithDir(baseDir.Path()),
+			); err != nil {
+				return newGitCommandError(err, buffer)
+			}
 		}
 	}
 
 	// Always checkout the FETCH_HEAD to populate the working directory.
 	// This allows for referencing HEAD in checkouts.
 	buffer.Reset()
-
-	// Include auth when using git-filters, so git can pull the required
-	// objects from the origin.
-	checkoutArgs := []string{"checkout", "--force", "FETCH_HEAD"}
-	if options.Filter != "" {
-		checkoutArgs = append(gitConfigAuthArgs, checkoutArgs...)
-	}
-
 	if err := execext.Run(
 		ctx,
 		"git",

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -193,10 +193,18 @@ func (c *cloner) CloneToBucket(
 	// Always checkout the FETCH_HEAD to populate the working directory.
 	// This allows for referencing HEAD in checkouts.
 	buffer.Reset()
+
+	// Include auth when using git-filters, so git can pull the required
+	// objects from the origin.
+	checkoutArgs := []string{"checkout", "--force", "FETCH_HEAD"}
+	if options.Filter != "" {
+		checkoutArgs = append(gitConfigAuthArgs, checkoutArgs...)
+	}
+
 	if err := execext.Run(
 		ctx,
 		"git",
-		execext.WithArgs("checkout", "--force", "FETCH_HEAD"),
+		execext.WithArgs(checkoutArgs...),
 		execext.WithEnv(app.Environ(envContainer)),
 		execext.WithStderr(buffer),
 		execext.WithDir(baseDir.Path()),


### PR DESCRIPTION
When using `filter` `buf` will fail to run `git checkout` as the credentials aren't passed to `git`.

This results in failures such as:

```
Failure: could not clone https://github.com/foo/bar.git: exit status 128
fatal: could not read Username for 'https://github.com': No such device or address
fatal: could not fetch <SHA> from promisor remote
```

I noticed this while testing bufbuild/buf-action#142 which relies on overriding `credential.helper` for authentication in GitHub Actions.