### PR TITLE
Run modernize tool to update to newer APIs

### DIFF
--- a/private/buf/bufcli/flags_args.go
+++ b/private/buf/bufcli/flags_args.go
@@ -17,6 +17,7 @@ package bufcli
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	modulev1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/module/v1"
 	pluginv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/plugin/v1beta1"
@@ -361,10 +362,8 @@ func ValidateErrorFormatFlagLint(errorFormatString string, errorFormatFlagName s
 }
 
 func validateErrorFormatFlag(validFormatStrings []string, errorFormatString string, errorFormatFlagName string) error {
-	for _, formatString := range validFormatStrings {
-		if errorFormatString == formatString {
-			return nil
-		}
+	if slices.Contains(validFormatStrings, errorFormatString) {
+		return nil
 	}
 	return appcmd.NewInvalidArgumentErrorf("--%s: invalid format: %q", errorFormatFlagName, errorFormatString)
 }

--- a/private/buf/bufconvert/bufconvert.go
+++ b/private/buf/bufconvert/bufconvert.go
@@ -16,6 +16,7 @@ package bufconvert
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/bufbuild/buf/private/bufpkg/bufimage"
@@ -138,10 +139,8 @@ func checkNoMessageSetWireFormat(descriptor protoreflect.MessageDescriptor, imag
 	// any message_set_wire_format option. So we must examine the file descriptor proto
 	// in the image to see if the option is set. If it is, we cannot support this message.
 	name := descriptor.FullName()
-	for _, alreadyChecked := range checked {
-		if name == alreadyChecked {
-			return nil
-		}
+	if slices.Contains(checked, name) {
+		return nil
 	}
 	checked = append(checked, name)
 

--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 
 	"buf.build/go/protoyaml"
@@ -1458,10 +1459,8 @@ func validateFileAnnotationErrorFormat(fileAnnotationErrorFormat string) error {
 	if fileAnnotationErrorFormat == "" {
 		return nil
 	}
-	for _, formatString := range bufanalysis.AllFormatStrings {
-		if fileAnnotationErrorFormat == formatString {
-			return nil
-		}
+	if slices.Contains(bufanalysis.AllFormatStrings, fileAnnotationErrorFormat) {
+		return nil
 	}
 	// TODO FUTURE: get standard flag names and bindings into this package.
 	fileAnnotationErrorFormatFlagName := "error-format"

--- a/private/buf/bufcurl/invoker.go
+++ b/private/buf/bufcurl/invoker.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -130,9 +131,7 @@ func (inv *invoker) handleUnary(ctx context.Context, dataSource string, data io.
 	}
 
 	req := connect.NewRequest(msg)
-	for k, v := range headers {
-		req.Header()[k] = v
-	}
+	maps.Copy(req.Header(), headers)
 	resp, err := inv.client.CallUnary(ctx, req)
 	if err != nil {
 		var connErr *connect.Error
@@ -149,9 +148,7 @@ func (inv *invoker) handleClientStream(ctx context.Context, dataSource string, d
 	provider := newStreamMessageProvider(dataSource, data, inv.res)
 	msg := dynamicpb.NewMessage(inv.md.Input())
 	stream := inv.client.CallClientStream(ctx)
-	for k, v := range headers {
-		stream.RequestHeader()[k] = v
-	}
+	maps.Copy(stream.RequestHeader(), headers)
 	defer func() {
 		if retErr != nil {
 			var connErr *connect.Error
@@ -191,9 +188,7 @@ func (inv *invoker) handleServerStream(ctx context.Context, dataSource string, d
 	}
 
 	req := connect.NewRequest(msg)
-	for k, v := range headers {
-		req.Header()[k] = v
-	}
+	maps.Copy(req.Header(), headers)
 	defer func() {
 		if retErr != nil {
 			var connErr *connect.Error
@@ -215,9 +210,7 @@ func (inv *invoker) handleBidiStream(ctx context.Context, dataSource string, dat
 	provider := newStreamMessageProvider(dataSource, data, inv.res)
 	msg := dynamicpb.NewMessage(inv.md.Input())
 	stream := inv.client.CallBidiStream(ctx)
-	for k, v := range headers {
-		stream.RequestHeader()[k] = v
-	}
+	maps.Copy(stream.RequestHeader(), headers)
 
 	defer func() {
 		if retErr != nil {

--- a/private/buf/bufcurl/reflection_resolver.go
+++ b/private/buf/bufcurl/reflection_resolver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -472,9 +473,7 @@ func (r *reflectionResolver) maybeCreateStreamLocked(client *reflectClient, stre
 		return false // already created
 	}
 	*stream = client.CallBidiStream(r.ctx)
-	for k, v := range r.headers {
-		(*stream).RequestHeader()[k] = v
-	}
+	maps.Copy((*stream).RequestHeader(), r.headers)
 	return true
 }
 
@@ -513,12 +512,12 @@ type extensionContainer interface {
 
 func registerExtensions(reg *protoregistry.Types, descriptor extensionContainer) {
 	exts := descriptor.Extensions()
-	for i := 0; i < exts.Len(); i++ {
+	for i := range exts.Len() {
 		extType := dynamicpb.NewExtensionType(exts.Get(i))
 		_ = reg.RegisterExtension(extType)
 	}
 	msgs := descriptor.Messages()
-	for i := 0; i < msgs.Len(); i++ {
+	for i := range msgs.Len() {
 		registerExtensions(reg, msgs.Get(i))
 	}
 }

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -500,7 +500,7 @@ func (f *formatter) writeOptionPrefix(optionNode *ast.OptionNode) {
 //	(custom.thing)
 //	(custom.thing).bridge.(another.thing)
 func (f *formatter) writeOptionName(optionNameNode *ast.OptionNameNode) {
-	for i := 0; i < len(optionNameNode.Parts); i++ {
+	for i := range optionNameNode.Parts {
 		if f.inCompactOptions && i == 0 {
 			// The leading comments of the first token (either open rune or the
 			// name) will have already been written, so we need to handle this
@@ -748,7 +748,7 @@ func arrayLiteralHasNestedMessageOrArray(arrayLiteralNode *ast.ArrayLiteralNode)
 //	foo: 1
 //	foo: 2
 func (f *formatter) writeMessageLiteralElements(messageLiteralNode *ast.MessageLiteralNode) {
-	for i := 0; i < len(messageLiteralNode.Elements); i++ {
+	for i := range messageLiteralNode.Elements {
 		// Separators ("," or ";") are optional. To avoid inconsistent formatted output,
 		// we suppress them, since they aren't needed. So we just write the element and
 		// ignore any optional separator in the AST.
@@ -1140,7 +1140,7 @@ func (f *formatter) writeGroup(groupNode *ast.GroupNode) {
 func (f *formatter) writeExtensionRange(extensionRangeNode *ast.ExtensionRangeNode) {
 	f.writeStart(extensionRangeNode.Keyword)
 	f.Space()
-	for i := 0; i < len(extensionRangeNode.Ranges); i++ {
+	for i := range extensionRangeNode.Ranges {
 		if i > 0 {
 			// The length of this slice must be exactly len(Ranges)-1.
 			f.writeInline(extensionRangeNode.Commas[i-1])
@@ -1179,7 +1179,7 @@ func (f *formatter) writeReserved(reservedNode *ast.ReservedNode) {
 		}
 	}
 	f.Space()
-	for i := 0; i < len(elements); i++ {
+	for i := range elements {
 		if i > 0 {
 			// The length of this slice must be exactly len({Names,Ranges})-1.
 			f.writeInline(reservedNode.Commas[i-1])
@@ -1327,7 +1327,7 @@ func (f *formatter) writeArrayLiteral(arrayLiteralNode *ast.ArrayLiteralNode) {
 	var elementWriterFunc func()
 	if len(arrayLiteralNode.Elements) > 0 {
 		elementWriterFunc = func() {
-			for i := 0; i < len(arrayLiteralNode.Elements); i++ {
+			for i := range arrayLiteralNode.Elements {
 				lastElement := i == len(arrayLiteralNode.Elements)-1
 				if compositeNode, ok := arrayLiteralNode.Elements[i].(ast.CompositeNode); ok {
 					f.writeCompositeValueForArrayLiteral(compositeNode, lastElement)
@@ -1491,7 +1491,7 @@ func (f *formatter) writeCompoundIdent(compoundIdentNode *ast.CompoundIdentNode)
 	if compoundIdentNode.LeadingDot != nil {
 		f.writeInline(compoundIdentNode.LeadingDot)
 	}
-	for i := 0; i < len(compoundIdentNode.Components); i++ {
+	for i := range compoundIdentNode.Components {
 		if i > 0 {
 			// The length of this slice must be exactly len(Components)-1.
 			f.writeInline(compoundIdentNode.Dots[i-1])
@@ -1513,7 +1513,7 @@ func (f *formatter) writeCompoundIdentForFieldName(compoundIdentNode *ast.Compou
 	if compoundIdentNode.LeadingDot != nil {
 		f.writeStart(compoundIdentNode.LeadingDot)
 	}
-	for i := 0; i < len(compoundIdentNode.Components); i++ {
+	for i := range compoundIdentNode.Components {
 		if i == 0 && compoundIdentNode.LeadingDot == nil {
 			f.writeStart(compoundIdentNode.Components[i])
 			continue
@@ -2055,7 +2055,7 @@ func (f *formatter) writeMultilineComments(comments ast.Comments) {
 
 func (f *formatter) writeMultilineCommentsMaybeCompact(comments ast.Comments, forceCompact bool) {
 	compact := forceCompact || isOpenBrace(f.previousNode)
-	for i := 0; i < comments.Len(); i++ {
+	for i := range comments.Len() {
 		comment := comments.Index(i)
 		if !compact && newlineCount(comment.LeadingWhitespace()) > 1 {
 			// Newlines between blocks of comments should be preserved.
@@ -2096,7 +2096,7 @@ func (f *formatter) writeMultilineCommentsMaybeCompact(comments ast.Comments, fo
 //	  optional string label = 20000;
 //	}
 func (f *formatter) writeInlineComments(comments ast.Comments) {
-	for i := 0; i < comments.Len(); i++ {
+	for i := range comments.Len() {
 		if i > 0 || comments.Index(i).LeadingWhitespace() != "" || f.lastWritten == ';' || f.lastWritten == '}' {
 			f.Space()
 		}
@@ -2132,7 +2132,7 @@ func (f *formatter) writeInlineComments(comments ast.Comments) {
 //	// This comment is attached to the '}'
 //	// So is this one.
 func (f *formatter) writeTrailingEndComments(comments ast.Comments) {
-	for i := 0; i < comments.Len(); i++ {
+	for i := range comments.Len() {
 		comment := comments.Index(i)
 		if i > 0 || comment.LeadingWhitespace() != "" {
 			f.Space()
@@ -2303,7 +2303,7 @@ func computeIndent(s string) (int, bool) {
 func (f *formatter) leadingCommentsContainBlankLine(n ast.Node) bool {
 	info := f.nodeInfo(n)
 	comments := info.LeadingComments()
-	for i := 0; i < comments.Len(); i++ {
+	for i := range comments.Len() {
 		if newlineCount(comments.Index(i).LeadingWhitespace()) > 1 {
 			return true
 		}

--- a/private/buf/buflsp/image.go
+++ b/private/buf/buflsp/image.go
@@ -85,7 +85,7 @@ func buildImage(
 		}
 
 		imports := descriptor.Imports()
-		for i := 0; i < imports.Len(); i++ {
+		for i := range imports.Len() {
 			dep := imports.Get(i).FileDescriptor
 			if dep == nil {
 				logger.Warn(fmt.Sprintf("found nil FileDescriptor for import %s", imports.Get(i).Path()))

--- a/private/buf/buflsp/nyi.go
+++ b/private/buf/buflsp/nyi.go
@@ -101,10 +101,10 @@ func (nyi) DocumentLink(ctx context.Context, params *protocol.DocumentLinkParams
 func (nyi) DocumentLinkResolve(ctx context.Context, params *protocol.DocumentLink) (result *protocol.DocumentLink, err error) {
 	return nil, newNYIError()
 }
-func (nyi) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) (result []interface{}, err error) {
+func (nyi) DocumentSymbol(ctx context.Context, params *protocol.DocumentSymbolParams) (result []any, err error) {
 	return nil, newNYIError()
 }
-func (nyi) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (result interface{}, err error) {
+func (nyi) ExecuteCommand(ctx context.Context, params *protocol.ExecuteCommandParams) (result any, err error) {
 	return nil, newNYIError()
 }
 func (nyi) Exit(ctx context.Context) (err error) {
@@ -161,13 +161,13 @@ func (nyi) References(ctx context.Context, params *protocol.ReferenceParams) (re
 func (nyi) Rename(ctx context.Context, params *protocol.RenameParams) (result *protocol.WorkspaceEdit, err error) {
 	return nil, newNYIError()
 }
-func (nyi) Request(ctx context.Context, method string, params interface{}) (result interface{}, err error) {
+func (nyi) Request(ctx context.Context, method string, params any) (result any, err error) {
 	return nil, newNYIError()
 }
 func (nyi) SemanticTokensFull(ctx context.Context, params *protocol.SemanticTokensParams) (result *protocol.SemanticTokens, err error) {
 	return nil, newNYIError()
 }
-func (nyi) SemanticTokensFullDelta(ctx context.Context, params *protocol.SemanticTokensDeltaParams) (result interface{}, err error) {
+func (nyi) SemanticTokensFullDelta(ctx context.Context, params *protocol.SemanticTokensDeltaParams) (result any, err error) {
 	return nil, newNYIError()
 }
 func (nyi) SemanticTokensRange(ctx context.Context, params *protocol.SemanticTokensRangeParams) (result *protocol.SemanticTokens, err error) {

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -295,7 +295,7 @@ func (s *server) Formatting(
 	// number of lines in the file. This is comparatively cheap, compared to sending the
 	// entire file over a domain socket.
 	var lastLine, lastLineStart int
-	for i := 0; i < len(file.text); i++ {
+	for i := range len(file.text) {
 		// NOTE: we are iterating over bytes, not runes.
 		if file.text[i] == '\n' {
 			lastLine++

--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -565,7 +565,7 @@ func (s *symbol) FormatDocs(ctx context.Context) string {
 	allComments := []ast.Comments{info.LeadingComments(), info.TrailingComments()}
 	var printed bool
 	for _, comments := range allComments {
-		for i := 0; i < comments.Len(); i++ {
+		for i := range comments.Len() {
 			// The compiler does not currently provide comments without their
 			// delimited removed, so we have to do this ourselves.
 			comment := commentToMarkdown(comments.Index(i).RawText())
@@ -644,7 +644,7 @@ func newWalker(file *file) *symbolWalker {
 	}
 
 	// NOTE: Don't use range here, that produces runes, not bytes.
-	for i := 0; i < len(file.text); i++ {
+	for i := range len(file.text) {
 		if file.text[i] == '\n' {
 			walker.lineSum = append(walker.lineSum, i+1)
 		}

--- a/private/buf/bufprint/bufprint.go
+++ b/private/buf/bufprint/bufprint.go
@@ -366,7 +366,7 @@ func getFieldNamesAndValuesForInfo(entity any) ([]string, []string, error) {
 	reflectValue := reflect.ValueOf(entity)
 	var fieldNames []string
 	var fieldValues []string
-	for i := 0; i < numField; i++ {
+	for i := range numField {
 		field := reflectType.Field(i)
 		bufprintTag, ok := field.Tag.Lookup("bufprint")
 		if !ok {
@@ -427,7 +427,7 @@ func (p *entityPage) MarshalJSON() ([]byte, error) {
 	value := reflect.ValueOf(*p)
 	t := value.Type()
 	fields := make([]reflect.StructField, 0)
-	for i := 0; i < t.NumField(); i++ {
+	for i := range t.NumField() {
 		fields = append(fields, t.Field(i))
 		if t.Field(i).Name == "Entities" {
 			fields[i].Tag = reflect.StructTag(fmt.Sprintf(`json:"%s"`, p.pluralEntityName))

--- a/private/buf/bufprint/pagination_wrapper.go
+++ b/private/buf/bufprint/pagination_wrapper.go
@@ -15,6 +15,6 @@
 package bufprint
 
 type paginationWrapper struct {
-	NextPage string      `json:"next_page,omitempty"`
-	Results  interface{} `json:"results"`
+	NextPage string `json:"next_page,omitempty"`
+	Results  any    `json:"results"`
 }

--- a/private/buf/bufprotoc/bufprotoc.go
+++ b/private/buf/bufprotoc/bufprotoc.go
@@ -143,7 +143,7 @@ func normalizeAndAbsolutePaths(paths []string, name string) ([]string, error) {
 		outputs[i] = output
 	}
 	sort.Strings(outputs)
-	for i := 0; i < len(outputs); i++ {
+	for i := range outputs {
 		for j := i + 1; j < len(outputs); j++ {
 			output1 := outputs[i]
 			output2 := outputs[j]

--- a/private/buf/bufwkt/cmd/wkt-go-data/main.go
+++ b/private/buf/bufwkt/cmd/wkt-go-data/main.go
@@ -287,10 +287,7 @@ const Version = "`)
 `)
 		data := pathToData[path]
 		for len(data) > 0 {
-			n := bytesPerLine
-			if n > len(data) {
-				n = len(data)
-			}
+			n := min(bytesPerLine, len(data))
 			var accum strings.Builder
 			for _, elem := range data[:n] {
 				_, _ = fmt.Fprintf(&accum, "0x%02x,", elem)

--- a/private/buf/cmd/buf/buf_test.go
+++ b/private/buf/cmd/buf/buf_test.go
@@ -1386,14 +1386,7 @@ func TestCheckLsBreakingRulesFromConfigExceptDeprecated(t *testing.T) {
 					expectedIDs := make([]string, 0, len(allPackageIDs))
 					replacements := deprecations[deprecatedRule]
 					for _, id := range allPackageIDs {
-						var skip bool
-						for _, replacement := range replacements {
-							if id == replacement {
-								skip = true
-								break
-							}
-						}
-						if skip {
+						if slices.Contains(replacements, id) {
 							continue
 						}
 						expectedIDs = append(expectedIDs, id)

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -27,7 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1039,9 +1039,7 @@ func run(ctx context.Context, container appext.Container, f *flags) (err error) 
 		if err != nil {
 			return err
 		}
-		sort.Slice(serviceNames, func(i, j int) bool {
-			return serviceNames[i] < serviceNames[j]
-		})
+		slices.Sort(serviceNames)
 		for _, serviceName := range serviceNames {
 			if f.ListServices {
 				if _, err := fmt.Fprintf(container.Stdout(), "%s\n", serviceName); err != nil {
@@ -1055,12 +1053,10 @@ func run(ctx context.Context, container appext.Container, f *flags) (err error) 
 				methods := serviceDescriptor.Methods()
 				length := methods.Len()
 				methodNames := make([]protoreflect.Name, length)
-				for i := 0; i < length; i++ {
+				for i := range length {
 					methodNames[i] = methods.Get(i).Name()
 				}
-				sort.Slice(methodNames, func(i, j int) bool {
-					return methodNames[i] < methodNames[j]
-				})
+				slices.Sort(methodNames)
 				for _, methodName := range methodNames {
 					if _, err := fmt.Fprintf(container.Stdout(), "%s/%s\n", serviceName, methodName); err != nil {
 						return err

--- a/private/buf/cmd/buf/command/generate/generate_test.go
+++ b/private/buf/cmd/buf/command/generate/generate_test.go
@@ -1079,7 +1079,7 @@ func testParseBoolPointer(t *testing.T, flagName string, expectedResult *bool, a
 }
 
 func newExternalConfigV1String(t *testing.T, plugins []*testPluginInfo, out string) string {
-	externalConfig := make(map[string]interface{})
+	externalConfig := make(map[string]any)
 	externalConfig["version"] = "v1"
 	pluginConfigs := []map[string]string{}
 	for _, plugin := range plugins {

--- a/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/main.go
+++ b/private/buf/cmd/buf/command/generate/internal/protoc-gen-top-level-type-names-yaml/main.go
@@ -43,15 +43,15 @@ func handle(
 	for _, fileDescriptor := range fileDescriptors {
 		externalFile := &externalFile{}
 		enumDescriptors := fileDescriptor.Enums()
-		for i := 0; i < enumDescriptors.Len(); i++ {
+		for i := range enumDescriptors.Len() {
 			externalFile.Enums = append(externalFile.Enums, string(enumDescriptors.Get(i).FullName()))
 		}
 		messageDescriptors := fileDescriptor.Messages()
-		for i := 0; i < messageDescriptors.Len(); i++ {
+		for i := range messageDescriptors.Len() {
 			externalFile.Messages = append(externalFile.Messages, string(messageDescriptors.Get(i).FullName()))
 		}
 		serviceDescriptors := fileDescriptor.Services()
-		for i := 0; i < serviceDescriptors.Len(); i++ {
+		for i := range serviceDescriptors.Len() {
 			externalFile.Services = append(externalFile.Services, string(serviceDescriptors.Get(i).FullName()))
 		}
 		sort.Strings(externalFile.Enums)

--- a/private/buf/cmd/buf/command/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/plugin/pluginpush/pluginpush.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
@@ -242,10 +243,8 @@ func validateTypeFlags(flags *flags) error {
 }
 
 func validateLabelFlagValues(flags *flags) error {
-	for _, label := range flags.Labels {
-		if label == "" {
-			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", labelFlagName)
-		}
+	if slices.Contains(flags.Labels, "") {
+		return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", labelFlagName)
 	}
 	return nil
 }

--- a/private/buf/cmd/buf/command/push/push.go
+++ b/private/buf/cmd/buf/command/push/push.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/bufbuild/buf/private/buf/bufcli"
@@ -401,15 +402,11 @@ func validateLabelFlagCombinations(flags *flags) error {
 }
 
 func validateLabelFlagValues(flags *flags) error {
-	for _, label := range flags.Labels {
-		if label == "" {
-			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", labelFlagName)
-		}
+	if slices.Contains(flags.Labels, "") {
+		return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", labelFlagName)
 	}
-	for _, tag := range flags.Tags {
-		if tag == "" {
-			return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", tagFlagName)
-		}
+	if slices.Contains(flags.Tags, "") {
+		return appcmd.NewInvalidArgumentErrorf("--%s requires a non-empty string", tagFlagName)
 	}
 	return nil
 }

--- a/private/bufpkg/bufcas/blob_set_test.go
+++ b/private/bufpkg/bufcas/blob_set_test.go
@@ -41,7 +41,7 @@ func TestNewBlobSetDuplicatesValid(t *testing.T) {
 
 func testNewBlobs(t *testing.T, size int) []Blob {
 	var blobs []Blob
-	for i := 0; i < size; i++ {
+	for i := range size {
 		content := fmt.Sprintf("some file content %d", i)
 		blob, err := NewBlobForContent(strings.NewReader(content))
 		require.NoError(t, err)

--- a/private/bufpkg/bufcas/manifest_test.go
+++ b/private/bufpkg/bufcas/manifest_test.go
@@ -30,7 +30,7 @@ func TestManifest(t *testing.T) {
 	t.Parallel()
 	var digests []Digest
 	var fileNodes []FileNode
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		digest, err := NewDigestForContent(strings.NewReader(fmt.Sprintf("content%d", i)))
 		require.NoError(t, err)
 		digests = append(digests, digest)
@@ -48,7 +48,7 @@ func TestManifest(t *testing.T) {
 		},
 	)
 	manifestFileNodes := manifest.FileNodes()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		digest := manifest.GetDigest(fmt.Sprintf("%d", i))
 		require.NotNil(t, digest)
 		assert.Equal(t, digests[i], digest)

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/breaking.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/breaking.go
@@ -1336,8 +1336,8 @@ func handleBreakingFileSamePackage(
 
 func checkFileSameValue(
 	responseWriter bufcheckserverutil.ResponseWriter,
-	previousValue interface{},
-	value interface{},
+	previousValue any,
+	value any,
 	file bufprotosource.File,
 	location bufprotosource.Location,
 	previousLocation bufprotosource.Location,

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/field_default_test.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/field_default_test.go
@@ -228,7 +228,7 @@ func TestGetDefault(t *testing.T) {
 		"repeated": {},
 		"map":      {},
 	}
-	for i := 0; i < msg.Fields().Len(); i++ {
+	for i := range msg.Fields().Len() {
 		field := msg.Fields().Get(i)
 		if _, nope := cannotHaveDefault[string(field.Name())]; nope {
 			assert.False(t, canHaveDefault(field))

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/lint.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/lint.go
@@ -945,7 +945,7 @@ func handleLintProtovalidate(
 		location bufprotosource.Location,
 		_ []bufprotosource.Location,
 		format string,
-		args ...interface{},
+		args ...any,
 	) {
 		responseWriter.AddProtosourceAnnotation(
 			location,

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/tag_ranges_test.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/bufcheckserverhandle/tag_ranges_test.go
@@ -132,7 +132,7 @@ func doCollapseRanges(t *testing.T, input, expected []simpleTagRange) {
 	assert.Equal(t, expected, collapsed)
 	// Try some random permutations of the inputs and make sure
 	// they resolve in the same way.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		rand.Shuffle(len(input), func(i, j int) {
 			input[i], input[j] = input[j], input[i]
 		})

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/adder.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/adder.go
@@ -44,7 +44,7 @@ type adder struct {
 	field               bufprotosource.Field
 	fieldPrettyTypeName string
 	basePath            []int32
-	addFunc             func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{})
+	addFunc             func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any)
 }
 
 func (a *adder) cloneWithNewBasePath(basePath ...int32) *adder {
@@ -56,7 +56,7 @@ func (a *adder) cloneWithNewBasePath(basePath ...int32) *adder {
 	}
 }
 
-func (a *adder) addForPathf(path []int32, format string, args ...interface{}) {
+func (a *adder) addForPathf(path []int32, format string, args ...any) {
 	// Copy a.basePath so it won't be modified by append.
 	combinedPath := make([]int32, len(a.basePath), len(a.basePath)+len(path))
 	copy(combinedPath, a.basePath)
@@ -69,7 +69,7 @@ func (a *adder) addForPathf(path []int32, format string, args ...interface{}) {
 	)
 }
 
-func (a *adder) addForPathsf(paths [][]int32, format string, args ...interface{}) {
+func (a *adder) addForPathsf(paths [][]int32, format string, args ...any) {
 	locations := make([]bufprotosource.Location, 0, len(paths))
 	for _, path := range paths {
 		// Copy a.basePath so it won't be modified by append.

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/buflintvalidate.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/buflintvalidate.go
@@ -28,7 +28,7 @@ const disabledFieldNumberInMessageConstraints = 1
 // It also checks all predefined rule extensions on the messages.
 func CheckMessage(
 	// addAnnotationFunc adds an annotation with the descriptor and location for check results.
-	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{}),
+	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any),
 	message bufprotosource.Message,
 ) error {
 	messageDescriptor, err := message.AsDescriptor()
@@ -60,7 +60,7 @@ func CheckMessage(
 //  2. have a type compatible with the field it validates.
 func CheckField(
 	// addAnnotationFunc adds an annotation with the descriptor and location for check results.
-	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{}),
+	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any),
 	field bufprotosource.Field,
 	extensionTypeResolver protoencoding.Resolver,
 ) error {
@@ -70,7 +70,7 @@ func CheckField(
 // CheckPredefinedRuleExtension checks that a predefined extension is valid, and any CEL expressions compile.
 func CheckPredefinedRuleExtension(
 	// addAnnotationFunc adds an annotation with the descriptor and location for check results.
-	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{}),
+	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any),
 	field bufprotosource.Field,
 	extensionResolver protoencoding.Resolver,
 ) error {

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/cel.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/cel.go
@@ -35,7 +35,7 @@ const (
 )
 
 func checkCELForMessage(
-	add func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{}),
+	add func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any),
 	messageConstraints *validate.MessageConstraints,
 	messageDescriptor protoreflect.MessageDescriptor,
 	message bufprotosource.Message,
@@ -59,7 +59,7 @@ func checkCELForMessage(
 		fmt.Sprintf("message %q", message.Name()),
 		fmt.Sprintf("Message %q", message.Name()),
 		"(buf.validate.message).cel",
-		func(index int, format string, args ...interface{}) {
+		func(index int, format string, args ...any) {
 			messageConstraintsOptionLocation := message.OptionExtensionLocation(
 				validate.E_Message,
 				celFieldNumberInMessageConstraints,
@@ -102,7 +102,7 @@ func checkCELForField(
 		fmt.Sprintf("field %q", adder.fieldName()),
 		fmt.Sprintf("Field %q", adder.fieldName()),
 		adder.getFieldRuleName(celFieldNumberInFieldConstraints),
-		func(index int, format string, args ...interface{}) {
+		func(index int, format string, args ...any) {
 			adder.addForPathf(
 				[]int32{celFieldNumberInFieldConstraints, int32(index)},
 				format,
@@ -120,7 +120,7 @@ func checkCEL(
 	parentName string,
 	parentNameCapitalized string,
 	celName string,
-	add func(int, string, ...interface{}),
+	add func(int, string, ...any),
 ) bool {
 	allCelExpressionsCompile := true
 	idToConstraintIndices := make(map[string][]int, len(celConstraints))

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
@@ -155,7 +155,7 @@ var (
 // checkField validates that protovalidate rules defined for this field are
 // valid, not including CEL expressions.
 func checkField(
-	add func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{}),
+	add func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any),
 	field bufprotosource.Field,
 	extensionTypeResolver protoencoding.Resolver,
 ) error {
@@ -247,7 +247,7 @@ func checkConstraintsForField(
 			exampleFieldNumber = int32(fd.Number())
 			// This assumed all *Rules.Example are repeated, otherwise it panics.
 			list := value.List()
-			for i := 0; i < list.Len(); i++ {
+			for i := range list.Len() {
 				exampleValues = append(exampleValues, list.Get(i))
 			}
 			return false
@@ -677,7 +677,7 @@ func checkDurationRules(adder *adder, r *validate.DurationRules) error {
 		r.ProtoReflect(),
 		getDurationFromValue,
 		compareDuration,
-		func(d *durationpb.Duration) interface{} { return d },
+		func(d *durationpb.Duration) any { return d },
 	)
 }
 
@@ -688,7 +688,7 @@ func checkTimestampRules(adder *adder, timestampRules *validate.TimestampRules) 
 		timestampRules.ProtoReflect(),
 		getTimestampFromValue,
 		compareTimestamp,
-		func(t *timestamppb.Timestamp) interface{} { return t },
+		func(t *timestamppb.Timestamp) any { return t },
 	); err != nil {
 		return err
 	}

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/numeric.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/numeric.go
@@ -51,7 +51,7 @@ func checkNumberRules[
 		ruleMessage,
 		getNumericPointerFromValue[T],
 		compareNumber[T],
-		func(t *T) interface{} { return *t },
+		func(t *T) any { return *t },
 	)
 }
 
@@ -66,7 +66,7 @@ func checkNumericRules[
 	// equalFunc returns whether two values are equal.
 	equalFunc func(*T, *T) bool,
 	// formatFunc returns the value suitable for printing with %v.
-	formatFunc func(*T) interface{},
+	formatFunc func(*T) any,
 ) error {
 	var fieldCount int
 	var constant, lowerBound, upperBound *T

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/predefined_rules.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/predefined_rules.go
@@ -30,7 +30,7 @@ const (
 )
 
 func checkPredefinedRuleExtension(
-	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...interface{}),
+	addAnnotationFunc func(bufprotosource.Descriptor, bufprotosource.Location, []bufprotosource.Location, string, ...any),
 	extension bufprotosource.Field,
 	extensionResolver protoencoding.Resolver,
 ) error {
@@ -104,7 +104,7 @@ func checkPredefinedRuleExtension(
 		"extension field",
 		"Extension field",
 		"(buf.validate.predefined).cel",
-		func(index int, format string, args ...interface{}) {
+		func(index int, format string, args ...any) {
 			addAnnotationFunc(
 				extension,
 				extension.OptionExtensionLocation(validate.E_Predefined, celFieldNumberPath, int32(index)),

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/util.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/util.go
@@ -36,7 +36,7 @@ func resolveExtension[C proto.Message](
 	num := extType.TypeDescriptor().Number()
 	var message proto.Message
 
-	proto.RangeExtensions(options, func(typ protoreflect.ExtensionType, i interface{}) bool {
+	proto.RangeExtensions(options, func(typ protoreflect.ExtensionType, i any) bool {
 		if num != typ.TypeDescriptor().Number() {
 			return true
 		}

--- a/private/bufpkg/bufcheck/internal/cmd/buf-plugin-protovalidate-ext/util.go
+++ b/private/bufpkg/bufcheck/internal/cmd/buf-plugin-protovalidate-ext/util.go
@@ -96,7 +96,7 @@ func forEachMessage(
 	againstMessages protoreflect.MessageDescriptors,
 	f func(message, againstMessage protoreflect.MessageDescriptor) error,
 ) error {
-	for i := 0; i < againstMessages.Len(); i++ {
+	for i := range againstMessages.Len() {
 		againstMessage := againstMessages.Get(i)
 		if message := messages.ByName(againstMessage.Name()); message != nil {
 			if err := f(message, againstMessage); err != nil {
@@ -115,7 +115,7 @@ func forEachField(
 	againstFields protoreflect.FieldDescriptors,
 	f func(field, againstField protoreflect.FieldDescriptor) error,
 ) error {
-	for i := 0; i < againstFields.Len(); i++ {
+	for i := range againstFields.Len() {
 		againstField := againstFields.Get(i)
 		if field := fields.ByName(againstField.Name()); field != nil {
 			if err := f(field, againstField); err != nil {

--- a/private/bufpkg/bufcheck/internal/cmd/buf-plugin-rpc-ext/main.go
+++ b/private/bufpkg/bufcheck/internal/cmd/buf-plugin-rpc-ext/main.go
@@ -98,7 +98,7 @@ func checkPageRequestHasToken(
 		pageTokenFieldName = pageTokenFieldNameOptionValue
 	}
 	fields := messageDescriptor.Fields()
-	for i := 0; i < fields.Len(); i++ {
+	for i := range fields.Len() {
 		fieldName := string(fields.Get(i).Name())
 		if fieldName == pageTokenFieldName {
 			return nil
@@ -148,7 +148,7 @@ func checkPageResponseHasToken(
 		pageTokenFieldName = pageTokenFieldNameOptionValue
 	}
 	fields := messageDescriptor.Fields()
-	for i := 0; i < fields.Len(); i++ {
+	for i := range fields.Len() {
 		fieldName := string(fields.Get(i).Name())
 		if fieldName == pageTokenFieldName {
 			return nil

--- a/private/bufpkg/bufcheck/internal/cmd/buf-plugin-suffix/handlers.go
+++ b/private/bufpkg/bufcheck/internal/cmd/buf-plugin-suffix/handlers.go
@@ -46,7 +46,7 @@ func handleLintServiceBannedSuffixes(
 	}
 	for _, fileDescriptor := range request.FileDescriptors() {
 		descriptor := fileDescriptor.ProtoreflectFileDescriptor()
-		for i := 0; i < descriptor.Services().Len(); i++ {
+		for i := range descriptor.Services().Len() {
 			service := descriptor.Services().Get(i)
 			checkDescriptorBannedSuffixes(responseWriter, service, bannedServiceSuffixes, "Service")
 		}
@@ -65,9 +65,9 @@ func handleLintRPCBannedSuffixes(
 	}
 	for _, fileDescriptor := range request.FileDescriptors() {
 		descriptor := fileDescriptor.ProtoreflectFileDescriptor()
-		for i := 0; i < descriptor.Services().Len(); i++ {
+		for i := range descriptor.Services().Len() {
 			methods := descriptor.Services().Get(i).Methods()
-			for j := 0; j < methods.Len(); j++ {
+			for j := range methods.Len() {
 				method := methods.Get(j)
 				checkDescriptorBannedSuffixes(responseWriter, method, bannedRPCSuffixes, "Method")
 			}
@@ -87,7 +87,7 @@ func handleLintFieldBannedSuffixes(
 	}
 	for _, fileDescriptor := range request.FileDescriptors() {
 		descriptor := fileDescriptor.ProtoreflectFileDescriptor()
-		for i := 0; i < descriptor.Messages().Len(); i++ {
+		for i := range descriptor.Messages().Len() {
 			message := descriptor.Messages().Get(i)
 			checkBannedFieldSuffixesForMessage(responseWriter, message, bannedFieldSuffixes)
 		}
@@ -101,12 +101,12 @@ func checkBannedFieldSuffixesForMessage(
 	bannedFieldSuffixes []string,
 ) {
 	// Check all fields of the message
-	for i := 0; i < messageDescriptor.Fields().Len(); i++ {
+	for i := range messageDescriptor.Fields().Len() {
 		field := messageDescriptor.Fields().Get(i)
 		checkDescriptorBannedSuffixes(responseWriter, field, bannedFieldSuffixes, "Field")
 	}
 	// Check each nested messages
-	for i := 0; i < messageDescriptor.Messages().Len(); i++ {
+	for i := range messageDescriptor.Messages().Len() {
 		message := messageDescriptor.Messages().Get(i)
 		checkBannedFieldSuffixesForMessage(responseWriter, message, bannedFieldSuffixes)
 	}
@@ -123,15 +123,15 @@ func handleLintEnumValueBannedSuffixes(
 	}
 	for _, fileDescriptor := range request.FileDescriptors() {
 		descriptor := fileDescriptor.ProtoreflectFileDescriptor()
-		for i := 0; i < descriptor.Enums().Len(); i++ {
+		for i := range descriptor.Enums().Len() {
 			enum := descriptor.Enums().Get(i)
-			for j := 0; j < enum.Values().Len(); j++ {
+			for j := range enum.Values().Len() {
 				enumValue := enum.Values().Get(j)
 				checkDescriptorBannedSuffixes(responseWriter, enumValue, bannedEnumValueSuffixes, "Enum value")
 			}
 		}
 		// Check messages for nested enums
-		for i := 0; i < descriptor.Messages().Len(); i++ {
+		for i := range descriptor.Messages().Len() {
 			message := descriptor.Messages().Get(i)
 			checkBannedEnumValueSuffixesForMessage(responseWriter, message, bannedEnumValueSuffixes)
 		}
@@ -145,15 +145,15 @@ func checkBannedEnumValueSuffixesForMessage(
 	bannedEnumValueSuffixes []string,
 ) {
 	// Check each nested enum
-	for i := 0; i < messageDescriptor.Enums().Len(); i++ {
+	for i := range messageDescriptor.Enums().Len() {
 		enum := messageDescriptor.Enums().Get(i)
-		for j := 0; j < enum.Values().Len(); j++ {
+		for j := range enum.Values().Len() {
 			enumValue := enum.Values().Get(j)
 			checkDescriptorBannedSuffixes(responseWriter, enumValue, bannedEnumValueSuffixes, "Enum value")
 		}
 	}
 	// Check each nested message for nested enums
-	for i := 0; i < messageDescriptor.Messages().Len(); i++ {
+	for i := range messageDescriptor.Messages().Len() {
 		message := messageDescriptor.Messages().Get(i)
 		checkBannedEnumValueSuffixesForMessage(responseWriter, message, bannedEnumValueSuffixes)
 	}
@@ -236,7 +236,7 @@ func mapServiceNameToServiceDescriptorForFilesAndNoChangeSuffixes(
 	result := map[string]protoreflect.ServiceDescriptor{}
 	for _, fileDescriptor := range fileDescriptors {
 		descriptor := fileDescriptor.ProtoreflectFileDescriptor()
-		for i := 0; i < descriptor.Services().Len(); i++ {
+		for i := range descriptor.Services().Len() {
 			service := descriptor.Services().Get(i)
 			if checkDescriptorHasNoChangeSuffix(service, serviceNoChangeSuffixes) {
 				result[string(service.FullName())] = service
@@ -248,7 +248,7 @@ func mapServiceNameToServiceDescriptorForFilesAndNoChangeSuffixes(
 
 func getAllMethodNamesSortedForService(serviceDescriptor protoreflect.ServiceDescriptor) []string {
 	var methodNames []string
-	for i := 0; i < serviceDescriptor.Methods().Len(); i++ {
+	for i := range serviceDescriptor.Methods().Len() {
 		method := serviceDescriptor.Methods().Get(i)
 		methodNames = append(methodNames, string(method.FullName()))
 	}
@@ -325,7 +325,7 @@ func getNestedMessageDescriptors(
 	messageNoChangeSuffixes []string,
 ) []protoreflect.MessageDescriptor {
 	var messages []protoreflect.MessageDescriptor
-	for i := 0; i < messageDescriptors.Len(); i++ {
+	for i := range messageDescriptors.Len() {
 		message := messageDescriptors.Get(i)
 		if checkDescriptorHasNoChangeSuffix(message, messageNoChangeSuffixes) {
 			messages = append(messages, message)
@@ -338,7 +338,7 @@ func getNestedMessageDescriptors(
 
 func getFieldNamesSortedForMessage(messageDescriptor protoreflect.MessageDescriptor) []string {
 	var fieldNames []string
-	for i := 0; i < messageDescriptor.Fields().Len(); i++ {
+	for i := range messageDescriptor.Fields().Len() {
 		field := messageDescriptor.Fields().Get(i)
 		fieldNames = append(fieldNames, string(field.FullName()))
 	}
@@ -399,7 +399,7 @@ func mapEnumNameToEnumDescriptorForFilesAndNoChangeSuffixes(
 	result := map[string]protoreflect.EnumDescriptor{}
 	for _, fileDescriptor := range fileDescriptors {
 		descriptor := fileDescriptor.ProtoreflectFileDescriptor()
-		for i := 0; i < descriptor.Enums().Len(); i++ {
+		for i := range descriptor.Enums().Len() {
 			enum := descriptor.Enums().Get(i)
 			if checkDescriptorHasNoChangeSuffix(enum, enumNoChangeSuffixes) {
 				result[string(enum.FullName())] = enum
@@ -415,7 +415,7 @@ func mapEnumNameToEnumDescriptorForFilesAndNoChangeSuffixes(
 
 func getEnumValueNamesSortedForEnum(enumDescriptor protoreflect.EnumDescriptor) []string {
 	var enumValueNames []string
-	for i := 0; i < enumDescriptor.Values().Len(); i++ {
+	for i := range enumDescriptor.Values().Len() {
 		enumValue := enumDescriptor.Values().Get(i)
 		enumValueNames = append(enumValueNames, string(enumValue.FullName()))
 	}
@@ -428,9 +428,9 @@ func getNestedEnumDescriptors(
 	enumNoChangeSuffixes []string,
 ) []protoreflect.EnumDescriptor {
 	var enums []protoreflect.EnumDescriptor
-	for i := 0; i < messageDescriptors.Len(); i++ {
+	for i := range messageDescriptors.Len() {
 		message := messageDescriptors.Get(i)
-		for j := 0; j < message.Enums().Len(); j++ {
+		for j := range message.Enums().Len() {
 			enum := message.Enums().Get(j)
 			if checkDescriptorHasNoChangeSuffix(enum, enumNoChangeSuffixes) {
 				enums = append(enums, enum)

--- a/private/bufpkg/bufconfig/buf_gen_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_gen_yaml_file.go
@@ -282,11 +282,11 @@ type externalBufGenYAMLFileV1Beta1 struct {
 
 // externalGeneratePluginConfigV1Beta1 represents a single plugin config in a v1beta1 buf.gen.yaml file.
 type externalGeneratePluginConfigV1Beta1 struct {
-	Name     string      `json:"name,omitempty" yaml:"name,omitempty"`
-	Out      string      `json:"out,omitempty" yaml:"out,omitempty"`
-	Opt      interface{} `json:"opt,omitempty" yaml:"opt,omitempty"`
-	Path     string      `json:"path,omitempty" yaml:"path,omitempty"`
-	Strategy string      `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Name     string `json:"name,omitempty" yaml:"name,omitempty"`
+	Out      string `json:"out,omitempty" yaml:"out,omitempty"`
+	Opt      any    `json:"opt,omitempty" yaml:"opt,omitempty"`
+	Path     string `json:"path,omitempty" yaml:"path,omitempty"`
+	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 }
 
 // externalGenerateManagedConfigV1Beta1 represents the options (for managed mode) config in a v1beta1 buf.gen.yaml file.
@@ -315,7 +315,7 @@ type externalGeneratePluginConfigV1 struct {
 	Out      string `json:"out,omitempty" yaml:"out,omitempty"`
 	Revision int    `json:"revision,omitempty" yaml:"revision,omitempty"`
 	// Opt can be one string or multiple strings.
-	Opt interface{} `json:"opt,omitempty" yaml:"opt,omitempty"`
+	Opt any `json:"opt,omitempty" yaml:"opt,omitempty"`
 	// Path can be one string or multiple strings.
 	Path       any    `json:"path,omitempty" yaml:"path,omitempty"`
 	ProtocPath any    `json:"protoc_path,omitempty" yaml:"protoc_path,omitempty"`
@@ -347,21 +347,21 @@ type externalJavaPackagePrefixConfigV1 struct {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface. This is done to maintain backward compatibility
 // of accepting a plain string value for java_package_prefix.
-func (e *externalJavaPackagePrefixConfigV1) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *externalJavaPackagePrefixConfigV1) UnmarshalYAML(unmarshal func(any) error) error {
 	return e.unmarshalWith(unmarshal)
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface. This is done to maintain backward compatibility
 // of accepting a plain string value for java_package_prefix.
 func (e *externalJavaPackagePrefixConfigV1) UnmarshalJSON(data []byte) error {
-	unmarshal := func(v interface{}) error {
+	unmarshal := func(v any) error {
 		return json.Unmarshal(data, v)
 	}
 	return e.unmarshalWith(unmarshal)
 }
 
 // unmarshalWith is used to unmarshal into json/yaml. See https://abhinavg.net/posts/flexible-yaml for details.
-func (e *externalJavaPackagePrefixConfigV1) unmarshalWith(unmarshal func(interface{}) error) error {
+func (e *externalJavaPackagePrefixConfigV1) unmarshalWith(unmarshal func(any) error) error {
 	var prefix string
 	if err := unmarshal(&prefix); err == nil {
 		e.Default = prefix
@@ -390,21 +390,21 @@ type externalOptimizeForConfigV1 struct {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface. This is done to maintain backward compatibility
 // of accepting a plain string value for optimize_for.
-func (e *externalOptimizeForConfigV1) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (e *externalOptimizeForConfigV1) UnmarshalYAML(unmarshal func(any) error) error {
 	return e.unmarshalWith(unmarshal)
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface. This is done to maintain backward compatibility
 // of accepting a plain string value for optimize_for.
 func (e *externalOptimizeForConfigV1) UnmarshalJSON(data []byte) error {
-	unmarshal := func(v interface{}) error {
+	unmarshal := func(v any) error {
 		return json.Unmarshal(data, v)
 	}
 	return e.unmarshalWith(unmarshal)
 }
 
 // unmarshalWith is used to unmarshal into json/yaml. See https://abhinavg.net/posts/flexible-yaml for details.
-func (e *externalOptimizeForConfigV1) unmarshalWith(unmarshal func(interface{}) error) error {
+func (e *externalOptimizeForConfigV1) unmarshalWith(unmarshal func(any) error) error {
 	var optimizeFor string
 	if err := unmarshal(&optimizeFor); err == nil {
 		e.Default = optimizeFor
@@ -552,7 +552,7 @@ type externalManagedOverrideConfigV2 struct {
 	// Field must not be set if FileOption is set.
 	Field string `json:"field,omitempty" yaml:"field,omitempty"`
 	// Value is required
-	Value interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+	Value any `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // externalInputConfigV2 is an external input configuration.

--- a/private/bufpkg/bufconfig/buf_work_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_work_yaml_file.go
@@ -233,7 +233,7 @@ func validateBufWorkYAMLDirPaths(dirPaths []string) ([]string, error) {
 	// We already know the paths are unique due to above validation.
 	// We sort to print deterministic errors.
 	sortedNormalizedDirPaths := slicesext.MapKeysToSortedSlice(normalizedDirPathToDirPath)
-	for i := 0; i < len(sortedNormalizedDirPaths); i++ {
+	for i := range sortedNormalizedDirPaths {
 		for j := i + 1; j < len(sortedNormalizedDirPaths); j++ {
 			left := sortedNormalizedDirPaths[i]
 			right := sortedNormalizedDirPaths[j]

--- a/private/bufpkg/bufconfig/buf_yaml_file.go
+++ b/private/bufpkg/bufconfig/buf_yaml_file.go
@@ -385,7 +385,7 @@ func readBufYAMLFile(
 	}
 	// Check if this file has the docs link comment from "buf config init" as its first line
 	// so we can preserve the comment in our round trip.
-	includeDocsLink := bytes.HasPrefix(data, []byte(fmt.Sprintf(docsLinkComment, fileVersion.String())))
+	includeDocsLink := bytes.HasPrefix(data, fmt.Appendf(nil, docsLinkComment, fileVersion.String()))
 	switch fileVersion {
 	case FileVersionV1Beta1, FileVersionV1:
 		var externalBufYAMLFile externalBufYAMLFileV1Beta1V1
@@ -747,7 +747,7 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 		if bufYAMLFile.IncludeDocsLink() {
 			data = bytes.Join(
 				[][]byte{
-					[]byte(fmt.Sprintf(docsLinkComment, fileVersion.String())),
+					fmt.Appendf(nil, docsLinkComment, fileVersion.String()),
 					data,
 				},
 				[]byte("\n"),
@@ -840,7 +840,7 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 			}
 			externalBufYAMLFile.Lint = externalLint
 			externalBufYAMLFile.Breaking = externalBreaking
-			for i := 0; i < len(externalBufYAMLFile.Modules); i++ {
+			for i := range externalBufYAMLFile.Modules {
 				externalBufYAMLFile.Modules[i].Lint = externalBufYAMLFileLintV2{}
 				externalBufYAMLFile.Modules[i].Breaking = externalBufYAMLFileBreakingV1Beta1V1V2{}
 			}
@@ -868,7 +868,7 @@ func writeBufYAMLFile(writer io.Writer, bufYAMLFile BufYAMLFile) error {
 		if bufYAMLFile.IncludeDocsLink() {
 			data = bytes.Join(
 				[][]byte{
-					[]byte(fmt.Sprintf(docsLinkComment, fileVersion.String())),
+					fmt.Appendf(nil, docsLinkComment, fileVersion.String()),
 					data,
 				},
 				[]byte("\n"),

--- a/private/bufpkg/bufconfig/file.go
+++ b/private/bufpkg/bufconfig/file.go
@@ -176,14 +176,14 @@ func writeFile[F File](
 	return nil
 }
 
-func getUnmarshalStrict(allowJSON bool) func([]byte, interface{}) error {
+func getUnmarshalStrict(allowJSON bool) func([]byte, any) error {
 	if allowJSON {
 		return encoding.UnmarshalJSONOrYAMLStrict
 	}
 	return encoding.UnmarshalYAMLStrict
 }
 
-func getUnmarshalNonStrict(allowJSON bool) func([]byte, interface{}) error {
+func getUnmarshalNonStrict(allowJSON bool) func([]byte, any) error {
 	if allowJSON {
 		return encoding.UnmarshalJSONOrYAMLNonStrict
 	}

--- a/private/bufpkg/bufconfig/generate_config_test.go
+++ b/private/bufpkg/bufconfig/generate_config_test.go
@@ -91,8 +91,8 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 					{
 						Name:     "go",
 						Out:      "go/out",
-						Path:     slicesext.Map([]string{"go", "run", "goplugin"}, func(s string) interface{} { return s }),
-						Opt:      slicesext.Map([]string{"a=b", "c"}, func(s string) interface{} { return s }),
+						Path:     slicesext.Map([]string{"go", "run", "goplugin"}, func(s string) any { return s }),
+						Opt:      slicesext.Map([]string{"a=b", "c"}, func(s string) any { return s }),
 						Strategy: "directory",
 					},
 				},
@@ -119,8 +119,8 @@ func TestParseConfigFromExternalV1(t *testing.T) {
 					{
 						Plugin:   "go",
 						Out:      "go/out",
-						Path:     slicesext.Map([]string{"go", "run", "goplugin"}, func(s string) interface{} { return s }),
-						Opt:      slicesext.Map([]string{"a=b", "c"}, func(s string) interface{} { return s }),
+						Path:     slicesext.Map([]string{"go", "run", "goplugin"}, func(s string) any { return s }),
+						Opt:      slicesext.Map([]string{"a=b", "c"}, func(s string) any { return s }),
 						Strategy: "directory",
 					},
 				},

--- a/private/bufpkg/bufconfig/generate_managed_config.go
+++ b/private/bufpkg/bufconfig/generate_managed_config.go
@@ -120,7 +120,7 @@ type ManagedOverrideRule interface {
 	// FieldOption returns the field option to disable managed mode for.
 	FieldOption() FieldOption
 	// Value returns the override value.
-	Value() interface{}
+	Value() any
 
 	isManagedOverrideRule()
 }
@@ -130,7 +130,7 @@ func NewManagedOverrideRuleForFileOption(
 	path string,
 	moduleFullName string,
 	fileOption FileOption,
-	value interface{},
+	value any,
 ) (ManagedOverrideRule, error) {
 	return newFileOptionManagedOverrideRule(
 		path,
@@ -146,7 +146,7 @@ func NewManagedOverrideRuleForFieldOption(
 	moduleFullName string,
 	fieldName string,
 	fieldOption FieldOption,
-	value interface{},
+	value any,
 ) (ManagedOverrideRule, error) {
 	return newFieldOptionManagedOverrideRule(
 		path,
@@ -572,14 +572,14 @@ type managedOverrideRule struct {
 	fieldName      string
 	fileOption     FileOption
 	fieldOption    FieldOption
-	value          interface{}
+	value          any
 }
 
 func newFileOptionManagedOverrideRule(
 	path string,
 	moduleFullName string,
 	fileOption FileOption,
-	value interface{},
+	value any,
 ) (*managedOverrideRule, error) {
 	// All valid file options have a parse func. This lookup implicitly validates the option.
 	parseOverrideValueFunc, ok := fileOptionToParseOverrideValueFunc[fileOption]
@@ -616,7 +616,7 @@ func newFieldOptionManagedOverrideRule(
 	moduleFullName string,
 	fieldName string,
 	fieldOption FieldOption,
-	value interface{},
+	value any,
 ) (ManagedOverrideRule, error) {
 	// All valid field options have a parse func. This lookup implicitly validates the option.
 	parseOverrideValueFunc, ok := fieldOptionToParseOverrideValueFunc[fieldOption]
@@ -669,7 +669,7 @@ func (m *managedOverrideRule) FieldOption() FieldOption {
 	return m.fieldOption
 }
 
-func (m *managedOverrideRule) Value() interface{} {
+func (m *managedOverrideRule) Value() any {
 	return m.value
 }
 
@@ -747,7 +747,7 @@ func overrideRulesForPerFileOverridesV1(
 				return nil, fmt.Errorf("invalid import path for override %s: %w", fileOptionString, err)
 			}
 			overrideString := filePathToOverride[filePath]
-			var overrideValue interface{} = overrideString
+			var overrideValue any = overrideString
 			switch fileOption {
 			case FileOptionCcEnableArenas, FileOptionJavaMultipleFiles, FileOptionJavaStringCheckUtf8:
 				overrideValue, err = strconv.ParseBool(overrideString)

--- a/private/bufpkg/bufconfig/generate_managed_option.go
+++ b/private/bufpkg/bufconfig/generate_managed_option.go
@@ -138,7 +138,7 @@ var (
 		"ruby_package":                  FileOptionRubyPackage,
 		"ruby_package_suffix":           FileOptionRubyPackageSuffix,
 	}
-	fileOptionToParseOverrideValueFunc = map[FileOption]func(interface{}) (interface{}, error){
+	fileOptionToParseOverrideValueFunc = map[FileOption]func(any) (any, error){
 		FileOptionJavaPackage:                parseOverrideValue[string],
 		FileOptionJavaPackagePrefix:          parseOverrideValue[string],
 		FileOptionJavaPackageSuffix:          parseOverrideValue[string],
@@ -164,7 +164,7 @@ var (
 	stringToFieldOption = map[string]FieldOption{
 		"jstype": FieldOptionJSType,
 	}
-	fieldOptionToParseOverrideValueFunc = map[FieldOption]func(interface{}) (interface{}, error){
+	fieldOptionToParseOverrideValueFunc = map[FieldOption]func(any) (any, error){
 		FieldOptionJSType: parseOverrideValueJSType,
 	}
 )
@@ -193,7 +193,7 @@ func parseFieldOption(s string) (FieldOption, error) {
 	return 0, fmt.Errorf("unknown field_option: %q", s)
 }
 
-func parseOverrideValue[T string | bool](overrideValue interface{}) (interface{}, error) {
+func parseOverrideValue[T string | bool](overrideValue any) (any, error) {
 	parsedValue, ok := overrideValue.(T)
 	if !ok {
 		return nil, fmt.Errorf("expected a %T, got %T", parsedValue, overrideValue)
@@ -201,7 +201,7 @@ func parseOverrideValue[T string | bool](overrideValue interface{}) (interface{}
 	return parsedValue, nil
 }
 
-func parseOverrideValueOptimizeMode(overrideValue interface{}) (interface{}, error) {
+func parseOverrideValueOptimizeMode(overrideValue any) (any, error) {
 	optimizeModeName, ok := overrideValue.(string)
 	if !ok {
 		return nil, errors.New("must be one of SPEED, CODE_SIZE or LITE_RUNTIME")
@@ -213,7 +213,7 @@ func parseOverrideValueOptimizeMode(overrideValue interface{}) (interface{}, err
 	return descriptorpb.FileOptions_OptimizeMode(optimizeMode), nil
 }
 
-func parseOverrideValueJSType(override interface{}) (interface{}, error) {
+func parseOverrideValueJSType(override any) (any, error) {
 	jsTypeName, ok := override.(string)
 	if !ok {
 		return nil, errors.New("must be one of JS_NORMAL, JS_STRING or JS_NUMBER")
@@ -229,7 +229,7 @@ func parseOverrideValueJSType(override interface{}) (interface{}, error) {
 // then we want to write out the string representation of the enum value, not
 // the corresponding int32.
 // Otherwise we just return the value.
-func getOverrideValue(fileOptionName string, fieldOptionName string, value interface{}) (interface{}, error) {
+func getOverrideValue(fileOptionName string, fieldOptionName string, value any) (any, error) {
 	var optionName string
 	if fileOptionName != "" && fieldOptionName != "" {
 		return externalGenerateManagedConfigV2{}, fmt.Errorf("field option %s and file option %s set on the same override", fileOptionName, fieldOptionName)

--- a/private/bufpkg/bufconfig/paths.go
+++ b/private/bufpkg/bufconfig/paths.go
@@ -46,7 +46,7 @@ func normalizeAndCheckPaths(paths []string, name string) ([]string, error) {
 		outputs[i] = output
 	}
 	sort.Strings(outputs)
-	for i := 0; i < len(outputs); i++ {
+	for i := range outputs {
 		for j := i + 1; j < len(outputs); j++ {
 			output1 := outputs[i]
 			output2 := outputs[j]

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -839,7 +839,7 @@ func newTestFileOptionOverrideRule(
 	path string,
 	moduleFullName string,
 	fileOption bufconfig.FileOption,
-	value interface{},
+	value any,
 ) bufconfig.ManagedOverrideRule {
 	fileOptionOverride, err := bufconfig.NewManagedOverrideRuleForFileOption(
 		path,

--- a/private/bufpkg/bufimage/bufimagetesting/bufimagetesting_test.go
+++ b/private/bufpkg/bufimage/bufimagetesting/bufimagetesting_test.go
@@ -34,7 +34,7 @@ import (
 
 func BenchmarkNewImageWithOnlyPathsAllowNotExistFileOnly(b *testing.B) {
 	var imageFiles []bufimage.ImageFile
-	for i := 0; i < 3000; i++ {
+	for i := range 3000 {
 		imageFiles = append(
 			imageFiles,
 			NewImageFile(
@@ -67,7 +67,7 @@ func BenchmarkNewImageWithOnlyPathsAllowNotExistFileOnly(b *testing.B) {
 
 func BenchmarkNewImageWithOnlyPathsAllowNotExistDirOnly(b *testing.B) {
 	var imageFiles []bufimage.ImageFile
-	for i := 0; i < 3000; i++ {
+	for i := range 3000 {
 		imageFiles = append(
 			imageFiles,
 			NewImageFile(

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -921,7 +921,7 @@ func (t *transitiveClosure) exploreOptionValueForAny(
 	case isMessageKind(fd.Kind()):
 		if fd.IsList() {
 			listVal := val.List()
-			for i := 0; i < listVal.Len(); i++ {
+			for i := range listVal.Len() {
 				if err := t.exploreOptionSingularValueForAny(listVal.Get(i).Message(), referrerFile, imageIndex, opts); err != nil {
 					return err
 				}

--- a/private/bufpkg/bufimage/bufimageutil/source_paths_remap_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/source_paths_remap_test.go
@@ -48,7 +48,7 @@ func TestSourcePathsRemapTrie_Insert(t *testing.T) {
 		require.Equal(t, expectedSlices, slices)
 	})
 	// shuffle a few times and make sure the trie is always constructed correctly
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		rnd := rand.New(rand.NewSource(int64(i)))
 		t.Run(fmt.Sprintf("random order %d", i), func(t *testing.T) {
 			t.Parallel()

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -303,7 +303,7 @@ func getImageFilesRec(
 		unusedDependencyIndexes = make([]int32, 0, len(unusedDependencyFilenames))
 	}
 	var err error
-	for i := 0; i < fileDescriptor.Imports().Len(); i++ {
+	for i := range fileDescriptor.Imports().Len() {
 		dependency := fileDescriptor.Imports().Get(i).FileDescriptor
 		if unusedDependencyFilenames != nil {
 			if _, ok := unusedDependencyFilenames[dependency.Path()]; ok {
@@ -533,7 +533,7 @@ func findExtension(d container, message protoreflect.FullName, field protoreflec
 			return extension
 		}
 	}
-	for i := 0; i < d.Messages().Len(); i++ {
+	for i := range d.Messages().Len() {
 		if ext := findExtension(d.Messages().Get(i), message, field); ext != nil {
 			return ext
 		}

--- a/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
+++ b/private/bufpkg/bufmodule/bufmodulecache/bufmodulecache_test.go
@@ -233,7 +233,7 @@ func TestConcurrentCacheReadWrite(t *testing.T) {
 	cacheDir := filepath.Join(tempDir, "cache")
 	logger := slogtestext.NewLogger(t)
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		require.NoError(t, os.MkdirAll(cacheDir, 0755))
 		jobs, err := slicesext.MapError(
 			[]int{0, 1, 2, 3, 4},

--- a/private/bufpkg/bufprotoplugin/bufprotoplugin_test.go
+++ b/private/bufpkg/bufprotoplugin/bufprotoplugin_test.go
@@ -172,7 +172,7 @@ at varied indentation levels` + whitespacePrefix + "// @@protoc_insertion_point(
 	inflatedLines := 1100
 
 	inflatedTargetFileContent := targetFileContent
-	for i := 0; i < inflatedLines-1; i++ {
+	for range inflatedLines - 1 {
 		inflatedTargetFileContent += "// this is just extra garbage\n"
 	}
 	// no trailing newline
@@ -222,7 +222,7 @@ that has more than one insertion point
     // @@protoc_insertion_point(ip2)
 
 at varied indentation levels` + whitespacePrefix + "// @@protoc_insertion_point(ip3)\n")
-		for i := 0; i < inflatedLines-1; i++ {
+		for range inflatedLines - 1 {
 			inflatedExpectContent = append(inflatedExpectContent, []byte("// this is just extra garbage\n")...)
 		}
 		// no trailing newline

--- a/private/bufpkg/bufprotosource/bufprotosource.go
+++ b/private/bufpkg/bufprotosource/bufprotosource.go
@@ -139,7 +139,7 @@ type OptionExtensionDescriptor interface {
 	//
 	// See https://pkg.go.dev/google.golang.org/protobuf/proto#HasExtension
 	// See https://pkg.go.dev/google.golang.org/protobuf/proto#GetExtension
-	OptionExtension(extensionType protoreflect.ExtensionType) (interface{}, bool)
+	OptionExtension(extensionType protoreflect.ExtensionType) (any, bool)
 
 	// OptionExtensionLocation returns the source location where the given extension
 	// field value is defined. This is the same as OptionLocation, but specific to

--- a/private/bufpkg/bufprotosource/option_extension_descriptor.go
+++ b/private/bufpkg/bufprotosource/option_extension_descriptor.go
@@ -36,7 +36,7 @@ func newOptionExtensionDescriptor(message proto.Message, optionsPath []int32, lo
 	}
 }
 
-func (o *optionExtensionDescriptor) OptionExtension(extensionType protoreflect.ExtensionType) (interface{}, bool) {
+func (o *optionExtensionDescriptor) OptionExtension(extensionType protoreflect.ExtensionType) (any, bool) {
 	if extensionType.TypeDescriptor().ContainingMessage().FullName() != o.message.ProtoReflect().Descriptor().FullName() {
 		return nil, false
 	}

--- a/private/bufpkg/bufremoteplugin/bufremoteplugin.go
+++ b/private/bufpkg/bufremoteplugin/bufremoteplugin.go
@@ -16,6 +16,7 @@ package bufremoteplugin
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -116,9 +117,7 @@ func OutputLanguagesToProtoLanguages(languages []string) ([]registryv1alpha1.Plu
 		}
 		return nil, fmt.Errorf("invalid plugin output language: %q\nsupported languages: %s", language, strings.Join(supportedLanguages, ", "))
 	}
-	sort.Slice(protoLanguages, func(i, j int) bool {
-		return protoLanguages[i] < protoLanguages[j]
-	})
+	slices.Sort(protoLanguages)
 	return protoLanguages, nil
 }
 

--- a/private/bufpkg/bufremoteplugin/bufremotepluginconfig/bufremotepluginconfig_test.go
+++ b/private/bufpkg/bufremoteplugin/bufremotepluginconfig/bufremotepluginconfig_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"testing"
 
@@ -520,7 +521,7 @@ func verifyDependencies(t testing.TB, validConfigBytes []byte, fail bool, invali
 	var cloned *ExternalConfig
 	err := yaml.Unmarshal(validConfigBytes, &cloned)
 	require.NoError(t, err)
-	cloned.Deps = append([]ExternalDependency{}, invalidDependencies...)
+	cloned.Deps = slices.Clone(invalidDependencies)
 	yamlBytes, err := yaml.Marshal(cloned)
 	require.NoError(t, err)
 	_, err = GetConfigForData(context.Background(), yamlBytes)

--- a/private/bufpkg/bufremoteplugin/bufremotepluginconfig/get.go
+++ b/private/bufpkg/bufremoteplugin/bufremotepluginconfig/get.go
@@ -82,8 +82,8 @@ func getConfigForData(ctx context.Context, data []byte, options []ConfigOption) 
 
 func getConfigForDataInternal(
 	ctx context.Context,
-	unmarshalNonStrict func([]byte, interface{}) error,
-	unmarshalStrict func([]byte, interface{}) error,
+	unmarshalNonStrict func([]byte, any) error,
+	unmarshalStrict func([]byte, any) error,
 	data []byte,
 	id string,
 	options []ConfigOption,

--- a/private/bufpkg/bufremoteplugin/bufremoteplugindocker/docker_test.go
+++ b/private/bufpkg/bufremoteplugin/bufremoteplugindocker/docker_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -298,10 +299,8 @@ func (d *dockerServer) imagesHandler(w http.ResponseWriter, r *http.Request) {
 
 func (d *dockerServer) findImageIDFromName(name string) string {
 	for imageID, builtImageInfo := range d.pushedImages {
-		for _, imageTag := range builtImageInfo.tags {
-			if imageTag == name {
-				return imageID
-			}
+		if slices.Contains(builtImageInfo.tags, name) {
+			return imageID
 		}
 	}
 	return ""

--- a/private/bufpkg/bufstyle/analyzer_provider.go
+++ b/private/bufpkg/bufstyle/analyzer_provider.go
@@ -60,7 +60,7 @@ func (a *analyzerProvider) modifyAnalyzer(analyzer *analysis.Analyzer) {
 		return
 	}
 	oldRun := analyzer.Run
-	analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+	analyzer.Run = func(pass *analysis.Pass) (any, error) {
 		oldReport := pass.Report
 		var reportErr error
 		pass.Report = func(diagnostic analysis.Diagnostic) {

--- a/private/bufpkg/bufstyle/analyzers.go
+++ b/private/bufpkg/bufstyle/analyzers.go
@@ -29,7 +29,7 @@ func newAnalyzers() []*analysis.Analyzer {
 		{
 			Name: "PACKAGE_FILENAME",
 			Doc:  "Verifies that every package has a file with the same name as the package.",
-			Run: func(pass *analysis.Pass) (interface{}, error) {
+			Run: func(pass *analysis.Pass) (any, error) {
 				if len(pass.Files) == 0 {
 					// Nothing to do. We can't report the error anywhere because
 					// this package doesn't have any files.
@@ -63,7 +63,7 @@ func newAnalyzers() []*analysis.Analyzer {
 		{
 			Name: "NO_SYNC_POOL",
 			Doc:  "Verifies that sync.Pool is not used.",
-			Run: func(pass *analysis.Pass) (interface{}, error) {
+			Run: func(pass *analysis.Pass) (any, error) {
 				if typesInfo := pass.TypesInfo; typesInfo != nil {
 					for expr, typeAndValue := range pass.TypesInfo.Types {
 						if t := typeAndValue.Type; t != nil {
@@ -79,7 +79,7 @@ func newAnalyzers() []*analysis.Analyzer {
 		{
 			Name: "BEHAVIOUR",
 			Doc:  "Verifies that the word \"behaviour\" is not used in any comment.",
-			Run: func(pass *analysis.Pass) (interface{}, error) {
+			Run: func(pass *analysis.Pass) (any, error) {
 				for _, file := range pass.Files {
 					for _, commentGroup := range file.Comments {
 						for _, comment := range commentGroup.List {
@@ -95,7 +95,7 @@ func newAnalyzers() []*analysis.Analyzer {
 		{
 			Name: "FILEPATH_CASING",
 			Doc:  "Verifies filePath or FilePath is used, not filepath or Filepath.",
-			Run: func(pass *analysis.Pass) (interface{}, error) {
+			Run: func(pass *analysis.Pass) (any, error) {
 				if typesInfo := pass.TypesInfo; typesInfo != nil {
 					for _, object := range pass.TypesInfo.Defs {
 						if object != nil {

--- a/private/pkg/app/app.go
+++ b/private/pkg/app/app.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sort"
 	"strconv"
@@ -71,9 +72,7 @@ func NewEnvContainerForOS() (EnvContainer, error) {
 // Empty values are effectively ignored. To unset a key, set the value to "" in overrides.
 func NewEnvContainerWithOverrides(envContainer EnvContainer, overrides map[string]string) EnvContainer {
 	m := EnvironMap(envContainer)
-	for key, value := range overrides {
-		m[key] = value
-	}
+	maps.Copy(m, overrides)
 	return newEnvContainer(m)
 }
 
@@ -268,7 +267,7 @@ func EnvironMap(envContainer EnvContainer) map[string]string {
 func Args(argList ArgContainer) []string {
 	numArgs := argList.NumArgs()
 	args := make([]string, numArgs)
-	for i := 0; i < numArgs; i++ {
+	for i := range numArgs {
 		args[i] = argList.Arg(i)
 	}
 	return args
@@ -343,7 +342,7 @@ func NewError(exitCode int, message string) error {
 // NewErrorf returns a new error that contains an exit code.
 //
 // The exit code cannot be 0.
-func NewErrorf(exitCode int, format string, args ...interface{}) error {
+func NewErrorf(exitCode int, format string, args ...any) error {
 	return newAppError(exitCode, fmt.Errorf(format, args...))
 }
 

--- a/private/pkg/app/appcmd/cobra.go
+++ b/private/pkg/app/appcmd/cobra.go
@@ -47,7 +47,7 @@ func rpad(s string, padding int) string {
 }
 
 // tmpl executes the given template text on data, writing the result to w.
-func tmpl(w io.Writer, text string, data interface{}) error {
+func tmpl(w io.Writer, text string, data any) error {
 	t := template.New("top")
 	t.Funcs(templateFuncs)
 	t, err := t.Parse(text)

--- a/private/pkg/app/appext/appext.go
+++ b/private/pkg/app/appext/appext.go
@@ -160,7 +160,7 @@ func BuilderWithLoggerProvider(loggerProvider LoggerProvider) BuilderOption {
 //
 // If the file does not exist, this is a no-op.
 // The value should be a pointer to unmarshal into.
-func ReadConfig(container NameContainer, value interface{}) error {
+func ReadConfig(container NameContainer, value any) error {
 	configFilePath := filepath.Join(container.ConfigDirPath(), configFileName)
 	data, err := os.ReadFile(configFilePath)
 	if !errors.Is(err, os.ErrNotExist) {
@@ -179,7 +179,7 @@ func ReadConfig(container NameContainer, value interface{}) error {
 //
 // If the file does not exist, this is a no-op.
 // The value should be a pointer to unmarshal into.
-func ReadConfigNonStrict(container NameContainer, value interface{}) error {
+func ReadConfigNonStrict(container NameContainer, value any) error {
 	configFilePath := filepath.Join(container.ConfigDirPath(), configFileName)
 	data, err := os.ReadFile(configFilePath)
 	if !errors.Is(err, os.ErrNotExist) {
@@ -209,7 +209,7 @@ func ReadSecret(container NameContainer, name string) (string, error) {
 //
 // The directory is created if it does not exist.
 // The value should be a pointer to marshal.
-func WriteConfig(container NameContainer, value interface{}) error {
+func WriteConfig(container NameContainer, value any) error {
 	data, err := encoding.MarshalYAML(value)
 	if err != nil {
 		return err

--- a/private/pkg/app/appext/builder.go
+++ b/private/pkg/app/appext/builder.go
@@ -194,7 +194,7 @@ func runProfile(
 		profile.ProfilePath(profilePath),
 		profileFunc,
 	)
-	for i := 0; i < profileLoops; i++ {
+	for range profileLoops {
 		if err := f(); err != nil {
 			if !profileAllowError {
 				return err

--- a/private/pkg/bandeps/util.go
+++ b/private/pkg/bandeps/util.go
@@ -15,6 +15,7 @@
 package bandeps
 
 import (
+	"maps"
 	"sort"
 	"strings"
 )
@@ -52,16 +53,14 @@ func getNonEmptyLines(s string) []string {
 	return lines
 }
 
-func addMaps(base map[string]struct{}, maps ...map[string]struct{}) {
-	for _, m := range maps {
-		for k, v := range m {
-			base[k] = v
-		}
+func addMaps(base map[string]struct{}, toAdd ...map[string]struct{}) {
+	for _, m := range toAdd {
+		maps.Copy(base, m)
 	}
 }
 
-func subtractMaps(base map[string]struct{}, maps ...map[string]struct{}) {
-	for _, m := range maps {
+func subtractMaps(base map[string]struct{}, toSubtract ...map[string]struct{}) {
+	for _, m := range toSubtract {
 		for k := range m {
 			delete(base, k)
 		}

--- a/private/pkg/connectclient/connectclient.go
+++ b/private/pkg/connectclient/connectclient.go
@@ -15,6 +15,8 @@
 package connectclient
 
 import (
+	"slices"
+
 	"connectrpc.com/connect"
 )
 
@@ -70,7 +72,7 @@ type StubFactory[T any] func(connect.HTTPClient, string, ...connect.ClientOption
 
 // Make uses the given generated factory function to create a new connect client.
 func Make[T any](cfg *Config, address string, factory StubFactory[T]) T {
-	interceptors := append([]connect.Interceptor{}, cfg.interceptors...)
+	interceptors := slices.Clone(cfg.interceptors)
 	if cfg.authInterceptorProvider != nil {
 		interceptor := cfg.authInterceptorProvider(address)
 		interceptors = append(interceptors, interceptor)

--- a/private/pkg/dag/dagtest/dagtest.go
+++ b/private/pkg/dag/dagtest/dagtest.go
@@ -92,11 +92,6 @@ func normalizeKeys[Key cmp.Ordered](keys []Key) []Key {
 		return []Key{}
 	}
 	keys = slices.Clone(keys)
-	sort.Slice(
-		keys,
-		func(i int, j int) bool {
-			return keys[i] < keys[j]
-		},
-	)
+	slices.Sort(keys)
 	return keys
 }

--- a/private/pkg/diff/diff.go
+++ b/private/pkg/diff/diff.go
@@ -175,12 +175,12 @@ func tryModifyHeader(
 	if filename1 == filename2 {
 		filename1 = filename1 + ".orig"
 	}
-	bs[0] = []byte(fmt.Sprintf("--- %s%s", filename1, t0))
-	bs[1] = []byte(fmt.Sprintf("+++ %s%s", filename2, t1))
+	bs[0] = fmt.Appendf(nil, "--- %s%s", filename1, t0)
+	bs[1] = fmt.Appendf(nil, "+++ %s%s", filename2, t1)
 	if !suppressCommands {
 		bs = append(
 			[][]byte{
-				[]byte(fmt.Sprintf("diff -u %s %s", filename1, filename2)),
+				fmt.Appendf(nil, "diff -u %s %s", filename1, filename2),
 			},
 			bs...,
 		)

--- a/private/pkg/diff/diffmyers/diffmyers.go
+++ b/private/pkg/diff/diffmyers/diffmyers.go
@@ -132,7 +132,7 @@ func Print(from, to [][]byte, edits []Edit) ([]byte, error) {
 		}
 		if printHunk {
 			// Print the hunk header.
-			hunk.line = []byte(fmt.Sprintf("@@ -%d,%d +%d,%d @@\n", hunkOldStart, deleteCount, hunkNewStart, insertCount))
+			hunk.line = fmt.Appendf(nil, "@@ -%d,%d +%d,%d @@\n", hunkOldStart, deleteCount, hunkNewStart, insertCount)
 			bufferSize += len(hunk.line) + 1
 		}
 	}
@@ -209,7 +209,7 @@ func findMiddleSnake(from, to [][]byte) (d int, x int, y int, u int, v int) {
 	// Wherever we access them we just offset by maxD.
 	vf := make([]int, 2*maxD+1)
 	vb := make([]int, 2*maxD+1)
-	for i := 0; i < len(vf); i++ {
+	for i := range vf {
 		vf[i] = -1
 		vb[i] = -1
 	}

--- a/private/pkg/encoding/encoding.go
+++ b/private/pkg/encoding/encoding.go
@@ -29,7 +29,7 @@ import (
 // UnmarshalJSONStrict unmarshals the data as JSON, returning a user error on failure.
 //
 // If the data length is 0, this is a no-op.
-func UnmarshalJSONStrict(data []byte, v interface{}) error {
+func UnmarshalJSONStrict(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -44,7 +44,7 @@ func UnmarshalJSONStrict(data []byte, v interface{}) error {
 // UnmarshalYAMLStrict unmarshals the data as YAML, returning a user error on failure.
 //
 // If the data length is 0, this is a no-op.
-func UnmarshalYAMLStrict(data []byte, v interface{}) error {
+func UnmarshalYAMLStrict(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -59,7 +59,7 @@ func UnmarshalYAMLStrict(data []byte, v interface{}) error {
 // a user error with both errors on failure.
 //
 // If the data length is 0, this is a no-op.
-func UnmarshalJSONOrYAMLStrict(data []byte, v interface{}) error {
+func UnmarshalJSONOrYAMLStrict(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -74,7 +74,7 @@ func UnmarshalJSONOrYAMLStrict(data []byte, v interface{}) error {
 // UnmarshalJSONNonStrict unmarshals the data as JSON, returning a user error on failure.
 //
 // If the data length is 0, this is a no-op.
-func UnmarshalJSONNonStrict(data []byte, v interface{}) error {
+func UnmarshalJSONNonStrict(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -88,7 +88,7 @@ func UnmarshalJSONNonStrict(data []byte, v interface{}) error {
 // UnmarshalYAMLNonStrict unmarshals the data as YAML, returning a user error on failure.
 //
 // If the data length is 0, this is a no-op.
-func UnmarshalYAMLNonStrict(data []byte, v interface{}) error {
+func UnmarshalYAMLNonStrict(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -103,7 +103,7 @@ func UnmarshalYAMLNonStrict(data []byte, v interface{}) error {
 // a user error with both errors on failure.
 //
 // If the data length is 0, this is a no-op.
-func UnmarshalJSONOrYAMLNonStrict(data []byte, v interface{}) error {
+func UnmarshalJSONOrYAMLNonStrict(data []byte, v any) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -131,7 +131,7 @@ func GetJSONStringOrStringValue(rawMessage json.RawMessage) string {
 }
 
 // MarshalYAML marshals the given value into YAML.
-func MarshalYAML(v interface{}) (_ []byte, retErr error) {
+func MarshalYAML(v any) (_ []byte, retErr error) {
 	buffer := bytes.NewBuffer(nil)
 	yamlEncoder := NewYAMLEncoder(buffer)
 	defer func() {
@@ -167,7 +167,7 @@ func NewYAMLDecoderNonStrict(reader io.Reader) *yaml.Decoder {
 // slice or string into a comma separated string. This is commonly
 // used with JSON or YAML fields that need to support both string slices
 // and string literals.
-func InterfaceSliceOrStringToCommaSepString(in interface{}) (string, error) {
+func InterfaceSliceOrStringToCommaSepString(in any) (string, error) {
 	values, err := InterfaceSliceOrStringToStringSlice(in)
 	if err != nil {
 		return "", err
@@ -175,7 +175,7 @@ func InterfaceSliceOrStringToCommaSepString(in interface{}) (string, error) {
 	return strings.Join(values, ","), nil
 }
 
-func InterfaceSliceOrStringToStringSlice(in interface{}) ([]string, error) {
+func InterfaceSliceOrStringToStringSlice(in any) ([]string, error) {
 	if in == nil {
 		return nil, nil
 	}

--- a/private/pkg/encoding/encoding_test.go
+++ b/private/pkg/encoding/encoding_test.go
@@ -25,9 +25,9 @@ func TestInterfaceSliceOrStringToCommaSepString(t *testing.T) {
 	testInterfaceSliceOrStringToCommaSepString(t, "mystring", "mystring")
 	testInterfaceSliceOrStringToCommaSepString(
 		t,
-		[]interface{}{
-			interface{}("mystring"),
-			interface{}("mystring2"),
+		[]any{
+			any("mystring"),
+			any("mystring2"),
 		},
 		"mystring,mystring2",
 	)
@@ -37,7 +37,7 @@ func TestInterfaceSliceOrStringToCommaSepString(t *testing.T) {
 	require.Error(t, err)
 }
 
-func testInterfaceSliceOrStringToCommaSepString(t *testing.T, in interface{}, expected string) {
+func testInterfaceSliceOrStringToCommaSepString(t *testing.T, in any, expected string) {
 	v, err := InterfaceSliceOrStringToCommaSepString(in)
 	require.NoError(t, err)
 	require.Equal(t, expected, v)

--- a/private/pkg/execext/execext_unix_test.go
+++ b/private/pkg/execext/execext_unix_test.go
@@ -28,7 +28,7 @@ func TestStartSimple(t *testing.T) {
 
 	ctx := context.Background()
 	processes := make([]Process, 4)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		process, err := Start(ctx, "sleep", WithArgs("1"))
 		require.NoError(t, err)
 		processes[i] = process

--- a/private/pkg/netrc/netrc_unix_test.go
+++ b/private/pkg/netrc/netrc_unix_test.go
@@ -135,7 +135,7 @@ func TestPutLotsOfBigMachinesSingleLineFiles(t *testing.T) {
 	password := strings.Repeat("abcdefghijklmnopqrstuvwxyz", size)
 	machines := make([]Machine, 0, size)
 	buffer := bytes.NewBuffer(nil)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		// Write the file manually in single-line format as this is where the failure happens.
 		fmt.Fprintf(buffer, "machine foo%d login bar%d password %s\n", i, i, password)
 		machines = append(
@@ -177,7 +177,7 @@ func TestPutLotsOfBigMachinesSingleLineFiles(t *testing.T) {
 
 	// Modify some of the existing machines.
 	machines = make([]Machine, 0, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		modifiedPassword := password
 		if i%2 == 0 {
 			modifiedPassword = modifiedPassword + "Z"

--- a/private/pkg/protoencoding/reparse_extensions.go
+++ b/private/pkg/protoencoding/reparse_extensions.go
@@ -94,7 +94,7 @@ func reparseInField(
 	}
 	if fieldDescriptor.IsList() {
 		list := value.List()
-		for i := 0; i < list.Len(); i++ {
+		for i := range list.Len() {
 			if err := ReparseExtensions(resolver, list.Get(i).Message()); err != nil {
 				return err
 			}

--- a/private/pkg/storage/cmd/storage-go-data/main.go
+++ b/private/pkg/storage/cmd/storage-go-data/main.go
@@ -150,10 +150,7 @@ var (
 `)
 		data := pathToData[path]
 		for len(data) > 0 {
-			n := sliceLength
-			if n > len(data) {
-				n = len(data)
-			}
+			n := min(sliceLength, len(data))
 			accum := ""
 			for _, elem := range data[:n] {
 				accum += fmt.Sprintf("0x%02x,", elem)

--- a/private/pkg/storage/storagetesting/storagetesting.go
+++ b/private/pkg/storage/storagetesting/storagetesting.go
@@ -1475,7 +1475,7 @@ func RunTestSuite(
 			writtenBytes atomic.Int64
 			triedBytes   atomic.Int64
 		)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()

--- a/private/pkg/thread/thread.go
+++ b/private/pkg/thread/thread.go
@@ -63,10 +63,7 @@ func Parallelize(ctx context.Context, jobs []func(context.Context) error, option
 	case 1:
 		return jobs[0](ctx)
 	}
-	multiplier := parallelizeOptions.multiplier
-	if multiplier < 1 {
-		multiplier = 1
-	}
+	multiplier := max(parallelizeOptions.multiplier, 1)
 	var cancel context.CancelFunc
 	if parallelizeOptions.cancelOnFailure {
 		ctx, cancel = context.WithCancel(ctx)

--- a/private/pkg/thread/thread_test.go
+++ b/private/pkg/thread/thread_test.go
@@ -33,7 +33,7 @@ func TestParallelizeWithImmediateCancellation(t *testing.T) {
 			executed atomic.Int64
 			jobs     = make([]func(context.Context) error, 0, jobsToExecute)
 		)
-		for i := 0; i < jobsToExecute; i++ {
+		for range jobsToExecute {
 			jobs = append(jobs, func(_ context.Context) error {
 				executed.Add(1)
 				return nil
@@ -47,7 +47,7 @@ func TestParallelizeWithImmediateCancellation(t *testing.T) {
 		t.Parallel()
 		var executed atomic.Int64
 		var jobs []func(context.Context) error
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			jobs = append(jobs, func(_ context.Context) error {
 				executed.Add(1)
 				return nil

--- a/private/pkg/uuidutil/uuidutil_test.go
+++ b/private/pkg/uuidutil/uuidutil_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestRoundTrip(t *testing.T) {
 	t.Parallel()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		id, err := New()
 		require.NoError(t, err)
 		dashless := ToDashless(id)

--- a/private/pkg/verbose/verbose.go
+++ b/private/pkg/verbose/verbose.go
@@ -39,7 +39,7 @@ type Printer interface {
 	//
 	// Callers should not rely on the print calls being reliable, i.e. errors to
 	// a backing Writer will be ignored.
-	Printf(format string, args ...interface{})
+	Printf(format string, args ...any)
 
 	isPrinter()
 }
@@ -63,7 +63,7 @@ func NewPrinterForFlagValue(writer io.Writer, prefix string, verboseValue bool) 
 
 type nopPrinter struct{}
 
-func (nopPrinter) Printf(string, ...interface{}) {}
+func (nopPrinter) Printf(string, ...any) {}
 
 func (nopPrinter) Enabled() bool {
 	return false
@@ -87,7 +87,7 @@ func newWritePrinter(writer io.Writer, prefix string) *writePrinter {
 	}
 }
 
-func (w *writePrinter) Printf(format string, args ...interface{}) {
+func (w *writePrinter) Printf(format string, args ...any) {
 	if value := strings.TrimSpace(fmt.Sprintf(format, args...)); value != "" {
 		// Errors are ignored per the interface spec.
 		_, _ = w.writer.Write([]byte(w.prefix + value + "\n"))


### PR DESCRIPTION
Run the modernize tool on buf's codebase to migrate to newer APIs and perform other migrations (e.g. `interface{}` to `any`).