### PR TITLE
Ensure deterministic order for filtered public imports

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -494,6 +494,10 @@ func TestDependencies(t *testing.T) {
 		t.Parallel()
 		runDiffTest(t, "testdata/deps", "test.EnumA.txtar", WithIncludeTypes("test.EnumA"))
 	})
+	t.Run("PublicOrder", func(t *testing.T) {
+		t.Parallel()
+		runDiffTest(t, "testdata/deps", "test.PublicOrder.txtar", WithIncludeTypes("test.PublicOrder"))
+	})
 }
 
 func getImage(ctx context.Context, logger *slog.Logger, testdataDir string, options ...bufimage.BuildImageOption) (storage.ReadWriteBucket, bufimage.Image, error) {

--- a/private/bufpkg/bufimage/bufimageutil/image_filter.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_filter.go
@@ -279,14 +279,13 @@ func (b *sourcePathsBuilder) remapDependencies(
 		}
 		indexFrom++
 	}
-	// Add imports picked up via a public import. The filtered files do no
-	// use public imports.
-	if n := len(importsRequired); n > 0 {
-		for key := range importsRequired {
-			newDependencies = append(newDependencies, key)
+	// Add imports picked up via a public import. The filtered files do not use public imports.
+	if publicImportCount := len(importsRequired); publicImportCount > 0 {
+		for importPath := range importsRequired {
+			newDependencies = append(newDependencies, importPath)
 		}
 		// Sort the public imports to ensure the output is deterministic.
-		sort.Strings(newDependencies[len(newDependencies)-n:])
+		sort.Strings(newDependencies[len(newDependencies)-publicImportCount:])
 	}
 
 	// Public dependencies are always removed on remapping.

--- a/private/bufpkg/bufimage/bufimageutil/testdata/deps/old.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/deps/old.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package old;
+
+import public "a.proto";
+import public "b.proto";
+import public "c.proto";
+
+message Old {}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/deps/test.PublicOrder.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/deps/test.PublicOrder.txtar
@@ -1,0 +1,328 @@
+-- a.proto --
+syntax = "proto3";
+package a;
+import "b.proto";
+option (b.B.file_c) = { c: "c" };
+message A {
+  option (b.message_c) = { c: "c" };
+  string a = 1 [(b.field_c) = { c: "c" }];
+  oneof oneof_a {
+    option (b.oneof_c) = { c: "c" };
+    string foo = 2;
+    string bar = 3;
+  }
+}
+-- b.proto --
+syntax = "proto3";
+package b;
+import "c.proto";
+import "google/protobuf/descriptor.proto";
+message B {
+  string b = 1;
+  extend google.protobuf.FileOptions {
+    c.C file_c = 50000;
+  }
+}
+extend google.protobuf.FieldOptions {
+  c.C field_c = 50000;
+}
+extend google.protobuf.MessageOptions {
+  c.C message_c = 50000;
+}
+extend google.protobuf.OneofOptions {
+  c.C oneof_c = 50000;
+}
+-- c.proto --
+syntax = "proto3";
+package c;
+message C {
+  string c = 1;
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message FeatureSet {
+  optional FieldPresence field_presence = 1 [
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "IMPLICIT", edition: EDITION_PROTO3 },
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_2023 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnumType enum_type = 2 [
+    edition_defaults = { value: "CLOSED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "OPEN", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional RepeatedFieldEncoding repeated_field_encoding = 3 [
+    edition_defaults = { value: "EXPANDED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "PACKED", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional Utf8Validation utf8_validation = 4 [
+    edition_defaults = { value: "NONE", edition: EDITION_LEGACY },
+    edition_defaults = { value: "VERIFY", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional MessageEncoding message_encoding = 5 [
+    edition_defaults = { value: "LENGTH_PREFIXED", edition: EDITION_LEGACY },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional JsonFormat json_format = 6 [
+    edition_defaults = { value: "LEGACY_BEST_EFFORT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "ALLOW", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnforceNamingStyle enforce_naming_style = 7 [
+    edition_defaults = { value: "STYLE_LEGACY", edition: EDITION_LEGACY },
+    edition_defaults = { value: "STYLE2024", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE,
+    targets = TARGET_TYPE_EXTENSION_RANGE,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_ONEOF,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_ENUM_ENTRY,
+    targets = TARGET_TYPE_SERVICE,
+    targets = TARGET_TYPE_METHOD
+  ];
+  enum EnforceNamingStyle {
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+    STYLE2024 = 1;
+    STYLE_LEGACY = 2;
+  }
+  enum EnumType {
+    ENUM_TYPE_UNKNOWN = 0;
+    OPEN = 1;
+    CLOSED = 2;
+  }
+  enum FieldPresence {
+    FIELD_PRESENCE_UNKNOWN = 0;
+    EXPLICIT = 1;
+    IMPLICIT = 2;
+    LEGACY_REQUIRED = 3;
+  }
+  enum JsonFormat {
+    JSON_FORMAT_UNKNOWN = 0;
+    ALLOW = 1;
+    LEGACY_BEST_EFFORT = 2;
+  }
+  enum MessageEncoding {
+    MESSAGE_ENCODING_UNKNOWN = 0;
+    LENGTH_PREFIXED = 1;
+    DELIMITED = 2;
+  }
+  enum RepeatedFieldEncoding {
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+    PACKED = 1;
+    EXPANDED = 2;
+  }
+  enum Utf8Validation {
+    UTF8_VALIDATION_UNKNOWN = 0;
+    VERIFY = 2;
+    NONE = 3;
+    reserved 1;
+  }
+  extensions 1000 to 9994 [
+    declaration = {
+      number: 1000,
+      full_name: ".pb.cpp",
+      type: ".pb.CppFeatures"
+    },
+    declaration = {
+      number: 1001,
+      full_name: ".pb.java",
+      type: ".pb.JavaFeatures"
+    },
+    declaration = {
+      number: 1002,
+      full_name: ".pb.go",
+      type: ".pb.GoFeatures"
+    },
+    declaration = {
+      number: 1003,
+      full_name: ".pb.python",
+      type: ".pb.PythonFeatures"
+    },
+    declaration = {
+      number: 9990,
+      full_name: ".pb.proto1",
+      type: ".pb.Proto1Features"
+    }
+  ];
+  extensions 9995 to 9999, 10000;
+  reserved 999;
+}
+message FieldOptions {
+  optional CType ctype = 1 [default = STRING];
+  optional bool packed = 2;
+  optional bool deprecated = 3 [default = false];
+  optional bool lazy = 5 [default = false];
+  optional JSType jstype = 6 [default = JS_NORMAL];
+  optional bool weak = 10 [default = false];
+  optional bool unverified_lazy = 15 [default = false];
+  optional bool debug_redact = 16 [default = false];
+  optional OptionRetention retention = 17;
+  repeated OptionTargetType targets = 19;
+  repeated EditionDefault edition_defaults = 20;
+  optional FeatureSet features = 21;
+  optional FeatureSupport feature_support = 22;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  message EditionDefault {
+    optional string value = 2;
+    optional Edition edition = 3;
+  }
+  message FeatureSupport {
+    optional Edition edition_introduced = 1;
+    optional Edition edition_deprecated = 2;
+    optional string deprecation_warning = 3;
+    optional Edition edition_removed = 4;
+  }
+  enum CType {
+    STRING = 0;
+    CORD = 1;
+    STRING_PIECE = 2;
+  }
+  enum JSType {
+    JS_NORMAL = 0;
+    JS_STRING = 1;
+    JS_NUMBER = 2;
+  }
+  enum OptionRetention {
+    RETENTION_UNKNOWN = 0;
+    RETENTION_RUNTIME = 1;
+    RETENTION_SOURCE = 2;
+  }
+  enum OptionTargetType {
+    TARGET_TYPE_UNKNOWN = 0;
+    TARGET_TYPE_FILE = 1;
+    TARGET_TYPE_EXTENSION_RANGE = 2;
+    TARGET_TYPE_MESSAGE = 3;
+    TARGET_TYPE_FIELD = 4;
+    TARGET_TYPE_ONEOF = 5;
+    TARGET_TYPE_ENUM = 6;
+    TARGET_TYPE_ENUM_ENTRY = 7;
+    TARGET_TYPE_SERVICE = 8;
+    TARGET_TYPE_METHOD = 9;
+  }
+  extensions 1000 to max;
+  reserved 4, 18;
+}
+message FileOptions {
+  optional string java_package = 1;
+  optional string java_outer_classname = 8;
+  optional OptimizeMode optimize_for = 9 [default = SPEED];
+  optional bool java_multiple_files = 10 [default = false];
+  optional string go_package = 11;
+  optional bool cc_generic_services = 16 [default = false];
+  optional bool java_generic_services = 17 [default = false];
+  optional bool py_generic_services = 18 [default = false];
+  optional bool java_generate_equals_and_hash = 20 [deprecated = true];
+  optional bool deprecated = 23 [default = false];
+  optional bool java_string_check_utf8 = 27 [default = false];
+  optional bool cc_enable_arenas = 31 [default = true];
+  optional string objc_class_prefix = 36;
+  optional string csharp_namespace = 37;
+  optional string swift_prefix = 39;
+  optional string php_class_prefix = 40;
+  optional string php_namespace = 41;
+  optional string php_metadata_namespace = 44;
+  optional string ruby_package = 45;
+  optional FeatureSet features = 50;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  enum OptimizeMode {
+    SPEED = 1;
+    CODE_SIZE = 2;
+    LITE_RUNTIME = 3;
+  }
+  extensions 1000 to max;
+  reserved 38, 42;
+  reserved "php_generic_services";
+}
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
+  optional FeatureSet features = 12;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message OneofOptions {
+  optional FeatureSet features = 1;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}
+enum Edition {
+  EDITION_UNKNOWN = 0;
+  EDITION_1_TEST_ONLY = 1;
+  EDITION_2_TEST_ONLY = 2;
+  EDITION_LEGACY = 900;
+  EDITION_PROTO2 = 998;
+  EDITION_PROTO3 = 999;
+  EDITION_2023 = 1000;
+  EDITION_2024 = 1001;
+  EDITION_99997_TEST_ONLY = 99997;
+  EDITION_99998_TEST_ONLY = 99998;
+  EDITION_99999_TEST_ONLY = 99999;
+  EDITION_MAX = 2147483647;
+}
+-- test.proto --
+syntax = "proto3";
+package test;
+import "a.proto";
+import "b.proto";
+import "c.proto";
+import "google/protobuf/descriptor.proto";
+message PublicOrder {
+  option (message_a) = { a: "a" };
+  option (message_b) = { b: "b" };
+  option (message_c) = { c: "c" };
+}
+extend google.protobuf.MessageOptions {
+  a.A message_a = 50001;
+  b.B message_b = 50002;
+  c.C message_c = 50003;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/deps/test.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/deps/test.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package test;
 
 import "a.proto";
+import "google/protobuf/descriptor.proto";
+import "old.proto";
 
 message FieldA {
   a.A a = 1;
@@ -9,4 +11,16 @@ message FieldA {
 
 message EnumA {
   a.A.AEnum a = 1;
+}
+
+message PublicOrder {
+  option (test.message_c).c = "c";
+  option (test.message_b).b = "b";
+  option (test.message_a).a = "a";
+}
+
+extend google.protobuf.MessageOptions {
+  optional a.A message_a = 50001;
+  optional b.B message_b = 50002;
+  optional c.C message_c = 50003;
 }


### PR DESCRIPTION
This ensures that public imports are always added to the image in a deterministic way. It changes the current order by first seen to order by file name. First seen is not valid as when including options we range over them in an [undefined order](https://pkg.go.dev/google.golang.org/protobuf@v1.36.6/reflect/protoreflect#Message) (although from testing it looks to always be in tag order).

Related to https://github.com/bufbuild/buf/issues/3506  and https://github.com/bufbuild/buf/issues/3725 . Both these issues link to the same error of adding unused imports. This was fixed in https://github.com/bufbuild/buf/pull/3727 . This PR fixes an edge case where if 2 or more public imports are resolved for a file, they must be appended to the current imports in a deterministic way.  