### PR TITLE
Add os environment for local plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix `exclude_type` on a non imported package.
 - Fix `--exclude-type` flag for `buf generate` when an input is specified.
 - Fix type filter import filtering for options.
-- Add OS environment to local buf plugins.
+- Add OS environment when invoking local buf plugins.
 
 ## [v1.51.0] - 2025-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `exclude_type` on a non imported package.
 - Fix `--exclude-type` flag for `buf generate` when an input is specified.
 - Fix type filter import filtering for options.
+- Add OS environment to local buf plugins.
 
 ## [v1.51.0] - 2025-03-28
 

--- a/private/pkg/pluginrpcutil/pluginrpcutil.go
+++ b/private/pkg/pluginrpcutil/pluginrpcutil.go
@@ -25,7 +25,8 @@ import (
 // NewLocalRunner returns a new pluginrpc.Runner for the local program.
 //
 // The programName is the path or name of the program. Any program args are passed to
-// the program when it is run. The programArgs may be nil.
+// the program when it is run. The programArgs may be nil. The environment is set to
+// os.Environ().
 func NewLocalRunner(programName string, programArgs ...string) pluginrpc.Runner {
 	return newRunner(programName, programArgs...)
 }

--- a/private/pkg/pluginrpcutil/runner.go
+++ b/private/pkg/pluginrpcutil/runner.go
@@ -17,6 +17,7 @@ package pluginrpcutil
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"slices"
 
@@ -51,6 +52,7 @@ func (r *runner) Run(ctx context.Context, env pluginrpc.Env) error {
 		execext.WithStdin(env.Stdin),
 		execext.WithStdout(env.Stdout),
 		execext.WithStderr(env.Stderr),
+		execext.WithEnv(os.Environ()),
 	); err != nil {
 		execExitError := &exec.ExitError{}
 		if errors.As(err, &execExitError) {


### PR DESCRIPTION
This adds the os environment to locally run plugins. Local plugins inherit the environment from buf. 

As a use case, plugins can now be managed with `go tool`. For instance [buf-plugin-aep](https://github.com/aep-dev/api-linter/tree/main/cmd/buf-plugin-aep) in `buf.yaml`:

```yaml
version: v2
lint:
  use:
  - AEP_CORE
plugins:
  - plugin: ["go", "tool", "buf-plugin-aep"]
```