### PR TITLE
Update to latest makego

### DIFF
--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -30,6 +30,7 @@ GOLANGCI_LINT_VERSION ?= v2.0.2
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):
 	@rm -f $(CACHE_BIN)/golangci-lint
+	@mkdir -p $(CACHE_BIN)
 	$(eval GOLANGCI_LINT_TMP := $(shell mktemp -d))
 	curl -fsSL -o $(GOLANGCI_LINT_TMP)/golangci-lint.tar.gz \
 		https://github.com/golangci/golangci-lint/releases/download/$(GOLANGCI_LINT_VERSION)/golangci-lint-$(subst v,,$(GOLANGCI_LINT_VERSION))-$(GOLANGCI_LINT_OS)-$(GOLANGCI_LINT_ARCH).tar.gz

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -91,10 +91,13 @@ godeps: deps
 	go mod download
 
 .PHONY: gofmtmodtidy
-gofmtmodtidy:
+gofmtmodtidy: $(GOLANGCI_LINT)
 	@echo gofmt -s -w ALL_GO_FILES
 	@gofmt -s -w .
 	go mod tidy -v
+ifeq ($(SKIP_GOLANGCI_LINT),)
+	golangci-lint fmt
+endif
 
 format:: gofmtmodtidy
 
@@ -114,6 +117,7 @@ golangcilint: $(GOLANGCI_LINT)
 ifneq ($(SKIP_GOLANGCI_LINT),)
 	@echo Skipping golangci-lint...
 else
+	golangci-lint fmt --diff
 	golangci-lint run --timeout $(GOLANGCILINTTIMEOUT)
 endif
 


### PR DESCRIPTION
This integrates the new `golangci-lint fmt` command into the appropriate places to ensure code is formatted consistenty going forward. This used to be caught by the linter but after the migration to golangci-lint v2 we were missing this.