### PR TITLE
Repository IdP group mapping

### DIFF
--- a/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/repository.connect.go
+++ b/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/repository.connect.go
@@ -104,6 +104,15 @@ const (
 	// RepositoryServiceGetRepositoryDependencyDOTStringProcedure is the fully-qualified name of the
 	// RepositoryService's GetRepositoryDependencyDOTString RPC.
 	RepositoryServiceGetRepositoryDependencyDOTStringProcedure = "/buf.alpha.registry.v1alpha1.RepositoryService/GetRepositoryDependencyDOTString"
+	// RepositoryServiceAddRepositoryGroupProcedure is the fully-qualified name of the
+	// RepositoryService's AddRepositoryGroup RPC.
+	RepositoryServiceAddRepositoryGroupProcedure = "/buf.alpha.registry.v1alpha1.RepositoryService/AddRepositoryGroup"
+	// RepositoryServiceUpdateRepositoryGroupProcedure is the fully-qualified name of the
+	// RepositoryService's UpdateRepositoryGroup RPC.
+	RepositoryServiceUpdateRepositoryGroupProcedure = "/buf.alpha.registry.v1alpha1.RepositoryService/UpdateRepositoryGroup"
+	// RepositoryServiceRemoveRepositoryGroupProcedure is the fully-qualified name of the
+	// RepositoryService's RemoveRepositoryGroup RPC.
+	RepositoryServiceRemoveRepositoryGroupProcedure = "/buf.alpha.registry.v1alpha1.RepositoryService/RemoveRepositoryGroup"
 )
 
 // RepositoryServiceClient is a client for the buf.alpha.registry.v1alpha1.RepositoryService
@@ -152,6 +161,12 @@ type RepositoryServiceClient interface {
 	GetRepositoriesMetadata(context.Context, *connect.Request[v1alpha1.GetRepositoriesMetadataRequest]) (*connect.Response[v1alpha1.GetRepositoriesMetadataResponse], error)
 	// GetRepositoryDependencyDOTString gets the dependency graph DOT string for the repository.
 	GetRepositoryDependencyDOTString(context.Context, *connect.Request[v1alpha1.GetRepositoryDependencyDOTStringRequest]) (*connect.Response[v1alpha1.GetRepositoryDependencyDOTStringResponse], error)
+	// AddRepositoryGroup adds an IdP Group to the repository.
+	AddRepositoryGroup(context.Context, *connect.Request[v1alpha1.AddRepositoryGroupRequest]) (*connect.Response[v1alpha1.AddRepositoryGroupResponse], error)
+	// UpdateRepositoryGroup updates an IdP Group for the repository.
+	UpdateRepositoryGroup(context.Context, *connect.Request[v1alpha1.UpdateRepositoryGroupRequest]) (*connect.Response[v1alpha1.UpdateRepositoryGroupResponse], error)
+	// RemoveRepositoryGroup removes an IdP Group from the repository.
+	RemoveRepositoryGroup(context.Context, *connect.Request[v1alpha1.RemoveRepositoryGroupRequest]) (*connect.Response[v1alpha1.RemoveRepositoryGroupResponse], error)
 }
 
 // NewRepositoryServiceClient constructs a client for the
@@ -295,6 +310,27 @@ func NewRepositoryServiceClient(httpClient connect.HTTPClient, baseURL string, o
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
+		addRepositoryGroup: connect.NewClient[v1alpha1.AddRepositoryGroupRequest, v1alpha1.AddRepositoryGroupResponse](
+			httpClient,
+			baseURL+RepositoryServiceAddRepositoryGroupProcedure,
+			connect.WithSchema(repositoryServiceMethods.ByName("AddRepositoryGroup")),
+			connect.WithIdempotency(connect.IdempotencyIdempotent),
+			connect.WithClientOptions(opts...),
+		),
+		updateRepositoryGroup: connect.NewClient[v1alpha1.UpdateRepositoryGroupRequest, v1alpha1.UpdateRepositoryGroupResponse](
+			httpClient,
+			baseURL+RepositoryServiceUpdateRepositoryGroupProcedure,
+			connect.WithSchema(repositoryServiceMethods.ByName("UpdateRepositoryGroup")),
+			connect.WithIdempotency(connect.IdempotencyIdempotent),
+			connect.WithClientOptions(opts...),
+		),
+		removeRepositoryGroup: connect.NewClient[v1alpha1.RemoveRepositoryGroupRequest, v1alpha1.RemoveRepositoryGroupResponse](
+			httpClient,
+			baseURL+RepositoryServiceRemoveRepositoryGroupProcedure,
+			connect.WithSchema(repositoryServiceMethods.ByName("RemoveRepositoryGroup")),
+			connect.WithIdempotency(connect.IdempotencyIdempotent),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -319,6 +355,9 @@ type repositoryServiceClient struct {
 	updateRepositorySettingsByName   *connect.Client[v1alpha1.UpdateRepositorySettingsByNameRequest, v1alpha1.UpdateRepositorySettingsByNameResponse]
 	getRepositoriesMetadata          *connect.Client[v1alpha1.GetRepositoriesMetadataRequest, v1alpha1.GetRepositoriesMetadataResponse]
 	getRepositoryDependencyDOTString *connect.Client[v1alpha1.GetRepositoryDependencyDOTStringRequest, v1alpha1.GetRepositoryDependencyDOTStringResponse]
+	addRepositoryGroup               *connect.Client[v1alpha1.AddRepositoryGroupRequest, v1alpha1.AddRepositoryGroupResponse]
+	updateRepositoryGroup            *connect.Client[v1alpha1.UpdateRepositoryGroupRequest, v1alpha1.UpdateRepositoryGroupResponse]
+	removeRepositoryGroup            *connect.Client[v1alpha1.RemoveRepositoryGroupRequest, v1alpha1.RemoveRepositoryGroupResponse]
 }
 
 // GetRepository calls buf.alpha.registry.v1alpha1.RepositoryService.GetRepository.
@@ -430,6 +469,21 @@ func (c *repositoryServiceClient) GetRepositoryDependencyDOTString(ctx context.C
 	return c.getRepositoryDependencyDOTString.CallUnary(ctx, req)
 }
 
+// AddRepositoryGroup calls buf.alpha.registry.v1alpha1.RepositoryService.AddRepositoryGroup.
+func (c *repositoryServiceClient) AddRepositoryGroup(ctx context.Context, req *connect.Request[v1alpha1.AddRepositoryGroupRequest]) (*connect.Response[v1alpha1.AddRepositoryGroupResponse], error) {
+	return c.addRepositoryGroup.CallUnary(ctx, req)
+}
+
+// UpdateRepositoryGroup calls buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositoryGroup.
+func (c *repositoryServiceClient) UpdateRepositoryGroup(ctx context.Context, req *connect.Request[v1alpha1.UpdateRepositoryGroupRequest]) (*connect.Response[v1alpha1.UpdateRepositoryGroupResponse], error) {
+	return c.updateRepositoryGroup.CallUnary(ctx, req)
+}
+
+// RemoveRepositoryGroup calls buf.alpha.registry.v1alpha1.RepositoryService.RemoveRepositoryGroup.
+func (c *repositoryServiceClient) RemoveRepositoryGroup(ctx context.Context, req *connect.Request[v1alpha1.RemoveRepositoryGroupRequest]) (*connect.Response[v1alpha1.RemoveRepositoryGroupResponse], error) {
+	return c.removeRepositoryGroup.CallUnary(ctx, req)
+}
+
 // RepositoryServiceHandler is an implementation of the
 // buf.alpha.registry.v1alpha1.RepositoryService service.
 type RepositoryServiceHandler interface {
@@ -476,6 +530,12 @@ type RepositoryServiceHandler interface {
 	GetRepositoriesMetadata(context.Context, *connect.Request[v1alpha1.GetRepositoriesMetadataRequest]) (*connect.Response[v1alpha1.GetRepositoriesMetadataResponse], error)
 	// GetRepositoryDependencyDOTString gets the dependency graph DOT string for the repository.
 	GetRepositoryDependencyDOTString(context.Context, *connect.Request[v1alpha1.GetRepositoryDependencyDOTStringRequest]) (*connect.Response[v1alpha1.GetRepositoryDependencyDOTStringResponse], error)
+	// AddRepositoryGroup adds an IdP Group to the repository.
+	AddRepositoryGroup(context.Context, *connect.Request[v1alpha1.AddRepositoryGroupRequest]) (*connect.Response[v1alpha1.AddRepositoryGroupResponse], error)
+	// UpdateRepositoryGroup updates an IdP Group for the repository.
+	UpdateRepositoryGroup(context.Context, *connect.Request[v1alpha1.UpdateRepositoryGroupRequest]) (*connect.Response[v1alpha1.UpdateRepositoryGroupResponse], error)
+	// RemoveRepositoryGroup removes an IdP Group from the repository.
+	RemoveRepositoryGroup(context.Context, *connect.Request[v1alpha1.RemoveRepositoryGroupRequest]) (*connect.Response[v1alpha1.RemoveRepositoryGroupResponse], error)
 }
 
 // NewRepositoryServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -614,6 +674,27 @@ func NewRepositoryServiceHandler(svc RepositoryServiceHandler, opts ...connect.H
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
+	repositoryServiceAddRepositoryGroupHandler := connect.NewUnaryHandler(
+		RepositoryServiceAddRepositoryGroupProcedure,
+		svc.AddRepositoryGroup,
+		connect.WithSchema(repositoryServiceMethods.ByName("AddRepositoryGroup")),
+		connect.WithIdempotency(connect.IdempotencyIdempotent),
+		connect.WithHandlerOptions(opts...),
+	)
+	repositoryServiceUpdateRepositoryGroupHandler := connect.NewUnaryHandler(
+		RepositoryServiceUpdateRepositoryGroupProcedure,
+		svc.UpdateRepositoryGroup,
+		connect.WithSchema(repositoryServiceMethods.ByName("UpdateRepositoryGroup")),
+		connect.WithIdempotency(connect.IdempotencyIdempotent),
+		connect.WithHandlerOptions(opts...),
+	)
+	repositoryServiceRemoveRepositoryGroupHandler := connect.NewUnaryHandler(
+		RepositoryServiceRemoveRepositoryGroupProcedure,
+		svc.RemoveRepositoryGroup,
+		connect.WithSchema(repositoryServiceMethods.ByName("RemoveRepositoryGroup")),
+		connect.WithIdempotency(connect.IdempotencyIdempotent),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/buf.alpha.registry.v1alpha1.RepositoryService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case RepositoryServiceGetRepositoryProcedure:
@@ -654,6 +735,12 @@ func NewRepositoryServiceHandler(svc RepositoryServiceHandler, opts ...connect.H
 			repositoryServiceGetRepositoriesMetadataHandler.ServeHTTP(w, r)
 		case RepositoryServiceGetRepositoryDependencyDOTStringProcedure:
 			repositoryServiceGetRepositoryDependencyDOTStringHandler.ServeHTTP(w, r)
+		case RepositoryServiceAddRepositoryGroupProcedure:
+			repositoryServiceAddRepositoryGroupHandler.ServeHTTP(w, r)
+		case RepositoryServiceUpdateRepositoryGroupProcedure:
+			repositoryServiceUpdateRepositoryGroupHandler.ServeHTTP(w, r)
+		case RepositoryServiceRemoveRepositoryGroupProcedure:
+			repositoryServiceRemoveRepositoryGroupHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -737,4 +824,16 @@ func (UnimplementedRepositoryServiceHandler) GetRepositoriesMetadata(context.Con
 
 func (UnimplementedRepositoryServiceHandler) GetRepositoryDependencyDOTString(context.Context, *connect.Request[v1alpha1.GetRepositoryDependencyDOTStringRequest]) (*connect.Response[v1alpha1.GetRepositoryDependencyDOTStringResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryDependencyDOTString is not implemented"))
+}
+
+func (UnimplementedRepositoryServiceHandler) AddRepositoryGroup(context.Context, *connect.Request[v1alpha1.AddRepositoryGroupRequest]) (*connect.Response[v1alpha1.AddRepositoryGroupResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("buf.alpha.registry.v1alpha1.RepositoryService.AddRepositoryGroup is not implemented"))
+}
+
+func (UnimplementedRepositoryServiceHandler) UpdateRepositoryGroup(context.Context, *connect.Request[v1alpha1.UpdateRepositoryGroupRequest]) (*connect.Response[v1alpha1.UpdateRepositoryGroupResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositoryGroup is not implemented"))
+}
+
+func (UnimplementedRepositoryServiceHandler) RemoveRepositoryGroup(context.Context, *connect.Request[v1alpha1.RemoveRepositoryGroupRequest]) (*connect.Response[v1alpha1.RemoveRepositoryGroupResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("buf.alpha.registry.v1alpha1.RepositoryService.RemoveRepositoryGroup is not implemented"))
 }

--- a/private/gen/proto/go/buf/alpha/audit/v1alpha1/event.pb.go
+++ b/private/gen/proto/go/buf/alpha/audit/v1alpha1/event.pb.go
@@ -194,9 +194,13 @@ const (
 	EventType_EVENT_TYPE_REPOSITORY_COMMIT_PUSHED              EventType = 8
 	EventType_EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ADDED          EventType = 9
 	EventType_EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLE_CHANGED   EventType = 10
+	EventType_EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLES_CHANGED  EventType = 63
 	EventType_EVENT_TYPE_REPOSITORY_CONTRIBUTOR_REMOVED        EventType = 11
 	EventType_EVENT_TYPE_REPOSITORY_VISIBILITY_CHANGED         EventType = 12
 	EventType_EVENT_TYPE_REPOSITORY_DEFAULT_LABEL_NAME_CHANGED EventType = 40
+	EventType_EVENT_TYPE_REPOSITORY_IDP_GROUP_ADDED            EventType = 60
+	EventType_EVENT_TYPE_REPOSITORY_IDP_GROUP_UPDATED          EventType = 61
+	EventType_EVENT_TYPE_REPOSITORY_IDP_GROUP_REMOVED          EventType = 62
 	EventType_EVENT_TYPE_POLICY_CREATED                        EventType = 54
 	EventType_EVENT_TYPE_POLICY_DELETED                        EventType = 55
 	EventType_EVENT_TYPE_POLICY_DEPRECATED                     EventType = 56
@@ -261,9 +265,13 @@ var (
 		8:  "EVENT_TYPE_REPOSITORY_COMMIT_PUSHED",
 		9:  "EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ADDED",
 		10: "EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLE_CHANGED",
+		63: "EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLES_CHANGED",
 		11: "EVENT_TYPE_REPOSITORY_CONTRIBUTOR_REMOVED",
 		12: "EVENT_TYPE_REPOSITORY_VISIBILITY_CHANGED",
 		40: "EVENT_TYPE_REPOSITORY_DEFAULT_LABEL_NAME_CHANGED",
+		60: "EVENT_TYPE_REPOSITORY_IDP_GROUP_ADDED",
+		61: "EVENT_TYPE_REPOSITORY_IDP_GROUP_UPDATED",
+		62: "EVENT_TYPE_REPOSITORY_IDP_GROUP_REMOVED",
 		54: "EVENT_TYPE_POLICY_CREATED",
 		55: "EVENT_TYPE_POLICY_DELETED",
 		56: "EVENT_TYPE_POLICY_DEPRECATED",
@@ -323,9 +331,13 @@ var (
 		"EVENT_TYPE_REPOSITORY_COMMIT_PUSHED":               8,
 		"EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ADDED":           9,
 		"EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLE_CHANGED":    10,
+		"EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLES_CHANGED":   63,
 		"EVENT_TYPE_REPOSITORY_CONTRIBUTOR_REMOVED":         11,
 		"EVENT_TYPE_REPOSITORY_VISIBILITY_CHANGED":          12,
 		"EVENT_TYPE_REPOSITORY_DEFAULT_LABEL_NAME_CHANGED":  40,
+		"EVENT_TYPE_REPOSITORY_IDP_GROUP_ADDED":             60,
+		"EVENT_TYPE_REPOSITORY_IDP_GROUP_UPDATED":           61,
+		"EVENT_TYPE_REPOSITORY_IDP_GROUP_REMOVED":           62,
 		"EVENT_TYPE_POLICY_CREATED":                         54,
 		"EVENT_TYPE_POLICY_DELETED":                         55,
 		"EVENT_TYPE_POLICY_DEPRECATED":                      56,
@@ -858,6 +870,15 @@ func (x *Event) GetRepositoryContributorRoleChanged() *PayloadRepositoryContribu
 	return nil
 }
 
+func (x *Event) GetRepositoryContributorRolesChanged() *PayloadRepositoryContributorRolesChanged {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*event_RepositoryContributorRolesChanged); ok {
+			return x.RepositoryContributorRolesChanged
+		}
+	}
+	return nil
+}
+
 func (x *Event) GetRepositoryContributorRemoved() *PayloadRepositoryContributorRemoved {
 	if x != nil {
 		if x, ok := x.xxx_hidden_Payload.(*event_RepositoryContributorRemoved); ok {
@@ -880,6 +901,33 @@ func (x *Event) GetRepositoryDefaultLabelNameChanged() *PayloadRepositoryDefault
 	if x != nil {
 		if x, ok := x.xxx_hidden_Payload.(*event_RepositoryDefaultLabelNameChanged); ok {
 			return x.RepositoryDefaultLabelNameChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRepositoryIdpGroupAdded() *PayloadRepositoryIDPGroupAdded {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupAdded); ok {
+			return x.RepositoryIdpGroupAdded
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRepositoryIdpGroupUpdated() *PayloadRepositoryIDPGroupUpdated {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupUpdated); ok {
+			return x.RepositoryIdpGroupUpdated
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetRepositoryIdpGroupRemoved() *PayloadRepositoryIDPGroupRemoved {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupRemoved); ok {
+			return x.RepositoryIdpGroupRemoved
 		}
 	}
 	return nil
@@ -1402,6 +1450,14 @@ func (x *Event) SetRepositoryContributorRoleChanged(v *PayloadRepositoryContribu
 	x.xxx_hidden_Payload = &event_RepositoryContributorRoleChanged{v}
 }
 
+func (x *Event) SetRepositoryContributorRolesChanged(v *PayloadRepositoryContributorRolesChanged) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &event_RepositoryContributorRolesChanged{v}
+}
+
 func (x *Event) SetRepositoryContributorRemoved(v *PayloadRepositoryContributorRemoved) {
 	if v == nil {
 		x.xxx_hidden_Payload = nil
@@ -1424,6 +1480,30 @@ func (x *Event) SetRepositoryDefaultLabelNameChanged(v *PayloadRepositoryDefault
 		return
 	}
 	x.xxx_hidden_Payload = &event_RepositoryDefaultLabelNameChanged{v}
+}
+
+func (x *Event) SetRepositoryIdpGroupAdded(v *PayloadRepositoryIDPGroupAdded) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &event_RepositoryIdpGroupAdded{v}
+}
+
+func (x *Event) SetRepositoryIdpGroupUpdated(v *PayloadRepositoryIDPGroupUpdated) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &event_RepositoryIdpGroupUpdated{v}
+}
+
+func (x *Event) SetRepositoryIdpGroupRemoved(v *PayloadRepositoryIDPGroupRemoved) {
+	if v == nil {
+		x.xxx_hidden_Payload = nil
+		return
+	}
+	x.xxx_hidden_Payload = &event_RepositoryIdpGroupRemoved{v}
 }
 
 func (x *Event) SetPolicyCreated(v *PayloadPolicyCreated) {
@@ -1911,6 +1991,14 @@ func (x *Event) HasRepositoryContributorRoleChanged() bool {
 	return ok
 }
 
+func (x *Event) HasRepositoryContributorRolesChanged() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*event_RepositoryContributorRolesChanged)
+	return ok
+}
+
 func (x *Event) HasRepositoryContributorRemoved() bool {
 	if x == nil {
 		return false
@@ -1932,6 +2020,30 @@ func (x *Event) HasRepositoryDefaultLabelNameChanged() bool {
 		return false
 	}
 	_, ok := x.xxx_hidden_Payload.(*event_RepositoryDefaultLabelNameChanged)
+	return ok
+}
+
+func (x *Event) HasRepositoryIdpGroupAdded() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupAdded)
+	return ok
+}
+
+func (x *Event) HasRepositoryIdpGroupUpdated() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupUpdated)
+	return ok
+}
+
+func (x *Event) HasRepositoryIdpGroupRemoved() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupRemoved)
 	return ok
 }
 
@@ -2379,6 +2491,12 @@ func (x *Event) ClearRepositoryContributorRoleChanged() {
 	}
 }
 
+func (x *Event) ClearRepositoryContributorRolesChanged() {
+	if _, ok := x.xxx_hidden_Payload.(*event_RepositoryContributorRolesChanged); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
 func (x *Event) ClearRepositoryContributorRemoved() {
 	if _, ok := x.xxx_hidden_Payload.(*event_RepositoryContributorRemoved); ok {
 		x.xxx_hidden_Payload = nil
@@ -2393,6 +2511,24 @@ func (x *Event) ClearRepositoryVisibilityChanged() {
 
 func (x *Event) ClearRepositoryDefaultLabelNameChanged() {
 	if _, ok := x.xxx_hidden_Payload.(*event_RepositoryDefaultLabelNameChanged); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *Event) ClearRepositoryIdpGroupAdded() {
+	if _, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupAdded); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *Event) ClearRepositoryIdpGroupUpdated() {
+	if _, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupUpdated); ok {
+		x.xxx_hidden_Payload = nil
+	}
+}
+
+func (x *Event) ClearRepositoryIdpGroupRemoved() {
+	if _, ok := x.xxx_hidden_Payload.(*event_RepositoryIdpGroupRemoved); ok {
 		x.xxx_hidden_Payload = nil
 	}
 }
@@ -2671,9 +2807,13 @@ const Event_RepositoryDeleted_case case_Event_Payload = 13
 const Event_RepositoryCommitPushed_case case_Event_Payload = 14
 const Event_RepositoryContributorAdded_case case_Event_Payload = 15
 const Event_RepositoryContributorRoleChanged_case case_Event_Payload = 16
+const Event_RepositoryContributorRolesChanged_case case_Event_Payload = 69
 const Event_RepositoryContributorRemoved_case case_Event_Payload = 17
 const Event_RepositoryVisibilityChanged_case case_Event_Payload = 18
 const Event_RepositoryDefaultLabelNameChanged_case case_Event_Payload = 46
+const Event_RepositoryIdpGroupAdded_case case_Event_Payload = 66
+const Event_RepositoryIdpGroupUpdated_case case_Event_Payload = 67
+const Event_RepositoryIdpGroupRemoved_case case_Event_Payload = 68
 const Event_PolicyCreated_case case_Event_Payload = 60
 const Event_PolicyDeleted_case case_Event_Payload = 61
 const Event_PolicyDeprecated_case case_Event_Payload = 62
@@ -2749,12 +2889,20 @@ func (x *Event) WhichPayload() case_Event_Payload {
 		return Event_RepositoryContributorAdded_case
 	case *event_RepositoryContributorRoleChanged:
 		return Event_RepositoryContributorRoleChanged_case
+	case *event_RepositoryContributorRolesChanged:
+		return Event_RepositoryContributorRolesChanged_case
 	case *event_RepositoryContributorRemoved:
 		return Event_RepositoryContributorRemoved_case
 	case *event_RepositoryVisibilityChanged:
 		return Event_RepositoryVisibilityChanged_case
 	case *event_RepositoryDefaultLabelNameChanged:
 		return Event_RepositoryDefaultLabelNameChanged_case
+	case *event_RepositoryIdpGroupAdded:
+		return Event_RepositoryIdpGroupAdded_case
+	case *event_RepositoryIdpGroupUpdated:
+		return Event_RepositoryIdpGroupUpdated_case
+	case *event_RepositoryIdpGroupRemoved:
+		return Event_RepositoryIdpGroupRemoved_case
 	case *event_PolicyCreated:
 		return Event_PolicyCreated_case
 	case *event_PolicyDeleted:
@@ -2877,9 +3025,13 @@ type Event_builder struct {
 	RepositoryCommitPushed            *PayloadRepositoryCommitPushed
 	RepositoryContributorAdded        *PayloadRepositoryContributorAdded
 	RepositoryContributorRoleChanged  *PayloadRepositoryContributorRoleChanged
+	RepositoryContributorRolesChanged *PayloadRepositoryContributorRolesChanged
 	RepositoryContributorRemoved      *PayloadRepositoryContributorRemoved
 	RepositoryVisibilityChanged       *PayloadRepositoryVisibilityChanged
 	RepositoryDefaultLabelNameChanged *PayloadRepositoryDefaultLabelNameChanged
+	RepositoryIdpGroupAdded           *PayloadRepositoryIDPGroupAdded
+	RepositoryIdpGroupUpdated         *PayloadRepositoryIDPGroupUpdated
+	RepositoryIdpGroupRemoved         *PayloadRepositoryIDPGroupRemoved
 	PolicyCreated                     *PayloadPolicyCreated
 	PolicyDeleted                     *PayloadPolicyDeleted
 	PolicyDeprecated                  *PayloadPolicyDeprecated
@@ -2977,6 +3129,9 @@ func (b0 Event_builder) Build() *Event {
 	if b.RepositoryContributorRoleChanged != nil {
 		x.xxx_hidden_Payload = &event_RepositoryContributorRoleChanged{b.RepositoryContributorRoleChanged}
 	}
+	if b.RepositoryContributorRolesChanged != nil {
+		x.xxx_hidden_Payload = &event_RepositoryContributorRolesChanged{b.RepositoryContributorRolesChanged}
+	}
 	if b.RepositoryContributorRemoved != nil {
 		x.xxx_hidden_Payload = &event_RepositoryContributorRemoved{b.RepositoryContributorRemoved}
 	}
@@ -2985,6 +3140,15 @@ func (b0 Event_builder) Build() *Event {
 	}
 	if b.RepositoryDefaultLabelNameChanged != nil {
 		x.xxx_hidden_Payload = &event_RepositoryDefaultLabelNameChanged{b.RepositoryDefaultLabelNameChanged}
+	}
+	if b.RepositoryIdpGroupAdded != nil {
+		x.xxx_hidden_Payload = &event_RepositoryIdpGroupAdded{b.RepositoryIdpGroupAdded}
+	}
+	if b.RepositoryIdpGroupUpdated != nil {
+		x.xxx_hidden_Payload = &event_RepositoryIdpGroupUpdated{b.RepositoryIdpGroupUpdated}
+	}
+	if b.RepositoryIdpGroupRemoved != nil {
+		x.xxx_hidden_Payload = &event_RepositoryIdpGroupRemoved{b.RepositoryIdpGroupRemoved}
 	}
 	if b.PolicyCreated != nil {
 		x.xxx_hidden_Payload = &event_PolicyCreated{b.PolicyCreated}
@@ -3184,6 +3348,10 @@ type event_RepositoryContributorRoleChanged struct {
 	RepositoryContributorRoleChanged *PayloadRepositoryContributorRoleChanged `protobuf:"bytes,16,opt,name=repository_contributor_role_changed,json=repositoryContributorRoleChanged,proto3,oneof"`
 }
 
+type event_RepositoryContributorRolesChanged struct {
+	RepositoryContributorRolesChanged *PayloadRepositoryContributorRolesChanged `protobuf:"bytes,69,opt,name=repository_contributor_roles_changed,json=repositoryContributorRolesChanged,proto3,oneof"`
+}
+
 type event_RepositoryContributorRemoved struct {
 	RepositoryContributorRemoved *PayloadRepositoryContributorRemoved `protobuf:"bytes,17,opt,name=repository_contributor_removed,json=repositoryContributorRemoved,proto3,oneof"`
 }
@@ -3194,6 +3362,18 @@ type event_RepositoryVisibilityChanged struct {
 
 type event_RepositoryDefaultLabelNameChanged struct {
 	RepositoryDefaultLabelNameChanged *PayloadRepositoryDefaultLabelNameChanged `protobuf:"bytes,46,opt,name=repository_default_label_name_changed,json=repositoryDefaultLabelNameChanged,proto3,oneof"`
+}
+
+type event_RepositoryIdpGroupAdded struct {
+	RepositoryIdpGroupAdded *PayloadRepositoryIDPGroupAdded `protobuf:"bytes,66,opt,name=repository_idp_group_added,json=repositoryIdpGroupAdded,proto3,oneof"`
+}
+
+type event_RepositoryIdpGroupUpdated struct {
+	RepositoryIdpGroupUpdated *PayloadRepositoryIDPGroupUpdated `protobuf:"bytes,67,opt,name=repository_idp_group_updated,json=repositoryIdpGroupUpdated,proto3,oneof"`
+}
+
+type event_RepositoryIdpGroupRemoved struct {
+	RepositoryIdpGroupRemoved *PayloadRepositoryIDPGroupRemoved `protobuf:"bytes,68,opt,name=repository_idp_group_removed,json=repositoryIdpGroupRemoved,proto3,oneof"`
 }
 
 type event_PolicyCreated struct {
@@ -3396,11 +3576,19 @@ func (*event_RepositoryContributorAdded) isEvent_Payload() {}
 
 func (*event_RepositoryContributorRoleChanged) isEvent_Payload() {}
 
+func (*event_RepositoryContributorRolesChanged) isEvent_Payload() {}
+
 func (*event_RepositoryContributorRemoved) isEvent_Payload() {}
 
 func (*event_RepositoryVisibilityChanged) isEvent_Payload() {}
 
 func (*event_RepositoryDefaultLabelNameChanged) isEvent_Payload() {}
+
+func (*event_RepositoryIdpGroupAdded) isEvent_Payload() {}
+
+func (*event_RepositoryIdpGroupUpdated) isEvent_Payload() {}
+
+func (*event_RepositoryIdpGroupRemoved) isEvent_Payload() {}
 
 func (*event_PolicyCreated) isEvent_Payload() {}
 
@@ -4967,6 +5155,7 @@ func (b0 PayloadRepositoryContributorAdded_builder) Build() *PayloadRepositoryCo
 	return m0
 }
 
+// Deprecated: Marked as deprecated in buf/alpha/audit/v1alpha1/event.proto.
 type PayloadRepositoryContributorRoleChanged struct {
 	state                     protoimpl.MessageState  `protogen:"opaque.v1"`
 	xxx_hidden_OwnerId        string                  `protobuf:"bytes,1,opt,name=owner_id,json=ownerId,proto3"`
@@ -5070,6 +5259,7 @@ func (x *PayloadRepositoryContributorRoleChanged) SetNewRole(v v1alpha1.Reposito
 	x.xxx_hidden_NewRole = v
 }
 
+// Deprecated: Marked as deprecated in buf/alpha/audit/v1alpha1/event.proto.
 type PayloadRepositoryContributorRoleChanged_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -5100,6 +5290,143 @@ func (b0 PayloadRepositoryContributorRoleChanged_builder) Build() *PayloadReposi
 	return m0
 }
 
+type PayloadRepositoryContributorRolesChanged struct {
+	state                     protoimpl.MessageState                                      `protogen:"opaque.v1"`
+	xxx_hidden_OwnerId        string                                                      `protobuf:"bytes,1,opt,name=owner_id,json=ownerId,proto3"`
+	xxx_hidden_OwnerName      string                                                      `protobuf:"bytes,2,opt,name=owner_name,json=ownerName,proto3"`
+	xxx_hidden_RepositoryId   string                                                      `protobuf:"bytes,3,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_RepositoryName string                                                      `protobuf:"bytes,4,opt,name=repository_name,json=repositoryName,proto3"`
+	xxx_hidden_OldRoles       *[]*PayloadRepositoryContributorRolesChanged_RepositoryRole `protobuf:"bytes,5,rep,name=old_roles,json=oldRoles,proto3"`
+	xxx_hidden_NewRoles       *[]*PayloadRepositoryContributorRolesChanged_RepositoryRole `protobuf:"bytes,6,rep,name=new_roles,json=newRoles,proto3"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) Reset() {
+	*x = PayloadRepositoryContributorRolesChanged{}
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PayloadRepositoryContributorRolesChanged) ProtoMessage() {}
+
+func (x *PayloadRepositoryContributorRolesChanged) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) GetOwnerId() string {
+	if x != nil {
+		return x.xxx_hidden_OwnerId
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) GetOwnerName() string {
+	if x != nil {
+		return x.xxx_hidden_OwnerName
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) GetRepositoryName() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryName
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) GetOldRoles() []*PayloadRepositoryContributorRolesChanged_RepositoryRole {
+	if x != nil {
+		if x.xxx_hidden_OldRoles != nil {
+			return *x.xxx_hidden_OldRoles
+		}
+	}
+	return nil
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) GetNewRoles() []*PayloadRepositoryContributorRolesChanged_RepositoryRole {
+	if x != nil {
+		if x.xxx_hidden_NewRoles != nil {
+			return *x.xxx_hidden_NewRoles
+		}
+	}
+	return nil
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) SetOwnerId(v string) {
+	x.xxx_hidden_OwnerId = v
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) SetOwnerName(v string) {
+	x.xxx_hidden_OwnerName = v
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) SetRepositoryName(v string) {
+	x.xxx_hidden_RepositoryName = v
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) SetOldRoles(v []*PayloadRepositoryContributorRolesChanged_RepositoryRole) {
+	x.xxx_hidden_OldRoles = &v
+}
+
+func (x *PayloadRepositoryContributorRolesChanged) SetNewRoles(v []*PayloadRepositoryContributorRolesChanged_RepositoryRole) {
+	x.xxx_hidden_NewRoles = &v
+}
+
+type PayloadRepositoryContributorRolesChanged_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// owner_id is the id of the owner of the repository.
+	OwnerId string
+	// owner_name is the name of the owner of the repository.
+	OwnerName string
+	// repository_id is the id of the repository within which the role was changed.
+	RepositoryId string
+	// repository_name is the name of the repository within which the role was changed.
+	RepositoryName string
+	// old_roles are the old roles of the contributor.
+	OldRoles []*PayloadRepositoryContributorRolesChanged_RepositoryRole
+	// new_roles are the new roles of the contributor.
+	NewRoles []*PayloadRepositoryContributorRolesChanged_RepositoryRole
+}
+
+func (b0 PayloadRepositoryContributorRolesChanged_builder) Build() *PayloadRepositoryContributorRolesChanged {
+	m0 := &PayloadRepositoryContributorRolesChanged{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_OwnerId = b.OwnerId
+	x.xxx_hidden_OwnerName = b.OwnerName
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_RepositoryName = b.RepositoryName
+	x.xxx_hidden_OldRoles = &b.OldRoles
+	x.xxx_hidden_NewRoles = &b.NewRoles
+	return m0
+}
+
 type PayloadRepositoryContributorRemoved struct {
 	state                      protoimpl.MessageState  `protogen:"opaque.v1"`
 	xxx_hidden_OwnerId         string                  `protobuf:"bytes,1,opt,name=owner_id,json=ownerId,proto3"`
@@ -5113,7 +5440,7 @@ type PayloadRepositoryContributorRemoved struct {
 
 func (x *PayloadRepositoryContributorRemoved) Reset() {
 	*x = PayloadRepositoryContributorRemoved{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[20]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5125,7 +5452,7 @@ func (x *PayloadRepositoryContributorRemoved) String() string {
 func (*PayloadRepositoryContributorRemoved) ProtoMessage() {}
 
 func (x *PayloadRepositoryContributorRemoved) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[20]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5230,7 +5557,7 @@ type PayloadRepositoryVisibilityChanged struct {
 
 func (x *PayloadRepositoryVisibilityChanged) Reset() {
 	*x = PayloadRepositoryVisibilityChanged{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[21]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5242,7 +5569,7 @@ func (x *PayloadRepositoryVisibilityChanged) String() string {
 func (*PayloadRepositoryVisibilityChanged) ProtoMessage() {}
 
 func (x *PayloadRepositoryVisibilityChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[21]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5333,7 +5660,7 @@ type PayloadRepositoryDefaultLabelNameChanged struct {
 
 func (x *PayloadRepositoryDefaultLabelNameChanged) Reset() {
 	*x = PayloadRepositoryDefaultLabelNameChanged{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[22]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5345,7 +5672,7 @@ func (x *PayloadRepositoryDefaultLabelNameChanged) String() string {
 func (*PayloadRepositoryDefaultLabelNameChanged) ProtoMessage() {}
 
 func (x *PayloadRepositoryDefaultLabelNameChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[22]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5441,7 +5768,7 @@ type PayloadRepositoryDefaultBranchChanged struct {
 
 func (x *PayloadRepositoryDefaultBranchChanged) Reset() {
 	*x = PayloadRepositoryDefaultBranchChanged{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[23]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5453,7 +5780,7 @@ func (x *PayloadRepositoryDefaultBranchChanged) String() string {
 func (*PayloadRepositoryDefaultBranchChanged) ProtoMessage() {}
 
 func (x *PayloadRepositoryDefaultBranchChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[23]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5533,6 +5860,287 @@ func (b0 PayloadRepositoryDefaultBranchChanged_builder) Build() *PayloadReposito
 	return m0
 }
 
+type PayloadRepositoryIDPGroupAdded struct {
+	state                     protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryId   string                  `protobuf:"bytes,1,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_RepositoryName string                  `protobuf:"bytes,2,opt,name=repository_name,json=repositoryName,proto3"`
+	xxx_hidden_RoleOverride   v1alpha1.RepositoryRole `protobuf:"varint,3,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) Reset() {
+	*x = PayloadRepositoryIDPGroupAdded{}
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PayloadRepositoryIDPGroupAdded) ProtoMessage() {}
+
+func (x *PayloadRepositoryIDPGroupAdded) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) GetRepositoryName() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryName
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) GetRoleOverride() v1alpha1.RepositoryRole {
+	if x != nil {
+		return x.xxx_hidden_RoleOverride
+	}
+	return v1alpha1.RepositoryRole(0)
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) SetRepositoryName(v string) {
+	x.xxx_hidden_RepositoryName = v
+}
+
+func (x *PayloadRepositoryIDPGroupAdded) SetRoleOverride(v v1alpha1.RepositoryRole) {
+	x.xxx_hidden_RoleOverride = v
+}
+
+type PayloadRepositoryIDPGroupAdded_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// repository_id is the id of the repository with the new IDP group.
+	RepositoryId string
+	// repository_name is the name of the repository with the new IDP group.
+	RepositoryName string
+	// role_override is the role override associated with the new IDP group.
+	RoleOverride v1alpha1.RepositoryRole
+}
+
+func (b0 PayloadRepositoryIDPGroupAdded_builder) Build() *PayloadRepositoryIDPGroupAdded {
+	m0 := &PayloadRepositoryIDPGroupAdded{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_RepositoryName = b.RepositoryName
+	x.xxx_hidden_RoleOverride = b.RoleOverride
+	return m0
+}
+
+type PayloadRepositoryIDPGroupUpdated struct {
+	state                      protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryId    string                  `protobuf:"bytes,1,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_RepositoryName  string                  `protobuf:"bytes,2,opt,name=repository_name,json=repositoryName,proto3"`
+	xxx_hidden_OldRoleOverride v1alpha1.RepositoryRole `protobuf:"varint,3,opt,name=old_role_override,json=oldRoleOverride,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	xxx_hidden_NewRoleOverride v1alpha1.RepositoryRole `protobuf:"varint,4,opt,name=new_role_override,json=newRoleOverride,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) Reset() {
+	*x = PayloadRepositoryIDPGroupUpdated{}
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PayloadRepositoryIDPGroupUpdated) ProtoMessage() {}
+
+func (x *PayloadRepositoryIDPGroupUpdated) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) GetRepositoryName() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryName
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) GetOldRoleOverride() v1alpha1.RepositoryRole {
+	if x != nil {
+		return x.xxx_hidden_OldRoleOverride
+	}
+	return v1alpha1.RepositoryRole(0)
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) GetNewRoleOverride() v1alpha1.RepositoryRole {
+	if x != nil {
+		return x.xxx_hidden_NewRoleOverride
+	}
+	return v1alpha1.RepositoryRole(0)
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) SetRepositoryName(v string) {
+	x.xxx_hidden_RepositoryName = v
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) SetOldRoleOverride(v v1alpha1.RepositoryRole) {
+	x.xxx_hidden_OldRoleOverride = v
+}
+
+func (x *PayloadRepositoryIDPGroupUpdated) SetNewRoleOverride(v v1alpha1.RepositoryRole) {
+	x.xxx_hidden_NewRoleOverride = v
+}
+
+type PayloadRepositoryIDPGroupUpdated_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// repository_id is the id of the repository with the updated IDP group.
+	RepositoryId string
+	// repository_name is the name of the repository with the updated IDP group.
+	RepositoryName string
+	// old_role_override is the role override associated with the IDP updated group. Only set if the
+	// role override was changed.
+	OldRoleOverride v1alpha1.RepositoryRole
+	// new_role_override is the role override associated with the IDP updated group. Only set if the
+	// role override was changed.
+	NewRoleOverride v1alpha1.RepositoryRole
+}
+
+func (b0 PayloadRepositoryIDPGroupUpdated_builder) Build() *PayloadRepositoryIDPGroupUpdated {
+	m0 := &PayloadRepositoryIDPGroupUpdated{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_RepositoryName = b.RepositoryName
+	x.xxx_hidden_OldRoleOverride = b.OldRoleOverride
+	x.xxx_hidden_NewRoleOverride = b.NewRoleOverride
+	return m0
+}
+
+type PayloadRepositoryIDPGroupRemoved struct {
+	state                     protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryId   string                  `protobuf:"bytes,1,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_RepositoryName string                  `protobuf:"bytes,2,opt,name=repository_name,json=repositoryName,proto3"`
+	xxx_hidden_RoleOverride   v1alpha1.RepositoryRole `protobuf:"varint,3,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) Reset() {
+	*x = PayloadRepositoryIDPGroupRemoved{}
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PayloadRepositoryIDPGroupRemoved) ProtoMessage() {}
+
+func (x *PayloadRepositoryIDPGroupRemoved) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) GetRepositoryName() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryName
+	}
+	return ""
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) GetRoleOverride() v1alpha1.RepositoryRole {
+	if x != nil {
+		return x.xxx_hidden_RoleOverride
+	}
+	return v1alpha1.RepositoryRole(0)
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) SetRepositoryName(v string) {
+	x.xxx_hidden_RepositoryName = v
+}
+
+func (x *PayloadRepositoryIDPGroupRemoved) SetRoleOverride(v v1alpha1.RepositoryRole) {
+	x.xxx_hidden_RoleOverride = v
+}
+
+type PayloadRepositoryIDPGroupRemoved_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// repository_id is the id of the repository with the removed IDP group.
+	RepositoryId string
+	// repository_name is the name of the repository with the removed IDP group.
+	RepositoryName string
+	// role_override is the role override associated with the removed IDP group.
+	RoleOverride v1alpha1.RepositoryRole
+}
+
+func (b0 PayloadRepositoryIDPGroupRemoved_builder) Build() *PayloadRepositoryIDPGroupRemoved {
+	m0 := &PayloadRepositoryIDPGroupRemoved{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_RepositoryName = b.RepositoryName
+	x.xxx_hidden_RoleOverride = b.RoleOverride
+	return m0
+}
+
 type PayloadPolicyCreated struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_OwnerId    string                 `protobuf:"bytes,1,opt,name=owner_id,json=ownerId,proto3"`
@@ -5544,7 +6152,7 @@ type PayloadPolicyCreated struct {
 
 func (x *PayloadPolicyCreated) Reset() {
 	*x = PayloadPolicyCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[24]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5556,7 +6164,7 @@ func (x *PayloadPolicyCreated) String() string {
 func (*PayloadPolicyCreated) ProtoMessage() {}
 
 func (x *PayloadPolicyCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[24]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5632,7 +6240,7 @@ type PayloadPolicyDeleted struct {
 
 func (x *PayloadPolicyDeleted) Reset() {
 	*x = PayloadPolicyDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[25]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5644,7 +6252,7 @@ func (x *PayloadPolicyDeleted) String() string {
 func (*PayloadPolicyDeleted) ProtoMessage() {}
 
 func (x *PayloadPolicyDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[25]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5720,7 +6328,7 @@ type PayloadPolicyDeprecated struct {
 
 func (x *PayloadPolicyDeprecated) Reset() {
 	*x = PayloadPolicyDeprecated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[26]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5732,7 +6340,7 @@ func (x *PayloadPolicyDeprecated) String() string {
 func (*PayloadPolicyDeprecated) ProtoMessage() {}
 
 func (x *PayloadPolicyDeprecated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[26]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5808,7 +6416,7 @@ type PayloadPolicyUndeprecated struct {
 
 func (x *PayloadPolicyUndeprecated) Reset() {
 	*x = PayloadPolicyUndeprecated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[27]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5820,7 +6428,7 @@ func (x *PayloadPolicyUndeprecated) String() string {
 func (*PayloadPolicyUndeprecated) ProtoMessage() {}
 
 func (x *PayloadPolicyUndeprecated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[27]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5897,7 +6505,7 @@ type PayloadPolicyVisibilityChanged struct {
 
 func (x *PayloadPolicyVisibilityChanged) Reset() {
 	*x = PayloadPolicyVisibilityChanged{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[28]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5909,7 +6517,7 @@ func (x *PayloadPolicyVisibilityChanged) String() string {
 func (*PayloadPolicyVisibilityChanged) ProtoMessage() {}
 
 func (x *PayloadPolicyVisibilityChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[28]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6000,7 +6608,7 @@ type PayloadPluginCreated struct {
 
 func (x *PayloadPluginCreated) Reset() {
 	*x = PayloadPluginCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[29]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6012,7 +6620,7 @@ func (x *PayloadPluginCreated) String() string {
 func (*PayloadPluginCreated) ProtoMessage() {}
 
 func (x *PayloadPluginCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[29]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6103,7 +6711,7 @@ type PayloadPluginDeleted struct {
 
 func (x *PayloadPluginDeleted) Reset() {
 	*x = PayloadPluginDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[30]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6115,7 +6723,7 @@ func (x *PayloadPluginDeleted) String() string {
 func (*PayloadPluginDeleted) ProtoMessage() {}
 
 func (x *PayloadPluginDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[30]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6206,7 +6814,7 @@ type PayloadPluginDeprecated struct {
 
 func (x *PayloadPluginDeprecated) Reset() {
 	*x = PayloadPluginDeprecated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[31]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6218,7 +6826,7 @@ func (x *PayloadPluginDeprecated) String() string {
 func (*PayloadPluginDeprecated) ProtoMessage() {}
 
 func (x *PayloadPluginDeprecated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[31]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6309,7 +6917,7 @@ type PayloadPluginUndeprecated struct {
 
 func (x *PayloadPluginUndeprecated) Reset() {
 	*x = PayloadPluginUndeprecated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[32]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6321,7 +6929,7 @@ func (x *PayloadPluginUndeprecated) String() string {
 func (*PayloadPluginUndeprecated) ProtoMessage() {}
 
 func (x *PayloadPluginUndeprecated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[32]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6413,7 +7021,7 @@ type PayloadPluginVisibilityChanged struct {
 
 func (x *PayloadPluginVisibilityChanged) Reset() {
 	*x = PayloadPluginVisibilityChanged{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[33]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6425,7 +7033,7 @@ func (x *PayloadPluginVisibilityChanged) String() string {
 func (*PayloadPluginVisibilityChanged) ProtoMessage() {}
 
 func (x *PayloadPluginVisibilityChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[33]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6531,7 +7139,7 @@ type PayloadPluginCommitPushed struct {
 
 func (x *PayloadPluginCommitPushed) Reset() {
 	*x = PayloadPluginCommitPushed{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[34]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6543,7 +7151,7 @@ func (x *PayloadPluginCommitPushed) String() string {
 func (*PayloadPluginCommitPushed) ProtoMessage() {}
 
 func (x *PayloadPluginCommitPushed) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[34]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6644,7 +7252,7 @@ type PayloadUserCreated struct {
 
 func (x *PayloadUserCreated) Reset() {
 	*x = PayloadUserCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[35]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6656,7 +7264,7 @@ func (x *PayloadUserCreated) String() string {
 func (*PayloadUserCreated) ProtoMessage() {}
 
 func (x *PayloadUserCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[35]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6687,7 +7295,7 @@ type PayloadUserReactivated struct {
 
 func (x *PayloadUserReactivated) Reset() {
 	*x = PayloadUserReactivated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[36]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6699,7 +7307,7 @@ func (x *PayloadUserReactivated) String() string {
 func (*PayloadUserReactivated) ProtoMessage() {}
 
 func (x *PayloadUserReactivated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[36]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6730,7 +7338,7 @@ type PayloadUserDeactivated struct {
 
 func (x *PayloadUserDeactivated) Reset() {
 	*x = PayloadUserDeactivated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[37]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6742,7 +7350,7 @@ func (x *PayloadUserDeactivated) String() string {
 func (*PayloadUserDeactivated) ProtoMessage() {}
 
 func (x *PayloadUserDeactivated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[37]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6773,7 +7381,7 @@ type PayloadUserDeleted struct {
 
 func (x *PayloadUserDeleted) Reset() {
 	*x = PayloadUserDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[38]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6785,7 +7393,7 @@ func (x *PayloadUserDeleted) String() string {
 func (*PayloadUserDeleted) ProtoMessage() {}
 
 func (x *PayloadUserDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[38]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6816,7 +7424,7 @@ type PayloadUserLoggedIn struct {
 
 func (x *PayloadUserLoggedIn) Reset() {
 	*x = PayloadUserLoggedIn{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[39]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6828,7 +7436,7 @@ func (x *PayloadUserLoggedIn) String() string {
 func (*PayloadUserLoggedIn) ProtoMessage() {}
 
 func (x *PayloadUserLoggedIn) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[39]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6859,7 +7467,7 @@ type PayloadUserLoggedOut struct {
 
 func (x *PayloadUserLoggedOut) Reset() {
 	*x = PayloadUserLoggedOut{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[40]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6871,7 +7479,7 @@ func (x *PayloadUserLoggedOut) String() string {
 func (*PayloadUserLoggedOut) ProtoMessage() {}
 
 func (x *PayloadUserLoggedOut) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[40]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6906,7 +7514,7 @@ type PayloadUserAutoMergedFromNewIdP struct {
 
 func (x *PayloadUserAutoMergedFromNewIdP) Reset() {
 	*x = PayloadUserAutoMergedFromNewIdP{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[41]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6918,7 +7526,7 @@ func (x *PayloadUserAutoMergedFromNewIdP) String() string {
 func (*PayloadUserAutoMergedFromNewIdP) ProtoMessage() {}
 
 func (x *PayloadUserAutoMergedFromNewIdP) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[41]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6951,7 +7559,7 @@ type PayloadCuratedPluginCreated struct {
 
 func (x *PayloadCuratedPluginCreated) Reset() {
 	*x = PayloadCuratedPluginCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[42]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6963,7 +7571,7 @@ func (x *PayloadCuratedPluginCreated) String() string {
 func (*PayloadCuratedPluginCreated) ProtoMessage() {}
 
 func (x *PayloadCuratedPluginCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[42]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7024,7 +7632,7 @@ type PayloadCuratedPluginDeleted struct {
 
 func (x *PayloadCuratedPluginDeleted) Reset() {
 	*x = PayloadCuratedPluginDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[43]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7036,7 +7644,7 @@ func (x *PayloadCuratedPluginDeleted) String() string {
 func (*PayloadCuratedPluginDeleted) ProtoMessage() {}
 
 func (x *PayloadCuratedPluginDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[43]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7097,7 +7705,7 @@ type PayloadTokenCreated struct {
 
 func (x *PayloadTokenCreated) Reset() {
 	*x = PayloadTokenCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[44]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7109,7 +7717,7 @@ func (x *PayloadTokenCreated) String() string {
 func (*PayloadTokenCreated) ProtoMessage() {}
 
 func (x *PayloadTokenCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[44]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7180,7 +7788,7 @@ type PayloadTokenDeleted struct {
 
 func (x *PayloadTokenDeleted) Reset() {
 	*x = PayloadTokenDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[45]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7192,7 +7800,7 @@ func (x *PayloadTokenDeleted) String() string {
 func (*PayloadTokenDeleted) ProtoMessage() {}
 
 func (x *PayloadTokenDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[45]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7238,7 +7846,7 @@ type PayloadSCIMTokenCreated struct {
 
 func (x *PayloadSCIMTokenCreated) Reset() {
 	*x = PayloadSCIMTokenCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[46]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7250,7 +7858,7 @@ func (x *PayloadSCIMTokenCreated) String() string {
 func (*PayloadSCIMTokenCreated) ProtoMessage() {}
 
 func (x *PayloadSCIMTokenCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[46]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7306,7 +7914,7 @@ type PayloadSCIMTokenDeleted struct {
 
 func (x *PayloadSCIMTokenDeleted) Reset() {
 	*x = PayloadSCIMTokenDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[47]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7318,7 +7926,7 @@ func (x *PayloadSCIMTokenDeleted) String() string {
 func (*PayloadSCIMTokenDeleted) ProtoMessage() {}
 
 func (x *PayloadSCIMTokenDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[47]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7359,7 +7967,7 @@ type PayloadRepositoryCommitDeleted struct {
 
 func (x *PayloadRepositoryCommitDeleted) Reset() {
 	*x = PayloadRepositoryCommitDeleted{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[48]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7371,7 +7979,7 @@ func (x *PayloadRepositoryCommitDeleted) String() string {
 func (*PayloadRepositoryCommitDeleted) ProtoMessage() {}
 
 func (x *PayloadRepositoryCommitDeleted) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[48]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7479,7 +8087,7 @@ type PayloadRepositoryLabelCreated struct {
 
 func (x *PayloadRepositoryLabelCreated) Reset() {
 	*x = PayloadRepositoryLabelCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[49]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7491,7 +8099,7 @@ func (x *PayloadRepositoryLabelCreated) String() string {
 func (*PayloadRepositoryLabelCreated) ProtoMessage() {}
 
 func (x *PayloadRepositoryLabelCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[49]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7617,7 +8225,7 @@ type PayloadRepositoryLabelMoved struct {
 
 func (x *PayloadRepositoryLabelMoved) Reset() {
 	*x = PayloadRepositoryLabelMoved{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[50]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7629,7 +8237,7 @@ func (x *PayloadRepositoryLabelMoved) String() string {
 func (*PayloadRepositoryLabelMoved) ProtoMessage() {}
 
 func (x *PayloadRepositoryLabelMoved) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[50]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7766,7 +8374,7 @@ type PayloadRepositoryLabelArchived struct {
 
 func (x *PayloadRepositoryLabelArchived) Reset() {
 	*x = PayloadRepositoryLabelArchived{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[51]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7778,7 +8386,7 @@ func (x *PayloadRepositoryLabelArchived) String() string {
 func (*PayloadRepositoryLabelArchived) ProtoMessage() {}
 
 func (x *PayloadRepositoryLabelArchived) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[51]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7869,7 +8477,7 @@ type PayloadRepositoryLabelUnarchived struct {
 
 func (x *PayloadRepositoryLabelUnarchived) Reset() {
 	*x = PayloadRepositoryLabelUnarchived{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[52]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7881,7 +8489,7 @@ func (x *PayloadRepositoryLabelUnarchived) String() string {
 func (*PayloadRepositoryLabelUnarchived) ProtoMessage() {}
 
 func (x *PayloadRepositoryLabelUnarchived) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[52]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7972,7 +8580,7 @@ type PayloadServerBreakingChangePolicyEnabled struct {
 
 func (x *PayloadServerBreakingChangePolicyEnabled) Reset() {
 	*x = PayloadServerBreakingChangePolicyEnabled{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[53]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7984,7 +8592,7 @@ func (x *PayloadServerBreakingChangePolicyEnabled) String() string {
 func (*PayloadServerBreakingChangePolicyEnabled) ProtoMessage() {}
 
 func (x *PayloadServerBreakingChangePolicyEnabled) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[53]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8059,7 +8667,7 @@ type PayloadServerBreakingChangePolicyDisabled struct {
 
 func (x *PayloadServerBreakingChangePolicyDisabled) Reset() {
 	*x = PayloadServerBreakingChangePolicyDisabled{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[54]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8071,7 +8679,7 @@ func (x *PayloadServerBreakingChangePolicyDisabled) String() string {
 func (*PayloadServerBreakingChangePolicyDisabled) ProtoMessage() {}
 
 func (x *PayloadServerBreakingChangePolicyDisabled) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[54]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8102,7 +8710,7 @@ type PayloadServerUniquenessPolicyEnabled struct {
 
 func (x *PayloadServerUniquenessPolicyEnabled) Reset() {
 	*x = PayloadServerUniquenessPolicyEnabled{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[55]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8114,7 +8722,7 @@ func (x *PayloadServerUniquenessPolicyEnabled) String() string {
 func (*PayloadServerUniquenessPolicyEnabled) ProtoMessage() {}
 
 func (x *PayloadServerUniquenessPolicyEnabled) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[55]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8145,7 +8753,7 @@ type PayloadServerUniquenessPolicyDisabled struct {
 
 func (x *PayloadServerUniquenessPolicyDisabled) Reset() {
 	*x = PayloadServerUniquenessPolicyDisabled{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[56]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8157,7 +8765,7 @@ func (x *PayloadServerUniquenessPolicyDisabled) String() string {
 func (*PayloadServerUniquenessPolicyDisabled) ProtoMessage() {}
 
 func (x *PayloadServerUniquenessPolicyDisabled) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[56]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8189,7 +8797,7 @@ type PayloadDeviceAuthorizationGrantApproved struct {
 
 func (x *PayloadDeviceAuthorizationGrantApproved) Reset() {
 	*x = PayloadDeviceAuthorizationGrantApproved{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[57]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8201,7 +8809,7 @@ func (x *PayloadDeviceAuthorizationGrantApproved) String() string {
 func (*PayloadDeviceAuthorizationGrantApproved) ProtoMessage() {}
 
 func (x *PayloadDeviceAuthorizationGrantApproved) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[57]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8247,7 +8855,7 @@ type PayloadDeviceAuthorizationGrantDenied struct {
 
 func (x *PayloadDeviceAuthorizationGrantDenied) Reset() {
 	*x = PayloadDeviceAuthorizationGrantDenied{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[58]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8259,7 +8867,7 @@ func (x *PayloadDeviceAuthorizationGrantDenied) String() string {
 func (*PayloadDeviceAuthorizationGrantDenied) ProtoMessage() {}
 
 func (x *PayloadDeviceAuthorizationGrantDenied) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[58]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8309,7 +8917,7 @@ type PayloadPluginLabelCreated struct {
 
 func (x *PayloadPluginLabelCreated) Reset() {
 	*x = PayloadPluginLabelCreated{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[59]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8321,7 +8929,7 @@ func (x *PayloadPluginLabelCreated) String() string {
 func (*PayloadPluginLabelCreated) ProtoMessage() {}
 
 func (x *PayloadPluginLabelCreated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[59]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8428,7 +9036,7 @@ type PayloadPluginLabelMoved struct {
 
 func (x *PayloadPluginLabelMoved) Reset() {
 	*x = PayloadPluginLabelMoved{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[60]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8440,7 +9048,7 @@ func (x *PayloadPluginLabelMoved) String() string {
 func (*PayloadPluginLabelMoved) ProtoMessage() {}
 
 func (x *PayloadPluginLabelMoved) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[60]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8559,7 +9167,7 @@ type PayloadPluginLabelArchived struct {
 
 func (x *PayloadPluginLabelArchived) Reset() {
 	*x = PayloadPluginLabelArchived{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[61]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8571,7 +9179,7 @@ func (x *PayloadPluginLabelArchived) String() string {
 func (*PayloadPluginLabelArchived) ProtoMessage() {}
 
 func (x *PayloadPluginLabelArchived) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[61]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8662,7 +9270,7 @@ type PayloadPluginLabelUnarchived struct {
 
 func (x *PayloadPluginLabelUnarchived) Reset() {
 	*x = PayloadPluginLabelUnarchived{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[62]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8674,7 +9282,7 @@ func (x *PayloadPluginLabelUnarchived) String() string {
 func (*PayloadPluginLabelUnarchived) ProtoMessage() {}
 
 func (x *PayloadPluginLabelUnarchived) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[62]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8763,7 +9371,7 @@ type PayloadOrganizationMemberRolesChanged_OrganizationRole struct {
 
 func (x *PayloadOrganizationMemberRolesChanged_OrganizationRole) Reset() {
 	*x = PayloadOrganizationMemberRolesChanged_OrganizationRole{}
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[63]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8775,7 +9383,7 @@ func (x *PayloadOrganizationMemberRolesChanged_OrganizationRole) String() string
 func (*PayloadOrganizationMemberRolesChanged_OrganizationRole) ProtoMessage() {}
 
 func (x *PayloadOrganizationMemberRolesChanged_OrganizationRole) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[63]
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8826,6 +9434,79 @@ func (b0 PayloadOrganizationMemberRolesChanged_OrganizationRole_builder) Build()
 	return m0
 }
 
+type PayloadRepositoryContributorRolesChanged_RepositoryRole struct {
+	state             protoimpl.MessageState        `protogen:"opaque.v1"`
+	xxx_hidden_Role   v1alpha1.RepositoryRole       `protobuf:"varint,1,opt,name=role,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	xxx_hidden_Source v1alpha1.RepositoryRoleSource `protobuf:"varint,2,opt,name=source,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRoleSource"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) Reset() {
+	*x = PayloadRepositoryContributorRolesChanged_RepositoryRole{}
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[68]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PayloadRepositoryContributorRolesChanged_RepositoryRole) ProtoMessage() {}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[68]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) GetRole() v1alpha1.RepositoryRole {
+	if x != nil {
+		return x.xxx_hidden_Role
+	}
+	return v1alpha1.RepositoryRole(0)
+}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) GetSource() v1alpha1.RepositoryRoleSource {
+	if x != nil {
+		return x.xxx_hidden_Source
+	}
+	return v1alpha1.RepositoryRoleSource(0)
+}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) SetRole(v v1alpha1.RepositoryRole) {
+	x.xxx_hidden_Role = v
+}
+
+func (x *PayloadRepositoryContributorRolesChanged_RepositoryRole) SetSource(v v1alpha1.RepositoryRoleSource) {
+	x.xxx_hidden_Source = v
+}
+
+type PayloadRepositoryContributorRolesChanged_RepositoryRole_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// role is the role of the member.
+	Role v1alpha1.RepositoryRole
+	// source is the source of the role granted to the member.
+	Source v1alpha1.RepositoryRoleSource
+}
+
+func (b0 PayloadRepositoryContributorRolesChanged_RepositoryRole_builder) Build() *PayloadRepositoryContributorRolesChanged_RepositoryRole {
+	m0 := &PayloadRepositoryContributorRolesChanged_RepositoryRole{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Role = b.Role
+	x.xxx_hidden_Source = b.Source
+	return m0
+}
+
 var File_buf_alpha_audit_v1alpha1_event_proto protoreflect.FileDescriptor
 
 const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
@@ -8843,7 +9524,7 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"\n" +
 	"user_agent\x18\x01 \x01(\tR\tuserAgent\x12\x0e\n" +
 	"\x02ip\x18\x02 \x01(\tR\x02ip\x12\x19\n" +
-	"\btrace_id\x18\x03 \x01(\tR\atraceId\"\xd67\n" +
+	"\btrace_id\x18\x03 \x01(\tR\atraceId\"\xe5;\n" +
 	"\x05Event\x12\x19\n" +
 	"\bevent_id\x18\x01 \x01(\tR\aeventId\x127\n" +
 	"\x04type\x18\x02 \x01(\x0e2#.buf.alpha.audit.v1alpha1.EventTypeR\x04type\x125\n" +
@@ -8865,10 +9546,14 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"\x12repository_deleted\x18\r \x01(\v22.buf.alpha.audit.v1alpha1.PayloadRepositoryDeletedH\x00R\x11repositoryDeleted\x12s\n" +
 	"\x18repository_commit_pushed\x18\x0e \x01(\v27.buf.alpha.audit.v1alpha1.PayloadRepositoryCommitPushedH\x00R\x16repositoryCommitPushed\x12\x7f\n" +
 	"\x1crepository_contributor_added\x18\x0f \x01(\v2;.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAddedH\x00R\x1arepositoryContributorAdded\x12\x92\x01\n" +
-	"#repository_contributor_role_changed\x18\x10 \x01(\v2A.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChangedH\x00R repositoryContributorRoleChanged\x12\x85\x01\n" +
+	"#repository_contributor_role_changed\x18\x10 \x01(\v2A.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChangedH\x00R repositoryContributorRoleChanged\x12\x95\x01\n" +
+	"$repository_contributor_roles_changed\x18E \x01(\v2B.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChangedH\x00R!repositoryContributorRolesChanged\x12\x85\x01\n" +
 	"\x1erepository_contributor_removed\x18\x11 \x01(\v2=.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemovedH\x00R\x1crepositoryContributorRemoved\x12\x82\x01\n" +
 	"\x1drepository_visibility_changed\x18\x12 \x01(\v2<.buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChangedH\x00R\x1brepositoryVisibilityChanged\x12\x96\x01\n" +
-	"%repository_default_label_name_changed\x18. \x01(\v2B.buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultLabelNameChangedH\x00R!repositoryDefaultLabelNameChanged\x12W\n" +
+	"%repository_default_label_name_changed\x18. \x01(\v2B.buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultLabelNameChangedH\x00R!repositoryDefaultLabelNameChanged\x12w\n" +
+	"\x1arepository_idp_group_added\x18B \x01(\v28.buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupAddedH\x00R\x17repositoryIdpGroupAdded\x12}\n" +
+	"\x1crepository_idp_group_updated\x18C \x01(\v2:.buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupUpdatedH\x00R\x19repositoryIdpGroupUpdated\x12}\n" +
+	"\x1crepository_idp_group_removed\x18D \x01(\v2:.buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupRemovedH\x00R\x19repositoryIdpGroupRemoved\x12W\n" +
 	"\x0epolicy_created\x18< \x01(\v2..buf.alpha.audit.v1alpha1.PayloadPolicyCreatedH\x00R\rpolicyCreated\x12W\n" +
 	"\x0epolicy_deleted\x18= \x01(\v2..buf.alpha.audit.v1alpha1.PayloadPolicyDeletedH\x00R\rpolicyDeleted\x12`\n" +
 	"\x11policy_deprecated\x18> \x01(\v21.buf.alpha.audit.v1alpha1.PayloadPolicyDeprecatedH\x00R\x10policyDeprecated\x12f\n" +
@@ -9002,7 +9687,7 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"owner_name\x18\x02 \x01(\tR\townerName\x12#\n" +
 	"\rrepository_id\x18\x03 \x01(\tR\frepositoryId\x12'\n" +
 	"\x0frepository_name\x18\x04 \x01(\tR\x0erepositoryName\x12V\n" +
-	"\x10contributor_role\x18\x05 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x0fcontributorRole\"\xc1\x02\n" +
+	"\x10contributor_role\x18\x05 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x0fcontributorRole\"\xc5\x02\n" +
 	"'PayloadRepositoryContributorRoleChanged\x12\x19\n" +
 	"\bowner_id\x18\x01 \x01(\tR\aownerId\x12\x1d\n" +
 	"\n" +
@@ -9010,7 +9695,18 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"\rrepository_id\x18\x03 \x01(\tR\frepositoryId\x12'\n" +
 	"\x0frepository_name\x18\x04 \x01(\tR\x0erepositoryName\x12F\n" +
 	"\bold_role\x18\x05 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\aoldRole\x12F\n" +
-	"\bnew_role\x18\x06 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\anewRole\"\x85\x02\n" +
+	"\bnew_role\x18\x06 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\anewRole:\x02\x18\x01\"\xb1\x04\n" +
+	"(PayloadRepositoryContributorRolesChanged\x12\x19\n" +
+	"\bowner_id\x18\x01 \x01(\tR\aownerId\x12\x1d\n" +
+	"\n" +
+	"owner_name\x18\x02 \x01(\tR\townerName\x12#\n" +
+	"\rrepository_id\x18\x03 \x01(\tR\frepositoryId\x12'\n" +
+	"\x0frepository_name\x18\x04 \x01(\tR\x0erepositoryName\x12n\n" +
+	"\told_roles\x18\x05 \x03(\v2Q.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRoleR\boldRoles\x12n\n" +
+	"\tnew_roles\x18\x06 \x03(\v2Q.buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRoleR\bnewRoles\x1a\x9c\x01\n" +
+	"\x0eRepositoryRole\x12?\n" +
+	"\x04role\x18\x01 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x04role\x12I\n" +
+	"\x06source\x18\x02 \x01(\x0e21.buf.alpha.registry.v1alpha1.RepositoryRoleSourceR\x06source\"\x85\x02\n" +
 	"#PayloadRepositoryContributorRemoved\x12\x19\n" +
 	"\bowner_id\x18\x01 \x01(\tR\aownerId\x12\x1d\n" +
 	"\n" +
@@ -9035,7 +9731,20 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"\n" +
 	"owner_name\x18\x02 \x01(\tR\townerName\x12,\n" +
 	"\x12old_default_branch\x18\x03 \x01(\tR\x10oldDefaultBranch\x12,\n" +
-	"\x12new_default_branch\x18\x04 \x01(\tR\x10newDefaultBranch:\x02\x18\x01\"\x99\x01\n" +
+	"\x12new_default_branch\x18\x04 \x01(\tR\x10newDefaultBranch:\x02\x18\x01\"\xc0\x01\n" +
+	"\x1ePayloadRepositoryIDPGroupAdded\x12#\n" +
+	"\rrepository_id\x18\x01 \x01(\tR\frepositoryId\x12'\n" +
+	"\x0frepository_name\x18\x02 \x01(\tR\x0erepositoryName\x12P\n" +
+	"\rrole_override\x18\x03 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\froleOverride\"\xa2\x02\n" +
+	" PayloadRepositoryIDPGroupUpdated\x12#\n" +
+	"\rrepository_id\x18\x01 \x01(\tR\frepositoryId\x12'\n" +
+	"\x0frepository_name\x18\x02 \x01(\tR\x0erepositoryName\x12W\n" +
+	"\x11old_role_override\x18\x03 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x0foldRoleOverride\x12W\n" +
+	"\x11new_role_override\x18\x04 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x0fnewRoleOverride\"\xc2\x01\n" +
+	" PayloadRepositoryIDPGroupRemoved\x12#\n" +
+	"\rrepository_id\x18\x01 \x01(\tR\frepositoryId\x12'\n" +
+	"\x0frepository_name\x18\x02 \x01(\tR\x0erepositoryName\x12P\n" +
+	"\rrole_override\x18\x03 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\froleOverride\"\x99\x01\n" +
 	"\x14PayloadPolicyCreated\x12\x19\n" +
 	"\bowner_id\x18\x01 \x01(\tR\aownerId\x12\x1d\n" +
 	"\n" +
@@ -9249,7 +9958,7 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"\x1eRESOURCE_TYPE_REPOSITORY_LABEL\x10\f\x12\x18\n" +
 	"\x14RESOURCE_TYPE_SERVER\x10\r\x12,\n" +
 	"(RESOURCE_TYPE_DEVICE_AUTHORIZATION_GRANT\x10\x0e\x12\x1e\n" +
-	"\x1aRESOURCE_TYPE_PLUGIN_LABEL\x10\x10*\xfa\x12\n" +
+	"\x1aRESOURCE_TYPE_PLUGIN_LABEL\x10\x10*\xb4\x14\n" +
 	"\tEventType\x12\x1a\n" +
 	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fEVENT_TYPE_ORGANIZATION_CREATED\x10\x01\x12#\n" +
@@ -9268,10 +9977,14 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"#EVENT_TYPE_REPOSITORY_COMMIT_PUSHED\x10\b\x12+\n" +
 	"'EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ADDED\x10\t\x122\n" +
 	".EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLE_CHANGED\x10\n" +
-	"\x12-\n" +
+	"\x123\n" +
+	"/EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLES_CHANGED\x10?\x12-\n" +
 	")EVENT_TYPE_REPOSITORY_CONTRIBUTOR_REMOVED\x10\v\x12,\n" +
 	"(EVENT_TYPE_REPOSITORY_VISIBILITY_CHANGED\x10\f\x124\n" +
-	"0EVENT_TYPE_REPOSITORY_DEFAULT_LABEL_NAME_CHANGED\x10(\x12\x1d\n" +
+	"0EVENT_TYPE_REPOSITORY_DEFAULT_LABEL_NAME_CHANGED\x10(\x12)\n" +
+	"%EVENT_TYPE_REPOSITORY_IDP_GROUP_ADDED\x10<\x12+\n" +
+	"'EVENT_TYPE_REPOSITORY_IDP_GROUP_UPDATED\x10=\x12+\n" +
+	"'EVENT_TYPE_REPOSITORY_IDP_GROUP_REMOVED\x10>\x12\x1d\n" +
 	"\x19EVENT_TYPE_POLICY_CREATED\x106\x12\x1d\n" +
 	"\x19EVENT_TYPE_POLICY_DELETED\x107\x12 \n" +
 	"\x1cEVENT_TYPE_POLICY_DEPRECATED\x108\x12\"\n" +
@@ -9316,81 +10029,87 @@ const file_buf_alpha_audit_v1alpha1_event_proto_rawDesc = "" +
 	"EventProtoP\x01ZSgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/audit/v1alpha1;auditv1alpha1\xa2\x02\x03BAA\xaa\x02\x18Buf.Alpha.Audit.V1alpha1\xca\x02\x18Buf\\Alpha\\Audit\\V1alpha1\xe2\x02$Buf\\Alpha\\Audit\\V1alpha1\\GPBMetadata\xea\x02\x1bBuf::Alpha::Audit::V1alpha1b\x06proto3"
 
 var file_buf_alpha_audit_v1alpha1_event_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_buf_alpha_audit_v1alpha1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
+var file_buf_alpha_audit_v1alpha1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_buf_alpha_audit_v1alpha1_event_proto_goTypes = []any{
-	(ActorType)(0),                                                 // 0: buf.alpha.audit.v1alpha1.ActorType
-	(ResourceType)(0),                                              // 1: buf.alpha.audit.v1alpha1.ResourceType
-	(EventType)(0),                                                 // 2: buf.alpha.audit.v1alpha1.EventType
-	(*Actor)(nil),                                                  // 3: buf.alpha.audit.v1alpha1.Actor
-	(*Resource)(nil),                                               // 4: buf.alpha.audit.v1alpha1.Resource
-	(*EventMetadata)(nil),                                          // 5: buf.alpha.audit.v1alpha1.EventMetadata
-	(*Event)(nil),                                                  // 6: buf.alpha.audit.v1alpha1.Event
-	(*PayloadOrganizationCreated)(nil),                             // 7: buf.alpha.audit.v1alpha1.PayloadOrganizationCreated
-	(*PayloadOrganizationDeleted)(nil),                             // 8: buf.alpha.audit.v1alpha1.PayloadOrganizationDeleted
-	(*PayloadOrganizationMemberAdded)(nil),                         // 9: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberAdded
-	(*PayloadOrganizationMemberRoleChanged)(nil),                   // 10: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged
-	(*PayloadOrganizationMemberRolesChanged)(nil),                  // 11: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged
-	(*PayloadOrganizationMemberRemoved)(nil),                       // 12: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved
-	(*PayloadOrganizationIDPGroupAdded)(nil),                       // 13: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded
-	(*PayloadOrganizationIDPGroupUpdated)(nil),                     // 14: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated
-	(*PayloadOrganizationIDPGroupRemoved)(nil),                     // 15: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved
-	(*PayloadRepositoryCreated)(nil),                               // 16: buf.alpha.audit.v1alpha1.PayloadRepositoryCreated
-	(*PayloadRepositoryDeleted)(nil),                               // 17: buf.alpha.audit.v1alpha1.PayloadRepositoryDeleted
-	(*PayloadRepositoryDeprecated)(nil),                            // 18: buf.alpha.audit.v1alpha1.PayloadRepositoryDeprecated
-	(*PayloadRepositoryUndeprecated)(nil),                          // 19: buf.alpha.audit.v1alpha1.PayloadRepositoryUndeprecated
-	(*PayloadRepositoryCommitPushed)(nil),                          // 20: buf.alpha.audit.v1alpha1.PayloadRepositoryCommitPushed
-	(*PayloadRepositoryContributorAdded)(nil),                      // 21: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded
-	(*PayloadRepositoryContributorRoleChanged)(nil),                // 22: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged
-	(*PayloadRepositoryContributorRemoved)(nil),                    // 23: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved
-	(*PayloadRepositoryVisibilityChanged)(nil),                     // 24: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged
-	(*PayloadRepositoryDefaultLabelNameChanged)(nil),               // 25: buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultLabelNameChanged
-	(*PayloadRepositoryDefaultBranchChanged)(nil),                  // 26: buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultBranchChanged
-	(*PayloadPolicyCreated)(nil),                                   // 27: buf.alpha.audit.v1alpha1.PayloadPolicyCreated
-	(*PayloadPolicyDeleted)(nil),                                   // 28: buf.alpha.audit.v1alpha1.PayloadPolicyDeleted
-	(*PayloadPolicyDeprecated)(nil),                                // 29: buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated
-	(*PayloadPolicyUndeprecated)(nil),                              // 30: buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated
-	(*PayloadPolicyVisibilityChanged)(nil),                         // 31: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged
-	(*PayloadPluginCreated)(nil),                                   // 32: buf.alpha.audit.v1alpha1.PayloadPluginCreated
-	(*PayloadPluginDeleted)(nil),                                   // 33: buf.alpha.audit.v1alpha1.PayloadPluginDeleted
-	(*PayloadPluginDeprecated)(nil),                                // 34: buf.alpha.audit.v1alpha1.PayloadPluginDeprecated
-	(*PayloadPluginUndeprecated)(nil),                              // 35: buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated
-	(*PayloadPluginVisibilityChanged)(nil),                         // 36: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged
-	(*PayloadPluginCommitPushed)(nil),                              // 37: buf.alpha.audit.v1alpha1.PayloadPluginCommitPushed
-	(*PayloadUserCreated)(nil),                                     // 38: buf.alpha.audit.v1alpha1.PayloadUserCreated
-	(*PayloadUserReactivated)(nil),                                 // 39: buf.alpha.audit.v1alpha1.PayloadUserReactivated
-	(*PayloadUserDeactivated)(nil),                                 // 40: buf.alpha.audit.v1alpha1.PayloadUserDeactivated
-	(*PayloadUserDeleted)(nil),                                     // 41: buf.alpha.audit.v1alpha1.PayloadUserDeleted
-	(*PayloadUserLoggedIn)(nil),                                    // 42: buf.alpha.audit.v1alpha1.PayloadUserLoggedIn
-	(*PayloadUserLoggedOut)(nil),                                   // 43: buf.alpha.audit.v1alpha1.PayloadUserLoggedOut
-	(*PayloadUserAutoMergedFromNewIdP)(nil),                        // 44: buf.alpha.audit.v1alpha1.PayloadUserAutoMergedFromNewIdP
-	(*PayloadCuratedPluginCreated)(nil),                            // 45: buf.alpha.audit.v1alpha1.PayloadCuratedPluginCreated
-	(*PayloadCuratedPluginDeleted)(nil),                            // 46: buf.alpha.audit.v1alpha1.PayloadCuratedPluginDeleted
-	(*PayloadTokenCreated)(nil),                                    // 47: buf.alpha.audit.v1alpha1.PayloadTokenCreated
-	(*PayloadTokenDeleted)(nil),                                    // 48: buf.alpha.audit.v1alpha1.PayloadTokenDeleted
-	(*PayloadSCIMTokenCreated)(nil),                                // 49: buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated
-	(*PayloadSCIMTokenDeleted)(nil),                                // 50: buf.alpha.audit.v1alpha1.PayloadSCIMTokenDeleted
-	(*PayloadRepositoryCommitDeleted)(nil),                         // 51: buf.alpha.audit.v1alpha1.PayloadRepositoryCommitDeleted
-	(*PayloadRepositoryLabelCreated)(nil),                          // 52: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelCreated
-	(*PayloadRepositoryLabelMoved)(nil),                            // 53: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelMoved
-	(*PayloadRepositoryLabelArchived)(nil),                         // 54: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelArchived
-	(*PayloadRepositoryLabelUnarchived)(nil),                       // 55: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelUnarchived
-	(*PayloadServerBreakingChangePolicyEnabled)(nil),               // 56: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled
-	(*PayloadServerBreakingChangePolicyDisabled)(nil),              // 57: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyDisabled
-	(*PayloadServerUniquenessPolicyEnabled)(nil),                   // 58: buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyEnabled
-	(*PayloadServerUniquenessPolicyDisabled)(nil),                  // 59: buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyDisabled
-	(*PayloadDeviceAuthorizationGrantApproved)(nil),                // 60: buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantApproved
-	(*PayloadDeviceAuthorizationGrantDenied)(nil),                  // 61: buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantDenied
-	(*PayloadPluginLabelCreated)(nil),                              // 62: buf.alpha.audit.v1alpha1.PayloadPluginLabelCreated
-	(*PayloadPluginLabelMoved)(nil),                                // 63: buf.alpha.audit.v1alpha1.PayloadPluginLabelMoved
-	(*PayloadPluginLabelArchived)(nil),                             // 64: buf.alpha.audit.v1alpha1.PayloadPluginLabelArchived
-	(*PayloadPluginLabelUnarchived)(nil),                           // 65: buf.alpha.audit.v1alpha1.PayloadPluginLabelUnarchived
-	(*PayloadOrganizationMemberRolesChanged_OrganizationRole)(nil), // 66: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
-	(*timestamppb.Timestamp)(nil),                                  // 67: google.protobuf.Timestamp
-	(v1alpha1.OrganizationRole)(0),                                 // 68: buf.alpha.registry.v1alpha1.OrganizationRole
-	(v1alpha1.OrganizationRoleSource)(0),                           // 69: buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	(v1alpha1.Visibility)(0),                                       // 70: buf.alpha.registry.v1alpha1.Visibility
-	(v1alpha1.RepositoryRole)(0),                                   // 71: buf.alpha.registry.v1alpha1.RepositoryRole
-	(v1alpha1.BreakingChangeCategory)(0),                           // 72: buf.alpha.registry.v1alpha1.BreakingChangeCategory
+	(ActorType)(0),                                                  // 0: buf.alpha.audit.v1alpha1.ActorType
+	(ResourceType)(0),                                               // 1: buf.alpha.audit.v1alpha1.ResourceType
+	(EventType)(0),                                                  // 2: buf.alpha.audit.v1alpha1.EventType
+	(*Actor)(nil),                                                   // 3: buf.alpha.audit.v1alpha1.Actor
+	(*Resource)(nil),                                                // 4: buf.alpha.audit.v1alpha1.Resource
+	(*EventMetadata)(nil),                                           // 5: buf.alpha.audit.v1alpha1.EventMetadata
+	(*Event)(nil),                                                   // 6: buf.alpha.audit.v1alpha1.Event
+	(*PayloadOrganizationCreated)(nil),                              // 7: buf.alpha.audit.v1alpha1.PayloadOrganizationCreated
+	(*PayloadOrganizationDeleted)(nil),                              // 8: buf.alpha.audit.v1alpha1.PayloadOrganizationDeleted
+	(*PayloadOrganizationMemberAdded)(nil),                          // 9: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberAdded
+	(*PayloadOrganizationMemberRoleChanged)(nil),                    // 10: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged
+	(*PayloadOrganizationMemberRolesChanged)(nil),                   // 11: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged
+	(*PayloadOrganizationMemberRemoved)(nil),                        // 12: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved
+	(*PayloadOrganizationIDPGroupAdded)(nil),                        // 13: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded
+	(*PayloadOrganizationIDPGroupUpdated)(nil),                      // 14: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated
+	(*PayloadOrganizationIDPGroupRemoved)(nil),                      // 15: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved
+	(*PayloadRepositoryCreated)(nil),                                // 16: buf.alpha.audit.v1alpha1.PayloadRepositoryCreated
+	(*PayloadRepositoryDeleted)(nil),                                // 17: buf.alpha.audit.v1alpha1.PayloadRepositoryDeleted
+	(*PayloadRepositoryDeprecated)(nil),                             // 18: buf.alpha.audit.v1alpha1.PayloadRepositoryDeprecated
+	(*PayloadRepositoryUndeprecated)(nil),                           // 19: buf.alpha.audit.v1alpha1.PayloadRepositoryUndeprecated
+	(*PayloadRepositoryCommitPushed)(nil),                           // 20: buf.alpha.audit.v1alpha1.PayloadRepositoryCommitPushed
+	(*PayloadRepositoryContributorAdded)(nil),                       // 21: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded
+	(*PayloadRepositoryContributorRoleChanged)(nil),                 // 22: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged
+	(*PayloadRepositoryContributorRolesChanged)(nil),                // 23: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged
+	(*PayloadRepositoryContributorRemoved)(nil),                     // 24: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved
+	(*PayloadRepositoryVisibilityChanged)(nil),                      // 25: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged
+	(*PayloadRepositoryDefaultLabelNameChanged)(nil),                // 26: buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultLabelNameChanged
+	(*PayloadRepositoryDefaultBranchChanged)(nil),                   // 27: buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultBranchChanged
+	(*PayloadRepositoryIDPGroupAdded)(nil),                          // 28: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupAdded
+	(*PayloadRepositoryIDPGroupUpdated)(nil),                        // 29: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupUpdated
+	(*PayloadRepositoryIDPGroupRemoved)(nil),                        // 30: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupRemoved
+	(*PayloadPolicyCreated)(nil),                                    // 31: buf.alpha.audit.v1alpha1.PayloadPolicyCreated
+	(*PayloadPolicyDeleted)(nil),                                    // 32: buf.alpha.audit.v1alpha1.PayloadPolicyDeleted
+	(*PayloadPolicyDeprecated)(nil),                                 // 33: buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated
+	(*PayloadPolicyUndeprecated)(nil),                               // 34: buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated
+	(*PayloadPolicyVisibilityChanged)(nil),                          // 35: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged
+	(*PayloadPluginCreated)(nil),                                    // 36: buf.alpha.audit.v1alpha1.PayloadPluginCreated
+	(*PayloadPluginDeleted)(nil),                                    // 37: buf.alpha.audit.v1alpha1.PayloadPluginDeleted
+	(*PayloadPluginDeprecated)(nil),                                 // 38: buf.alpha.audit.v1alpha1.PayloadPluginDeprecated
+	(*PayloadPluginUndeprecated)(nil),                               // 39: buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated
+	(*PayloadPluginVisibilityChanged)(nil),                          // 40: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged
+	(*PayloadPluginCommitPushed)(nil),                               // 41: buf.alpha.audit.v1alpha1.PayloadPluginCommitPushed
+	(*PayloadUserCreated)(nil),                                      // 42: buf.alpha.audit.v1alpha1.PayloadUserCreated
+	(*PayloadUserReactivated)(nil),                                  // 43: buf.alpha.audit.v1alpha1.PayloadUserReactivated
+	(*PayloadUserDeactivated)(nil),                                  // 44: buf.alpha.audit.v1alpha1.PayloadUserDeactivated
+	(*PayloadUserDeleted)(nil),                                      // 45: buf.alpha.audit.v1alpha1.PayloadUserDeleted
+	(*PayloadUserLoggedIn)(nil),                                     // 46: buf.alpha.audit.v1alpha1.PayloadUserLoggedIn
+	(*PayloadUserLoggedOut)(nil),                                    // 47: buf.alpha.audit.v1alpha1.PayloadUserLoggedOut
+	(*PayloadUserAutoMergedFromNewIdP)(nil),                         // 48: buf.alpha.audit.v1alpha1.PayloadUserAutoMergedFromNewIdP
+	(*PayloadCuratedPluginCreated)(nil),                             // 49: buf.alpha.audit.v1alpha1.PayloadCuratedPluginCreated
+	(*PayloadCuratedPluginDeleted)(nil),                             // 50: buf.alpha.audit.v1alpha1.PayloadCuratedPluginDeleted
+	(*PayloadTokenCreated)(nil),                                     // 51: buf.alpha.audit.v1alpha1.PayloadTokenCreated
+	(*PayloadTokenDeleted)(nil),                                     // 52: buf.alpha.audit.v1alpha1.PayloadTokenDeleted
+	(*PayloadSCIMTokenCreated)(nil),                                 // 53: buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated
+	(*PayloadSCIMTokenDeleted)(nil),                                 // 54: buf.alpha.audit.v1alpha1.PayloadSCIMTokenDeleted
+	(*PayloadRepositoryCommitDeleted)(nil),                          // 55: buf.alpha.audit.v1alpha1.PayloadRepositoryCommitDeleted
+	(*PayloadRepositoryLabelCreated)(nil),                           // 56: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelCreated
+	(*PayloadRepositoryLabelMoved)(nil),                             // 57: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelMoved
+	(*PayloadRepositoryLabelArchived)(nil),                          // 58: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelArchived
+	(*PayloadRepositoryLabelUnarchived)(nil),                        // 59: buf.alpha.audit.v1alpha1.PayloadRepositoryLabelUnarchived
+	(*PayloadServerBreakingChangePolicyEnabled)(nil),                // 60: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled
+	(*PayloadServerBreakingChangePolicyDisabled)(nil),               // 61: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyDisabled
+	(*PayloadServerUniquenessPolicyEnabled)(nil),                    // 62: buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyEnabled
+	(*PayloadServerUniquenessPolicyDisabled)(nil),                   // 63: buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyDisabled
+	(*PayloadDeviceAuthorizationGrantApproved)(nil),                 // 64: buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantApproved
+	(*PayloadDeviceAuthorizationGrantDenied)(nil),                   // 65: buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantDenied
+	(*PayloadPluginLabelCreated)(nil),                               // 66: buf.alpha.audit.v1alpha1.PayloadPluginLabelCreated
+	(*PayloadPluginLabelMoved)(nil),                                 // 67: buf.alpha.audit.v1alpha1.PayloadPluginLabelMoved
+	(*PayloadPluginLabelArchived)(nil),                              // 68: buf.alpha.audit.v1alpha1.PayloadPluginLabelArchived
+	(*PayloadPluginLabelUnarchived)(nil),                            // 69: buf.alpha.audit.v1alpha1.PayloadPluginLabelUnarchived
+	(*PayloadOrganizationMemberRolesChanged_OrganizationRole)(nil),  // 70: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
+	(*PayloadRepositoryContributorRolesChanged_RepositoryRole)(nil), // 71: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRole
+	(*timestamppb.Timestamp)(nil),                                   // 72: google.protobuf.Timestamp
+	(v1alpha1.OrganizationRole)(0),                                  // 73: buf.alpha.registry.v1alpha1.OrganizationRole
+	(v1alpha1.OrganizationRoleSource)(0),                            // 74: buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	(v1alpha1.Visibility)(0),                                        // 75: buf.alpha.registry.v1alpha1.Visibility
+	(v1alpha1.RepositoryRole)(0),                                    // 76: buf.alpha.registry.v1alpha1.RepositoryRole
+	(v1alpha1.BreakingChangeCategory)(0),                            // 77: buf.alpha.registry.v1alpha1.BreakingChangeCategory
+	(v1alpha1.RepositoryRoleSource)(0),                              // 78: buf.alpha.registry.v1alpha1.RepositoryRoleSource
 }
 var file_buf_alpha_audit_v1alpha1_event_proto_depIdxs = []int32{
 	0,   // 0: buf.alpha.audit.v1alpha1.Actor.type:type_name -> buf.alpha.audit.v1alpha1.ActorType
@@ -9398,7 +10117,7 @@ var file_buf_alpha_audit_v1alpha1_event_proto_depIdxs = []int32{
 	2,   // 2: buf.alpha.audit.v1alpha1.Event.type:type_name -> buf.alpha.audit.v1alpha1.EventType
 	3,   // 3: buf.alpha.audit.v1alpha1.Event.actor:type_name -> buf.alpha.audit.v1alpha1.Actor
 	4,   // 4: buf.alpha.audit.v1alpha1.Event.resource:type_name -> buf.alpha.audit.v1alpha1.Resource
-	67,  // 5: buf.alpha.audit.v1alpha1.Event.event_time:type_name -> google.protobuf.Timestamp
+	72,  // 5: buf.alpha.audit.v1alpha1.Event.event_time:type_name -> google.protobuf.Timestamp
 	5,   // 6: buf.alpha.audit.v1alpha1.Event.metadata:type_name -> buf.alpha.audit.v1alpha1.EventMetadata
 	7,   // 7: buf.alpha.audit.v1alpha1.Event.organization_created:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationCreated
 	8,   // 8: buf.alpha.audit.v1alpha1.Event.organization_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationDeleted
@@ -9413,98 +10132,110 @@ var file_buf_alpha_audit_v1alpha1_event_proto_depIdxs = []int32{
 	20,  // 17: buf.alpha.audit.v1alpha1.Event.repository_commit_pushed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryCommitPushed
 	21,  // 18: buf.alpha.audit.v1alpha1.Event.repository_contributor_added:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded
 	22,  // 19: buf.alpha.audit.v1alpha1.Event.repository_contributor_role_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged
-	23,  // 20: buf.alpha.audit.v1alpha1.Event.repository_contributor_removed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved
-	24,  // 21: buf.alpha.audit.v1alpha1.Event.repository_visibility_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged
-	25,  // 22: buf.alpha.audit.v1alpha1.Event.repository_default_label_name_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultLabelNameChanged
-	27,  // 23: buf.alpha.audit.v1alpha1.Event.policy_created:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyCreated
-	28,  // 24: buf.alpha.audit.v1alpha1.Event.policy_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyDeleted
-	29,  // 25: buf.alpha.audit.v1alpha1.Event.policy_deprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated
-	30,  // 26: buf.alpha.audit.v1alpha1.Event.policy_undeprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated
-	31,  // 27: buf.alpha.audit.v1alpha1.Event.policy_visibility_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged
-	32,  // 28: buf.alpha.audit.v1alpha1.Event.plugin_created:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginCreated
-	33,  // 29: buf.alpha.audit.v1alpha1.Event.plugin_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginDeleted
-	34,  // 30: buf.alpha.audit.v1alpha1.Event.plugin_deprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginDeprecated
-	35,  // 31: buf.alpha.audit.v1alpha1.Event.plugin_undeprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated
-	36,  // 32: buf.alpha.audit.v1alpha1.Event.plugin_visibility_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged
-	37,  // 33: buf.alpha.audit.v1alpha1.Event.plugin_commit_pushed:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginCommitPushed
-	38,  // 34: buf.alpha.audit.v1alpha1.Event.user_created:type_name -> buf.alpha.audit.v1alpha1.PayloadUserCreated
-	40,  // 35: buf.alpha.audit.v1alpha1.Event.user_deactivated:type_name -> buf.alpha.audit.v1alpha1.PayloadUserDeactivated
-	41,  // 36: buf.alpha.audit.v1alpha1.Event.user_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadUserDeleted
-	42,  // 37: buf.alpha.audit.v1alpha1.Event.user_logged_in:type_name -> buf.alpha.audit.v1alpha1.PayloadUserLoggedIn
-	43,  // 38: buf.alpha.audit.v1alpha1.Event.user_logged_out:type_name -> buf.alpha.audit.v1alpha1.PayloadUserLoggedOut
-	45,  // 39: buf.alpha.audit.v1alpha1.Event.curated_plugin_created:type_name -> buf.alpha.audit.v1alpha1.PayloadCuratedPluginCreated
-	13,  // 40: buf.alpha.audit.v1alpha1.Event.idp_group_added:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded
-	14,  // 41: buf.alpha.audit.v1alpha1.Event.idp_group_updated:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated
-	15,  // 42: buf.alpha.audit.v1alpha1.Event.idp_group_removed:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved
-	47,  // 43: buf.alpha.audit.v1alpha1.Event.token_created:type_name -> buf.alpha.audit.v1alpha1.PayloadTokenCreated
-	48,  // 44: buf.alpha.audit.v1alpha1.Event.token_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadTokenDeleted
-	39,  // 45: buf.alpha.audit.v1alpha1.Event.user_reactivated:type_name -> buf.alpha.audit.v1alpha1.PayloadUserReactivated
-	49,  // 46: buf.alpha.audit.v1alpha1.Event.scim_token_created:type_name -> buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated
-	50,  // 47: buf.alpha.audit.v1alpha1.Event.scim_token_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadSCIMTokenDeleted
-	51,  // 48: buf.alpha.audit.v1alpha1.Event.repository_commit_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryCommitDeleted
-	52,  // 49: buf.alpha.audit.v1alpha1.Event.repository_label_created:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelCreated
-	53,  // 50: buf.alpha.audit.v1alpha1.Event.repository_label_moved:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelMoved
-	54,  // 51: buf.alpha.audit.v1alpha1.Event.repository_label_archived:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelArchived
-	55,  // 52: buf.alpha.audit.v1alpha1.Event.repository_label_unarchived:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelUnarchived
-	46,  // 53: buf.alpha.audit.v1alpha1.Event.curated_plugin_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadCuratedPluginDeleted
-	56,  // 54: buf.alpha.audit.v1alpha1.Event.payload_server_breaking_change_policy_enabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled
-	57,  // 55: buf.alpha.audit.v1alpha1.Event.payload_server_breaking_change_policy_disabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyDisabled
-	26,  // 56: buf.alpha.audit.v1alpha1.Event.repository_default_branch_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultBranchChanged
-	58,  // 57: buf.alpha.audit.v1alpha1.Event.payload_server_uniqueness_policy_enabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyEnabled
-	59,  // 58: buf.alpha.audit.v1alpha1.Event.payload_server_uniqueness_policy_disabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyDisabled
-	44,  // 59: buf.alpha.audit.v1alpha1.Event.user_auto_merged_from_new_idp:type_name -> buf.alpha.audit.v1alpha1.PayloadUserAutoMergedFromNewIdP
-	60,  // 60: buf.alpha.audit.v1alpha1.Event.device_authorization_grant_approved:type_name -> buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantApproved
-	61,  // 61: buf.alpha.audit.v1alpha1.Event.device_authorization_grant_denied:type_name -> buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantDenied
-	62,  // 62: buf.alpha.audit.v1alpha1.Event.plugin_label_created:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelCreated
-	63,  // 63: buf.alpha.audit.v1alpha1.Event.plugin_label_moved:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelMoved
-	64,  // 64: buf.alpha.audit.v1alpha1.Event.plugin_label_archived:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelArchived
-	65,  // 65: buf.alpha.audit.v1alpha1.Event.plugin_label_unarchived:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelUnarchived
-	68,  // 66: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberAdded.member_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	69,  // 67: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberAdded.member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	68,  // 68: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.old_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	68,  // 69: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.new_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	69,  // 70: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.old_member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	69,  // 71: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.new_member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	66,  // 72: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.old_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
-	66,  // 73: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.new_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
-	68,  // 74: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved.member_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	69,  // 75: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved.member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	68,  // 76: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	68,  // 77: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated.old_role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	68,  // 78: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated.new_role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	68,  // 79: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	70,  // 80: buf.alpha.audit.v1alpha1.PayloadRepositoryCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 81: buf.alpha.audit.v1alpha1.PayloadRepositoryDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 82: buf.alpha.audit.v1alpha1.PayloadRepositoryDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 83: buf.alpha.audit.v1alpha1.PayloadRepositoryUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	71,  // 84: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	71,  // 85: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.old_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	71,  // 86: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.new_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	71,  // 87: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	70,  // 88: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 89: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 90: buf.alpha.audit.v1alpha1.PayloadPolicyCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 91: buf.alpha.audit.v1alpha1.PayloadPolicyDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 92: buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 93: buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 94: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 95: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 96: buf.alpha.audit.v1alpha1.PayloadPluginCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 97: buf.alpha.audit.v1alpha1.PayloadPluginDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 98: buf.alpha.audit.v1alpha1.PayloadPluginDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 99: buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 100: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	70,  // 101: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	67,  // 102: buf.alpha.audit.v1alpha1.PayloadTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
-	67,  // 103: buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
-	72,  // 104: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled.category:type_name -> buf.alpha.registry.v1alpha1.BreakingChangeCategory
-	68,  // 105: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
-	69,  // 106: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
-	107, // [107:107] is the sub-list for method output_type
-	107, // [107:107] is the sub-list for method input_type
-	107, // [107:107] is the sub-list for extension type_name
-	107, // [107:107] is the sub-list for extension extendee
-	0,   // [0:107] is the sub-list for field type_name
+	23,  // 20: buf.alpha.audit.v1alpha1.Event.repository_contributor_roles_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged
+	24,  // 21: buf.alpha.audit.v1alpha1.Event.repository_contributor_removed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved
+	25,  // 22: buf.alpha.audit.v1alpha1.Event.repository_visibility_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged
+	26,  // 23: buf.alpha.audit.v1alpha1.Event.repository_default_label_name_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultLabelNameChanged
+	28,  // 24: buf.alpha.audit.v1alpha1.Event.repository_idp_group_added:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupAdded
+	29,  // 25: buf.alpha.audit.v1alpha1.Event.repository_idp_group_updated:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupUpdated
+	30,  // 26: buf.alpha.audit.v1alpha1.Event.repository_idp_group_removed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupRemoved
+	31,  // 27: buf.alpha.audit.v1alpha1.Event.policy_created:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyCreated
+	32,  // 28: buf.alpha.audit.v1alpha1.Event.policy_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyDeleted
+	33,  // 29: buf.alpha.audit.v1alpha1.Event.policy_deprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated
+	34,  // 30: buf.alpha.audit.v1alpha1.Event.policy_undeprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated
+	35,  // 31: buf.alpha.audit.v1alpha1.Event.policy_visibility_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged
+	36,  // 32: buf.alpha.audit.v1alpha1.Event.plugin_created:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginCreated
+	37,  // 33: buf.alpha.audit.v1alpha1.Event.plugin_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginDeleted
+	38,  // 34: buf.alpha.audit.v1alpha1.Event.plugin_deprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginDeprecated
+	39,  // 35: buf.alpha.audit.v1alpha1.Event.plugin_undeprecated:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated
+	40,  // 36: buf.alpha.audit.v1alpha1.Event.plugin_visibility_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged
+	41,  // 37: buf.alpha.audit.v1alpha1.Event.plugin_commit_pushed:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginCommitPushed
+	42,  // 38: buf.alpha.audit.v1alpha1.Event.user_created:type_name -> buf.alpha.audit.v1alpha1.PayloadUserCreated
+	44,  // 39: buf.alpha.audit.v1alpha1.Event.user_deactivated:type_name -> buf.alpha.audit.v1alpha1.PayloadUserDeactivated
+	45,  // 40: buf.alpha.audit.v1alpha1.Event.user_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadUserDeleted
+	46,  // 41: buf.alpha.audit.v1alpha1.Event.user_logged_in:type_name -> buf.alpha.audit.v1alpha1.PayloadUserLoggedIn
+	47,  // 42: buf.alpha.audit.v1alpha1.Event.user_logged_out:type_name -> buf.alpha.audit.v1alpha1.PayloadUserLoggedOut
+	49,  // 43: buf.alpha.audit.v1alpha1.Event.curated_plugin_created:type_name -> buf.alpha.audit.v1alpha1.PayloadCuratedPluginCreated
+	13,  // 44: buf.alpha.audit.v1alpha1.Event.idp_group_added:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded
+	14,  // 45: buf.alpha.audit.v1alpha1.Event.idp_group_updated:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated
+	15,  // 46: buf.alpha.audit.v1alpha1.Event.idp_group_removed:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved
+	51,  // 47: buf.alpha.audit.v1alpha1.Event.token_created:type_name -> buf.alpha.audit.v1alpha1.PayloadTokenCreated
+	52,  // 48: buf.alpha.audit.v1alpha1.Event.token_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadTokenDeleted
+	43,  // 49: buf.alpha.audit.v1alpha1.Event.user_reactivated:type_name -> buf.alpha.audit.v1alpha1.PayloadUserReactivated
+	53,  // 50: buf.alpha.audit.v1alpha1.Event.scim_token_created:type_name -> buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated
+	54,  // 51: buf.alpha.audit.v1alpha1.Event.scim_token_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadSCIMTokenDeleted
+	55,  // 52: buf.alpha.audit.v1alpha1.Event.repository_commit_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryCommitDeleted
+	56,  // 53: buf.alpha.audit.v1alpha1.Event.repository_label_created:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelCreated
+	57,  // 54: buf.alpha.audit.v1alpha1.Event.repository_label_moved:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelMoved
+	58,  // 55: buf.alpha.audit.v1alpha1.Event.repository_label_archived:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelArchived
+	59,  // 56: buf.alpha.audit.v1alpha1.Event.repository_label_unarchived:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryLabelUnarchived
+	50,  // 57: buf.alpha.audit.v1alpha1.Event.curated_plugin_deleted:type_name -> buf.alpha.audit.v1alpha1.PayloadCuratedPluginDeleted
+	60,  // 58: buf.alpha.audit.v1alpha1.Event.payload_server_breaking_change_policy_enabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled
+	61,  // 59: buf.alpha.audit.v1alpha1.Event.payload_server_breaking_change_policy_disabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyDisabled
+	27,  // 60: buf.alpha.audit.v1alpha1.Event.repository_default_branch_changed:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryDefaultBranchChanged
+	62,  // 61: buf.alpha.audit.v1alpha1.Event.payload_server_uniqueness_policy_enabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyEnabled
+	63,  // 62: buf.alpha.audit.v1alpha1.Event.payload_server_uniqueness_policy_disabled:type_name -> buf.alpha.audit.v1alpha1.PayloadServerUniquenessPolicyDisabled
+	48,  // 63: buf.alpha.audit.v1alpha1.Event.user_auto_merged_from_new_idp:type_name -> buf.alpha.audit.v1alpha1.PayloadUserAutoMergedFromNewIdP
+	64,  // 64: buf.alpha.audit.v1alpha1.Event.device_authorization_grant_approved:type_name -> buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantApproved
+	65,  // 65: buf.alpha.audit.v1alpha1.Event.device_authorization_grant_denied:type_name -> buf.alpha.audit.v1alpha1.PayloadDeviceAuthorizationGrantDenied
+	66,  // 66: buf.alpha.audit.v1alpha1.Event.plugin_label_created:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelCreated
+	67,  // 67: buf.alpha.audit.v1alpha1.Event.plugin_label_moved:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelMoved
+	68,  // 68: buf.alpha.audit.v1alpha1.Event.plugin_label_archived:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelArchived
+	69,  // 69: buf.alpha.audit.v1alpha1.Event.plugin_label_unarchived:type_name -> buf.alpha.audit.v1alpha1.PayloadPluginLabelUnarchived
+	73,  // 70: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberAdded.member_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	74,  // 71: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberAdded.member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	73,  // 72: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.old_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	73,  // 73: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.new_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	74,  // 74: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.old_member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	74,  // 75: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRoleChanged.new_member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	70,  // 76: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.old_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
+	70,  // 77: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.new_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole
+	73,  // 78: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved.member_role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	74,  // 79: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRemoved.member_role_source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	73,  // 80: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupAdded.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	73,  // 81: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated.old_role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	73,  // 82: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupUpdated.new_role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	73,  // 83: buf.alpha.audit.v1alpha1.PayloadOrganizationIDPGroupRemoved.role_override:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	75,  // 84: buf.alpha.audit.v1alpha1.PayloadRepositoryCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 85: buf.alpha.audit.v1alpha1.PayloadRepositoryDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 86: buf.alpha.audit.v1alpha1.PayloadRepositoryDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 87: buf.alpha.audit.v1alpha1.PayloadRepositoryUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	76,  // 88: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorAdded.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	76,  // 89: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.old_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	76,  // 90: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRoleChanged.new_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	71,  // 91: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.old_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRole
+	71,  // 92: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.new_roles:type_name -> buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRole
+	76,  // 93: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRemoved.contributor_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	75,  // 94: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 95: buf.alpha.audit.v1alpha1.PayloadRepositoryVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	76,  // 96: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupAdded.role_override:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	76,  // 97: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupUpdated.old_role_override:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	76,  // 98: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupUpdated.new_role_override:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	76,  // 99: buf.alpha.audit.v1alpha1.PayloadRepositoryIDPGroupRemoved.role_override:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	75,  // 100: buf.alpha.audit.v1alpha1.PayloadPolicyCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 101: buf.alpha.audit.v1alpha1.PayloadPolicyDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 102: buf.alpha.audit.v1alpha1.PayloadPolicyDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 103: buf.alpha.audit.v1alpha1.PayloadPolicyUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 104: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 105: buf.alpha.audit.v1alpha1.PayloadPolicyVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 106: buf.alpha.audit.v1alpha1.PayloadPluginCreated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 107: buf.alpha.audit.v1alpha1.PayloadPluginDeleted.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 108: buf.alpha.audit.v1alpha1.PayloadPluginDeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 109: buf.alpha.audit.v1alpha1.PayloadPluginUndeprecated.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 110: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.old_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	75,  // 111: buf.alpha.audit.v1alpha1.PayloadPluginVisibilityChanged.new_visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
+	72,  // 112: buf.alpha.audit.v1alpha1.PayloadTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
+	72,  // 113: buf.alpha.audit.v1alpha1.PayloadSCIMTokenCreated.token_expiry_time:type_name -> google.protobuf.Timestamp
+	77,  // 114: buf.alpha.audit.v1alpha1.PayloadServerBreakingChangePolicyEnabled.category:type_name -> buf.alpha.registry.v1alpha1.BreakingChangeCategory
+	73,  // 115: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.role:type_name -> buf.alpha.registry.v1alpha1.OrganizationRole
+	74,  // 116: buf.alpha.audit.v1alpha1.PayloadOrganizationMemberRolesChanged.OrganizationRole.source:type_name -> buf.alpha.registry.v1alpha1.OrganizationRoleSource
+	76,  // 117: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRole.role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	78,  // 118: buf.alpha.audit.v1alpha1.PayloadRepositoryContributorRolesChanged.RepositoryRole.source:type_name -> buf.alpha.registry.v1alpha1.RepositoryRoleSource
+	119, // [119:119] is the sub-list for method output_type
+	119, // [119:119] is the sub-list for method input_type
+	119, // [119:119] is the sub-list for extension type_name
+	119, // [119:119] is the sub-list for extension extendee
+	0,   // [0:119] is the sub-list for field type_name
 }
 
 func init() { file_buf_alpha_audit_v1alpha1_event_proto_init() }
@@ -9526,9 +10257,13 @@ func file_buf_alpha_audit_v1alpha1_event_proto_init() {
 		(*event_RepositoryCommitPushed)(nil),
 		(*event_RepositoryContributorAdded)(nil),
 		(*event_RepositoryContributorRoleChanged)(nil),
+		(*event_RepositoryContributorRolesChanged)(nil),
 		(*event_RepositoryContributorRemoved)(nil),
 		(*event_RepositoryVisibilityChanged)(nil),
 		(*event_RepositoryDefaultLabelNameChanged)(nil),
+		(*event_RepositoryIdpGroupAdded)(nil),
+		(*event_RepositoryIdpGroupUpdated)(nil),
+		(*event_RepositoryIdpGroupRemoved)(nil),
 		(*event_PolicyCreated)(nil),
 		(*event_PolicyDeleted)(nil),
 		(*event_PolicyDeprecated)(nil),
@@ -9573,14 +10308,14 @@ func file_buf_alpha_audit_v1alpha1_event_proto_init() {
 		(*event_PluginLabelArchived)(nil),
 		(*event_PluginLabelUnarchived)(nil),
 	}
-	file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[53].OneofWrappers = []any{}
+	file_buf_alpha_audit_v1alpha1_event_proto_msgTypes[57].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_alpha_audit_v1alpha1_event_proto_rawDesc), len(file_buf_alpha_audit_v1alpha1_event_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   64,
+			NumMessages:   69,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/repository.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/repository.pb.go
@@ -3550,6 +3550,407 @@ func (b0 GetRepositoryDependencyDOTStringResponse_builder) Build() *GetRepositor
 	return m0
 }
 
+type AddRepositoryGroupRequest struct {
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryId   string                 `protobuf:"bytes,1,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_GroupName      string                 `protobuf:"bytes,2,opt,name=group_name,json=groupName,proto3"`
+	xxx_hidden_RepositoryRole RepositoryRole         `protobuf:"varint,3,opt,name=repository_role,json=repositoryRole,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *AddRepositoryGroupRequest) Reset() {
+	*x = AddRepositoryGroupRequest{}
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddRepositoryGroupRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddRepositoryGroupRequest) ProtoMessage() {}
+
+func (x *AddRepositoryGroupRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *AddRepositoryGroupRequest) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *AddRepositoryGroupRequest) GetGroupName() string {
+	if x != nil {
+		return x.xxx_hidden_GroupName
+	}
+	return ""
+}
+
+func (x *AddRepositoryGroupRequest) GetRepositoryRole() RepositoryRole {
+	if x != nil {
+		return x.xxx_hidden_RepositoryRole
+	}
+	return RepositoryRole_REPOSITORY_ROLE_UNSPECIFIED
+}
+
+func (x *AddRepositoryGroupRequest) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *AddRepositoryGroupRequest) SetGroupName(v string) {
+	x.xxx_hidden_GroupName = v
+}
+
+func (x *AddRepositoryGroupRequest) SetRepositoryRole(v RepositoryRole) {
+	x.xxx_hidden_RepositoryRole = v
+}
+
+type AddRepositoryGroupRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The ID of the repository for which to add the group.
+	RepositoryId string
+	// The name of the group to add.
+	GroupName string
+	// The role to associate with any user who is added to the repository via this group.
+	RepositoryRole RepositoryRole
+}
+
+func (b0 AddRepositoryGroupRequest_builder) Build() *AddRepositoryGroupRequest {
+	m0 := &AddRepositoryGroupRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_GroupName = b.GroupName
+	x.xxx_hidden_RepositoryRole = b.RepositoryRole
+	return m0
+}
+
+type AddRepositoryGroupResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddRepositoryGroupResponse) Reset() {
+	*x = AddRepositoryGroupResponse{}
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddRepositoryGroupResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddRepositoryGroupResponse) ProtoMessage() {}
+
+func (x *AddRepositoryGroupResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type AddRepositoryGroupResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 AddRepositoryGroupResponse_builder) Build() *AddRepositoryGroupResponse {
+	m0 := &AddRepositoryGroupResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type UpdateRepositoryGroupRequest struct {
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryId string                 `protobuf:"bytes,1,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_GroupName    string                 `protobuf:"bytes,2,opt,name=group_name,json=groupName,proto3"`
+	xxx_hidden_RoleOverride RepositoryRole         `protobuf:"varint,3,opt,name=role_override,json=roleOverride,proto3,enum=buf.alpha.registry.v1alpha1.RepositoryRole,oneof"`
+	XXX_raceDetectHookData  protoimpl.RaceDetectHookData
+	XXX_presence            [1]uint32
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *UpdateRepositoryGroupRequest) Reset() {
+	*x = UpdateRepositoryGroupRequest{}
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateRepositoryGroupRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateRepositoryGroupRequest) ProtoMessage() {}
+
+func (x *UpdateRepositoryGroupRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UpdateRepositoryGroupRequest) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *UpdateRepositoryGroupRequest) GetGroupName() string {
+	if x != nil {
+		return x.xxx_hidden_GroupName
+	}
+	return ""
+}
+
+func (x *UpdateRepositoryGroupRequest) GetRoleOverride() RepositoryRole {
+	if x != nil {
+		if protoimpl.X.Present(&(x.XXX_presence[0]), 2) {
+			return x.xxx_hidden_RoleOverride
+		}
+	}
+	return RepositoryRole_REPOSITORY_ROLE_UNSPECIFIED
+}
+
+func (x *UpdateRepositoryGroupRequest) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *UpdateRepositoryGroupRequest) SetGroupName(v string) {
+	x.xxx_hidden_GroupName = v
+}
+
+func (x *UpdateRepositoryGroupRequest) SetRoleOverride(v RepositoryRole) {
+	x.xxx_hidden_RoleOverride = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 3)
+}
+
+func (x *UpdateRepositoryGroupRequest) HasRoleOverride() bool {
+	if x == nil {
+		return false
+	}
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
+}
+
+func (x *UpdateRepositoryGroupRequest) ClearRoleOverride() {
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
+	x.xxx_hidden_RoleOverride = RepositoryRole_REPOSITORY_ROLE_UNSPECIFIED
+}
+
+type UpdateRepositoryGroupRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The ID of the repository to which this group belongs.
+	RepositoryId string
+	// The name of the group to update.
+	GroupName string
+	// The role to associate with this repository group.
+	//
+	// Setting this to 'UNSPECIFIED' will remove the override. Leaving this unset will not update this
+	// property.
+	RoleOverride *RepositoryRole
+}
+
+func (b0 UpdateRepositoryGroupRequest_builder) Build() *UpdateRepositoryGroupRequest {
+	m0 := &UpdateRepositoryGroupRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_GroupName = b.GroupName
+	if b.RoleOverride != nil {
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 3)
+		x.xxx_hidden_RoleOverride = *b.RoleOverride
+	}
+	return m0
+}
+
+type UpdateRepositoryGroupResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateRepositoryGroupResponse) Reset() {
+	*x = UpdateRepositoryGroupResponse{}
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateRepositoryGroupResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateRepositoryGroupResponse) ProtoMessage() {}
+
+func (x *UpdateRepositoryGroupResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type UpdateRepositoryGroupResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 UpdateRepositoryGroupResponse_builder) Build() *UpdateRepositoryGroupResponse {
+	m0 := &UpdateRepositoryGroupResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type RemoveRepositoryGroupRequest struct {
+	state                   protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_RepositoryId string                 `protobuf:"bytes,1,opt,name=repository_id,json=repositoryId,proto3"`
+	xxx_hidden_GroupName    string                 `protobuf:"bytes,2,opt,name=group_name,json=groupName,proto3"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *RemoveRepositoryGroupRequest) Reset() {
+	*x = RemoveRepositoryGroupRequest{}
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveRepositoryGroupRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveRepositoryGroupRequest) ProtoMessage() {}
+
+func (x *RemoveRepositoryGroupRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *RemoveRepositoryGroupRequest) GetRepositoryId() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryId
+	}
+	return ""
+}
+
+func (x *RemoveRepositoryGroupRequest) GetGroupName() string {
+	if x != nil {
+		return x.xxx_hidden_GroupName
+	}
+	return ""
+}
+
+func (x *RemoveRepositoryGroupRequest) SetRepositoryId(v string) {
+	x.xxx_hidden_RepositoryId = v
+}
+
+func (x *RemoveRepositoryGroupRequest) SetGroupName(v string) {
+	x.xxx_hidden_GroupName = v
+}
+
+type RemoveRepositoryGroupRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The ID of the repository for which to remove the group.
+	RepositoryId string
+	// The name of the group to remove.
+	GroupName string
+}
+
+func (b0 RemoveRepositoryGroupRequest_builder) Build() *RemoveRepositoryGroupRequest {
+	m0 := &RemoveRepositoryGroupRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_RepositoryId = b.RepositoryId
+	x.xxx_hidden_GroupName = b.GroupName
+	return m0
+}
+
+type RemoveRepositoryGroupResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RemoveRepositoryGroupResponse) Reset() {
+	*x = RemoveRepositoryGroupResponse{}
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RemoveRepositoryGroupResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RemoveRepositoryGroupResponse) ProtoMessage() {}
+
+func (x *RemoveRepositoryGroupResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type RemoveRepositoryGroupResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 RemoveRepositoryGroupResponse_builder) Build() *RemoveRepositoryGroupResponse {
+	m0 := &RemoveRepositoryGroupResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_buf_alpha_registry_v1alpha1_repository_proto protoreflect.FileDescriptor
 
 const file_buf_alpha_registry_v1alpha1_repository_proto_rawDesc = "" +
@@ -3730,12 +4131,30 @@ const file_buf_alpha_registry_v1alpha1_repository_proto_rawDesc = "" +
 	"\treference\x18\x03 \x01(\tR\treference\"I\n" +
 	"(GetRepositoryDependencyDOTStringResponse\x12\x1d\n" +
 	"\n" +
-	"dot_string\x18\x01 \x01(\tR\tdotString*W\n" +
+	"dot_string\x18\x01 \x01(\tR\tdotString\"\xb5\x01\n" +
+	"\x19AddRepositoryGroupRequest\x12#\n" +
+	"\rrepository_id\x18\x01 \x01(\tR\frepositoryId\x12\x1d\n" +
+	"\n" +
+	"group_name\x18\x02 \x01(\tR\tgroupName\x12T\n" +
+	"\x0frepository_role\x18\x03 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleR\x0erepositoryRole\"\x1c\n" +
+	"\x1aAddRepositoryGroupResponse\"\xcb\x01\n" +
+	"\x1cUpdateRepositoryGroupRequest\x12#\n" +
+	"\rrepository_id\x18\x01 \x01(\tR\frepositoryId\x12\x1d\n" +
+	"\n" +
+	"group_name\x18\x02 \x01(\tR\tgroupName\x12U\n" +
+	"\rrole_override\x18\x03 \x01(\x0e2+.buf.alpha.registry.v1alpha1.RepositoryRoleH\x00R\froleOverride\x88\x01\x01B\x10\n" +
+	"\x0e_role_override\"\x1f\n" +
+	"\x1dUpdateRepositoryGroupResponse\"b\n" +
+	"\x1cRemoveRepositoryGroupRequest\x12#\n" +
+	"\rrepository_id\x18\x01 \x01(\tR\frepositoryId\x12\x1d\n" +
+	"\n" +
+	"group_name\x18\x02 \x01(\tR\tgroupName\"\x1f\n" +
+	"\x1dRemoveRepositoryGroupResponse*W\n" +
 	"\n" +
 	"Visibility\x12\x1a\n" +
 	"\x16VISIBILITY_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11VISIBILITY_PUBLIC\x10\x01\x12\x16\n" +
-	"\x12VISIBILITY_PRIVATE\x10\x022\xc5\x17\n" +
+	"\x12VISIBILITY_PRIVATE\x10\x022\xfe\x1a\n" +
 	"\x11RepositoryService\x12{\n" +
 	"\rGetRepository\x121.buf.alpha.registry.v1alpha1.GetRepositoryRequest\x1a2.buf.alpha.registry.v1alpha1.GetRepositoryResponse\"\x03\x90\x02\x01\x12\x99\x01\n" +
 	"\x17GetRepositoryByFullName\x12;.buf.alpha.registry.v1alpha1.GetRepositoryByFullNameRequest\x1a<.buf.alpha.registry.v1alpha1.GetRepositoryByFullNameResponse\"\x03\x90\x02\x01\x12\x84\x01\n" +
@@ -3755,11 +4174,14 @@ const file_buf_alpha_registry_v1alpha1_repository_proto_rawDesc = "" +
 	"\x15GetRepositorySettings\x129.buf.alpha.registry.v1alpha1.GetRepositorySettingsRequest\x1a:.buf.alpha.registry.v1alpha1.GetRepositorySettingsResponse\"\x03\x90\x02\x01\x12\xa9\x01\n" +
 	"\x1eUpdateRepositorySettingsByName\x12B.buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameRequest\x1aC.buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameResponse\x12\x99\x01\n" +
 	"\x17GetRepositoriesMetadata\x12;.buf.alpha.registry.v1alpha1.GetRepositoriesMetadataRequest\x1a<.buf.alpha.registry.v1alpha1.GetRepositoriesMetadataResponse\"\x03\x90\x02\x01\x12\xb4\x01\n" +
-	" GetRepositoryDependencyDOTString\x12D.buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringRequest\x1aE.buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringResponse\"\x03\x90\x02\x01B\x9c\x02\n" +
+	" GetRepositoryDependencyDOTString\x12D.buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringRequest\x1aE.buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringResponse\"\x03\x90\x02\x01\x12\x8a\x01\n" +
+	"\x12AddRepositoryGroup\x126.buf.alpha.registry.v1alpha1.AddRepositoryGroupRequest\x1a7.buf.alpha.registry.v1alpha1.AddRepositoryGroupResponse\"\x03\x90\x02\x02\x12\x93\x01\n" +
+	"\x15UpdateRepositoryGroup\x129.buf.alpha.registry.v1alpha1.UpdateRepositoryGroupRequest\x1a:.buf.alpha.registry.v1alpha1.UpdateRepositoryGroupResponse\"\x03\x90\x02\x02\x12\x93\x01\n" +
+	"\x15RemoveRepositoryGroup\x129.buf.alpha.registry.v1alpha1.RemoveRepositoryGroupRequest\x1a:.buf.alpha.registry.v1alpha1.RemoveRepositoryGroupResponse\"\x03\x90\x02\x02B\x9c\x02\n" +
 	"\x1fcom.buf.alpha.registry.v1alpha1B\x0fRepositoryProtoP\x01ZYgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1;registryv1alpha1\xa2\x02\x03BAR\xaa\x02\x1bBuf.Alpha.Registry.V1alpha1\xca\x02\x1bBuf\\Alpha\\Registry\\V1alpha1\xe2\x02'Buf\\Alpha\\Registry\\V1alpha1\\GPBMetadata\xea\x02\x1eBuf::Alpha::Registry::V1alpha1b\x06proto3"
 
 var file_buf_alpha_registry_v1alpha1_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_buf_alpha_registry_v1alpha1_repository_proto_goTypes = []any{
 	(Visibility)(0),                                  // 0: buf.alpha.registry.v1alpha1.Visibility
 	(*Repository)(nil),                               // 1: buf.alpha.registry.v1alpha1.Repository
@@ -3804,20 +4226,26 @@ var file_buf_alpha_registry_v1alpha1_repository_proto_goTypes = []any{
 	(*GetRepositoriesMetadataResponse)(nil),          // 40: buf.alpha.registry.v1alpha1.GetRepositoriesMetadataResponse
 	(*GetRepositoryDependencyDOTStringRequest)(nil),  // 41: buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringRequest
 	(*GetRepositoryDependencyDOTStringResponse)(nil), // 42: buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringResponse
-	(*timestamppb.Timestamp)(nil),                    // 43: google.protobuf.Timestamp
-	(*User)(nil),                                     // 44: buf.alpha.registry.v1alpha1.User
-	(RepositoryRole)(0),                              // 45: buf.alpha.registry.v1alpha1.RepositoryRole
-	(VerificationStatus)(0),                          // 46: buf.alpha.registry.v1alpha1.VerificationStatus
+	(*AddRepositoryGroupRequest)(nil),                // 43: buf.alpha.registry.v1alpha1.AddRepositoryGroupRequest
+	(*AddRepositoryGroupResponse)(nil),               // 44: buf.alpha.registry.v1alpha1.AddRepositoryGroupResponse
+	(*UpdateRepositoryGroupRequest)(nil),             // 45: buf.alpha.registry.v1alpha1.UpdateRepositoryGroupRequest
+	(*UpdateRepositoryGroupResponse)(nil),            // 46: buf.alpha.registry.v1alpha1.UpdateRepositoryGroupResponse
+	(*RemoveRepositoryGroupRequest)(nil),             // 47: buf.alpha.registry.v1alpha1.RemoveRepositoryGroupRequest
+	(*RemoveRepositoryGroupResponse)(nil),            // 48: buf.alpha.registry.v1alpha1.RemoveRepositoryGroupResponse
+	(*timestamppb.Timestamp)(nil),                    // 49: google.protobuf.Timestamp
+	(*User)(nil),                                     // 50: buf.alpha.registry.v1alpha1.User
+	(RepositoryRole)(0),                              // 51: buf.alpha.registry.v1alpha1.RepositoryRole
+	(VerificationStatus)(0),                          // 52: buf.alpha.registry.v1alpha1.VerificationStatus
 }
 var file_buf_alpha_registry_v1alpha1_repository_proto_depIdxs = []int32{
-	43, // 0: buf.alpha.registry.v1alpha1.Repository.create_time:type_name -> google.protobuf.Timestamp
-	43, // 1: buf.alpha.registry.v1alpha1.Repository.update_time:type_name -> google.protobuf.Timestamp
+	49, // 0: buf.alpha.registry.v1alpha1.Repository.create_time:type_name -> google.protobuf.Timestamp
+	49, // 1: buf.alpha.registry.v1alpha1.Repository.update_time:type_name -> google.protobuf.Timestamp
 	0,  // 2: buf.alpha.registry.v1alpha1.Repository.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
-	44, // 3: buf.alpha.registry.v1alpha1.RepositoryContributor.user:type_name -> buf.alpha.registry.v1alpha1.User
-	45, // 4: buf.alpha.registry.v1alpha1.RepositoryContributor.explicit_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	45, // 5: buf.alpha.registry.v1alpha1.RepositoryContributor.implicit_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
-	46, // 6: buf.alpha.registry.v1alpha1.RepositoryMetadata.owner_verification_status:type_name -> buf.alpha.registry.v1alpha1.VerificationStatus
-	43, // 7: buf.alpha.registry.v1alpha1.RepositoryMetadata.latest_commit_time:type_name -> google.protobuf.Timestamp
+	50, // 3: buf.alpha.registry.v1alpha1.RepositoryContributor.user:type_name -> buf.alpha.registry.v1alpha1.User
+	51, // 4: buf.alpha.registry.v1alpha1.RepositoryContributor.explicit_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	51, // 5: buf.alpha.registry.v1alpha1.RepositoryContributor.implicit_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	52, // 6: buf.alpha.registry.v1alpha1.RepositoryMetadata.owner_verification_status:type_name -> buf.alpha.registry.v1alpha1.VerificationStatus
+	49, // 7: buf.alpha.registry.v1alpha1.RepositoryMetadata.latest_commit_time:type_name -> google.protobuf.Timestamp
 	1,  // 8: buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameResponse.repositories:type_name -> buf.alpha.registry.v1alpha1.Repository
 	1,  // 9: buf.alpha.registry.v1alpha1.GetRepositoryResponse.repository:type_name -> buf.alpha.registry.v1alpha1.Repository
 	2,  // 10: buf.alpha.registry.v1alpha1.GetRepositoryResponse.counts:type_name -> buf.alpha.registry.v1alpha1.RepositoryCounts
@@ -3831,54 +4259,62 @@ var file_buf_alpha_registry_v1alpha1_repository_proto_depIdxs = []int32{
 	1,  // 18: buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameResponse.repository:type_name -> buf.alpha.registry.v1alpha1.Repository
 	1,  // 19: buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameResponse.repository:type_name -> buf.alpha.registry.v1alpha1.Repository
 	1,  // 20: buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameResponse.repository:type_name -> buf.alpha.registry.v1alpha1.Repository
-	45, // 21: buf.alpha.registry.v1alpha1.SetRepositoryContributorRequest.repository_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	51, // 21: buf.alpha.registry.v1alpha1.SetRepositoryContributorRequest.repository_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
 	3,  // 22: buf.alpha.registry.v1alpha1.ListRepositoryContributorsResponse.users:type_name -> buf.alpha.registry.v1alpha1.RepositoryContributor
 	3,  // 23: buf.alpha.registry.v1alpha1.GetRepositoryContributorResponse.user:type_name -> buf.alpha.registry.v1alpha1.RepositoryContributor
 	0,  // 24: buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameRequest.visibility:type_name -> buf.alpha.registry.v1alpha1.Visibility
 	4,  // 25: buf.alpha.registry.v1alpha1.GetRepositoriesMetadataResponse.metadata:type_name -> buf.alpha.registry.v1alpha1.RepositoryMetadata
-	7,  // 26: buf.alpha.registry.v1alpha1.RepositoryService.GetRepository:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryRequest
-	9,  // 27: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryByFullName:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryByFullNameRequest
-	11, // 28: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositories:input_type -> buf.alpha.registry.v1alpha1.ListRepositoriesRequest
-	13, // 29: buf.alpha.registry.v1alpha1.RepositoryService.ListUserRepositories:input_type -> buf.alpha.registry.v1alpha1.ListUserRepositoriesRequest
-	15, // 30: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoriesUserCanAccess:input_type -> buf.alpha.registry.v1alpha1.ListRepositoriesUserCanAccessRequest
-	17, // 31: buf.alpha.registry.v1alpha1.RepositoryService.ListOrganizationRepositories:input_type -> buf.alpha.registry.v1alpha1.ListOrganizationRepositoriesRequest
-	19, // 32: buf.alpha.registry.v1alpha1.RepositoryService.CreateRepositoryByFullName:input_type -> buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameRequest
-	21, // 33: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepository:input_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryRequest
-	23, // 34: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepositoryByFullName:input_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryByFullNameRequest
-	25, // 35: buf.alpha.registry.v1alpha1.RepositoryService.DeprecateRepositoryByName:input_type -> buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameRequest
-	27, // 36: buf.alpha.registry.v1alpha1.RepositoryService.UndeprecateRepositoryByName:input_type -> buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameRequest
-	5,  // 37: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesByFullName:input_type -> buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameRequest
-	29, // 38: buf.alpha.registry.v1alpha1.RepositoryService.SetRepositoryContributor:input_type -> buf.alpha.registry.v1alpha1.SetRepositoryContributorRequest
-	31, // 39: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoryContributors:input_type -> buf.alpha.registry.v1alpha1.ListRepositoryContributorsRequest
-	33, // 40: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryContributor:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryContributorRequest
-	35, // 41: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositorySettings:input_type -> buf.alpha.registry.v1alpha1.GetRepositorySettingsRequest
-	37, // 42: buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositorySettingsByName:input_type -> buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameRequest
-	39, // 43: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesMetadata:input_type -> buf.alpha.registry.v1alpha1.GetRepositoriesMetadataRequest
-	41, // 44: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryDependencyDOTString:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringRequest
-	8,  // 45: buf.alpha.registry.v1alpha1.RepositoryService.GetRepository:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryResponse
-	10, // 46: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryByFullName:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryByFullNameResponse
-	12, // 47: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositories:output_type -> buf.alpha.registry.v1alpha1.ListRepositoriesResponse
-	14, // 48: buf.alpha.registry.v1alpha1.RepositoryService.ListUserRepositories:output_type -> buf.alpha.registry.v1alpha1.ListUserRepositoriesResponse
-	16, // 49: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoriesUserCanAccess:output_type -> buf.alpha.registry.v1alpha1.ListRepositoriesUserCanAccessResponse
-	18, // 50: buf.alpha.registry.v1alpha1.RepositoryService.ListOrganizationRepositories:output_type -> buf.alpha.registry.v1alpha1.ListOrganizationRepositoriesResponse
-	20, // 51: buf.alpha.registry.v1alpha1.RepositoryService.CreateRepositoryByFullName:output_type -> buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameResponse
-	22, // 52: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepository:output_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryResponse
-	24, // 53: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepositoryByFullName:output_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryByFullNameResponse
-	26, // 54: buf.alpha.registry.v1alpha1.RepositoryService.DeprecateRepositoryByName:output_type -> buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameResponse
-	28, // 55: buf.alpha.registry.v1alpha1.RepositoryService.UndeprecateRepositoryByName:output_type -> buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameResponse
-	6,  // 56: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesByFullName:output_type -> buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameResponse
-	30, // 57: buf.alpha.registry.v1alpha1.RepositoryService.SetRepositoryContributor:output_type -> buf.alpha.registry.v1alpha1.SetRepositoryContributorResponse
-	32, // 58: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoryContributors:output_type -> buf.alpha.registry.v1alpha1.ListRepositoryContributorsResponse
-	34, // 59: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryContributor:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryContributorResponse
-	36, // 60: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositorySettings:output_type -> buf.alpha.registry.v1alpha1.GetRepositorySettingsResponse
-	38, // 61: buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositorySettingsByName:output_type -> buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameResponse
-	40, // 62: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesMetadata:output_type -> buf.alpha.registry.v1alpha1.GetRepositoriesMetadataResponse
-	42, // 63: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryDependencyDOTString:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringResponse
-	45, // [45:64] is the sub-list for method output_type
-	26, // [26:45] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	51, // 26: buf.alpha.registry.v1alpha1.AddRepositoryGroupRequest.repository_role:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	51, // 27: buf.alpha.registry.v1alpha1.UpdateRepositoryGroupRequest.role_override:type_name -> buf.alpha.registry.v1alpha1.RepositoryRole
+	7,  // 28: buf.alpha.registry.v1alpha1.RepositoryService.GetRepository:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryRequest
+	9,  // 29: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryByFullName:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryByFullNameRequest
+	11, // 30: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositories:input_type -> buf.alpha.registry.v1alpha1.ListRepositoriesRequest
+	13, // 31: buf.alpha.registry.v1alpha1.RepositoryService.ListUserRepositories:input_type -> buf.alpha.registry.v1alpha1.ListUserRepositoriesRequest
+	15, // 32: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoriesUserCanAccess:input_type -> buf.alpha.registry.v1alpha1.ListRepositoriesUserCanAccessRequest
+	17, // 33: buf.alpha.registry.v1alpha1.RepositoryService.ListOrganizationRepositories:input_type -> buf.alpha.registry.v1alpha1.ListOrganizationRepositoriesRequest
+	19, // 34: buf.alpha.registry.v1alpha1.RepositoryService.CreateRepositoryByFullName:input_type -> buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameRequest
+	21, // 35: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepository:input_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryRequest
+	23, // 36: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepositoryByFullName:input_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryByFullNameRequest
+	25, // 37: buf.alpha.registry.v1alpha1.RepositoryService.DeprecateRepositoryByName:input_type -> buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameRequest
+	27, // 38: buf.alpha.registry.v1alpha1.RepositoryService.UndeprecateRepositoryByName:input_type -> buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameRequest
+	5,  // 39: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesByFullName:input_type -> buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameRequest
+	29, // 40: buf.alpha.registry.v1alpha1.RepositoryService.SetRepositoryContributor:input_type -> buf.alpha.registry.v1alpha1.SetRepositoryContributorRequest
+	31, // 41: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoryContributors:input_type -> buf.alpha.registry.v1alpha1.ListRepositoryContributorsRequest
+	33, // 42: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryContributor:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryContributorRequest
+	35, // 43: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositorySettings:input_type -> buf.alpha.registry.v1alpha1.GetRepositorySettingsRequest
+	37, // 44: buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositorySettingsByName:input_type -> buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameRequest
+	39, // 45: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesMetadata:input_type -> buf.alpha.registry.v1alpha1.GetRepositoriesMetadataRequest
+	41, // 46: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryDependencyDOTString:input_type -> buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringRequest
+	43, // 47: buf.alpha.registry.v1alpha1.RepositoryService.AddRepositoryGroup:input_type -> buf.alpha.registry.v1alpha1.AddRepositoryGroupRequest
+	45, // 48: buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositoryGroup:input_type -> buf.alpha.registry.v1alpha1.UpdateRepositoryGroupRequest
+	47, // 49: buf.alpha.registry.v1alpha1.RepositoryService.RemoveRepositoryGroup:input_type -> buf.alpha.registry.v1alpha1.RemoveRepositoryGroupRequest
+	8,  // 50: buf.alpha.registry.v1alpha1.RepositoryService.GetRepository:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryResponse
+	10, // 51: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryByFullName:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryByFullNameResponse
+	12, // 52: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositories:output_type -> buf.alpha.registry.v1alpha1.ListRepositoriesResponse
+	14, // 53: buf.alpha.registry.v1alpha1.RepositoryService.ListUserRepositories:output_type -> buf.alpha.registry.v1alpha1.ListUserRepositoriesResponse
+	16, // 54: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoriesUserCanAccess:output_type -> buf.alpha.registry.v1alpha1.ListRepositoriesUserCanAccessResponse
+	18, // 55: buf.alpha.registry.v1alpha1.RepositoryService.ListOrganizationRepositories:output_type -> buf.alpha.registry.v1alpha1.ListOrganizationRepositoriesResponse
+	20, // 56: buf.alpha.registry.v1alpha1.RepositoryService.CreateRepositoryByFullName:output_type -> buf.alpha.registry.v1alpha1.CreateRepositoryByFullNameResponse
+	22, // 57: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepository:output_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryResponse
+	24, // 58: buf.alpha.registry.v1alpha1.RepositoryService.DeleteRepositoryByFullName:output_type -> buf.alpha.registry.v1alpha1.DeleteRepositoryByFullNameResponse
+	26, // 59: buf.alpha.registry.v1alpha1.RepositoryService.DeprecateRepositoryByName:output_type -> buf.alpha.registry.v1alpha1.DeprecateRepositoryByNameResponse
+	28, // 60: buf.alpha.registry.v1alpha1.RepositoryService.UndeprecateRepositoryByName:output_type -> buf.alpha.registry.v1alpha1.UndeprecateRepositoryByNameResponse
+	6,  // 61: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesByFullName:output_type -> buf.alpha.registry.v1alpha1.GetRepositoriesByFullNameResponse
+	30, // 62: buf.alpha.registry.v1alpha1.RepositoryService.SetRepositoryContributor:output_type -> buf.alpha.registry.v1alpha1.SetRepositoryContributorResponse
+	32, // 63: buf.alpha.registry.v1alpha1.RepositoryService.ListRepositoryContributors:output_type -> buf.alpha.registry.v1alpha1.ListRepositoryContributorsResponse
+	34, // 64: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryContributor:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryContributorResponse
+	36, // 65: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositorySettings:output_type -> buf.alpha.registry.v1alpha1.GetRepositorySettingsResponse
+	38, // 66: buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositorySettingsByName:output_type -> buf.alpha.registry.v1alpha1.UpdateRepositorySettingsByNameResponse
+	40, // 67: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoriesMetadata:output_type -> buf.alpha.registry.v1alpha1.GetRepositoriesMetadataResponse
+	42, // 68: buf.alpha.registry.v1alpha1.RepositoryService.GetRepositoryDependencyDOTString:output_type -> buf.alpha.registry.v1alpha1.GetRepositoryDependencyDOTStringResponse
+	44, // 69: buf.alpha.registry.v1alpha1.RepositoryService.AddRepositoryGroup:output_type -> buf.alpha.registry.v1alpha1.AddRepositoryGroupResponse
+	46, // 70: buf.alpha.registry.v1alpha1.RepositoryService.UpdateRepositoryGroup:output_type -> buf.alpha.registry.v1alpha1.UpdateRepositoryGroupResponse
+	48, // 71: buf.alpha.registry.v1alpha1.RepositoryService.RemoveRepositoryGroup:output_type -> buf.alpha.registry.v1alpha1.RemoveRepositoryGroupResponse
+	50, // [50:72] is the sub-list for method output_type
+	28, // [28:50] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_buf_alpha_registry_v1alpha1_repository_proto_init() }
@@ -3894,13 +4330,14 @@ func file_buf_alpha_registry_v1alpha1_repository_proto_init() {
 		(*repository_OrganizationId)(nil),
 	}
 	file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[36].OneofWrappers = []any{}
+	file_buf_alpha_registry_v1alpha1_repository_proto_msgTypes[44].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_alpha_registry_v1alpha1_repository_proto_rawDesc), len(file_buf_alpha_registry_v1alpha1_repository_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   42,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/role.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/role.pb.go
@@ -232,6 +232,51 @@ func (x RepositoryRole) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// The source of a user's role in a Repository.
+type RepositoryRoleSource int32
+
+const (
+	RepositoryRoleSource_REPOSITORY_ROLE_SOURCE_UNSPECIFIED RepositoryRoleSource = 0
+	RepositoryRoleSource_REPOSITORY_ROLE_SOURCE_DIRECT      RepositoryRoleSource = 1
+	RepositoryRoleSource_REPOSITORY_ROLE_SOURCE_IDP_GROUP   RepositoryRoleSource = 2
+)
+
+// Enum value maps for RepositoryRoleSource.
+var (
+	RepositoryRoleSource_name = map[int32]string{
+		0: "REPOSITORY_ROLE_SOURCE_UNSPECIFIED",
+		1: "REPOSITORY_ROLE_SOURCE_DIRECT",
+		2: "REPOSITORY_ROLE_SOURCE_IDP_GROUP",
+	}
+	RepositoryRoleSource_value = map[string]int32{
+		"REPOSITORY_ROLE_SOURCE_UNSPECIFIED": 0,
+		"REPOSITORY_ROLE_SOURCE_DIRECT":      1,
+		"REPOSITORY_ROLE_SOURCE_IDP_GROUP":   2,
+	}
+)
+
+func (x RepositoryRoleSource) Enum() *RepositoryRoleSource {
+	p := new(RepositoryRoleSource)
+	*p = x
+	return p
+}
+
+func (x RepositoryRoleSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RepositoryRoleSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_buf_alpha_registry_v1alpha1_role_proto_enumTypes[4].Descriptor()
+}
+
+func (RepositoryRoleSource) Type() protoreflect.EnumType {
+	return &file_buf_alpha_registry_v1alpha1_role_proto_enumTypes[4]
+}
+
+func (x RepositoryRoleSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 var File_buf_alpha_registry_v1alpha1_role_proto protoreflect.FileDescriptor
 
 const file_buf_alpha_registry_v1alpha1_role_proto_rawDesc = "" +
@@ -259,15 +304,20 @@ const file_buf_alpha_registry_v1alpha1_role_proto_rawDesc = "" +
 	"\x15REPOSITORY_ROLE_ADMIN\x10\x02\x12\x19\n" +
 	"\x15REPOSITORY_ROLE_WRITE\x10\x03\x12\x18\n" +
 	"\x14REPOSITORY_ROLE_READ\x10\x04\x12!\n" +
-	"\x1dREPOSITORY_ROLE_LIMITED_WRITE\x10\x05B\x96\x02\n" +
+	"\x1dREPOSITORY_ROLE_LIMITED_WRITE\x10\x05*\x87\x01\n" +
+	"\x14RepositoryRoleSource\x12&\n" +
+	"\"REPOSITORY_ROLE_SOURCE_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dREPOSITORY_ROLE_SOURCE_DIRECT\x10\x01\x12$\n" +
+	" REPOSITORY_ROLE_SOURCE_IDP_GROUP\x10\x02B\x96\x02\n" +
 	"\x1fcom.buf.alpha.registry.v1alpha1B\tRoleProtoP\x01ZYgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1;registryv1alpha1\xa2\x02\x03BAR\xaa\x02\x1bBuf.Alpha.Registry.V1alpha1\xca\x02\x1bBuf\\Alpha\\Registry\\V1alpha1\xe2\x02'Buf\\Alpha\\Registry\\V1alpha1\\GPBMetadata\xea\x02\x1eBuf::Alpha::Registry::V1alpha1b\x06proto3"
 
-var file_buf_alpha_registry_v1alpha1_role_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_buf_alpha_registry_v1alpha1_role_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_buf_alpha_registry_v1alpha1_role_proto_goTypes = []any{
 	(ServerRole)(0),             // 0: buf.alpha.registry.v1alpha1.ServerRole
 	(OrganizationRole)(0),       // 1: buf.alpha.registry.v1alpha1.OrganizationRole
 	(OrganizationRoleSource)(0), // 2: buf.alpha.registry.v1alpha1.OrganizationRoleSource
 	(RepositoryRole)(0),         // 3: buf.alpha.registry.v1alpha1.RepositoryRole
+	(RepositoryRoleSource)(0),   // 4: buf.alpha.registry.v1alpha1.RepositoryRoleSource
 }
 var file_buf_alpha_registry_v1alpha1_role_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -287,7 +337,7 @@ func file_buf_alpha_registry_v1alpha1_role_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_alpha_registry_v1alpha1_role_proto_rawDesc), len(file_buf_alpha_registry_v1alpha1_role_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      5,
 			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/proto/buf/alpha/audit/v1alpha1/event.proto
+++ b/proto/buf/alpha/audit/v1alpha1/event.proto
@@ -90,9 +90,13 @@ enum EventType {
   EVENT_TYPE_REPOSITORY_COMMIT_PUSHED = 8;
   EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ADDED = 9;
   EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLE_CHANGED = 10;
+  EVENT_TYPE_REPOSITORY_CONTRIBUTOR_ROLES_CHANGED = 63;
   EVENT_TYPE_REPOSITORY_CONTRIBUTOR_REMOVED = 11;
   EVENT_TYPE_REPOSITORY_VISIBILITY_CHANGED = 12;
   EVENT_TYPE_REPOSITORY_DEFAULT_LABEL_NAME_CHANGED = 40;
+  EVENT_TYPE_REPOSITORY_IDP_GROUP_ADDED = 60;
+  EVENT_TYPE_REPOSITORY_IDP_GROUP_UPDATED = 61;
+  EVENT_TYPE_REPOSITORY_IDP_GROUP_REMOVED = 62;
   EVENT_TYPE_POLICY_CREATED = 54;
   EVENT_TYPE_POLICY_DELETED = 55;
   EVENT_TYPE_POLICY_DEPRECATED = 56;
@@ -176,9 +180,13 @@ message Event {
     PayloadRepositoryCommitPushed repository_commit_pushed = 14;
     PayloadRepositoryContributorAdded repository_contributor_added = 15;
     PayloadRepositoryContributorRoleChanged repository_contributor_role_changed = 16;
+    PayloadRepositoryContributorRolesChanged repository_contributor_roles_changed = 69;
     PayloadRepositoryContributorRemoved repository_contributor_removed = 17;
     PayloadRepositoryVisibilityChanged repository_visibility_changed = 18;
     PayloadRepositoryDefaultLabelNameChanged repository_default_label_name_changed = 46;
+    PayloadRepositoryIDPGroupAdded repository_idp_group_added = 66;
+    PayloadRepositoryIDPGroupUpdated repository_idp_group_updated = 67;
+    PayloadRepositoryIDPGroupRemoved repository_idp_group_removed = 68;
     PayloadPolicyCreated policy_created = 60;
     PayloadPolicyDeleted policy_deleted = 61;
     PayloadPolicyDeprecated policy_deprecated = 62;
@@ -241,6 +249,7 @@ message PayloadOrganizationMemberAdded {
 }
 
 message PayloadOrganizationMemberRoleChanged {
+  // Deprecated, use PayloadOrganizationMemberRolesChanged instead.
   option deprecated = true;
 
   // organization_id is the id of the organization within which the role was changed.
@@ -390,6 +399,9 @@ message PayloadRepositoryContributorAdded {
 }
 
 message PayloadRepositoryContributorRoleChanged {
+  // Deprecated, use PayloadRepositoryContributorRolesChanged instead.
+  option deprecated = true;
+
   // owner_id is the id of the owner of the repository.
   string owner_id = 1;
   // owner_name is the name of the owner of the repository.
@@ -402,6 +414,27 @@ message PayloadRepositoryContributorRoleChanged {
   buf.alpha.registry.v1alpha1.RepositoryRole old_role = 5;
   // new_role is the new role of the contributor whose role was changed.
   buf.alpha.registry.v1alpha1.RepositoryRole new_role = 6;
+}
+
+message PayloadRepositoryContributorRolesChanged {
+  message RepositoryRole {
+    // role is the role of the member.
+    buf.alpha.registry.v1alpha1.RepositoryRole role = 1;
+    // source is the source of the role granted to the member.
+    buf.alpha.registry.v1alpha1.RepositoryRoleSource source = 2;
+  }
+  // owner_id is the id of the owner of the repository.
+  string owner_id = 1;
+  // owner_name is the name of the owner of the repository.
+  string owner_name = 2;
+  // repository_id is the id of the repository within which the role was changed.
+  string repository_id = 3;
+  // repository_name is the name of the repository within which the role was changed.
+  string repository_name = 4;
+  // old_roles are the old roles of the contributor.
+  repeated RepositoryRole old_roles = 5;
+  // new_roles are the new roles of the contributor.
+  repeated RepositoryRole new_roles = 6;
 }
 
 message PayloadRepositoryContributorRemoved {
@@ -453,6 +486,37 @@ message PayloadRepositoryDefaultBranchChanged {
   string old_default_branch = 3;
   // new_default_branch is the new default branch of the repository.
   string new_default_branch = 4;
+}
+
+message PayloadRepositoryIDPGroupAdded {
+  // repository_id is the id of the repository with the new IDP group.
+  string repository_id = 1;
+  // repository_name is the name of the repository with the new IDP group.
+  string repository_name = 2;
+  // role_override is the role override associated with the new IDP group.
+  buf.alpha.registry.v1alpha1.RepositoryRole role_override = 3;
+}
+
+message PayloadRepositoryIDPGroupUpdated {
+  // repository_id is the id of the repository with the updated IDP group.
+  string repository_id = 1;
+  // repository_name is the name of the repository with the updated IDP group.
+  string repository_name = 2;
+  // old_role_override is the role override associated with the IDP updated group. Only set if the
+  // role override was changed.
+  buf.alpha.registry.v1alpha1.RepositoryRole old_role_override = 3;
+  // new_role_override is the role override associated with the IDP updated group. Only set if the
+  // role override was changed.
+  buf.alpha.registry.v1alpha1.RepositoryRole new_role_override = 4;
+}
+
+message PayloadRepositoryIDPGroupRemoved {
+  // repository_id is the id of the repository with the removed IDP group.
+  string repository_id = 1;
+  // repository_name is the name of the repository with the removed IDP group.
+  string repository_name = 2;
+  // role_override is the role override associated with the removed IDP group.
+  buf.alpha.registry.v1alpha1.RepositoryRole role_override = 3;
 }
 
 message PayloadPolicyCreated {

--- a/proto/buf/alpha/registry/v1alpha1/repository.proto
+++ b/proto/buf/alpha/registry/v1alpha1/repository.proto
@@ -170,6 +170,18 @@ service RepositoryService {
   rpc GetRepositoryDependencyDOTString(GetRepositoryDependencyDOTStringRequest) returns (GetRepositoryDependencyDOTStringResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // AddRepositoryGroup adds an IdP Group to the repository.
+  rpc AddRepositoryGroup(AddRepositoryGroupRequest) returns (AddRepositoryGroupResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  // UpdateRepositoryGroup updates an IdP Group for the repository.
+  rpc UpdateRepositoryGroup(UpdateRepositoryGroupRequest) returns (UpdateRepositoryGroupResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  // RemoveRepositoryGroup removes an IdP Group from the repository.
+  rpc RemoveRepositoryGroup(RemoveRepositoryGroupRequest) returns (RemoveRepositoryGroupResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
 }
 
 message GetRepositoriesByFullNameRequest {
@@ -387,3 +399,37 @@ message GetRepositoryDependencyDOTStringResponse {
   // DOT language reference: https://graphviz.org/doc/info/lang.html
   string dot_string = 1;
 }
+
+message AddRepositoryGroupRequest {
+  // The ID of the repository for which to add the group.
+  string repository_id = 1;
+  // The name of the group to add.
+  string group_name = 2;
+  // The role to associate with any user who is added to the repository via this group.
+  RepositoryRole repository_role = 3;
+}
+
+message AddRepositoryGroupResponse {}
+
+message UpdateRepositoryGroupRequest {
+  // The ID of the repository to which this group belongs.
+  string repository_id = 1;
+  // The name of the group to update.
+  string group_name = 2;
+  // The role to associate with this repository group.
+  //
+  // Setting this to 'UNSPECIFIED' will remove the override. Leaving this unset will not update this
+  // property.
+  optional RepositoryRole role_override = 3;
+}
+
+message UpdateRepositoryGroupResponse {}
+
+message RemoveRepositoryGroupRequest {
+  // The ID of the repository for which to remove the group.
+  string repository_id = 1;
+  // The name of the group to remove.
+  string group_name = 2;
+}
+
+message RemoveRepositoryGroupResponse {}

--- a/proto/buf/alpha/registry/v1alpha1/role.proto
+++ b/proto/buf/alpha/registry/v1alpha1/role.proto
@@ -49,3 +49,10 @@ enum RepositoryRole {
   REPOSITORY_ROLE_READ = 4;
   REPOSITORY_ROLE_LIMITED_WRITE = 5;
 }
+
+// The source of a user's role in a Repository.
+enum RepositoryRoleSource {
+  REPOSITORY_ROLE_SOURCE_UNSPECIFIED = 0;
+  REPOSITORY_ROLE_SOURCE_DIRECT = 1;
+  REPOSITORY_ROLE_SOURCE_IDP_GROUP = 2;
+}


### PR DESCRIPTION
This PR adds the following RPCs and their associated audit logs:
- AddRepositoryGroup
- UpdateRepositoryGroup
- RemoveRepositoryGroup

For now, these RPCs live in v1alpha1 until we have stabilized the schema for roles/permissions generally.

I did not yet add an RPC to expose the set of groups currently configured as that is pending what we need for the UI.