### PR TITLE
Add `role_override` to `AddOrganizationGroupRequest`

### DIFF
--- a/private/gen/proto/go/buf/alpha/audit/v1alpha1/event.pb.go
+++ b/private/gen/proto/go/buf/alpha/audit/v1alpha1/event.pb.go
@@ -3976,9 +3976,10 @@ func (b0 PayloadOrganizationMemberRemoved_builder) Build() *PayloadOrganizationM
 }
 
 type PayloadOrganizationIDPGroupAdded struct {
-	state                       protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_OrganizationId   string                 `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3"`
-	xxx_hidden_OrganizationName string                 `protobuf:"bytes,2,opt,name=organization_name,json=organizationName,proto3"`
+	state                       protoimpl.MessageState    `protogen:"opaque.v1"`
+	xxx_hidden_OrganizationId   string                    `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3"`
+	xxx_hidden_OrganizationName string                    `protobuf:"bytes,2,opt,name=organization_name,json=organizationName,proto3"`
+	xxx_hidden_RoleOverride     v1alpha1.OrganizationRole `protobuf:"varint,3,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.OrganizationRole"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -4022,12 +4023,23 @@ func (x *PayloadOrganizationIDPGroupAdded) GetOrganizationName() string {
 	return ""
 }
 
+func (x *PayloadOrganizationIDPGroupAdded) GetRoleOverride() v1alpha1.OrganizationRole {
+	if x != nil {
+		return x.xxx_hidden_RoleOverride
+	}
+	return v1alpha1.OrganizationRole(0)
+}
+
 func (x *PayloadOrganizationIDPGroupAdded) SetOrganizationId(v string) {
 	x.xxx_hidden_OrganizationId = v
 }
 
 func (x *PayloadOrganizationIDPGroupAdded) SetOrganizationName(v string) {
 	x.xxx_hidden_OrganizationName = v
+}
+
+func (x *PayloadOrganizationIDPGroupAdded) SetRoleOverride(v v1alpha1.OrganizationRole) {
+	x.xxx_hidden_RoleOverride = v
 }
 
 type PayloadOrganizationIDPGroupAdded_builder struct {
@@ -4037,6 +4049,8 @@ type PayloadOrganizationIDPGroupAdded_builder struct {
 	OrganizationId string
 	// organization_name is the name of the organization with the new IDP group.
 	OrganizationName string
+	// role_override is the role override associated with the new IDP group.
+	RoleOverride v1alpha1.OrganizationRole
 }
 
 func (b0 PayloadOrganizationIDPGroupAdded_builder) Build() *PayloadOrganizationIDPGroupAdded {
@@ -4045,13 +4059,15 @@ func (b0 PayloadOrganizationIDPGroupAdded_builder) Build() *PayloadOrganizationI
 	_, _ = b, x
 	x.xxx_hidden_OrganizationId = b.OrganizationId
 	x.xxx_hidden_OrganizationName = b.OrganizationName
+	x.xxx_hidden_RoleOverride = b.RoleOverride
 	return m0
 }
 
 type PayloadOrganizationIDPGroupRemoved struct {
-	state                       protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_OrganizationId   string                 `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3"`
-	xxx_hidden_OrganizationName string                 `protobuf:"bytes,2,opt,name=organization_name,json=organizationName,proto3"`
+	state                       protoimpl.MessageState    `protogen:"opaque.v1"`
+	xxx_hidden_OrganizationId   string                    `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3"`
+	xxx_hidden_OrganizationName string                    `protobuf:"bytes,2,opt,name=organization_name,json=organizationName,proto3"`
+	xxx_hidden_RoleOverride     v1alpha1.OrganizationRole `protobuf:"varint,3,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.OrganizationRole"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -4095,12 +4111,23 @@ func (x *PayloadOrganizationIDPGroupRemoved) GetOrganizationName() string {
 	return ""
 }
 
+func (x *PayloadOrganizationIDPGroupRemoved) GetRoleOverride() v1alpha1.OrganizationRole {
+	if x != nil {
+		return x.xxx_hidden_RoleOverride
+	}
+	return v1alpha1.OrganizationRole(0)
+}
+
 func (x *PayloadOrganizationIDPGroupRemoved) SetOrganizationId(v string) {
 	x.xxx_hidden_OrganizationId = v
 }
 
 func (x *PayloadOrganizationIDPGroupRemoved) SetOrganizationName(v string) {
 	x.xxx_hidden_OrganizationName = v
+}
+
+func (x *PayloadOrganizationIDPGroupRemoved) SetRoleOverride(v v1alpha1.OrganizationRole) {
+	x.xxx_hidden_RoleOverride = v
 }
 
 type PayloadOrganizationIDPGroupRemoved_builder struct {
@@ -4110,6 +4137,8 @@ type PayloadOrganizationIDPGroupRemoved_builder struct {
 	OrganizationId string
 	// organization_name is the name of the organization with the removed IDP group.
 	OrganizationName string
+	// role_override is the role override associated with the removed IDP group.
+	RoleOverride v1alpha1.OrganizationRole
 }
 
 func (b0 PayloadOrganizationIDPGroupRemoved_builder) Build() *PayloadOrganizationIDPGroupRemoved {
@@ -4118,6 +4147,7 @@ func (b0 PayloadOrganizationIDPGroupRemoved_builder) Build() *PayloadOrganizatio
 	_, _ = b, x
 	x.xxx_hidden_OrganizationId = b.OrganizationId
 	x.xxx_hidden_OrganizationName = b.OrganizationName
+	x.xxx_hidden_RoleOverride = b.RoleOverride
 	return m0
 }
 
@@ -8758,13 +8788,15 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"\x11organization_name\x18\x02 \x01(\tR\x10organizationName\x12N\n" +
 	"\vmember_role\x18\x03 \x01(\x0e2-.buf.alpha.registry.v1alpha1.OrganizationRoleR\n" +
 	"memberRole\x12a\n" +
-	"\x12member_role_source\x18\x04 \x01(\x0e23.buf.alpha.registry.v1alpha1.OrganizationRoleSourceR\x10memberRoleSource\"x\n" +
+	"\x12member_role_source\x18\x04 \x01(\x0e23.buf.alpha.registry.v1alpha1.OrganizationRoleSourceR\x10memberRoleSource\"\xcc\x01\n" +
 	" PayloadOrganizationIDPGroupAdded\x12'\n" +
 	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\x12+\n" +
-	"\x11organization_name\x18\x02 \x01(\tR\x10organizationName\"z\n" +
+	"\x11organization_name\x18\x02 \x01(\tR\x10organizationName\x12R\n" +
+	"\rrole_override\x18\x03 \x01(\x0e2-.buf.alpha.registry.v1alpha1.OrganizationRoleR\froleOverride\"\xce\x01\n" +
 	"\"PayloadOrganizationIDPGroupRemoved\x12'\n" +
 	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\x12+\n" +
-	"\x11organization_name\x18\x02 \x01(\tR\x10organizationName\"\xcb\x01\n" +
+	"\x11organization_name\x18\x02 \x01(\tR\x10organizationName\x12R\n" +
+	"\rrole_override\x18\x03 \x01(\x0e2-.buf.alpha.registry.v1alpha1.OrganizationRoleR\froleOverride\"\xcb\x01\n" +
 	"\x18PayloadRepositoryCreated\x12\x19\n" +
 	"\bowner_id\x18\x01 \x01(\tR\aownerId\x12\x1d\n" +
 	"\n" +
@@ -9276,38 +9308,40 @@ var file_buf_alpha_audit_v1alpha1_event_proto_depIdxs = []int32{
 	65,  // 72: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.new_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
 	67,  // 73: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved.member_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
 	68,  // 74: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved.member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	69,  // 75: buf.alpha.audit.v1alpha1.PayloadRepositoryCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 76: buf.alpha.audit.v1alpha1.PayloadRepositoryDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 77: buf.alpha.audit.v1alpha1.PayloadRepositoryDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 78: buf.alpha.audit.v1alpha1.PayloadRepositoryUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 79: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	70,  // 80: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.old_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	70,  // 81: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.new_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	70,  // 82: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	69,  // 83: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 84: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 85: buf.alpha.audit.v1alpha1.PayloadPolicyCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 86: buf.alpha.audit.v1alpha1.PayloadPolicyDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 87: buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 88: buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 89: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 90: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 91: buf.alpha.audit.v1alpha1.PayloadPluginCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 92: buf.alpha.audit.v1alpha1.PayloadPluginDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 93: buf.alpha.audit.v1alpha1.PayloadPluginDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 94: buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 95: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	69,  // 96: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	66,  // 97: buf.alpha.audit.v1alpha1.PayloadTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
-	66,  // 98: buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
-	71,  // 99: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled.category:type_name -> buf.alpha.registry.v1alpha1.BreakingChangeCategory
-	67,  // 100: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	68,  // 101: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	102, // [102:102] is the sub-list for method output_type
-	102, // [102:102] is the sub-list for method input_type
-	102, // [102:102] is the sub-list for extension type_name
-	102, // [102:102] is the sub-list for extension extendee
-	0,   // [0:102] is the sub-list for field type_name
+	67,  // 75: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	67,  // 76: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	69,  // 77: buf.alpha.audit.v1alpha1.PayloadRepositoryCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 78: buf.alpha.audit.v1alpha1.PayloadRepositoryDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 79: buf.alpha.audit.v1alpha1.PayloadRepositoryDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 80: buf.alpha.audit.v1alpha1.PayloadRepositoryUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	70,  // 81: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	70,  // 82: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.old_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	70,  // 83: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.new_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	70,  // 84: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	69,  // 85: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 86: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 87: buf.alpha.audit.v1alpha1.PayloadPolicyCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 88: buf.alpha.audit.v1alpha1.PayloadPolicyDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 89: buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 90: buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 91: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 92: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 93: buf.alpha.audit.v1alpha1.PayloadPluginCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 94: buf.alpha.audit.v1alpha1.PayloadPluginDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 95: buf.alpha.audit.v1alpha1.PayloadPluginDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 96: buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 97: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	69,  // 98: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	66,  // 99: buf.alpha.audit.v1alpha1.PayloadTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
+	66,  // 100: buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
+	71,  // 101: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled.category:type_name -> buf.alpha.registry.v1alpha1.BreakingChangeCategory
+	67,  // 102: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	68,  // 103: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	104, // [104:104] is the sub-list for method output_type
+	104, // [104:104] is the sub-list for method input_type
+	104, // [104:104] is the sub-list for extension type_name
+	104, // [104:104] is the sub-list for extension extendee
+	0,   // [0:104] is the sub-list for field type_name
 }
 
 func init() { file_buf_alpha_audit_v1alpha1_event_proto_init() }

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/organization.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/organization.pb.go
@@ -1911,10 +1911,10 @@ func (b0 GetOrganizationSettingsRequest_builder) Build() *GetOrganizationSetting
 }
 
 type GetOrganizationSettingsResponse struct {
-	state                         protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_RepositoryBaseRole RepositoryRole         `protobuf:"varint,1,opt,name=repository_base_role,json=repositoryBaseRole,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
-	xxx_hidden_MembersCount       uint32                 `protobuf:"varint,4,opt,name=members_count,json=membersCount,proto3"`
-	xxx_hidden_IdpGroups          []string               `protobuf:"bytes,5,rep,name=idp_groups,json=idpGroups,proto3"`
+	state                         protoimpl.MessageState                       `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryBaseRole RepositoryRole                               `protobuf:"varint,1,opt,name=repository_base_role,json=repositoryBaseRole,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	xxx_hidden_MembersCount       uint32                                       `protobuf:"varint,4,opt,name=members_count,json=membersCount,proto3"`
+	xxx_hidden_IdpGroups          *[]*GetOrganizationSettingsResponse_IdPGroup `protobuf:"bytes,5,rep,name=idp_groups,json=idpGroups,proto3"`
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache
 }
@@ -1958,9 +1958,11 @@ func (x *GetOrganizationSettingsResponse) GetMembersCount() uint32 {
 	return 0
 }
 
-func (x *GetOrganizationSettingsResponse) GetIdpGroups() []string {
+func (x *GetOrganizationSettingsResponse) GetIdpGroups() []*GetOrganizationSettingsResponse_IdPGroup {
 	if x != nil {
-		return x.xxx_hidden_IdpGroups
+		if x.xxx_hidden_IdpGroups != nil {
+			return *x.xxx_hidden_IdpGroups
+		}
 	}
 	return nil
 }
@@ -1973,8 +1975,8 @@ func (x *GetOrganizationSettingsResponse) SetMembersCount(v uint32) {
 	x.xxx_hidden_MembersCount = v
 }
 
-func (x *GetOrganizationSettingsResponse) SetIdpGroups(v []string) {
-	x.xxx_hidden_IdpGroups = v
+func (x *GetOrganizationSettingsResponse) SetIdpGroups(v []*GetOrganizationSettingsResponse_IdPGroup) {
+	x.xxx_hidden_IdpGroups = &v
 }
 
 type GetOrganizationSettingsResponse_builder struct {
@@ -1984,7 +1986,7 @@ type GetOrganizationSettingsResponse_builder struct {
 	// The number of members in the organization.
 	MembersCount uint32
 	// The IdP groups associated with the organization.
-	IdpGroups []string
+	IdpGroups []*GetOrganizationSettingsResponse_IdPGroup
 }
 
 func (b0 GetOrganizationSettingsResponse_builder) Build() *GetOrganizationSettingsResponse {
@@ -1993,7 +1995,7 @@ func (b0 GetOrganizationSettingsResponse_builder) Build() *GetOrganizationSettin
 	_, _ = b, x
 	x.xxx_hidden_RepositoryBaseRole = b.RepositoryBaseRole
 	x.xxx_hidden_MembersCount = b.MembersCount
-	x.xxx_hidden_IdpGroups = b.IdpGroups
+	x.xxx_hidden_IdpGroups = &b.IdpGroups
 	return m0
 }
 
@@ -2187,6 +2189,7 @@ type AddOrganizationGroupRequest struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_OrganizationId string                 `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3"`
 	xxx_hidden_GroupName      string                 `protobuf:"bytes,2,opt,name=group_name,json=groupName,proto3"`
+	xxx_hidden_RoleOverride   OrganizationRole       `protobuf:"varint,3,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.OrganizationRole"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -2230,12 +2233,23 @@ func (x *AddOrganizationGroupRequest) GetGroupName() string {
 	return ""
 }
 
+func (x *AddOrganizationGroupRequest) GetRoleOverride() OrganizationRole {
+	if x != nil {
+		return x.xxx_hidden_RoleOverride
+	}
+	return OrganizationRole_ORGANIZATION_ROLE_UNSPECIFIED
+}
+
 func (x *AddOrganizationGroupRequest) SetOrganizationId(v string) {
 	x.xxx_hidden_OrganizationId = v
 }
 
 func (x *AddOrganizationGroupRequest) SetGroupName(v string) {
 	x.xxx_hidden_GroupName = v
+}
+
+func (x *AddOrganizationGroupRequest) SetRoleOverride(v OrganizationRole) {
+	x.xxx_hidden_RoleOverride = v
 }
 
 type AddOrganizationGroupRequest_builder struct {
@@ -2245,6 +2259,11 @@ type AddOrganizationGroupRequest_builder struct {
 	OrganizationId string
 	// The name of the group to add.
 	GroupName string
+	// The role to associate with this organization group.
+	//
+	// Any user who maps to this organization via this group will be granted this role. If no role is
+	// set, the user will be granted the 'member' role.
+	RoleOverride OrganizationRole
 }
 
 func (b0 AddOrganizationGroupRequest_builder) Build() *AddOrganizationGroupRequest {
@@ -2253,6 +2272,7 @@ func (b0 AddOrganizationGroupRequest_builder) Build() *AddOrganizationGroupReque
 	_, _ = b, x
 	x.xxx_hidden_OrganizationId = b.OrganizationId
 	x.xxx_hidden_GroupName = b.GroupName
+	x.xxx_hidden_RoleOverride = b.RoleOverride
 	return m0
 }
 
@@ -2415,6 +2435,79 @@ func (b0 RemoveOrganizationGroupResponse_builder) Build() *RemoveOrganizationGro
 	return m0
 }
 
+type GetOrganizationSettingsResponse_IdPGroup struct {
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name         string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_RoleOverride OrganizationRole       `protobuf:"varint,2,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.OrganizationRole"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) Reset() {
+	*x = GetOrganizationSettingsResponse_IdPGroup{}
+	mi := &file_buf_alpha_registry_v1alpha1_organization_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetOrganizationSettingsResponse_IdPGroup) ProtoMessage() {}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_organization_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) GetRoleOverride() OrganizationRole {
+	if x != nil {
+		return x.xxx_hidden_RoleOverride
+	}
+	return OrganizationRole_ORGANIZATION_ROLE_UNSPECIFIED
+}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *GetOrganizationSettingsResponse_IdPGroup) SetRoleOverride(v OrganizationRole) {
+	x.xxx_hidden_RoleOverride = v
+}
+
+type GetOrganizationSettingsResponse_IdPGroup_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the IdP group.
+	Name string
+	// The role override associated with this group.
+	RoleOverride OrganizationRole
+}
+
+func (b0 GetOrganizationSettingsResponse_IdPGroup_builder) Build() *GetOrganizationSettingsResponse_IdPGroup {
+	m0 := &GetOrganizationSettingsResponse_IdPGroup{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_RoleOverride = b.RoleOverride
+	return m0
+}
+
 var File_buf_alpha_registry_v1alpha1_organization_proto protoreflect.FileDescriptor
 
 const file_buf_alpha_registry_v1alpha1_organization_proto_rawDesc = "" +
@@ -2493,12 +2586,15 @@ const file_buf_alpha_registry_v1alpha1_organization_proto_rawDesc = "" +
 	"\x11organization_role\x18\x03 \x01(\x0e2-.buf.alpha.registry.v1alpha1.OrganizationRoleR\x10organizationRole\"\x1f\n" +
 	"\x1dSetOrganizationMemberResponse\"I\n" +
 	"\x1eGetOrganizationSettingsRequest\x12'\n" +
-	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\"\xf6\x01\n" +
+	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\"\xb1\x03\n" +
 	"\x1fGetOrganizationSettingsResponse\x12]\n" +
 	"\x14repository_base_role\x18\x01 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x12repositoryBaseRole\x12#\n" +
-	"\rmembers_count\x18\x04 \x01(\rR\fmembersCount\x12\x1d\n" +
+	"\rmembers_count\x18\x04 \x01(\rR\fmembersCount\x12d\n" +
 	"\n" +
-	"idp_groups\x18\x05 \x03(\tR\tidpGroupsJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x10plugin_base_roleR\x12template_base_role\"\xb3\x02\n" +
+	"idp_groups\x18\x05 \x03(\v2E.buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.IdPGroupR\tidpGroups\x1ar\n" +
+	"\bIdPGroup\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12R\n" +
+	"\rrole_override\x18\x02 \x01(\x0e2-.buf.alpha.registry.v1alpha1.OrganizationRoleR\froleOverrideJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x10plugin_base_roleR\x12template_base_role\"\xb3\x02\n" +
 	"!UpdateOrganizationSettingsRequest\x12'\n" +
 	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\x12]\n" +
 	"\x14repository_base_role\x18\x02 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x12repositoryBaseRole\x12%\n" +
@@ -2506,11 +2602,12 @@ const file_buf_alpha_registry_v1alpha1_organization_proto_rawDesc = "" +
 	"\x03url\x18\x06 \x01(\tH\x01R\x03url\x88\x01\x01B\x0e\n" +
 	"\f_descriptionB\x06\n" +
 	"\x04_urlJ\x04\b\x03\x10\x04J\x04\b\x04\x10\x05R\x10plugin_base_roleR\x12template_base_role\"$\n" +
-	"\"UpdateOrganizationSettingsResponse\"e\n" +
+	"\"UpdateOrganizationSettingsResponse\"\xb9\x01\n" +
 	"\x1bAddOrganizationGroupRequest\x12'\n" +
 	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\x12\x1d\n" +
 	"\n" +
-	"group_name\x18\x02 \x01(\tR\tgroupName\"\x1e\n" +
+	"group_name\x18\x02 \x01(\tR\tgroupName\x12R\n" +
+	"\rrole_override\x18\x03 \x01(\x0e2-.buf.alpha.registry.v1alpha1.OrganizationRoleR\froleOverride\"\x1e\n" +
 	"\x1cAddOrganizationGroupResponse\"h\n" +
 	"\x1eRemoveOrganizationGroupRequest\x12'\n" +
 	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\x12\x1d\n" +
@@ -2536,101 +2633,105 @@ const file_buf_alpha_registry_v1alpha1_organization_proto_rawDesc = "" +
 	"\x17RemoveOrganizationGroup\x12;.buf.alpha.registry.v1alpha1.RemoveOrganizationGroupRequest\x1a<.buf.alpha.registry.v1alpha1.RemoveOrganizationGroupResponse\"\x03\x90\x02\x02B\x9e\x02\n" +
 	"\x1fcom.buf.alpha.registry.v1alpha1B\x11OrganizationProtoP\x01ZYgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1;registryv1alpha1\xa2\x02\x03BAR\xaa\x02\x1bBuf.Alpha.Registry.V1alpha1\xca\x02\x1bBuf\\Alpha\\Registry\\V1alpha1\xe2\x02'Buf\\Alpha\\Registry\\V1alpha1\\GPBMetadata\xea\x02\x1eBuf::Alpha::Registry::V1alpha1b\x06proto3"
 
-var file_buf_alpha_registry_v1alpha1_organization_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_buf_alpha_registry_v1alpha1_organization_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_buf_alpha_registry_v1alpha1_organization_proto_goTypes = []any{
-	(*Organization)(nil),                       // 0: buf.alpha.registry.v1alpha1.Organization
-	(*OrganizationMembership)(nil),             // 1: buf.alpha.registry.v1alpha1.OrganizationMembership
-	(*GetOrganizationRequest)(nil),             // 2: buf.alpha.registry.v1alpha1.GetOrganizationRequest
-	(*GetOrganizationResponse)(nil),            // 3: buf.alpha.registry.v1alpha1.GetOrganizationResponse
-	(*GetOrganizationByNameRequest)(nil),       // 4: buf.alpha.registry.v1alpha1.GetOrganizationByNameRequest
-	(*GetOrganizationByNameResponse)(nil),      // 5: buf.alpha.registry.v1alpha1.GetOrganizationByNameResponse
-	(*ListOrganizationsRequest)(nil),           // 6: buf.alpha.registry.v1alpha1.ListOrganizationsRequest
-	(*ListOrganizationsResponse)(nil),          // 7: buf.alpha.registry.v1alpha1.ListOrganizationsResponse
-	(*ListUserOrganizationsRequest)(nil),       // 8: buf.alpha.registry.v1alpha1.ListUserOrganizationsRequest
-	(*ListUserOrganizationsResponse)(nil),      // 9: buf.alpha.registry.v1alpha1.ListUserOrganizationsResponse
-	(*GetUserOrganizationRequest)(nil),         // 10: buf.alpha.registry.v1alpha1.GetUserOrganizationRequest
-	(*GetUserOrganizationResponse)(nil),        // 11: buf.alpha.registry.v1alpha1.GetUserOrganizationResponse
-	(*CreateOrganizationRequest)(nil),          // 12: buf.alpha.registry.v1alpha1.CreateOrganizationRequest
-	(*CreateOrganizationResponse)(nil),         // 13: buf.alpha.registry.v1alpha1.CreateOrganizationResponse
-	(*DeleteOrganizationRequest)(nil),          // 14: buf.alpha.registry.v1alpha1.DeleteOrganizationRequest
-	(*DeleteOrganizationResponse)(nil),         // 15: buf.alpha.registry.v1alpha1.DeleteOrganizationResponse
-	(*DeleteOrganizationByNameRequest)(nil),    // 16: buf.alpha.registry.v1alpha1.DeleteOrganizationByNameRequest
-	(*DeleteOrganizationByNameResponse)(nil),   // 17: buf.alpha.registry.v1alpha1.DeleteOrganizationByNameResponse
-	(*AddOrganizationMemberRequest)(nil),       // 18: buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest
-	(*AddOrganizationMemberResponse)(nil),      // 19: buf.alpha.registry.v1alpha1.AddOrganizationMemberResponse
-	(*UpdateOrganizationMemberRequest)(nil),    // 20: buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest
-	(*UpdateOrganizationMemberResponse)(nil),   // 21: buf.alpha.registry.v1alpha1.UpdateOrganizationMemberResponse
-	(*RemoveOrganizationMemberRequest)(nil),    // 22: buf.alpha.registry.v1alpha1.RemoveOrganizationMemberRequest
-	(*RemoveOrganizationMemberResponse)(nil),   // 23: buf.alpha.registry.v1alpha1.RemoveOrganizationMemberResponse
-	(*SetOrganizationMemberRequest)(nil),       // 24: buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest
-	(*SetOrganizationMemberResponse)(nil),      // 25: buf.alpha.registry.v1alpha1.SetOrganizationMemberResponse
-	(*GetOrganizationSettingsRequest)(nil),     // 26: buf.alpha.registry.v1alpha1.GetOrganizationSettingsRequest
-	(*GetOrganizationSettingsResponse)(nil),    // 27: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse
-	(*UpdateOrganizationSettingsRequest)(nil),  // 28: buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest
-	(*UpdateOrganizationSettingsResponse)(nil), // 29: buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsResponse
-	(*AddOrganizationGroupRequest)(nil),        // 30: buf.alpha.registry.v1alpha1.AddOrganizationGroupRequest
-	(*AddOrganizationGroupResponse)(nil),       // 31: buf.alpha.registry.v1alpha1.AddOrganizationGroupResponse
-	(*RemoveOrganizationGroupRequest)(nil),     // 32: buf.alpha.registry.v1alpha1.RemoveOrganizationGroupRequest
-	(*RemoveOrganizationGroupResponse)(nil),    // 33: buf.alpha.registry.v1alpha1.RemoveOrganizationGroupResponse
-	(*timestamppb.Timestamp)(nil),              // 34: google.protobuf.Timestamp
-	(VerificationStatus)(0),                    // 35: buf.alpha.registry.v1alpha1.VerificationStatus
-	(OrganizationRole)(0),                      // 36: buf.alpha.registry.v1alpha1.OrganizationRole
-	(RepositoryRole)(0),                        // 37: buf.alpha.registry.v1alpha1.RepositoryRole
+	(*Organization)(nil),                             // 0: buf.alpha.registry.v1alpha1.Organization
+	(*OrganizationMembership)(nil),                   // 1: buf.alpha.registry.v1alpha1.OrganizationMembership
+	(*GetOrganizationRequest)(nil),                   // 2: buf.alpha.registry.v1alpha1.GetOrganizationRequest
+	(*GetOrganizationResponse)(nil),                  // 3: buf.alpha.registry.v1alpha1.GetOrganizationResponse
+	(*GetOrganizationByNameRequest)(nil),             // 4: buf.alpha.registry.v1alpha1.GetOrganizationByNameRequest
+	(*GetOrganizationByNameResponse)(nil),            // 5: buf.alpha.registry.v1alpha1.GetOrganizationByNameResponse
+	(*ListOrganizationsRequest)(nil),                 // 6: buf.alpha.registry.v1alpha1.ListOrganizationsRequest
+	(*ListOrganizationsResponse)(nil),                // 7: buf.alpha.registry.v1alpha1.ListOrganizationsResponse
+	(*ListUserOrganizationsRequest)(nil),             // 8: buf.alpha.registry.v1alpha1.ListUserOrganizationsRequest
+	(*ListUserOrganizationsResponse)(nil),            // 9: buf.alpha.registry.v1alpha1.ListUserOrganizationsResponse
+	(*GetUserOrganizationRequest)(nil),               // 10: buf.alpha.registry.v1alpha1.GetUserOrganizationRequest
+	(*GetUserOrganizationResponse)(nil),              // 11: buf.alpha.registry.v1alpha1.GetUserOrganizationResponse
+	(*CreateOrganizationRequest)(nil),                // 12: buf.alpha.registry.v1alpha1.CreateOrganizationRequest
+	(*CreateOrganizationResponse)(nil),               // 13: buf.alpha.registry.v1alpha1.CreateOrganizationResponse
+	(*DeleteOrganizationRequest)(nil),                // 14: buf.alpha.registry.v1alpha1.DeleteOrganizationRequest
+	(*DeleteOrganizationResponse)(nil),               // 15: buf.alpha.registry.v1alpha1.DeleteOrganizationResponse
+	(*DeleteOrganizationByNameRequest)(nil),          // 16: buf.alpha.registry.v1alpha1.DeleteOrganizationByNameRequest
+	(*DeleteOrganizationByNameResponse)(nil),         // 17: buf.alpha.registry.v1alpha1.DeleteOrganizationByNameResponse
+	(*AddOrganizationMemberRequest)(nil),             // 18: buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest
+	(*AddOrganizationMemberResponse)(nil),            // 19: buf.alpha.registry.v1alpha1.AddOrganizationMemberResponse
+	(*UpdateOrganizationMemberRequest)(nil),          // 20: buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest
+	(*UpdateOrganizationMemberResponse)(nil),         // 21: buf.alpha.registry.v1alpha1.UpdateOrganizationMemberResponse
+	(*RemoveOrganizationMemberRequest)(nil),          // 22: buf.alpha.registry.v1alpha1.RemoveOrganizationMemberRequest
+	(*RemoveOrganizationMemberResponse)(nil),         // 23: buf.alpha.registry.v1alpha1.RemoveOrganizationMemberResponse
+	(*SetOrganizationMemberRequest)(nil),             // 24: buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest
+	(*SetOrganizationMemberResponse)(nil),            // 25: buf.alpha.registry.v1alpha1.SetOrganizationMemberResponse
+	(*GetOrganizationSettingsRequest)(nil),           // 26: buf.alpha.registry.v1alpha1.GetOrganizationSettingsRequest
+	(*GetOrganizationSettingsResponse)(nil),          // 27: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse
+	(*UpdateOrganizationSettingsRequest)(nil),        // 28: buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest
+	(*UpdateOrganizationSettingsResponse)(nil),       // 29: buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsResponse
+	(*AddOrganizationGroupRequest)(nil),              // 30: buf.alpha.registry.v1alpha1.AddOrganizationGroupRequest
+	(*AddOrganizationGroupResponse)(nil),             // 31: buf.alpha.registry.v1alpha1.AddOrganizationGroupResponse
+	(*RemoveOrganizationGroupRequest)(nil),           // 32: buf.alpha.registry.v1alpha1.RemoveOrganizationGroupRequest
+	(*RemoveOrganizationGroupResponse)(nil),          // 33: buf.alpha.registry.v1alpha1.RemoveOrganizationGroupResponse
+	(*GetOrganizationSettingsResponse_IdPGroup)(nil), // 34: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.IdPGroup
+	(*timestamppb.Timestamp)(nil),                    // 35: google.protobuf.Timestamp
+	(VerificationStatus)(0),                          // 36: buf.alpha.registry.v1alpha1.VerificationStatus
+	(OrganizationRole)(0),                            // 37: buf.alpha.registry.v1alpha1.OrganizationRole
+	(RepositoryRole)(0),                              // 38: buf.alpha.registry.v1alpha1.RepositoryRole
 }
 var file_buf_alpha_registry_v1alpha1_organization_proto_depIdxs = []int32{
-	34, // 0: buf.alpha.registry.v1alpha1.Organization.create_time:type_name -> google.protobuf.Timestamp
-	34, // 1: buf.alpha.registry.v1alpha1.Organization.update_time:type_name -> google.protobuf.Timestamp
-	35, // 2: buf.alpha.registry.v1alpha1.Organization.verification_status:type_name -> buf.alpha.registry.v1alpha1.VerificationStatus
+	35, // 0: buf.alpha.registry.v1alpha1.Organization.create_time:type_name -> google.protobuf.Timestamp
+	35, // 1: buf.alpha.registry.v1alpha1.Organization.update_time:type_name -> google.protobuf.Timestamp
+	36, // 2: buf.alpha.registry.v1alpha1.Organization.verification_status:type_name -> buf.alpha.registry.v1alpha1.VerificationStatus
 	0,  // 3: buf.alpha.registry.v1alpha1.OrganizationMembership.organization:type_name -> buf.alpha.registry.v1alpha1.Organization
-	36, // 4: buf.alpha.registry.v1alpha1.OrganizationMembership.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	37, // 4: buf.alpha.registry.v1alpha1.OrganizationMembership.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
 	0,  // 5: buf.alpha.registry.v1alpha1.GetOrganizationResponse.organization:type_name -> buf.alpha.registry.v1alpha1.Organization
 	0,  // 6: buf.alpha.registry.v1alpha1.GetOrganizationByNameResponse.organization:type_name -> buf.alpha.registry.v1alpha1.Organization
 	0,  // 7: buf.alpha.registry.v1alpha1.ListOrganizationsResponse.organizations:type_name -> buf.alpha.registry.v1alpha1.Organization
 	1,  // 8: buf.alpha.registry.v1alpha1.ListUserOrganizationsResponse.organizations:type_name -> buf.alpha.registry.v1alpha1.OrganizationMembership
 	1,  // 9: buf.alpha.registry.v1alpha1.GetUserOrganizationResponse.organization_membership:type_name -> buf.alpha.registry.v1alpha1.OrganizationMembership
 	0,  // 10: buf.alpha.registry.v1alpha1.CreateOrganizationResponse.organization:type_name -> buf.alpha.registry.v1alpha1.Organization
-	36, // 11: buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	36, // 12: buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	36, // 13: buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	37, // 14: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.repository_base_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	37, // 15: buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest.repository_base_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	2,  // 16: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganization:input_type -> buf.alpha.registry.v1alpha1.GetOrganizationRequest
-	4,  // 17: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationByName:input_type -> buf.alpha.registry.v1alpha1.GetOrganizationByNameRequest
-	6,  // 18: buf.alpha.registry.v1alpha1.OrganizationService.ListOrganizations:input_type -> buf.alpha.registry.v1alpha1.ListOrganizationsRequest
-	8,  // 19: buf.alpha.registry.v1alpha1.OrganizationService.ListUserOrganizations:input_type -> buf.alpha.registry.v1alpha1.ListUserOrganizationsRequest
-	10, // 20: buf.alpha.registry.v1alpha1.OrganizationService.GetUserOrganization:input_type -> buf.alpha.registry.v1alpha1.GetUserOrganizationRequest
-	12, // 21: buf.alpha.registry.v1alpha1.OrganizationService.CreateOrganization:input_type -> buf.alpha.registry.v1alpha1.CreateOrganizationRequest
-	14, // 22: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganization:input_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationRequest
-	16, // 23: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganizationByName:input_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationByNameRequest
-	18, // 24: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest
-	20, // 25: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest
-	22, // 26: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationMemberRequest
-	24, // 27: buf.alpha.registry.v1alpha1.OrganizationService.SetOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest
-	26, // 28: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationSettings:input_type -> buf.alpha.registry.v1alpha1.GetOrganizationSettingsRequest
-	28, // 29: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationSettings:input_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest
-	30, // 30: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationGroup:input_type -> buf.alpha.registry.v1alpha1.AddOrganizationGroupRequest
-	32, // 31: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationGroup:input_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationGroupRequest
-	3,  // 32: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganization:output_type -> buf.alpha.registry.v1alpha1.GetOrganizationResponse
-	5,  // 33: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationByName:output_type -> buf.alpha.registry.v1alpha1.GetOrganizationByNameResponse
-	7,  // 34: buf.alpha.registry.v1alpha1.OrganizationService.ListOrganizations:output_type -> buf.alpha.registry.v1alpha1.ListOrganizationsResponse
-	9,  // 35: buf.alpha.registry.v1alpha1.OrganizationService.ListUserOrganizations:output_type -> buf.alpha.registry.v1alpha1.ListUserOrganizationsResponse
-	11, // 36: buf.alpha.registry.v1alpha1.OrganizationService.GetUserOrganization:output_type -> buf.alpha.registry.v1alpha1.GetUserOrganizationResponse
-	13, // 37: buf.alpha.registry.v1alpha1.OrganizationService.CreateOrganization:output_type -> buf.alpha.registry.v1alpha1.CreateOrganizationResponse
-	15, // 38: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganization:output_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationResponse
-	17, // 39: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganizationByName:output_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationByNameResponse
-	19, // 40: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.AddOrganizationMemberResponse
-	21, // 41: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationMemberResponse
-	23, // 42: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationMemberResponse
-	25, // 43: buf.alpha.registry.v1alpha1.OrganizationService.SetOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.SetOrganizationMemberResponse
-	27, // 44: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationSettings:output_type -> buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse
-	29, // 45: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationSettings:output_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsResponse
-	31, // 46: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationGroup:output_type -> buf.alpha.registry.v1alpha1.AddOrganizationGroupResponse
-	33, // 47: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationGroup:output_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationGroupResponse
-	32, // [32:48] is the sub-list for method output_type
-	16, // [16:32] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	37, // 11: buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	37, // 12: buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	37, // 13: buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest.organization_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	38, // 14: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.repository_base_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	34, // 15: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.idp_groups:type_name -> buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.IdPGroup
+	38, // 16: buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest.repository_base_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	37, // 17: buf.alpha.registry.v1alpha1.AddOrganizationGroupRequest.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	37, // 18: buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse.IdPGroup.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	2,  // 19: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganization:input_type -> buf.alpha.registry.v1alpha1.GetOrganizationRequest
+	4,  // 20: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationByName:input_type -> buf.alpha.registry.v1alpha1.GetOrganizationByNameRequest
+	6,  // 21: buf.alpha.registry.v1alpha1.OrganizationService.ListOrganizations:input_type -> buf.alpha.registry.v1alpha1.ListOrganizationsRequest
+	8,  // 22: buf.alpha.registry.v1alpha1.OrganizationService.ListUserOrganizations:input_type -> buf.alpha.registry.v1alpha1.ListUserOrganizationsRequest
+	10, // 23: buf.alpha.registry.v1alpha1.OrganizationService.GetUserOrganization:input_type -> buf.alpha.registry.v1alpha1.GetUserOrganizationRequest
+	12, // 24: buf.alpha.registry.v1alpha1.OrganizationService.CreateOrganization:input_type -> buf.alpha.registry.v1alpha1.CreateOrganizationRequest
+	14, // 25: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganization:input_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationRequest
+	16, // 26: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganizationByName:input_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationByNameRequest
+	18, // 27: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.AddOrganizationMemberRequest
+	20, // 28: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationMemberRequest
+	22, // 29: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationMemberRequest
+	24, // 30: buf.alpha.registry.v1alpha1.OrganizationService.SetOrganizationMember:input_type -> buf.alpha.registry.v1alpha1.SetOrganizationMemberRequest
+	26, // 31: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationSettings:input_type -> buf.alpha.registry.v1alpha1.GetOrganizationSettingsRequest
+	28, // 32: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationSettings:input_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsRequest
+	30, // 33: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationGroup:input_type -> buf.alpha.registry.v1alpha1.AddOrganizationGroupRequest
+	32, // 34: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationGroup:input_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationGroupRequest
+	3,  // 35: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganization:output_type -> buf.alpha.registry.v1alpha1.GetOrganizationResponse
+	5,  // 36: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationByName:output_type -> buf.alpha.registry.v1alpha1.GetOrganizationByNameResponse
+	7,  // 37: buf.alpha.registry.v1alpha1.OrganizationService.ListOrganizations:output_type -> buf.alpha.registry.v1alpha1.ListOrganizationsResponse
+	9,  // 38: buf.alpha.registry.v1alpha1.OrganizationService.ListUserOrganizations:output_type -> buf.alpha.registry.v1alpha1.ListUserOrganizationsResponse
+	11, // 39: buf.alpha.registry.v1alpha1.OrganizationService.GetUserOrganization:output_type -> buf.alpha.registry.v1alpha1.GetUserOrganizationResponse
+	13, // 40: buf.alpha.registry.v1alpha1.OrganizationService.CreateOrganization:output_type -> buf.alpha.registry.v1alpha1.CreateOrganizationResponse
+	15, // 41: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganization:output_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationResponse
+	17, // 42: buf.alpha.registry.v1alpha1.OrganizationService.DeleteOrganizationByName:output_type -> buf.alpha.registry.v1alpha1.DeleteOrganizationByNameResponse
+	19, // 43: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.AddOrganizationMemberResponse
+	21, // 44: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationMemberResponse
+	23, // 45: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationMemberResponse
+	25, // 46: buf.alpha.registry.v1alpha1.OrganizationService.SetOrganizationMember:output_type -> buf.alpha.registry.v1alpha1.SetOrganizationMemberResponse
+	27, // 47: buf.alpha.registry.v1alpha1.OrganizationService.GetOrganizationSettings:output_type -> buf.alpha.registry.v1alpha1.GetOrganizationSettingsResponse
+	29, // 48: buf.alpha.registry.v1alpha1.OrganizationService.UpdateOrganizationSettings:output_type -> buf.alpha.registry.v1alpha1.UpdateOrganizationSettingsResponse
+	31, // 49: buf.alpha.registry.v1alpha1.OrganizationService.AddOrganizationGroup:output_type -> buf.alpha.registry.v1alpha1.AddOrganizationGroupResponse
+	33, // 50: buf.alpha.registry.v1alpha1.OrganizationService.RemoveOrganizationGroup:output_type -> buf.alpha.registry.v1alpha1.RemoveOrganizationGroupResponse
+	35, // [35:51] is the sub-list for method output_type
+	19, // [19:35] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_buf_alpha_registry_v1alpha1_organization_proto_init() }
@@ -2647,7 +2748,7 @@ func file_buf_alpha_registry_v1alpha1_organization_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_alpha_registry_v1alpha1_organization_proto_rawDesc), len(file_buf_alpha_registry_v1alpha1_organization_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/buf/alpha/audit/v1alpha1/event.proto
+++ b/proto/buf/alpha/audit/v1alpha1/event.proto
@@ -288,6 +288,8 @@ message PayloadOrganizationIDPGroupAdded {
   string organization_id = 1;
   // organization_name is the name of the organization with the new IDP group.
   string organization_name = 2;
+  // role_override is the role override associated with the new IDP group.
+  buf.alpha.registry.v1alpha1.OrganizationRole role_override = 3;
 }
 
 message PayloadOrganizationIDPGroupRemoved {
@@ -295,6 +297,8 @@ message PayloadOrganizationIDPGroupRemoved {
   string organization_id = 1;
   // organization_name is the name of the organization with the removed IDP group.
   string organization_name = 2;
+  // role_override is the role override associated with the removed IDP group.
+  buf.alpha.registry.v1alpha1.OrganizationRole role_override = 3;
 }
 
 message PayloadRepositoryCreated {

--- a/proto/buf/alpha/registry/v1alpha1/organization.proto
+++ b/proto/buf/alpha/registry/v1alpha1/organization.proto
@@ -231,6 +231,13 @@ message GetOrganizationSettingsRequest {
 }
 
 message GetOrganizationSettingsResponse {
+  message IdPGroup {
+    // The name of the IdP group.
+    string name = 1;
+    // The role override associated with this group.
+    OrganizationRole role_override = 2;
+  }
+
   reserved 2, 3;
   reserved "plugin_base_role", "template_base_role";
 
@@ -238,7 +245,7 @@ message GetOrganizationSettingsResponse {
   // The number of members in the organization.
   uint32 members_count = 4;
   // The IdP groups associated with the organization.
-  repeated string idp_groups = 5;
+  repeated IdPGroup idp_groups = 5;
 }
 
 message UpdateOrganizationSettingsRequest {
@@ -262,6 +269,11 @@ message AddOrganizationGroupRequest {
   string organization_id = 1;
   // The name of the group to add.
   string group_name = 2;
+  // The role to associate with this organization group.
+  //
+  // Any user who maps to this organization via this group will be granted this role. If no role is
+  // set, the user will be granted the 'member' role.
+  OrganizationRole role_override = 3;
 }
 
 message AddOrganizationGroupResponse {}


### PR DESCRIPTION
This allows admins to associate a role override with the group, which will grant the specific role upon mapping instead of the 'member' role.