### PR TITLE
Cleanup Wasm runtime creation

### DIFF
--- a/private/buf/cmd/buf/command/beta/lsp/lsp.go
+++ b/private/buf/cmd/buf/command/beta/lsp/lsp.go
@@ -29,7 +29,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
 	"github.com/bufbuild/buf/private/pkg/ioext"
-	"github.com/bufbuild/buf/private/pkg/wasm"
 	"github.com/spf13/pflag"
 	"go.lsp.dev/jsonrpc2"
 )
@@ -101,11 +100,7 @@ func run(
 		return err
 	}
 
-	wasmRuntimeCacheDir, err := bufcli.CreateWasmRuntimeCacheDir(container)
-	if err != nil {
-		return err
-	}
-	wasmRuntime, err := wasm.NewRuntime(ctx, wasm.WithLocalCacheDir(wasmRuntimeCacheDir))
+	wasmRuntime, err := bufcli.NewWasmRuntime(ctx, container)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/breaking/breaking.go
+++ b/private/buf/cmd/buf/command/breaking/breaking.go
@@ -176,11 +176,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	wasmRuntimeCacheDir, err := bufcli.CreateWasmRuntimeCacheDir(container)
-	if err != nil {
-		return err
-	}
-	wasmRuntime, err := wasm.NewRuntime(ctx, wasm.WithLocalCacheDir(wasmRuntimeCacheDir))
+	wasmRuntime, err := bufcli.NewWasmRuntime(ctx, container)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/config/internal/internal.go
+++ b/private/buf/cmd/buf/command/config/internal/internal.go
@@ -31,7 +31,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/slicesext"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
 	"github.com/bufbuild/buf/private/pkg/syserror"
-	"github.com/bufbuild/buf/private/pkg/wasm"
 	"github.com/spf13/pflag"
 )
 
@@ -183,11 +182,7 @@ func lsRun(
 			return err
 		}
 	}
-	wasmRuntimeCacheDir, err := bufcli.CreateWasmRuntimeCacheDir(container)
-	if err != nil {
-		return err
-	}
-	wasmRuntime, err := wasm.NewRuntime(ctx, wasm.WithLocalCacheDir(wasmRuntimeCacheDir))
+	wasmRuntime, err := bufcli.NewWasmRuntime(ctx, container)
 	if err != nil {
 		return err
 	}

--- a/private/buf/cmd/buf/command/lint/lint.go
+++ b/private/buf/cmd/buf/command/lint/lint.go
@@ -27,7 +27,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/app/appcmd"
 	"github.com/bufbuild/buf/private/pkg/app/appext"
 	"github.com/bufbuild/buf/private/pkg/stringutil"
-	"github.com/bufbuild/buf/private/pkg/wasm"
 	"github.com/spf13/pflag"
 )
 
@@ -122,11 +121,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	wasmRuntimeCacheDir, err := bufcli.CreateWasmRuntimeCacheDir(container)
-	if err != nil {
-		return err
-	}
-	wasmRuntime, err := wasm.NewRuntime(ctx, wasm.WithLocalCacheDir(wasmRuntimeCacheDir))
+	wasmRuntime, err := bufcli.NewWasmRuntime(ctx, container)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a cleanup to bind the cache directory creation to the creation of the wasm runtime.