### PR TITLE
LSP ensure check diagnostics are always published

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -313,8 +313,9 @@ func (f *file) Refresh(ctx context.Context) {
 //
 // Checks are executed in a background goroutine to avoid blocking the LSP
 // call. Each call to RunChecks invalidates any ongoing checks, triggering a
-// fresh run. The checks acquire the LSP mutex. Subsequent LSP calls will wait
-// for the current check to complete before proceeding.
+// fresh run. However, previous checks are not interrupted. The checks acquire
+// the LSP mutex. Subsequent LSP calls will wait for the current check to
+// complete before proceeding.
 //
 // Checks are debounce (with the delay defined by checkRefreshPeriod) to avoid
 // overwhelming the client with expensive checks. If the file is not open in the


### PR DESCRIPTION
This ensures checks diagnostics are always published to the LSP client. We adopt a worker model that runs checks in the background. On updates, the caller invalidates the previous checks. Checks are then re-evaluated and published. This ensures checks are eventually consistent.

Thanks to https://github.com/bufbuild/buf/pull/3706 for finding the issue for missing check diagnostics. This fixes that issue and solves the error case where the checks are never run due to try locking.