### PR TITLE
Filter out `GIT_DIR` from cloner environment variables

### DIFF
--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -76,16 +76,12 @@ func (c *cloner) CloneToBucket(
 
 	depthArg := strconv.Itoa(int(depth))
 
-	// In the case where this is being run in an environment where GIT_DIR is set, e.g. within
-	// a submodule, we want to treat this as a stand-alone clone rather than interacting with
-	// an existing GIT_DIR. So we filter out GIT_DIR from our environment variables.
-	filteredEnv := make(map[string]string)
-	envContainer.ForEachEnv(func(key, value string) {
-		if key != "GIT_DIR" {
-			filteredEnv[key] = value
-		}
+	envContainer = app.NewEnvContainerWithOverrides(envContainer, map[string]string{
+		// In the case where this is being run in an environment where GIT_DIR is set, e.g. within
+		// a submodule, we want to treat this as a stand-alone clone rather than interacting with
+		// an existing GIT_DIR. So we filter out GIT_DIR from our environment variables.
+		"GIT_DIR": "",
 	})
-	envContainer = app.NewEnvContainer(filteredEnv)
 
 	baseDir, err := tmp.NewDir(ctx)
 	if err != nil {

--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -76,6 +76,17 @@ func (c *cloner) CloneToBucket(
 
 	depthArg := strconv.Itoa(int(depth))
 
+	// In the case where this is being run in an environment where GIT_DIR is set, e.g. within
+	// a submodule, we want to treat this as a stand-alone clone rather than interacting with
+	// an existing GIT_DIR. So we filter out GIT_DIR from our environment variables.
+	filteredEnv := make(map[string]string)
+	envContainer.ForEachEnv(func(key, value string) {
+		if key != "GIT_DIR" {
+			filteredEnv[key] = value
+		}
+	})
+	envContainer = app.NewEnvContainer(filteredEnv)
+
 	baseDir, err := tmp.NewDir(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
In the case where `buf` is being run in an environment where `GIT_DIR`
is set, e.g. within a submodule, `git init` will defer to using the `GIT_DIR`
rather than creating its own. We want to avoid mutating an existing `GIT_DIR`
through `CloneToBucket`, and should instead be treating it as a stand-alone
clone, so we filter out `GIT_DIR` from the environment variables.

An example of this came up in #3752 where a submodule is running `buf` in
repository-local pre-commit hooks.

Fixes #3752