### PR TITLE
Update pre-commit hooks language version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,42 +1,42 @@
 - id: buf-generate
   name: buf generate
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf generate
   types: [proto]
   pass_filenames: false
 - id: buf-breaking
   name: buf breaking
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf breaking
   types: [proto]
   pass_filenames: false
 - id: buf-lint
   name: buf lint
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf lint
   types: [proto]
   pass_filenames: false
 - id: buf-format
   name: buf format
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf format -w --exit-code
   types: [proto]
   pass_filenames: false
 - id: buf-dep-update
   name: buf dep update
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf dep update
   files: '(buf\.lock|buf\.yaml)'
   pass_filenames: false
 - id: buf-dep-prune
   name: buf dep prune
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf dep prune
   files: '(buf\.lock|buf\.yaml)'
   pass_filenames: false
@@ -44,7 +44,7 @@
 - id: buf-mod-update
   name: buf mod update
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf mod update
   files: '(buf\.lock|buf\.yaml)'
   pass_filenames: false
@@ -52,7 +52,7 @@
 - id: buf-mod-prune
   name: buf mod prune
   language: golang
-  language_version: 1.23.0
+  language_version: 1.23.4
   entry: buf mod prune
   files: '(buf\.lock|buf\.yaml)'
   pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix language version for pre-commit hooks.
 
 ## [v1.52.0] - 2025-04-07
 


### PR DESCRIPTION
We currently require `go 1.23.4` (based on our dependency on
`protovalidate-go`), so pre-commit hooks need to be updated to
fetch a compliant version of Go.

Fixes #3750