### PR TITLE
Report lint/breaking check results as `DiagnosticSeverityWarning` in LSP

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -744,7 +744,7 @@ func (f *file) appendLintErrors(source string, err error) bool {
 				},
 			},
 			Code:     annotation.Type(),
-			Severity: protocol.DiagnosticSeverityError,
+			Severity: protocol.DiagnosticSeverityWarning,
 			Source:   source,
 			Message:  annotation.Message(),
 		})


### PR DESCRIPTION
This changes the severity of the lint and breaking changes to `DiagnosticSeverityWarning`.
Checked a couple of reference implementations (e.g. gopls, rust-analyzer), surfacing lint/breaking
file annotations as "warning" level diagnostics is reasonable. We may want to make this configurable
in the future.

Fixes #3701, this would allow format to run with lint/breaking results.
We still want to continue blocking formatting with an invalid AST.