### PR TITLE
Fix AddProtosourceAnnotation file name for breaking

### DIFF
--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/breaking.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/breaking.go
@@ -1636,8 +1636,8 @@ func handleBreakingMessageSameJSONFormat(
 		responseWriter.AddProtosourceAnnotation(
 			withBackupLocation(message.Features().JSONFormatLocation(), message.Location()),
 			withBackupLocation(previousMessage.Features().JSONFormatLocation(), previousMessage.Location()),
-			`Message %q JSON format support changed from %v to %v.`,
 			message.File().Path(),
+			`Message %q JSON format support changed from %v to %v.`,
 			message.Name(),
 			previousJSONFormat,
 			jsonFormat,


### PR DESCRIPTION
This fixes a typo on the breaking annotation.  Looked at all other method calls, seems like the only out of order one. 