### PR TITLE
Add `GetSDKInfo` rpc to `ResolveService`

### DIFF
--- a/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
+++ b/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
@@ -99,7 +99,7 @@ type ResolveServiceClient interface {
 	// plugin version, plugin revision, and the SDK version string
 	// for the SDK.
 	//
-	// If the the module reference and/or plugin version is included, then the SDK at the
+	// If the module reference and/or plugin version is included, then the SDK at the
 	// specified version will be resolved. If the SDK version is included, then it will be
 	// validated with the module and plugin information provided.
 	//
@@ -289,7 +289,7 @@ type ResolveServiceHandler interface {
 	// plugin version, plugin revision, and the SDK version string
 	// for the SDK.
 	//
-	// If the the module reference and/or plugin version is included, then the SDK at the
+	// If the module reference and/or plugin version is included, then the SDK at the
 	// specified version will be resolved. If the SDK version is included, then it will be
 	// validated with the module and plugin information provided.
 	//

--- a/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
+++ b/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
@@ -103,7 +103,7 @@ type ResolveServiceClient interface {
 	// specified version will be resolved. If the SDK version is included, then it will be
 	// validated with the module and plugin information provided.
 	//
-	// This replaces the need for all subsequent RPCs, which requirees the caller to resolve
+	// This replaces the need for all subsequent RPCs, which requires the caller to resolve
 	// the registry type first. Instead, the registry type will be resolved based on the plugin
 	// information provided.
 	GetSDKInfo(context.Context, *connect.Request[v1alpha1.GetSDKInfoRequest]) (*connect.Response[v1alpha1.GetSDKInfoResponse], error)
@@ -293,7 +293,7 @@ type ResolveServiceHandler interface {
 	// specified version will be resolved. If the SDK version is included, then it will be
 	// validated with the module and plugin information provided.
 	//
-	// This replaces the need for all subsequent RPCs, which requirees the caller to resolve
+	// This replaces the need for all subsequent RPCs, which requires the caller to resolve
 	// the registry type first. Instead, the registry type will be resolved based on the plugin
 	// information provided.
 	GetSDKInfo(context.Context, *connect.Request[v1alpha1.GetSDKInfoRequest]) (*connect.Response[v1alpha1.GetSDKInfoResponse], error)

--- a/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
+++ b/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect/resolve.connect.go
@@ -76,6 +76,9 @@ const (
 	// ResolveServiceGetCmakeVersionProcedure is the fully-qualified name of the ResolveService's
 	// GetCmakeVersion RPC.
 	ResolveServiceGetCmakeVersionProcedure = "/buf.alpha.registry.v1alpha1.ResolveService/GetCmakeVersion"
+	// ResolveServiceGetParsedSDKVersionProcedure is the fully-qualified name of the ResolveService's
+	// GetParsedSDKVersion RPC.
+	ResolveServiceGetParsedSDKVersionProcedure = "/buf.alpha.registry.v1alpha1.ResolveService/GetParsedSDKVersion"
 	// LocalResolveServiceGetLocalModulePinsProcedure is the fully-qualified name of the
 	// LocalResolveService's GetLocalModulePins RPC.
 	LocalResolveServiceGetLocalModulePinsProcedure = "/buf.alpha.registry.v1alpha1.LocalResolveService/GetLocalModulePins"
@@ -107,6 +110,10 @@ type ResolveServiceClient interface {
 	GetNugetVersion(context.Context, *connect.Request[v1alpha1.GetNugetVersionRequest]) (*connect.Response[v1alpha1.GetNugetVersionResponse], error)
 	// GetCmakeVersion resolves the given plugin and module references to a version.
 	GetCmakeVersion(context.Context, *connect.Request[v1alpha1.GetCmakeVersionRequest]) (*connect.Response[v1alpha1.GetCmakeVersionResponse], error)
+	// GetSDKVersion takes a module reference, plugin identity, and SDK version string and returns
+	// a parsed SDK version that provides the plugin version, plugin revision, module commit,
+	// and module commit create time (optional).
+	GetParsedSDKVersion(context.Context, *connect.Request[v1alpha1.GetParsedSDKVersionRequest]) (*connect.Response[v1alpha1.GetParsedSDKVersionResponse], error)
 }
 
 // NewResolveServiceClient constructs a client for the buf.alpha.registry.v1alpha1.ResolveService
@@ -183,20 +190,28 @@ func NewResolveServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
+		getParsedSDKVersion: connect.NewClient[v1alpha1.GetParsedSDKVersionRequest, v1alpha1.GetParsedSDKVersionResponse](
+			httpClient,
+			baseURL+ResolveServiceGetParsedSDKVersionProcedure,
+			connect.WithSchema(resolveServiceMethods.ByName("GetParsedSDKVersion")),
+			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // resolveServiceClient implements ResolveServiceClient.
 type resolveServiceClient struct {
-	getModulePins    *connect.Client[v1alpha1.GetModulePinsRequest, v1alpha1.GetModulePinsResponse]
-	getGoVersion     *connect.Client[v1alpha1.GetGoVersionRequest, v1alpha1.GetGoVersionResponse]
-	getSwiftVersion  *connect.Client[v1alpha1.GetSwiftVersionRequest, v1alpha1.GetSwiftVersionResponse]
-	getMavenVersion  *connect.Client[v1alpha1.GetMavenVersionRequest, v1alpha1.GetMavenVersionResponse]
-	getNPMVersion    *connect.Client[v1alpha1.GetNPMVersionRequest, v1alpha1.GetNPMVersionResponse]
-	getPythonVersion *connect.Client[v1alpha1.GetPythonVersionRequest, v1alpha1.GetPythonVersionResponse]
-	getCargoVersion  *connect.Client[v1alpha1.GetCargoVersionRequest, v1alpha1.GetCargoVersionResponse]
-	getNugetVersion  *connect.Client[v1alpha1.GetNugetVersionRequest, v1alpha1.GetNugetVersionResponse]
-	getCmakeVersion  *connect.Client[v1alpha1.GetCmakeVersionRequest, v1alpha1.GetCmakeVersionResponse]
+	getModulePins       *connect.Client[v1alpha1.GetModulePinsRequest, v1alpha1.GetModulePinsResponse]
+	getGoVersion        *connect.Client[v1alpha1.GetGoVersionRequest, v1alpha1.GetGoVersionResponse]
+	getSwiftVersion     *connect.Client[v1alpha1.GetSwiftVersionRequest, v1alpha1.GetSwiftVersionResponse]
+	getMavenVersion     *connect.Client[v1alpha1.GetMavenVersionRequest, v1alpha1.GetMavenVersionResponse]
+	getNPMVersion       *connect.Client[v1alpha1.GetNPMVersionRequest, v1alpha1.GetNPMVersionResponse]
+	getPythonVersion    *connect.Client[v1alpha1.GetPythonVersionRequest, v1alpha1.GetPythonVersionResponse]
+	getCargoVersion     *connect.Client[v1alpha1.GetCargoVersionRequest, v1alpha1.GetCargoVersionResponse]
+	getNugetVersion     *connect.Client[v1alpha1.GetNugetVersionRequest, v1alpha1.GetNugetVersionResponse]
+	getCmakeVersion     *connect.Client[v1alpha1.GetCmakeVersionRequest, v1alpha1.GetCmakeVersionResponse]
+	getParsedSDKVersion *connect.Client[v1alpha1.GetParsedSDKVersionRequest, v1alpha1.GetParsedSDKVersionResponse]
 }
 
 // GetModulePins calls buf.alpha.registry.v1alpha1.ResolveService.GetModulePins.
@@ -244,6 +259,11 @@ func (c *resolveServiceClient) GetCmakeVersion(ctx context.Context, req *connect
 	return c.getCmakeVersion.CallUnary(ctx, req)
 }
 
+// GetParsedSDKVersion calls buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion.
+func (c *resolveServiceClient) GetParsedSDKVersion(ctx context.Context, req *connect.Request[v1alpha1.GetParsedSDKVersionRequest]) (*connect.Response[v1alpha1.GetParsedSDKVersionResponse], error) {
+	return c.getParsedSDKVersion.CallUnary(ctx, req)
+}
+
 // ResolveServiceHandler is an implementation of the buf.alpha.registry.v1alpha1.ResolveService
 // service.
 type ResolveServiceHandler interface {
@@ -271,6 +291,10 @@ type ResolveServiceHandler interface {
 	GetNugetVersion(context.Context, *connect.Request[v1alpha1.GetNugetVersionRequest]) (*connect.Response[v1alpha1.GetNugetVersionResponse], error)
 	// GetCmakeVersion resolves the given plugin and module references to a version.
 	GetCmakeVersion(context.Context, *connect.Request[v1alpha1.GetCmakeVersionRequest]) (*connect.Response[v1alpha1.GetCmakeVersionResponse], error)
+	// GetSDKVersion takes a module reference, plugin identity, and SDK version string and returns
+	// a parsed SDK version that provides the plugin version, plugin revision, module commit,
+	// and module commit create time (optional).
+	GetParsedSDKVersion(context.Context, *connect.Request[v1alpha1.GetParsedSDKVersionRequest]) (*connect.Response[v1alpha1.GetParsedSDKVersionResponse], error)
 }
 
 // NewResolveServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -343,6 +367,13 @@ func NewResolveServiceHandler(svc ResolveServiceHandler, opts ...connect.Handler
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
+	resolveServiceGetParsedSDKVersionHandler := connect.NewUnaryHandler(
+		ResolveServiceGetParsedSDKVersionProcedure,
+		svc.GetParsedSDKVersion,
+		connect.WithSchema(resolveServiceMethods.ByName("GetParsedSDKVersion")),
+		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/buf.alpha.registry.v1alpha1.ResolveService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ResolveServiceGetModulePinsProcedure:
@@ -363,6 +394,8 @@ func NewResolveServiceHandler(svc ResolveServiceHandler, opts ...connect.Handler
 			resolveServiceGetNugetVersionHandler.ServeHTTP(w, r)
 		case ResolveServiceGetCmakeVersionProcedure:
 			resolveServiceGetCmakeVersionHandler.ServeHTTP(w, r)
+		case ResolveServiceGetParsedSDKVersionProcedure:
+			resolveServiceGetParsedSDKVersionHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -406,6 +439,10 @@ func (UnimplementedResolveServiceHandler) GetNugetVersion(context.Context, *conn
 
 func (UnimplementedResolveServiceHandler) GetCmakeVersion(context.Context, *connect.Request[v1alpha1.GetCmakeVersionRequest]) (*connect.Response[v1alpha1.GetCmakeVersionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion is not implemented"))
+}
+
+func (UnimplementedResolveServiceHandler) GetParsedSDKVersion(context.Context, *connect.Request[v1alpha1.GetParsedSDKVersionRequest]) (*connect.Response[v1alpha1.GetParsedSDKVersionResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion is not implemented"))
 }
 
 // LocalResolveServiceClient is a client for the buf.alpha.registry.v1alpha1.LocalResolveService

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
@@ -1815,6 +1815,7 @@ type GetParsedSDKVersionRequest struct {
 	state                      protoimpl.MessageState         `protogen:"opaque.v1"`
 	xxx_hidden_ModuleReference *LocalModuleReference          `protobuf:"bytes,1,opt,name=module_reference,json=moduleReference,proto3"`
 	xxx_hidden_PluginReference *GetRemotePackageVersionPlugin `protobuf:"bytes,2,opt,name=plugin_reference,json=pluginReference,proto3"`
+	xxx_hidden_SdkVersion      string                         `protobuf:"bytes,3,opt,name=sdk_version,json=sdkVersion,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -1858,12 +1859,23 @@ func (x *GetParsedSDKVersionRequest) GetPluginReference() *GetRemotePackageVersi
 	return nil
 }
 
+func (x *GetParsedSDKVersionRequest) GetSdkVersion() string {
+	if x != nil {
+		return x.xxx_hidden_SdkVersion
+	}
+	return ""
+}
+
 func (x *GetParsedSDKVersionRequest) SetModuleReference(v *LocalModuleReference) {
 	x.xxx_hidden_ModuleReference = v
 }
 
 func (x *GetParsedSDKVersionRequest) SetPluginReference(v *GetRemotePackageVersionPlugin) {
 	x.xxx_hidden_PluginReference = v
+}
+
+func (x *GetParsedSDKVersionRequest) SetSdkVersion(v string) {
+	x.xxx_hidden_SdkVersion = v
 }
 
 func (x *GetParsedSDKVersionRequest) HasModuleReference() bool {
@@ -1893,6 +1905,7 @@ type GetParsedSDKVersionRequest_builder struct {
 
 	ModuleReference *LocalModuleReference
 	PluginReference *GetRemotePackageVersionPlugin
+	SdkVersion      string
 }
 
 func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest {
@@ -1901,6 +1914,7 @@ func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest
 	_, _ = b, x
 	x.xxx_hidden_ModuleReference = b.ModuleReference
 	x.xxx_hidden_PluginReference = b.PluginReference
+	x.xxx_hidden_SdkVersion = b.SdkVersion
 	return m0
 }
 
@@ -2153,10 +2167,12 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12\x1a\n" +
-	"\brevision\x18\x04 \x01(\rR\brevision\"\xe1\x01\n" +
+	"\brevision\x18\x04 \x01(\rR\brevision\"\x82\x02\n" +
 	"\x1aGetParsedSDKVersionRequest\x12\\\n" +
 	"\x10module_reference\x18\x01 \x01(\v21.buf.alpha.registry.v1alpha1.LocalModuleReferenceR\x0fmoduleReference\x12e\n" +
-	"\x10plugin_reference\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetRemotePackageVersionPluginR\x0fpluginReference\"\x80\x03\n" +
+	"\x10plugin_reference\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetRemotePackageVersionPluginR\x0fpluginReference\x12\x1f\n" +
+	"\vsdk_version\x18\x03 \x01(\tR\n" +
+	"sdkVersion\"\x80\x03\n" +
 	"\x1bGetParsedSDKVersionResponse\x12w\n" +
 	"\x12parsed_sdk_version\x18\x01 \x01(\v2I.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersionR\x10parsedSdkVersion\x1a\xe7\x01\n" +
 	"\x10ParsedSDKVersion\x12%\n" +

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
@@ -1903,9 +1903,12 @@ func (x *GetParsedSDKVersionRequest) ClearPluginReference() {
 type GetParsedSDKVersionRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	// The local module reference to parse.
 	ModuleReference *LocalModuleReference
+	// The plugin reference to parse.
 	PluginReference *GetRemotePackageVersionPlugin
-	SdkVersion      string
+	// The SDK version to parse.
+	SdkVersion string
 }
 
 func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest {
@@ -1919,10 +1922,11 @@ func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest
 }
 
 type GetParsedSDKVersionResponse struct {
-	state                       protoimpl.MessageState                        `protogen:"opaque.v1"`
-	xxx_hidden_ParsedSdkVersion *GetParsedSDKVersionResponse_ParsedSDKVersion `protobuf:"bytes,1,opt,name=parsed_sdk_version,json=parsedSdkVersion,proto3"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	state                 protoimpl.MessageState                  `protogen:"opaque.v1"`
+	xxx_hidden_ModuleInfo *GetParsedSDKVersionResponse_ModuleInfo `protobuf:"bytes,1,opt,name=module_info,json=moduleInfo,proto3"`
+	xxx_hidden_PluginInfo *GetParsedSDKVersionResponse_PluginInfo `protobuf:"bytes,2,opt,name=plugin_info,json=pluginInfo,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *GetParsedSDKVersionResponse) Reset() {
@@ -1950,66 +1954,91 @@ func (x *GetParsedSDKVersionResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *GetParsedSDKVersionResponse) GetParsedSdkVersion() *GetParsedSDKVersionResponse_ParsedSDKVersion {
+func (x *GetParsedSDKVersionResponse) GetModuleInfo() *GetParsedSDKVersionResponse_ModuleInfo {
 	if x != nil {
-		return x.xxx_hidden_ParsedSdkVersion
+		return x.xxx_hidden_ModuleInfo
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionResponse) SetParsedSdkVersion(v *GetParsedSDKVersionResponse_ParsedSDKVersion) {
-	x.xxx_hidden_ParsedSdkVersion = v
+func (x *GetParsedSDKVersionResponse) GetPluginInfo() *GetParsedSDKVersionResponse_PluginInfo {
+	if x != nil {
+		return x.xxx_hidden_PluginInfo
+	}
+	return nil
 }
 
-func (x *GetParsedSDKVersionResponse) HasParsedSdkVersion() bool {
+func (x *GetParsedSDKVersionResponse) SetModuleInfo(v *GetParsedSDKVersionResponse_ModuleInfo) {
+	x.xxx_hidden_ModuleInfo = v
+}
+
+func (x *GetParsedSDKVersionResponse) SetPluginInfo(v *GetParsedSDKVersionResponse_PluginInfo) {
+	x.xxx_hidden_PluginInfo = v
+}
+
+func (x *GetParsedSDKVersionResponse) HasModuleInfo() bool {
 	if x == nil {
 		return false
 	}
-	return x.xxx_hidden_ParsedSdkVersion != nil
+	return x.xxx_hidden_ModuleInfo != nil
 }
 
-func (x *GetParsedSDKVersionResponse) ClearParsedSdkVersion() {
-	x.xxx_hidden_ParsedSdkVersion = nil
+func (x *GetParsedSDKVersionResponse) HasPluginInfo() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_PluginInfo != nil
+}
+
+func (x *GetParsedSDKVersionResponse) ClearModuleInfo() {
+	x.xxx_hidden_ModuleInfo = nil
+}
+
+func (x *GetParsedSDKVersionResponse) ClearPluginInfo() {
+	x.xxx_hidden_PluginInfo = nil
 }
 
 type GetParsedSDKVersionResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ParsedSdkVersion *GetParsedSDKVersionResponse_ParsedSDKVersion
+	ModuleInfo *GetParsedSDKVersionResponse_ModuleInfo
+	PluginInfo *GetParsedSDKVersionResponse_PluginInfo
 }
 
 func (b0 GetParsedSDKVersionResponse_builder) Build() *GetParsedSDKVersionResponse {
 	m0 := &GetParsedSDKVersionResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_ParsedSdkVersion = b.ParsedSdkVersion
+	x.xxx_hidden_ModuleInfo = b.ModuleInfo
+	x.xxx_hidden_PluginInfo = b.PluginInfo
 	return m0
 }
 
-type GetParsedSDKVersionResponse_ParsedSDKVersion struct {
+// ModuleInfo is the parsed module information for the SDK.
+type GetParsedSDKVersionResponse_ModuleInfo struct {
 	state                             protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_PluginVersion          string                 `protobuf:"bytes,1,opt,name=plugin_version,json=pluginVersion,proto3"`
-	xxx_hidden_PluginRevision         uint32                 `protobuf:"varint,2,opt,name=plugin_revision,json=pluginRevision,proto3"`
-	xxx_hidden_ModuleCommitName       string                 `protobuf:"bytes,3,opt,name=module_commit_name,json=moduleCommitName,proto3"`
+	xxx_hidden_Owner                  string                 `protobuf:"bytes,1,opt,name=owner,proto3"`
+	xxx_hidden_Name                   string                 `protobuf:"bytes,2,opt,name=name,proto3"`
+	xxx_hidden_Commit                 string                 `protobuf:"bytes,3,opt,name=commit,proto3"`
 	xxx_hidden_ModuleCommitCreateTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=module_commit_create_time,json=moduleCommitCreateTime,proto3"`
 	unknownFields                     protoimpl.UnknownFields
 	sizeCache                         protoimpl.SizeCache
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) Reset() {
-	*x = GetParsedSDKVersionResponse_ParsedSDKVersion{}
+func (x *GetParsedSDKVersionResponse_ModuleInfo) Reset() {
+	*x = GetParsedSDKVersionResponse_ModuleInfo{}
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) String() string {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetParsedSDKVersionResponse_ParsedSDKVersion) ProtoMessage() {}
+func (*GetParsedSDKVersionResponse_ModuleInfo) ProtoMessage() {}
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) ProtoReflect() protoreflect.Message {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) ProtoReflect() protoreflect.Message {
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2021,85 +2050,186 @@ func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) ProtoReflect() protorefle
 	return mi.MessageOf(x)
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetPluginVersion() string {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) GetOwner() string {
 	if x != nil {
-		return x.xxx_hidden_PluginVersion
+		return x.xxx_hidden_Owner
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetPluginRevision() uint32 {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) GetName() string {
 	if x != nil {
-		return x.xxx_hidden_PluginRevision
-	}
-	return 0
-}
-
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetModuleCommitName() string {
-	if x != nil {
-		return x.xxx_hidden_ModuleCommitName
+		return x.xxx_hidden_Name
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetModuleCommitCreateTime() *timestamppb.Timestamp {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) GetCommit() string {
+	if x != nil {
+		return x.xxx_hidden_Commit
+	}
+	return ""
+}
+
+func (x *GetParsedSDKVersionResponse_ModuleInfo) GetModuleCommitCreateTime() *timestamppb.Timestamp {
 	if x != nil {
 		return x.xxx_hidden_ModuleCommitCreateTime
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetPluginVersion(v string) {
-	x.xxx_hidden_PluginVersion = v
+func (x *GetParsedSDKVersionResponse_ModuleInfo) SetOwner(v string) {
+	x.xxx_hidden_Owner = v
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetPluginRevision(v uint32) {
-	x.xxx_hidden_PluginRevision = v
+func (x *GetParsedSDKVersionResponse_ModuleInfo) SetName(v string) {
+	x.xxx_hidden_Name = v
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetModuleCommitName(v string) {
-	x.xxx_hidden_ModuleCommitName = v
+func (x *GetParsedSDKVersionResponse_ModuleInfo) SetCommit(v string) {
+	x.xxx_hidden_Commit = v
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetModuleCommitCreateTime(v *timestamppb.Timestamp) {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) SetModuleCommitCreateTime(v *timestamppb.Timestamp) {
 	x.xxx_hidden_ModuleCommitCreateTime = v
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) HasModuleCommitCreateTime() bool {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) HasModuleCommitCreateTime() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_ModuleCommitCreateTime != nil
 }
 
-func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) ClearModuleCommitCreateTime() {
+func (x *GetParsedSDKVersionResponse_ModuleInfo) ClearModuleCommitCreateTime() {
 	x.xxx_hidden_ModuleCommitCreateTime = nil
 }
 
-type GetParsedSDKVersionResponse_ParsedSDKVersion_builder struct {
+type GetParsedSDKVersionResponse_ModuleInfo_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// The plugin version of the plugin used to generate the SDK version.
-	// This will always be valid semver.
-	PluginVersion string
-	// The revision of the plugin version.
-	PluginRevision uint32
-	// This is the short version of the module commit name, at least 12 char in length.
-	ModuleCommitName string
-	// This is the creation time of the module commit.
-	//
-	// This will always be in UTC. This may be empty.
+	// The module owner name.
+	Owner string
+	// The module name.
+	Name string
+	// The module commit for the SDK.
+	Commit string
+	// The module commit create time. This will always be in UTC.
 	ModuleCommitCreateTime *timestamppb.Timestamp
 }
 
-func (b0 GetParsedSDKVersionResponse_ParsedSDKVersion_builder) Build() *GetParsedSDKVersionResponse_ParsedSDKVersion {
-	m0 := &GetParsedSDKVersionResponse_ParsedSDKVersion{}
+func (b0 GetParsedSDKVersionResponse_ModuleInfo_builder) Build() *GetParsedSDKVersionResponse_ModuleInfo {
+	m0 := &GetParsedSDKVersionResponse_ModuleInfo{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_PluginVersion = b.PluginVersion
-	x.xxx_hidden_PluginRevision = b.PluginRevision
-	x.xxx_hidden_ModuleCommitName = b.ModuleCommitName
+	x.xxx_hidden_Owner = b.Owner
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Commit = b.Commit
 	x.xxx_hidden_ModuleCommitCreateTime = b.ModuleCommitCreateTime
+	return m0
+}
+
+// PluginInfo is the parsed plugin information for the SDK.
+type GetParsedSDKVersionResponse_PluginInfo struct {
+	state                     protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Owner          string                 `protobuf:"bytes,1,opt,name=owner,proto3"`
+	xxx_hidden_Name           string                 `protobuf:"bytes,2,opt,name=name,proto3"`
+	xxx_hidden_Version        string                 `protobuf:"bytes,3,opt,name=version,proto3"`
+	xxx_hidden_PluginRevision uint32                 `protobuf:"varint,4,opt,name=plugin_revision,json=pluginRevision,proto3"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) Reset() {
+	*x = GetParsedSDKVersionResponse_PluginInfo{}
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetParsedSDKVersionResponse_PluginInfo) ProtoMessage() {}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) GetOwner() string {
+	if x != nil {
+		return x.xxx_hidden_Owner
+	}
+	return ""
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) GetVersion() string {
+	if x != nil {
+		return x.xxx_hidden_Version
+	}
+	return ""
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) GetPluginRevision() uint32 {
+	if x != nil {
+		return x.xxx_hidden_PluginRevision
+	}
+	return 0
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) SetOwner(v string) {
+	x.xxx_hidden_Owner = v
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) SetVersion(v string) {
+	x.xxx_hidden_Version = v
+}
+
+func (x *GetParsedSDKVersionResponse_PluginInfo) SetPluginRevision(v uint32) {
+	x.xxx_hidden_PluginRevision = v
+}
+
+type GetParsedSDKVersionResponse_PluginInfo_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The plugin owner.
+	Owner string
+	// The plugin name.
+	Name string
+	// The semver plugin version. This will always be valid semver.
+	Version string
+	// The plugin revision.
+	PluginRevision uint32
+}
+
+func (b0 GetParsedSDKVersionResponse_PluginInfo_builder) Build() *GetParsedSDKVersionResponse_PluginInfo {
+	m0 := &GetParsedSDKVersionResponse_PluginInfo{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Owner = b.Owner
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Version = b.Version
+	x.xxx_hidden_PluginRevision = b.PluginRevision
 	return m0
 }
 
@@ -2172,14 +2302,24 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x10module_reference\x18\x01 \x01(\v21.buf.alpha.registry.v1alpha1.LocalModuleReferenceR\x0fmoduleReference\x12e\n" +
 	"\x10plugin_reference\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetRemotePackageVersionPluginR\x0fpluginReference\x12\x1f\n" +
 	"\vsdk_version\x18\x03 \x01(\tR\n" +
-	"sdkVersion\"\x80\x03\n" +
-	"\x1bGetParsedSDKVersionResponse\x12w\n" +
-	"\x12parsed_sdk_version\x18\x01 \x01(\v2I.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersionR\x10parsedSdkVersion\x1a\xe7\x01\n" +
-	"\x10ParsedSDKVersion\x12%\n" +
-	"\x0eplugin_version\x18\x01 \x01(\tR\rpluginVersion\x12'\n" +
-	"\x0fplugin_revision\x18\x02 \x01(\rR\x0epluginRevision\x12,\n" +
-	"\x12module_commit_name\x18\x03 \x01(\tR\x10moduleCommitName\x12U\n" +
-	"\x19module_commit_create_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x16moduleCommitCreateTime*\xf1\x01\n" +
+	"sdkVersion\"\x8c\x04\n" +
+	"\x1bGetParsedSDKVersionResponse\x12d\n" +
+	"\vmodule_info\x18\x01 \x01(\v2C.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfoR\n" +
+	"moduleInfo\x12d\n" +
+	"\vplugin_info\x18\x02 \x01(\v2C.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.PluginInfoR\n" +
+	"pluginInfo\x1a\xa5\x01\n" +
+	"\n" +
+	"ModuleInfo\x12\x14\n" +
+	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +
+	"\x06commit\x18\x03 \x01(\tR\x06commit\x12U\n" +
+	"\x19module_commit_create_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x16moduleCommitCreateTime\x1ay\n" +
+	"\n" +
+	"PluginInfo\x12\x14\n" +
+	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\x12'\n" +
+	"\x0fplugin_revision\x18\x04 \x01(\rR\x0epluginRevision*\xf1\x01\n" +
 	"\x15ResolvedReferenceType\x12'\n" +
 	"#RESOLVED_REFERENCE_TYPE_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eRESOLVED_REFERENCE_TYPE_COMMIT\x10\x01\x12\"\n" +
@@ -2203,97 +2343,99 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x1fcom.buf.alpha.registry.v1alpha1B\fResolveProtoP\x01ZYgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1;registryv1alpha1\xa2\x02\x03BAR\xaa\x02\x1bBuf.Alpha.Registry.V1alpha1\xca\x02\x1bBuf\\Alpha\\Registry\\V1alpha1\xe2\x02'Buf\\Alpha\\Registry\\V1alpha1\\GPBMetadata\xea\x02\x1eBuf::Alpha::Registry::V1alpha1b\x06proto3"
 
 var file_buf_alpha_registry_v1alpha1_resolve_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_buf_alpha_registry_v1alpha1_resolve_proto_goTypes = []any{
-	(ResolvedReferenceType)(0),                           // 0: buf.alpha.registry.v1alpha1.ResolvedReferenceType
-	(*GetModulePinsRequest)(nil),                         // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest
-	(*GetModulePinsResponse)(nil),                        // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse
-	(*GetLocalModulePinsRequest)(nil),                    // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
-	(*LocalModuleResolveResult)(nil),                     // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult
-	(*GetLocalModulePinsResponse)(nil),                   // 5: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
-	(*GetGoVersionRequest)(nil),                          // 6: buf.alpha.registry.v1alpha1.GetGoVersionRequest
-	(*GetGoVersionResponse)(nil),                         // 7: buf.alpha.registry.v1alpha1.GetGoVersionResponse
-	(*GetMavenVersionRequest)(nil),                       // 8: buf.alpha.registry.v1alpha1.GetMavenVersionRequest
-	(*GetMavenVersionResponse)(nil),                      // 9: buf.alpha.registry.v1alpha1.GetMavenVersionResponse
-	(*GetNPMVersionRequest)(nil),                         // 10: buf.alpha.registry.v1alpha1.GetNPMVersionRequest
-	(*GetNPMVersionResponse)(nil),                        // 11: buf.alpha.registry.v1alpha1.GetNPMVersionResponse
-	(*GetSwiftVersionRequest)(nil),                       // 12: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
-	(*GetSwiftVersionResponse)(nil),                      // 13: buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
-	(*GetPythonVersionRequest)(nil),                      // 14: buf.alpha.registry.v1alpha1.GetPythonVersionRequest
-	(*GetPythonVersionResponse)(nil),                     // 15: buf.alpha.registry.v1alpha1.GetPythonVersionResponse
-	(*GetCargoVersionRequest)(nil),                       // 16: buf.alpha.registry.v1alpha1.GetCargoVersionRequest
-	(*GetCargoVersionResponse)(nil),                      // 17: buf.alpha.registry.v1alpha1.GetCargoVersionResponse
-	(*GetNugetVersionRequest)(nil),                       // 18: buf.alpha.registry.v1alpha1.GetNugetVersionRequest
-	(*GetNugetVersionResponse)(nil),                      // 19: buf.alpha.registry.v1alpha1.GetNugetVersionResponse
-	(*GetCmakeVersionRequest)(nil),                       // 20: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
-	(*GetCmakeVersionResponse)(nil),                      // 21: buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
-	(*GetRemotePackageVersionPlugin)(nil),                // 22: buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	(*GetParsedSDKVersionRequest)(nil),                   // 23: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
-	(*GetParsedSDKVersionResponse)(nil),                  // 24: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
-	(*GetParsedSDKVersionResponse_ParsedSDKVersion)(nil), // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersion
-	(*v1alpha1.ModuleReference)(nil),                     // 26: buf.alpha.module.v1alpha1.ModuleReference
-	(*v1alpha1.ModulePin)(nil),                           // 27: buf.alpha.module.v1alpha1.ModulePin
-	(*LocalModuleReference)(nil),                         // 28: buf.alpha.registry.v1alpha1.LocalModuleReference
-	(*LocalModulePin)(nil),                               // 29: buf.alpha.registry.v1alpha1.LocalModulePin
-	(*timestamppb.Timestamp)(nil),                        // 30: google.protobuf.Timestamp
+	(ResolvedReferenceType)(0),                     // 0: buf.alpha.registry.v1alpha1.ResolvedReferenceType
+	(*GetModulePinsRequest)(nil),                   // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest
+	(*GetModulePinsResponse)(nil),                  // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse
+	(*GetLocalModulePinsRequest)(nil),              // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
+	(*LocalModuleResolveResult)(nil),               // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult
+	(*GetLocalModulePinsResponse)(nil),             // 5: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
+	(*GetGoVersionRequest)(nil),                    // 6: buf.alpha.registry.v1alpha1.GetGoVersionRequest
+	(*GetGoVersionResponse)(nil),                   // 7: buf.alpha.registry.v1alpha1.GetGoVersionResponse
+	(*GetMavenVersionRequest)(nil),                 // 8: buf.alpha.registry.v1alpha1.GetMavenVersionRequest
+	(*GetMavenVersionResponse)(nil),                // 9: buf.alpha.registry.v1alpha1.GetMavenVersionResponse
+	(*GetNPMVersionRequest)(nil),                   // 10: buf.alpha.registry.v1alpha1.GetNPMVersionRequest
+	(*GetNPMVersionResponse)(nil),                  // 11: buf.alpha.registry.v1alpha1.GetNPMVersionResponse
+	(*GetSwiftVersionRequest)(nil),                 // 12: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
+	(*GetSwiftVersionResponse)(nil),                // 13: buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
+	(*GetPythonVersionRequest)(nil),                // 14: buf.alpha.registry.v1alpha1.GetPythonVersionRequest
+	(*GetPythonVersionResponse)(nil),               // 15: buf.alpha.registry.v1alpha1.GetPythonVersionResponse
+	(*GetCargoVersionRequest)(nil),                 // 16: buf.alpha.registry.v1alpha1.GetCargoVersionRequest
+	(*GetCargoVersionResponse)(nil),                // 17: buf.alpha.registry.v1alpha1.GetCargoVersionResponse
+	(*GetNugetVersionRequest)(nil),                 // 18: buf.alpha.registry.v1alpha1.GetNugetVersionRequest
+	(*GetNugetVersionResponse)(nil),                // 19: buf.alpha.registry.v1alpha1.GetNugetVersionResponse
+	(*GetCmakeVersionRequest)(nil),                 // 20: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
+	(*GetCmakeVersionResponse)(nil),                // 21: buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
+	(*GetRemotePackageVersionPlugin)(nil),          // 22: buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
+	(*GetParsedSDKVersionRequest)(nil),             // 23: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
+	(*GetParsedSDKVersionResponse)(nil),            // 24: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
+	(*GetParsedSDKVersionResponse_ModuleInfo)(nil), // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfo
+	(*GetParsedSDKVersionResponse_PluginInfo)(nil), // 26: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.PluginInfo
+	(*v1alpha1.ModuleReference)(nil),               // 27: buf.alpha.module.v1alpha1.ModuleReference
+	(*v1alpha1.ModulePin)(nil),                     // 28: buf.alpha.module.v1alpha1.ModulePin
+	(*LocalModuleReference)(nil),                   // 29: buf.alpha.registry.v1alpha1.LocalModuleReference
+	(*LocalModulePin)(nil),                         // 30: buf.alpha.registry.v1alpha1.LocalModulePin
+	(*timestamppb.Timestamp)(nil),                  // 31: google.protobuf.Timestamp
 }
 var file_buf_alpha_registry_v1alpha1_resolve_proto_depIdxs = []int32{
-	26, // 0: buf.alpha.registry.v1alpha1.GetModulePinsRequest.module_references:type_name -> buf.alpha.module.v1alpha1.ModuleReference
-	27, // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest.current_module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
-	27, // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse.module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
-	28, // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest.local_module_references:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	28, // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	29, // 5: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.pin:type_name -> buf.alpha.registry.v1alpha1.LocalModulePin
+	27, // 0: buf.alpha.registry.v1alpha1.GetModulePinsRequest.module_references:type_name -> buf.alpha.module.v1alpha1.ModuleReference
+	28, // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest.current_module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
+	28, // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse.module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
+	29, // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest.local_module_references:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	30, // 5: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.pin:type_name -> buf.alpha.registry.v1alpha1.LocalModulePin
 	0,  // 6: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.resolved_reference_type:type_name -> buf.alpha.registry.v1alpha1.ResolvedReferenceType
 	4,  // 7: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse.local_module_resolve_results:type_name -> buf.alpha.registry.v1alpha1.LocalModuleResolveResult
-	27, // 8: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse.dependencies:type_name -> buf.alpha.module.v1alpha1.ModulePin
+	28, // 8: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse.dependencies:type_name -> buf.alpha.module.v1alpha1.ModulePin
 	22, // 9: buf.alpha.registry.v1alpha1.GetGoVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 10: buf.alpha.registry.v1alpha1.GetGoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 10: buf.alpha.registry.v1alpha1.GetGoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 11: buf.alpha.registry.v1alpha1.GetMavenVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 12: buf.alpha.registry.v1alpha1.GetMavenVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 12: buf.alpha.registry.v1alpha1.GetMavenVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 13: buf.alpha.registry.v1alpha1.GetNPMVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 14: buf.alpha.registry.v1alpha1.GetNPMVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 14: buf.alpha.registry.v1alpha1.GetNPMVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 15: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 16: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 16: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 17: buf.alpha.registry.v1alpha1.GetPythonVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 18: buf.alpha.registry.v1alpha1.GetPythonVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 18: buf.alpha.registry.v1alpha1.GetPythonVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 19: buf.alpha.registry.v1alpha1.GetCargoVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 20: buf.alpha.registry.v1alpha1.GetCargoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 20: buf.alpha.registry.v1alpha1.GetCargoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 21: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 22: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 22: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 23: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	28, // 24: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	28, // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 24: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 26: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 27: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.parsed_sdk_version:type_name -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersion
-	30, // 28: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersion.module_commit_create_time:type_name -> google.protobuf.Timestamp
-	1,  // 29: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:input_type -> buf.alpha.registry.v1alpha1.GetModulePinsRequest
-	6,  // 30: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:input_type -> buf.alpha.registry.v1alpha1.GetGoVersionRequest
-	12, // 31: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:input_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
-	8,  // 32: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:input_type -> buf.alpha.registry.v1alpha1.GetMavenVersionRequest
-	10, // 33: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:input_type -> buf.alpha.registry.v1alpha1.GetNPMVersionRequest
-	14, // 34: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:input_type -> buf.alpha.registry.v1alpha1.GetPythonVersionRequest
-	16, // 35: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:input_type -> buf.alpha.registry.v1alpha1.GetCargoVersionRequest
-	18, // 36: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:input_type -> buf.alpha.registry.v1alpha1.GetNugetVersionRequest
-	20, // 37: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:input_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
-	23, // 38: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:input_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
-	3,  // 39: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:input_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
-	2,  // 40: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:output_type -> buf.alpha.registry.v1alpha1.GetModulePinsResponse
-	7,  // 41: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:output_type -> buf.alpha.registry.v1alpha1.GetGoVersionResponse
-	13, // 42: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:output_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
-	9,  // 43: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:output_type -> buf.alpha.registry.v1alpha1.GetMavenVersionResponse
-	11, // 44: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:output_type -> buf.alpha.registry.v1alpha1.GetNPMVersionResponse
-	15, // 45: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:output_type -> buf.alpha.registry.v1alpha1.GetPythonVersionResponse
-	17, // 46: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:output_type -> buf.alpha.registry.v1alpha1.GetCargoVersionResponse
-	19, // 47: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:output_type -> buf.alpha.registry.v1alpha1.GetNugetVersionResponse
-	21, // 48: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:output_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
-	24, // 49: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:output_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
-	5,  // 50: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:output_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
-	40, // [40:51] is the sub-list for method output_type
-	29, // [29:40] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	25, // 27: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.module_info:type_name -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfo
+	26, // 28: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.plugin_info:type_name -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.PluginInfo
+	31, // 29: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfo.module_commit_create_time:type_name -> google.protobuf.Timestamp
+	1,  // 30: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:input_type -> buf.alpha.registry.v1alpha1.GetModulePinsRequest
+	6,  // 31: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:input_type -> buf.alpha.registry.v1alpha1.GetGoVersionRequest
+	12, // 32: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:input_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
+	8,  // 33: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:input_type -> buf.alpha.registry.v1alpha1.GetMavenVersionRequest
+	10, // 34: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:input_type -> buf.alpha.registry.v1alpha1.GetNPMVersionRequest
+	14, // 35: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:input_type -> buf.alpha.registry.v1alpha1.GetPythonVersionRequest
+	16, // 36: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:input_type -> buf.alpha.registry.v1alpha1.GetCargoVersionRequest
+	18, // 37: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:input_type -> buf.alpha.registry.v1alpha1.GetNugetVersionRequest
+	20, // 38: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:input_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
+	23, // 39: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:input_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
+	3,  // 40: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:input_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
+	2,  // 41: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:output_type -> buf.alpha.registry.v1alpha1.GetModulePinsResponse
+	7,  // 42: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:output_type -> buf.alpha.registry.v1alpha1.GetGoVersionResponse
+	13, // 43: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:output_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
+	9,  // 44: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:output_type -> buf.alpha.registry.v1alpha1.GetMavenVersionResponse
+	11, // 45: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:output_type -> buf.alpha.registry.v1alpha1.GetNPMVersionResponse
+	15, // 46: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:output_type -> buf.alpha.registry.v1alpha1.GetPythonVersionResponse
+	17, // 47: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:output_type -> buf.alpha.registry.v1alpha1.GetCargoVersionResponse
+	19, // 48: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:output_type -> buf.alpha.registry.v1alpha1.GetNugetVersionResponse
+	21, // 49: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:output_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
+	24, // 50: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:output_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
+	5,  // 51: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:output_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
+	41, // [41:52] is the sub-list for method output_type
+	30, // [30:41] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_buf_alpha_registry_v1alpha1_resolve_proto_init() }
@@ -2308,7 +2450,7 @@ func file_buf_alpha_registry_v1alpha1_resolve_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc), len(file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   25,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
@@ -24,6 +24,7 @@ import (
 	v1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/module/v1alpha1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	unsafe "unsafe"
 )
@@ -1810,11 +1811,289 @@ func (b0 GetRemotePackageVersionPlugin_builder) Build() *GetRemotePackageVersion
 	return m0
 }
 
+type GetParsedSDKVersionRequest struct {
+	state                      protoimpl.MessageState         `protogen:"opaque.v1"`
+	xxx_hidden_ModuleReference *LocalModuleReference          `protobuf:"bytes,1,opt,name=module_reference,json=moduleReference,proto3"`
+	xxx_hidden_PluginReference *GetRemotePackageVersionPlugin `protobuf:"bytes,2,opt,name=plugin_reference,json=pluginReference,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *GetParsedSDKVersionRequest) Reset() {
+	*x = GetParsedSDKVersionRequest{}
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetParsedSDKVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetParsedSDKVersionRequest) ProtoMessage() {}
+
+func (x *GetParsedSDKVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetParsedSDKVersionRequest) GetModuleReference() *LocalModuleReference {
+	if x != nil {
+		return x.xxx_hidden_ModuleReference
+	}
+	return nil
+}
+
+func (x *GetParsedSDKVersionRequest) GetPluginReference() *GetRemotePackageVersionPlugin {
+	if x != nil {
+		return x.xxx_hidden_PluginReference
+	}
+	return nil
+}
+
+func (x *GetParsedSDKVersionRequest) SetModuleReference(v *LocalModuleReference) {
+	x.xxx_hidden_ModuleReference = v
+}
+
+func (x *GetParsedSDKVersionRequest) SetPluginReference(v *GetRemotePackageVersionPlugin) {
+	x.xxx_hidden_PluginReference = v
+}
+
+func (x *GetParsedSDKVersionRequest) HasModuleReference() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ModuleReference != nil
+}
+
+func (x *GetParsedSDKVersionRequest) HasPluginReference() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_PluginReference != nil
+}
+
+func (x *GetParsedSDKVersionRequest) ClearModuleReference() {
+	x.xxx_hidden_ModuleReference = nil
+}
+
+func (x *GetParsedSDKVersionRequest) ClearPluginReference() {
+	x.xxx_hidden_PluginReference = nil
+}
+
+type GetParsedSDKVersionRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	ModuleReference *LocalModuleReference
+	PluginReference *GetRemotePackageVersionPlugin
+}
+
+func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest {
+	m0 := &GetParsedSDKVersionRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_ModuleReference = b.ModuleReference
+	x.xxx_hidden_PluginReference = b.PluginReference
+	return m0
+}
+
+type GetParsedSDKVersionResponse struct {
+	state                       protoimpl.MessageState                        `protogen:"opaque.v1"`
+	xxx_hidden_ParsedSdkVersion *GetParsedSDKVersionResponse_ParsedSDKVersion `protobuf:"bytes,1,opt,name=parsed_sdk_version,json=parsedSdkVersion,proto3"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
+}
+
+func (x *GetParsedSDKVersionResponse) Reset() {
+	*x = GetParsedSDKVersionResponse{}
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetParsedSDKVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetParsedSDKVersionResponse) ProtoMessage() {}
+
+func (x *GetParsedSDKVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetParsedSDKVersionResponse) GetParsedSdkVersion() *GetParsedSDKVersionResponse_ParsedSDKVersion {
+	if x != nil {
+		return x.xxx_hidden_ParsedSdkVersion
+	}
+	return nil
+}
+
+func (x *GetParsedSDKVersionResponse) SetParsedSdkVersion(v *GetParsedSDKVersionResponse_ParsedSDKVersion) {
+	x.xxx_hidden_ParsedSdkVersion = v
+}
+
+func (x *GetParsedSDKVersionResponse) HasParsedSdkVersion() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ParsedSdkVersion != nil
+}
+
+func (x *GetParsedSDKVersionResponse) ClearParsedSdkVersion() {
+	x.xxx_hidden_ParsedSdkVersion = nil
+}
+
+type GetParsedSDKVersionResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	ParsedSdkVersion *GetParsedSDKVersionResponse_ParsedSDKVersion
+}
+
+func (b0 GetParsedSDKVersionResponse_builder) Build() *GetParsedSDKVersionResponse {
+	m0 := &GetParsedSDKVersionResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_ParsedSdkVersion = b.ParsedSdkVersion
+	return m0
+}
+
+type GetParsedSDKVersionResponse_ParsedSDKVersion struct {
+	state                             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PluginVersion          string                 `protobuf:"bytes,1,opt,name=plugin_version,json=pluginVersion,proto3"`
+	xxx_hidden_PluginRevision         uint32                 `protobuf:"varint,2,opt,name=plugin_revision,json=pluginRevision,proto3"`
+	xxx_hidden_ModuleCommitName       string                 `protobuf:"bytes,3,opt,name=module_commit_name,json=moduleCommitName,proto3"`
+	xxx_hidden_ModuleCommitCreateTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=module_commit_create_time,json=moduleCommitCreateTime,proto3"`
+	unknownFields                     protoimpl.UnknownFields
+	sizeCache                         protoimpl.SizeCache
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) Reset() {
+	*x = GetParsedSDKVersionResponse_ParsedSDKVersion{}
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetParsedSDKVersionResponse_ParsedSDKVersion) ProtoMessage() {}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetPluginVersion() string {
+	if x != nil {
+		return x.xxx_hidden_PluginVersion
+	}
+	return ""
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetPluginRevision() uint32 {
+	if x != nil {
+		return x.xxx_hidden_PluginRevision
+	}
+	return 0
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetModuleCommitName() string {
+	if x != nil {
+		return x.xxx_hidden_ModuleCommitName
+	}
+	return ""
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) GetModuleCommitCreateTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_ModuleCommitCreateTime
+	}
+	return nil
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetPluginVersion(v string) {
+	x.xxx_hidden_PluginVersion = v
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetPluginRevision(v uint32) {
+	x.xxx_hidden_PluginRevision = v
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetModuleCommitName(v string) {
+	x.xxx_hidden_ModuleCommitName = v
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) SetModuleCommitCreateTime(v *timestamppb.Timestamp) {
+	x.xxx_hidden_ModuleCommitCreateTime = v
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) HasModuleCommitCreateTime() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ModuleCommitCreateTime != nil
+}
+
+func (x *GetParsedSDKVersionResponse_ParsedSDKVersion) ClearModuleCommitCreateTime() {
+	x.xxx_hidden_ModuleCommitCreateTime = nil
+}
+
+type GetParsedSDKVersionResponse_ParsedSDKVersion_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The plugin version of the plugin used to generate the SDK version.
+	// This will always be valid semver.
+	PluginVersion string
+	// The revision of the plugin version.
+	PluginRevision uint32
+	// This is the short version of the module commit name, at least 12 char in length.
+	ModuleCommitName string
+	// This is the creation time of the module commit.
+	//
+	// This will always be in UTC. This may be empty.
+	ModuleCommitCreateTime *timestamppb.Timestamp
+}
+
+func (b0 GetParsedSDKVersionResponse_ParsedSDKVersion_builder) Build() *GetParsedSDKVersionResponse_ParsedSDKVersion {
+	m0 := &GetParsedSDKVersionResponse_ParsedSDKVersion{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PluginVersion = b.PluginVersion
+	x.xxx_hidden_PluginRevision = b.PluginRevision
+	x.xxx_hidden_ModuleCommitName = b.ModuleCommitName
+	x.xxx_hidden_ModuleCommitCreateTime = b.ModuleCommitCreateTime
+	return m0
+}
+
 var File_buf_alpha_registry_v1alpha1_resolve_proto protoreflect.FileDescriptor
 
 const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\n" +
-	")buf/alpha/registry/v1alpha1/resolve.proto\x12\x1bbuf.alpha.registry.v1alpha1\x1a&buf/alpha/module/v1alpha1/module.proto\x1a(buf/alpha/registry/v1alpha1/module.proto\"\xc5\x01\n" +
+	")buf/alpha/registry/v1alpha1/resolve.proto\x12\x1bbuf.alpha.registry.v1alpha1\x1a&buf/alpha/module/v1alpha1/module.proto\x1a(buf/alpha/registry/v1alpha1/module.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc5\x01\n" +
 	"\x14GetModulePinsRequest\x12W\n" +
 	"\x11module_references\x18\x01 \x03(\v2*.buf.alpha.module.v1alpha1.ModuleReferenceR\x10moduleReferences\x12T\n" +
 	"\x13current_module_pins\x18\x02 \x03(\v2$.buf.alpha.module.v1alpha1.ModulePinR\x11currentModulePins\"^\n" +
@@ -1874,13 +2153,24 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12\x1a\n" +
-	"\brevision\x18\x04 \x01(\rR\brevision*\xf1\x01\n" +
+	"\brevision\x18\x04 \x01(\rR\brevision\"\xe1\x01\n" +
+	"\x1aGetParsedSDKVersionRequest\x12\\\n" +
+	"\x10module_reference\x18\x01 \x01(\v21.buf.alpha.registry.v1alpha1.LocalModuleReferenceR\x0fmoduleReference\x12e\n" +
+	"\x10plugin_reference\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetRemotePackageVersionPluginR\x0fpluginReference\"\x80\x03\n" +
+	"\x1bGetParsedSDKVersionResponse\x12w\n" +
+	"\x12parsed_sdk_version\x18\x01 \x01(\v2I.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersionR\x10parsedSdkVersion\x1a\xe7\x01\n" +
+	"\x10ParsedSDKVersion\x12%\n" +
+	"\x0eplugin_version\x18\x01 \x01(\tR\rpluginVersion\x12'\n" +
+	"\x0fplugin_revision\x18\x02 \x01(\rR\x0epluginRevision\x12,\n" +
+	"\x12module_commit_name\x18\x03 \x01(\tR\x10moduleCommitName\x12U\n" +
+	"\x19module_commit_create_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x16moduleCommitCreateTime*\xf1\x01\n" +
 	"\x15ResolvedReferenceType\x12'\n" +
 	"#RESOLVED_REFERENCE_TYPE_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eRESOLVED_REFERENCE_TYPE_COMMIT\x10\x01\x12\"\n" +
 	"\x1eRESOLVED_REFERENCE_TYPE_BRANCH\x10\x02\x12\x1f\n" +
 	"\x1bRESOLVED_REFERENCE_TYPE_TAG\x10\x03\x12!\n" +
-	"\x1dRESOLVED_REFERENCE_TYPE_DRAFT\x10\x05\"\x04\b\x04\x10\x04*\x1dRESOLVED_REFERENCE_TYPE_TRACK2\x9f\t\n" +
+	"\x1dRESOLVED_REFERENCE_TYPE_DRAFT\x10\x05\"\x04\b\x04\x10\x04*\x1dRESOLVED_REFERENCE_TYPE_TRACK2\xaf\n" +
+	"\n" +
 	"\x0eResolveService\x12{\n" +
 	"\rGetModulePins\x121.buf.alpha.registry.v1alpha1.GetModulePinsRequest\x1a2.buf.alpha.registry.v1alpha1.GetModulePinsResponse\"\x03\x90\x02\x01\x12x\n" +
 	"\fGetGoVersion\x120.buf.alpha.registry.v1alpha1.GetGoVersionRequest\x1a1.buf.alpha.registry.v1alpha1.GetGoVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
@@ -1890,93 +2180,104 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x10GetPythonVersion\x124.buf.alpha.registry.v1alpha1.GetPythonVersionRequest\x1a5.buf.alpha.registry.v1alpha1.GetPythonVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
 	"\x0fGetCargoVersion\x123.buf.alpha.registry.v1alpha1.GetCargoVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetCargoVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
 	"\x0fGetNugetVersion\x123.buf.alpha.registry.v1alpha1.GetNugetVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetNugetVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
-	"\x0fGetCmakeVersion\x123.buf.alpha.registry.v1alpha1.GetCmakeVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetCmakeVersionResponse\"\x03\x90\x02\x012\xa2\x01\n" +
+	"\x0fGetCmakeVersion\x123.buf.alpha.registry.v1alpha1.GetCmakeVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetCmakeVersionResponse\"\x03\x90\x02\x01\x12\x8d\x01\n" +
+	"\x13GetParsedSDKVersion\x127.buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest\x1a8.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse\"\x03\x90\x02\x012\xa2\x01\n" +
 	"\x13LocalResolveService\x12\x8a\x01\n" +
 	"\x12GetLocalModulePins\x126.buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest\x1a7.buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse\"\x03\x90\x02\x01B\x99\x02\n" +
 	"\x1fcom.buf.alpha.registry.v1alpha1B\fResolveProtoP\x01ZYgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1;registryv1alpha1\xa2\x02\x03BAR\xaa\x02\x1bBuf.Alpha.Registry.V1alpha1\xca\x02\x1bBuf\\Alpha\\Registry\\V1alpha1\xe2\x02'Buf\\Alpha\\Registry\\V1alpha1\\GPBMetadata\xea\x02\x1eBuf::Alpha::Registry::V1alpha1b\x06proto3"
 
 var file_buf_alpha_registry_v1alpha1_resolve_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_buf_alpha_registry_v1alpha1_resolve_proto_goTypes = []any{
-	(ResolvedReferenceType)(0),            // 0: buf.alpha.registry.v1alpha1.ResolvedReferenceType
-	(*GetModulePinsRequest)(nil),          // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest
-	(*GetModulePinsResponse)(nil),         // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse
-	(*GetLocalModulePinsRequest)(nil),     // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
-	(*LocalModuleResolveResult)(nil),      // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult
-	(*GetLocalModulePinsResponse)(nil),    // 5: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
-	(*GetGoVersionRequest)(nil),           // 6: buf.alpha.registry.v1alpha1.GetGoVersionRequest
-	(*GetGoVersionResponse)(nil),          // 7: buf.alpha.registry.v1alpha1.GetGoVersionResponse
-	(*GetMavenVersionRequest)(nil),        // 8: buf.alpha.registry.v1alpha1.GetMavenVersionRequest
-	(*GetMavenVersionResponse)(nil),       // 9: buf.alpha.registry.v1alpha1.GetMavenVersionResponse
-	(*GetNPMVersionRequest)(nil),          // 10: buf.alpha.registry.v1alpha1.GetNPMVersionRequest
-	(*GetNPMVersionResponse)(nil),         // 11: buf.alpha.registry.v1alpha1.GetNPMVersionResponse
-	(*GetSwiftVersionRequest)(nil),        // 12: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
-	(*GetSwiftVersionResponse)(nil),       // 13: buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
-	(*GetPythonVersionRequest)(nil),       // 14: buf.alpha.registry.v1alpha1.GetPythonVersionRequest
-	(*GetPythonVersionResponse)(nil),      // 15: buf.alpha.registry.v1alpha1.GetPythonVersionResponse
-	(*GetCargoVersionRequest)(nil),        // 16: buf.alpha.registry.v1alpha1.GetCargoVersionRequest
-	(*GetCargoVersionResponse)(nil),       // 17: buf.alpha.registry.v1alpha1.GetCargoVersionResponse
-	(*GetNugetVersionRequest)(nil),        // 18: buf.alpha.registry.v1alpha1.GetNugetVersionRequest
-	(*GetNugetVersionResponse)(nil),       // 19: buf.alpha.registry.v1alpha1.GetNugetVersionResponse
-	(*GetCmakeVersionRequest)(nil),        // 20: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
-	(*GetCmakeVersionResponse)(nil),       // 21: buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
-	(*GetRemotePackageVersionPlugin)(nil), // 22: buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	(*v1alpha1.ModuleReference)(nil),      // 23: buf.alpha.module.v1alpha1.ModuleReference
-	(*v1alpha1.ModulePin)(nil),            // 24: buf.alpha.module.v1alpha1.ModulePin
-	(*LocalModuleReference)(nil),          // 25: buf.alpha.registry.v1alpha1.LocalModuleReference
-	(*LocalModulePin)(nil),                // 26: buf.alpha.registry.v1alpha1.LocalModulePin
+	(ResolvedReferenceType)(0),                           // 0: buf.alpha.registry.v1alpha1.ResolvedReferenceType
+	(*GetModulePinsRequest)(nil),                         // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest
+	(*GetModulePinsResponse)(nil),                        // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse
+	(*GetLocalModulePinsRequest)(nil),                    // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
+	(*LocalModuleResolveResult)(nil),                     // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult
+	(*GetLocalModulePinsResponse)(nil),                   // 5: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
+	(*GetGoVersionRequest)(nil),                          // 6: buf.alpha.registry.v1alpha1.GetGoVersionRequest
+	(*GetGoVersionResponse)(nil),                         // 7: buf.alpha.registry.v1alpha1.GetGoVersionResponse
+	(*GetMavenVersionRequest)(nil),                       // 8: buf.alpha.registry.v1alpha1.GetMavenVersionRequest
+	(*GetMavenVersionResponse)(nil),                      // 9: buf.alpha.registry.v1alpha1.GetMavenVersionResponse
+	(*GetNPMVersionRequest)(nil),                         // 10: buf.alpha.registry.v1alpha1.GetNPMVersionRequest
+	(*GetNPMVersionResponse)(nil),                        // 11: buf.alpha.registry.v1alpha1.GetNPMVersionResponse
+	(*GetSwiftVersionRequest)(nil),                       // 12: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
+	(*GetSwiftVersionResponse)(nil),                      // 13: buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
+	(*GetPythonVersionRequest)(nil),                      // 14: buf.alpha.registry.v1alpha1.GetPythonVersionRequest
+	(*GetPythonVersionResponse)(nil),                     // 15: buf.alpha.registry.v1alpha1.GetPythonVersionResponse
+	(*GetCargoVersionRequest)(nil),                       // 16: buf.alpha.registry.v1alpha1.GetCargoVersionRequest
+	(*GetCargoVersionResponse)(nil),                      // 17: buf.alpha.registry.v1alpha1.GetCargoVersionResponse
+	(*GetNugetVersionRequest)(nil),                       // 18: buf.alpha.registry.v1alpha1.GetNugetVersionRequest
+	(*GetNugetVersionResponse)(nil),                      // 19: buf.alpha.registry.v1alpha1.GetNugetVersionResponse
+	(*GetCmakeVersionRequest)(nil),                       // 20: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
+	(*GetCmakeVersionResponse)(nil),                      // 21: buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
+	(*GetRemotePackageVersionPlugin)(nil),                // 22: buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
+	(*GetParsedSDKVersionRequest)(nil),                   // 23: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
+	(*GetParsedSDKVersionResponse)(nil),                  // 24: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
+	(*GetParsedSDKVersionResponse_ParsedSDKVersion)(nil), // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersion
+	(*v1alpha1.ModuleReference)(nil),                     // 26: buf.alpha.module.v1alpha1.ModuleReference
+	(*v1alpha1.ModulePin)(nil),                           // 27: buf.alpha.module.v1alpha1.ModulePin
+	(*LocalModuleReference)(nil),                         // 28: buf.alpha.registry.v1alpha1.LocalModuleReference
+	(*LocalModulePin)(nil),                               // 29: buf.alpha.registry.v1alpha1.LocalModulePin
+	(*timestamppb.Timestamp)(nil),                        // 30: google.protobuf.Timestamp
 }
 var file_buf_alpha_registry_v1alpha1_resolve_proto_depIdxs = []int32{
-	23, // 0: buf.alpha.registry.v1alpha1.GetModulePinsRequest.module_references:type_name -> buf.alpha.module.v1alpha1.ModuleReference
-	24, // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest.current_module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
-	24, // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse.module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
-	25, // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest.local_module_references:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	25, // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	26, // 5: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.pin:type_name -> buf.alpha.registry.v1alpha1.LocalModulePin
+	26, // 0: buf.alpha.registry.v1alpha1.GetModulePinsRequest.module_references:type_name -> buf.alpha.module.v1alpha1.ModuleReference
+	27, // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest.current_module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
+	27, // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse.module_pins:type_name -> buf.alpha.module.v1alpha1.ModulePin
+	28, // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest.local_module_references:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	29, // 5: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.pin:type_name -> buf.alpha.registry.v1alpha1.LocalModulePin
 	0,  // 6: buf.alpha.registry.v1alpha1.LocalModuleResolveResult.resolved_reference_type:type_name -> buf.alpha.registry.v1alpha1.ResolvedReferenceType
 	4,  // 7: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse.local_module_resolve_results:type_name -> buf.alpha.registry.v1alpha1.LocalModuleResolveResult
-	24, // 8: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse.dependencies:type_name -> buf.alpha.module.v1alpha1.ModulePin
+	27, // 8: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse.dependencies:type_name -> buf.alpha.module.v1alpha1.ModulePin
 	22, // 9: buf.alpha.registry.v1alpha1.GetGoVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 10: buf.alpha.registry.v1alpha1.GetGoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 10: buf.alpha.registry.v1alpha1.GetGoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 11: buf.alpha.registry.v1alpha1.GetMavenVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 12: buf.alpha.registry.v1alpha1.GetMavenVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 12: buf.alpha.registry.v1alpha1.GetMavenVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 13: buf.alpha.registry.v1alpha1.GetNPMVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 14: buf.alpha.registry.v1alpha1.GetNPMVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 14: buf.alpha.registry.v1alpha1.GetNPMVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 15: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 16: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 16: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 17: buf.alpha.registry.v1alpha1.GetPythonVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 18: buf.alpha.registry.v1alpha1.GetPythonVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 18: buf.alpha.registry.v1alpha1.GetPythonVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 19: buf.alpha.registry.v1alpha1.GetCargoVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 20: buf.alpha.registry.v1alpha1.GetCargoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 20: buf.alpha.registry.v1alpha1.GetCargoVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 21: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 22: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 22: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 23: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 24: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	1,  // 25: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:input_type -> buf.alpha.registry.v1alpha1.GetModulePinsRequest
-	6,  // 26: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:input_type -> buf.alpha.registry.v1alpha1.GetGoVersionRequest
-	12, // 27: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:input_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
-	8,  // 28: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:input_type -> buf.alpha.registry.v1alpha1.GetMavenVersionRequest
-	10, // 29: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:input_type -> buf.alpha.registry.v1alpha1.GetNPMVersionRequest
-	14, // 30: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:input_type -> buf.alpha.registry.v1alpha1.GetPythonVersionRequest
-	16, // 31: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:input_type -> buf.alpha.registry.v1alpha1.GetCargoVersionRequest
-	18, // 32: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:input_type -> buf.alpha.registry.v1alpha1.GetNugetVersionRequest
-	20, // 33: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:input_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
-	3,  // 34: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:input_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
-	2,  // 35: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:output_type -> buf.alpha.registry.v1alpha1.GetModulePinsResponse
-	7,  // 36: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:output_type -> buf.alpha.registry.v1alpha1.GetGoVersionResponse
-	13, // 37: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:output_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
-	9,  // 38: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:output_type -> buf.alpha.registry.v1alpha1.GetMavenVersionResponse
-	11, // 39: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:output_type -> buf.alpha.registry.v1alpha1.GetNPMVersionResponse
-	15, // 40: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:output_type -> buf.alpha.registry.v1alpha1.GetPythonVersionResponse
-	17, // 41: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:output_type -> buf.alpha.registry.v1alpha1.GetCargoVersionResponse
-	19, // 42: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:output_type -> buf.alpha.registry.v1alpha1.GetNugetVersionResponse
-	21, // 43: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:output_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
-	5,  // 44: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:output_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
-	35, // [35:45] is the sub-list for method output_type
-	25, // [25:35] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	28, // 24: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	28, // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	22, // 26: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
+	25, // 27: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.parsed_sdk_version:type_name -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersion
+	30, // 28: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ParsedSDKVersion.module_commit_create_time:type_name -> google.protobuf.Timestamp
+	1,  // 29: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:input_type -> buf.alpha.registry.v1alpha1.GetModulePinsRequest
+	6,  // 30: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:input_type -> buf.alpha.registry.v1alpha1.GetGoVersionRequest
+	12, // 31: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:input_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
+	8,  // 32: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:input_type -> buf.alpha.registry.v1alpha1.GetMavenVersionRequest
+	10, // 33: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:input_type -> buf.alpha.registry.v1alpha1.GetNPMVersionRequest
+	14, // 34: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:input_type -> buf.alpha.registry.v1alpha1.GetPythonVersionRequest
+	16, // 35: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:input_type -> buf.alpha.registry.v1alpha1.GetCargoVersionRequest
+	18, // 36: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:input_type -> buf.alpha.registry.v1alpha1.GetNugetVersionRequest
+	20, // 37: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:input_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
+	23, // 38: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:input_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
+	3,  // 39: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:input_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
+	2,  // 40: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:output_type -> buf.alpha.registry.v1alpha1.GetModulePinsResponse
+	7,  // 41: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:output_type -> buf.alpha.registry.v1alpha1.GetGoVersionResponse
+	13, // 42: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:output_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
+	9,  // 43: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:output_type -> buf.alpha.registry.v1alpha1.GetMavenVersionResponse
+	11, // 44: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:output_type -> buf.alpha.registry.v1alpha1.GetNPMVersionResponse
+	15, // 45: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:output_type -> buf.alpha.registry.v1alpha1.GetPythonVersionResponse
+	17, // 46: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:output_type -> buf.alpha.registry.v1alpha1.GetCargoVersionResponse
+	19, // 47: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:output_type -> buf.alpha.registry.v1alpha1.GetNugetVersionResponse
+	21, // 48: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:output_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
+	24, // 49: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:output_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
+	5,  // 50: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:output_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
+	40, // [40:51] is the sub-list for method output_type
+	29, // [29:40] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_buf_alpha_registry_v1alpha1_resolve_proto_init() }
@@ -1991,7 +2292,7 @@ func file_buf_alpha_registry_v1alpha1_resolve_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc), len(file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   22,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
@@ -1811,7 +1811,7 @@ func (b0 GetRemotePackageVersionPlugin_builder) Build() *GetRemotePackageVersion
 	return m0
 }
 
-type GetParsedSDKVersionRequest struct {
+type GetSDKInfoRequest struct {
 	state                      protoimpl.MessageState         `protogen:"opaque.v1"`
 	xxx_hidden_ModuleReference *LocalModuleReference          `protobuf:"bytes,1,opt,name=module_reference,json=moduleReference,proto3"`
 	xxx_hidden_PluginReference *GetRemotePackageVersionPlugin `protobuf:"bytes,2,opt,name=plugin_reference,json=pluginReference,proto3"`
@@ -1820,20 +1820,20 @@ type GetParsedSDKVersionRequest struct {
 	sizeCache                  protoimpl.SizeCache
 }
 
-func (x *GetParsedSDKVersionRequest) Reset() {
-	*x = GetParsedSDKVersionRequest{}
+func (x *GetSDKInfoRequest) Reset() {
+	*x = GetSDKInfoRequest{}
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetParsedSDKVersionRequest) String() string {
+func (x *GetSDKInfoRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetParsedSDKVersionRequest) ProtoMessage() {}
+func (*GetSDKInfoRequest) ProtoMessage() {}
 
-func (x *GetParsedSDKVersionRequest) ProtoReflect() protoreflect.Message {
+func (x *GetSDKInfoRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1845,74 +1845,75 @@ func (x *GetParsedSDKVersionRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *GetParsedSDKVersionRequest) GetModuleReference() *LocalModuleReference {
+func (x *GetSDKInfoRequest) GetModuleReference() *LocalModuleReference {
 	if x != nil {
 		return x.xxx_hidden_ModuleReference
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionRequest) GetPluginReference() *GetRemotePackageVersionPlugin {
+func (x *GetSDKInfoRequest) GetPluginReference() *GetRemotePackageVersionPlugin {
 	if x != nil {
 		return x.xxx_hidden_PluginReference
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionRequest) GetSdkVersion() string {
+func (x *GetSDKInfoRequest) GetSdkVersion() string {
 	if x != nil {
 		return x.xxx_hidden_SdkVersion
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionRequest) SetModuleReference(v *LocalModuleReference) {
+func (x *GetSDKInfoRequest) SetModuleReference(v *LocalModuleReference) {
 	x.xxx_hidden_ModuleReference = v
 }
 
-func (x *GetParsedSDKVersionRequest) SetPluginReference(v *GetRemotePackageVersionPlugin) {
+func (x *GetSDKInfoRequest) SetPluginReference(v *GetRemotePackageVersionPlugin) {
 	x.xxx_hidden_PluginReference = v
 }
 
-func (x *GetParsedSDKVersionRequest) SetSdkVersion(v string) {
+func (x *GetSDKInfoRequest) SetSdkVersion(v string) {
 	x.xxx_hidden_SdkVersion = v
 }
 
-func (x *GetParsedSDKVersionRequest) HasModuleReference() bool {
+func (x *GetSDKInfoRequest) HasModuleReference() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_ModuleReference != nil
 }
 
-func (x *GetParsedSDKVersionRequest) HasPluginReference() bool {
+func (x *GetSDKInfoRequest) HasPluginReference() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_PluginReference != nil
 }
 
-func (x *GetParsedSDKVersionRequest) ClearModuleReference() {
+func (x *GetSDKInfoRequest) ClearModuleReference() {
 	x.xxx_hidden_ModuleReference = nil
 }
 
-func (x *GetParsedSDKVersionRequest) ClearPluginReference() {
+func (x *GetSDKInfoRequest) ClearPluginReference() {
 	x.xxx_hidden_PluginReference = nil
 }
 
-type GetParsedSDKVersionRequest_builder struct {
+type GetSDKInfoRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// The local module reference to parse.
+	// The local module reference for the SDK.
 	ModuleReference *LocalModuleReference
-	// The plugin reference to parse.
+	// The plugin reference for the SDK.
 	PluginReference *GetRemotePackageVersionPlugin
-	// The SDK version to parse.
+	// The SDK version string. If this is not provided, then it will be resolved using the module
+	// and plugin references provided.
 	SdkVersion string
 }
 
-func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest {
-	m0 := &GetParsedSDKVersionRequest{}
+func (b0 GetSDKInfoRequest_builder) Build() *GetSDKInfoRequest {
+	m0 := &GetSDKInfoRequest{}
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_ModuleReference = b.ModuleReference
@@ -1921,28 +1922,29 @@ func (b0 GetParsedSDKVersionRequest_builder) Build() *GetParsedSDKVersionRequest
 	return m0
 }
 
-type GetParsedSDKVersionResponse struct {
-	state                 protoimpl.MessageState                  `protogen:"opaque.v1"`
-	xxx_hidden_ModuleInfo *GetParsedSDKVersionResponse_ModuleInfo `protobuf:"bytes,1,opt,name=module_info,json=moduleInfo,proto3"`
-	xxx_hidden_PluginInfo *GetParsedSDKVersionResponse_PluginInfo `protobuf:"bytes,2,opt,name=plugin_info,json=pluginInfo,proto3"`
+type GetSDKInfoResponse struct {
+	state                 protoimpl.MessageState         `protogen:"opaque.v1"`
+	xxx_hidden_ModuleInfo *GetSDKInfoResponse_ModuleInfo `protobuf:"bytes,1,opt,name=module_info,json=moduleInfo,proto3"`
+	xxx_hidden_PluginInfo *GetSDKInfoResponse_PluginInfo `protobuf:"bytes,2,opt,name=plugin_info,json=pluginInfo,proto3"`
+	xxx_hidden_Version    string                         `protobuf:"bytes,3,opt,name=version,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
 
-func (x *GetParsedSDKVersionResponse) Reset() {
-	*x = GetParsedSDKVersionResponse{}
+func (x *GetSDKInfoResponse) Reset() {
+	*x = GetSDKInfoResponse{}
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetParsedSDKVersionResponse) String() string {
+func (x *GetSDKInfoResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetParsedSDKVersionResponse) ProtoMessage() {}
+func (*GetSDKInfoResponse) ProtoMessage() {}
 
-func (x *GetParsedSDKVersionResponse) ProtoReflect() protoreflect.Message {
+func (x *GetSDKInfoResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1954,68 +1956,83 @@ func (x *GetParsedSDKVersionResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *GetParsedSDKVersionResponse) GetModuleInfo() *GetParsedSDKVersionResponse_ModuleInfo {
+func (x *GetSDKInfoResponse) GetModuleInfo() *GetSDKInfoResponse_ModuleInfo {
 	if x != nil {
 		return x.xxx_hidden_ModuleInfo
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionResponse) GetPluginInfo() *GetParsedSDKVersionResponse_PluginInfo {
+func (x *GetSDKInfoResponse) GetPluginInfo() *GetSDKInfoResponse_PluginInfo {
 	if x != nil {
 		return x.xxx_hidden_PluginInfo
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionResponse) SetModuleInfo(v *GetParsedSDKVersionResponse_ModuleInfo) {
+func (x *GetSDKInfoResponse) GetVersion() string {
+	if x != nil {
+		return x.xxx_hidden_Version
+	}
+	return ""
+}
+
+func (x *GetSDKInfoResponse) SetModuleInfo(v *GetSDKInfoResponse_ModuleInfo) {
 	x.xxx_hidden_ModuleInfo = v
 }
 
-func (x *GetParsedSDKVersionResponse) SetPluginInfo(v *GetParsedSDKVersionResponse_PluginInfo) {
+func (x *GetSDKInfoResponse) SetPluginInfo(v *GetSDKInfoResponse_PluginInfo) {
 	x.xxx_hidden_PluginInfo = v
 }
 
-func (x *GetParsedSDKVersionResponse) HasModuleInfo() bool {
+func (x *GetSDKInfoResponse) SetVersion(v string) {
+	x.xxx_hidden_Version = v
+}
+
+func (x *GetSDKInfoResponse) HasModuleInfo() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_ModuleInfo != nil
 }
 
-func (x *GetParsedSDKVersionResponse) HasPluginInfo() bool {
+func (x *GetSDKInfoResponse) HasPluginInfo() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_PluginInfo != nil
 }
 
-func (x *GetParsedSDKVersionResponse) ClearModuleInfo() {
+func (x *GetSDKInfoResponse) ClearModuleInfo() {
 	x.xxx_hidden_ModuleInfo = nil
 }
 
-func (x *GetParsedSDKVersionResponse) ClearPluginInfo() {
+func (x *GetSDKInfoResponse) ClearPluginInfo() {
 	x.xxx_hidden_PluginInfo = nil
 }
 
-type GetParsedSDKVersionResponse_builder struct {
+type GetSDKInfoResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ModuleInfo *GetParsedSDKVersionResponse_ModuleInfo
-	PluginInfo *GetParsedSDKVersionResponse_PluginInfo
+	ModuleInfo *GetSDKInfoResponse_ModuleInfo
+	PluginInfo *GetSDKInfoResponse_PluginInfo
+	// The SDK version string. The format is based on the SDK registry supported by the
+	// provided plugin.
+	Version string
 }
 
-func (b0 GetParsedSDKVersionResponse_builder) Build() *GetParsedSDKVersionResponse {
-	m0 := &GetParsedSDKVersionResponse{}
+func (b0 GetSDKInfoResponse_builder) Build() *GetSDKInfoResponse {
+	m0 := &GetSDKInfoResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_ModuleInfo = b.ModuleInfo
 	x.xxx_hidden_PluginInfo = b.PluginInfo
+	x.xxx_hidden_Version = b.Version
 	return m0
 }
 
 // ModuleInfo is the parsed module information for the SDK.
-type GetParsedSDKVersionResponse_ModuleInfo struct {
+type GetSDKInfoResponse_ModuleInfo struct {
 	state                             protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Owner                  string                 `protobuf:"bytes,1,opt,name=owner,proto3"`
 	xxx_hidden_Name                   string                 `protobuf:"bytes,2,opt,name=name,proto3"`
@@ -2025,20 +2042,20 @@ type GetParsedSDKVersionResponse_ModuleInfo struct {
 	sizeCache                         protoimpl.SizeCache
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) Reset() {
-	*x = GetParsedSDKVersionResponse_ModuleInfo{}
+func (x *GetSDKInfoResponse_ModuleInfo) Reset() {
+	*x = GetSDKInfoResponse_ModuleInfo{}
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) String() string {
+func (x *GetSDKInfoResponse_ModuleInfo) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetParsedSDKVersionResponse_ModuleInfo) ProtoMessage() {}
+func (*GetSDKInfoResponse_ModuleInfo) ProtoMessage() {}
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) ProtoReflect() protoreflect.Message {
+func (x *GetSDKInfoResponse_ModuleInfo) ProtoReflect() protoreflect.Message {
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2050,62 +2067,62 @@ func (x *GetParsedSDKVersionResponse_ModuleInfo) ProtoReflect() protoreflect.Mes
 	return mi.MessageOf(x)
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) GetOwner() string {
+func (x *GetSDKInfoResponse_ModuleInfo) GetOwner() string {
 	if x != nil {
 		return x.xxx_hidden_Owner
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) GetName() string {
+func (x *GetSDKInfoResponse_ModuleInfo) GetName() string {
 	if x != nil {
 		return x.xxx_hidden_Name
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) GetCommit() string {
+func (x *GetSDKInfoResponse_ModuleInfo) GetCommit() string {
 	if x != nil {
 		return x.xxx_hidden_Commit
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) GetModuleCommitCreateTime() *timestamppb.Timestamp {
+func (x *GetSDKInfoResponse_ModuleInfo) GetModuleCommitCreateTime() *timestamppb.Timestamp {
 	if x != nil {
 		return x.xxx_hidden_ModuleCommitCreateTime
 	}
 	return nil
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) SetOwner(v string) {
+func (x *GetSDKInfoResponse_ModuleInfo) SetOwner(v string) {
 	x.xxx_hidden_Owner = v
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) SetName(v string) {
+func (x *GetSDKInfoResponse_ModuleInfo) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) SetCommit(v string) {
+func (x *GetSDKInfoResponse_ModuleInfo) SetCommit(v string) {
 	x.xxx_hidden_Commit = v
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) SetModuleCommitCreateTime(v *timestamppb.Timestamp) {
+func (x *GetSDKInfoResponse_ModuleInfo) SetModuleCommitCreateTime(v *timestamppb.Timestamp) {
 	x.xxx_hidden_ModuleCommitCreateTime = v
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) HasModuleCommitCreateTime() bool {
+func (x *GetSDKInfoResponse_ModuleInfo) HasModuleCommitCreateTime() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_ModuleCommitCreateTime != nil
 }
 
-func (x *GetParsedSDKVersionResponse_ModuleInfo) ClearModuleCommitCreateTime() {
+func (x *GetSDKInfoResponse_ModuleInfo) ClearModuleCommitCreateTime() {
 	x.xxx_hidden_ModuleCommitCreateTime = nil
 }
 
-type GetParsedSDKVersionResponse_ModuleInfo_builder struct {
+type GetSDKInfoResponse_ModuleInfo_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// The module owner name.
@@ -2118,8 +2135,8 @@ type GetParsedSDKVersionResponse_ModuleInfo_builder struct {
 	ModuleCommitCreateTime *timestamppb.Timestamp
 }
 
-func (b0 GetParsedSDKVersionResponse_ModuleInfo_builder) Build() *GetParsedSDKVersionResponse_ModuleInfo {
-	m0 := &GetParsedSDKVersionResponse_ModuleInfo{}
+func (b0 GetSDKInfoResponse_ModuleInfo_builder) Build() *GetSDKInfoResponse_ModuleInfo {
+	m0 := &GetSDKInfoResponse_ModuleInfo{}
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Owner = b.Owner
@@ -2130,7 +2147,7 @@ func (b0 GetParsedSDKVersionResponse_ModuleInfo_builder) Build() *GetParsedSDKVe
 }
 
 // PluginInfo is the parsed plugin information for the SDK.
-type GetParsedSDKVersionResponse_PluginInfo struct {
+type GetSDKInfoResponse_PluginInfo struct {
 	state                     protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Owner          string                 `protobuf:"bytes,1,opt,name=owner,proto3"`
 	xxx_hidden_Name           string                 `protobuf:"bytes,2,opt,name=name,proto3"`
@@ -2140,20 +2157,20 @@ type GetParsedSDKVersionResponse_PluginInfo struct {
 	sizeCache                 protoimpl.SizeCache
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) Reset() {
-	*x = GetParsedSDKVersionResponse_PluginInfo{}
+func (x *GetSDKInfoResponse_PluginInfo) Reset() {
+	*x = GetSDKInfoResponse_PluginInfo{}
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) String() string {
+func (x *GetSDKInfoResponse_PluginInfo) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetParsedSDKVersionResponse_PluginInfo) ProtoMessage() {}
+func (*GetSDKInfoResponse_PluginInfo) ProtoMessage() {}
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) ProtoReflect() protoreflect.Message {
+func (x *GetSDKInfoResponse_PluginInfo) ProtoReflect() protoreflect.Message {
 	mi := &file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2165,51 +2182,51 @@ func (x *GetParsedSDKVersionResponse_PluginInfo) ProtoReflect() protoreflect.Mes
 	return mi.MessageOf(x)
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) GetOwner() string {
+func (x *GetSDKInfoResponse_PluginInfo) GetOwner() string {
 	if x != nil {
 		return x.xxx_hidden_Owner
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) GetName() string {
+func (x *GetSDKInfoResponse_PluginInfo) GetName() string {
 	if x != nil {
 		return x.xxx_hidden_Name
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) GetVersion() string {
+func (x *GetSDKInfoResponse_PluginInfo) GetVersion() string {
 	if x != nil {
 		return x.xxx_hidden_Version
 	}
 	return ""
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) GetPluginRevision() uint32 {
+func (x *GetSDKInfoResponse_PluginInfo) GetPluginRevision() uint32 {
 	if x != nil {
 		return x.xxx_hidden_PluginRevision
 	}
 	return 0
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) SetOwner(v string) {
+func (x *GetSDKInfoResponse_PluginInfo) SetOwner(v string) {
 	x.xxx_hidden_Owner = v
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) SetName(v string) {
+func (x *GetSDKInfoResponse_PluginInfo) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) SetVersion(v string) {
+func (x *GetSDKInfoResponse_PluginInfo) SetVersion(v string) {
 	x.xxx_hidden_Version = v
 }
 
-func (x *GetParsedSDKVersionResponse_PluginInfo) SetPluginRevision(v uint32) {
+func (x *GetSDKInfoResponse_PluginInfo) SetPluginRevision(v uint32) {
 	x.xxx_hidden_PluginRevision = v
 }
 
-type GetParsedSDKVersionResponse_PluginInfo_builder struct {
+type GetSDKInfoResponse_PluginInfo_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// The plugin owner.
@@ -2222,8 +2239,8 @@ type GetParsedSDKVersionResponse_PluginInfo_builder struct {
 	PluginRevision uint32
 }
 
-func (b0 GetParsedSDKVersionResponse_PluginInfo_builder) Build() *GetParsedSDKVersionResponse_PluginInfo {
-	m0 := &GetParsedSDKVersionResponse_PluginInfo{}
+func (b0 GetSDKInfoResponse_PluginInfo_builder) Build() *GetSDKInfoResponse_PluginInfo {
+	m0 := &GetSDKInfoResponse_PluginInfo{}
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_Owner = b.Owner
@@ -2297,17 +2314,18 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12\x1a\n" +
-	"\brevision\x18\x04 \x01(\rR\brevision\"\x82\x02\n" +
-	"\x1aGetParsedSDKVersionRequest\x12\\\n" +
+	"\brevision\x18\x04 \x01(\rR\brevision\"\xf9\x01\n" +
+	"\x11GetSDKInfoRequest\x12\\\n" +
 	"\x10module_reference\x18\x01 \x01(\v21.buf.alpha.registry.v1alpha1.LocalModuleReferenceR\x0fmoduleReference\x12e\n" +
 	"\x10plugin_reference\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetRemotePackageVersionPluginR\x0fpluginReference\x12\x1f\n" +
 	"\vsdk_version\x18\x03 \x01(\tR\n" +
-	"sdkVersion\"\x8c\x04\n" +
-	"\x1bGetParsedSDKVersionResponse\x12d\n" +
-	"\vmodule_info\x18\x01 \x01(\v2C.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfoR\n" +
-	"moduleInfo\x12d\n" +
-	"\vplugin_info\x18\x02 \x01(\v2C.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.PluginInfoR\n" +
-	"pluginInfo\x1a\xa5\x01\n" +
+	"sdkVersion\"\x8b\x04\n" +
+	"\x12GetSDKInfoResponse\x12[\n" +
+	"\vmodule_info\x18\x01 \x01(\v2:.buf.alpha.registry.v1alpha1.GetSDKInfoResponse.ModuleInfoR\n" +
+	"moduleInfo\x12[\n" +
+	"\vplugin_info\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetSDKInfoResponse.PluginInfoR\n" +
+	"pluginInfo\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\x1a\xa5\x01\n" +
 	"\n" +
 	"ModuleInfo\x12\x14\n" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +
@@ -2325,10 +2343,12 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x1eRESOLVED_REFERENCE_TYPE_COMMIT\x10\x01\x12\"\n" +
 	"\x1eRESOLVED_REFERENCE_TYPE_BRANCH\x10\x02\x12\x1f\n" +
 	"\x1bRESOLVED_REFERENCE_TYPE_TAG\x10\x03\x12!\n" +
-	"\x1dRESOLVED_REFERENCE_TYPE_DRAFT\x10\x05\"\x04\b\x04\x10\x04*\x1dRESOLVED_REFERENCE_TYPE_TRACK2\xaf\n" +
+	"\x1dRESOLVED_REFERENCE_TYPE_DRAFT\x10\x05\"\x04\b\x04\x10\x04*\x1dRESOLVED_REFERENCE_TYPE_TRACK2\x93\n" +
 	"\n" +
 	"\x0eResolveService\x12{\n" +
-	"\rGetModulePins\x121.buf.alpha.registry.v1alpha1.GetModulePinsRequest\x1a2.buf.alpha.registry.v1alpha1.GetModulePinsResponse\"\x03\x90\x02\x01\x12x\n" +
+	"\rGetModulePins\x121.buf.alpha.registry.v1alpha1.GetModulePinsRequest\x1a2.buf.alpha.registry.v1alpha1.GetModulePinsResponse\"\x03\x90\x02\x01\x12r\n" +
+	"\n" +
+	"GetSDKInfo\x12..buf.alpha.registry.v1alpha1.GetSDKInfoRequest\x1a/.buf.alpha.registry.v1alpha1.GetSDKInfoResponse\"\x03\x90\x02\x01\x12x\n" +
 	"\fGetGoVersion\x120.buf.alpha.registry.v1alpha1.GetGoVersionRequest\x1a1.buf.alpha.registry.v1alpha1.GetGoVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
 	"\x0fGetSwiftVersion\x123.buf.alpha.registry.v1alpha1.GetSwiftVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetSwiftVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
 	"\x0fGetMavenVersion\x123.buf.alpha.registry.v1alpha1.GetMavenVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetMavenVersionResponse\"\x03\x90\x02\x01\x12{\n" +
@@ -2336,8 +2356,7 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x10GetPythonVersion\x124.buf.alpha.registry.v1alpha1.GetPythonVersionRequest\x1a5.buf.alpha.registry.v1alpha1.GetPythonVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
 	"\x0fGetCargoVersion\x123.buf.alpha.registry.v1alpha1.GetCargoVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetCargoVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
 	"\x0fGetNugetVersion\x123.buf.alpha.registry.v1alpha1.GetNugetVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetNugetVersionResponse\"\x03\x90\x02\x01\x12\x81\x01\n" +
-	"\x0fGetCmakeVersion\x123.buf.alpha.registry.v1alpha1.GetCmakeVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetCmakeVersionResponse\"\x03\x90\x02\x01\x12\x8d\x01\n" +
-	"\x13GetParsedSDKVersion\x127.buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest\x1a8.buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse\"\x03\x90\x02\x012\xa2\x01\n" +
+	"\x0fGetCmakeVersion\x123.buf.alpha.registry.v1alpha1.GetCmakeVersionRequest\x1a4.buf.alpha.registry.v1alpha1.GetCmakeVersionResponse\"\x03\x90\x02\x012\xa2\x01\n" +
 	"\x13LocalResolveService\x12\x8a\x01\n" +
 	"\x12GetLocalModulePins\x126.buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest\x1a7.buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse\"\x03\x90\x02\x01B\x99\x02\n" +
 	"\x1fcom.buf.alpha.registry.v1alpha1B\fResolveProtoP\x01ZYgithub.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1;registryv1alpha1\xa2\x02\x03BAR\xaa\x02\x1bBuf.Alpha.Registry.V1alpha1\xca\x02\x1bBuf\\Alpha\\Registry\\V1alpha1\xe2\x02'Buf\\Alpha\\Registry\\V1alpha1\\GPBMetadata\xea\x02\x1eBuf::Alpha::Registry::V1alpha1b\x06proto3"
@@ -2345,38 +2364,38 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 var file_buf_alpha_registry_v1alpha1_resolve_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_buf_alpha_registry_v1alpha1_resolve_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_buf_alpha_registry_v1alpha1_resolve_proto_goTypes = []any{
-	(ResolvedReferenceType)(0),                     // 0: buf.alpha.registry.v1alpha1.ResolvedReferenceType
-	(*GetModulePinsRequest)(nil),                   // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest
-	(*GetModulePinsResponse)(nil),                  // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse
-	(*GetLocalModulePinsRequest)(nil),              // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
-	(*LocalModuleResolveResult)(nil),               // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult
-	(*GetLocalModulePinsResponse)(nil),             // 5: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
-	(*GetGoVersionRequest)(nil),                    // 6: buf.alpha.registry.v1alpha1.GetGoVersionRequest
-	(*GetGoVersionResponse)(nil),                   // 7: buf.alpha.registry.v1alpha1.GetGoVersionResponse
-	(*GetMavenVersionRequest)(nil),                 // 8: buf.alpha.registry.v1alpha1.GetMavenVersionRequest
-	(*GetMavenVersionResponse)(nil),                // 9: buf.alpha.registry.v1alpha1.GetMavenVersionResponse
-	(*GetNPMVersionRequest)(nil),                   // 10: buf.alpha.registry.v1alpha1.GetNPMVersionRequest
-	(*GetNPMVersionResponse)(nil),                  // 11: buf.alpha.registry.v1alpha1.GetNPMVersionResponse
-	(*GetSwiftVersionRequest)(nil),                 // 12: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
-	(*GetSwiftVersionResponse)(nil),                // 13: buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
-	(*GetPythonVersionRequest)(nil),                // 14: buf.alpha.registry.v1alpha1.GetPythonVersionRequest
-	(*GetPythonVersionResponse)(nil),               // 15: buf.alpha.registry.v1alpha1.GetPythonVersionResponse
-	(*GetCargoVersionRequest)(nil),                 // 16: buf.alpha.registry.v1alpha1.GetCargoVersionRequest
-	(*GetCargoVersionResponse)(nil),                // 17: buf.alpha.registry.v1alpha1.GetCargoVersionResponse
-	(*GetNugetVersionRequest)(nil),                 // 18: buf.alpha.registry.v1alpha1.GetNugetVersionRequest
-	(*GetNugetVersionResponse)(nil),                // 19: buf.alpha.registry.v1alpha1.GetNugetVersionResponse
-	(*GetCmakeVersionRequest)(nil),                 // 20: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
-	(*GetCmakeVersionResponse)(nil),                // 21: buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
-	(*GetRemotePackageVersionPlugin)(nil),          // 22: buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	(*GetParsedSDKVersionRequest)(nil),             // 23: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
-	(*GetParsedSDKVersionResponse)(nil),            // 24: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
-	(*GetParsedSDKVersionResponse_ModuleInfo)(nil), // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfo
-	(*GetParsedSDKVersionResponse_PluginInfo)(nil), // 26: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.PluginInfo
-	(*v1alpha1.ModuleReference)(nil),               // 27: buf.alpha.module.v1alpha1.ModuleReference
-	(*v1alpha1.ModulePin)(nil),                     // 28: buf.alpha.module.v1alpha1.ModulePin
-	(*LocalModuleReference)(nil),                   // 29: buf.alpha.registry.v1alpha1.LocalModuleReference
-	(*LocalModulePin)(nil),                         // 30: buf.alpha.registry.v1alpha1.LocalModulePin
-	(*timestamppb.Timestamp)(nil),                  // 31: google.protobuf.Timestamp
+	(ResolvedReferenceType)(0),            // 0: buf.alpha.registry.v1alpha1.ResolvedReferenceType
+	(*GetModulePinsRequest)(nil),          // 1: buf.alpha.registry.v1alpha1.GetModulePinsRequest
+	(*GetModulePinsResponse)(nil),         // 2: buf.alpha.registry.v1alpha1.GetModulePinsResponse
+	(*GetLocalModulePinsRequest)(nil),     // 3: buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
+	(*LocalModuleResolveResult)(nil),      // 4: buf.alpha.registry.v1alpha1.LocalModuleResolveResult
+	(*GetLocalModulePinsResponse)(nil),    // 5: buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
+	(*GetGoVersionRequest)(nil),           // 6: buf.alpha.registry.v1alpha1.GetGoVersionRequest
+	(*GetGoVersionResponse)(nil),          // 7: buf.alpha.registry.v1alpha1.GetGoVersionResponse
+	(*GetMavenVersionRequest)(nil),        // 8: buf.alpha.registry.v1alpha1.GetMavenVersionRequest
+	(*GetMavenVersionResponse)(nil),       // 9: buf.alpha.registry.v1alpha1.GetMavenVersionResponse
+	(*GetNPMVersionRequest)(nil),          // 10: buf.alpha.registry.v1alpha1.GetNPMVersionRequest
+	(*GetNPMVersionResponse)(nil),         // 11: buf.alpha.registry.v1alpha1.GetNPMVersionResponse
+	(*GetSwiftVersionRequest)(nil),        // 12: buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
+	(*GetSwiftVersionResponse)(nil),       // 13: buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
+	(*GetPythonVersionRequest)(nil),       // 14: buf.alpha.registry.v1alpha1.GetPythonVersionRequest
+	(*GetPythonVersionResponse)(nil),      // 15: buf.alpha.registry.v1alpha1.GetPythonVersionResponse
+	(*GetCargoVersionRequest)(nil),        // 16: buf.alpha.registry.v1alpha1.GetCargoVersionRequest
+	(*GetCargoVersionResponse)(nil),       // 17: buf.alpha.registry.v1alpha1.GetCargoVersionResponse
+	(*GetNugetVersionRequest)(nil),        // 18: buf.alpha.registry.v1alpha1.GetNugetVersionRequest
+	(*GetNugetVersionResponse)(nil),       // 19: buf.alpha.registry.v1alpha1.GetNugetVersionResponse
+	(*GetCmakeVersionRequest)(nil),        // 20: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
+	(*GetCmakeVersionResponse)(nil),       // 21: buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
+	(*GetRemotePackageVersionPlugin)(nil), // 22: buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
+	(*GetSDKInfoRequest)(nil),             // 23: buf.alpha.registry.v1alpha1.GetSDKInfoRequest
+	(*GetSDKInfoResponse)(nil),            // 24: buf.alpha.registry.v1alpha1.GetSDKInfoResponse
+	(*GetSDKInfoResponse_ModuleInfo)(nil), // 25: buf.alpha.registry.v1alpha1.GetSDKInfoResponse.ModuleInfo
+	(*GetSDKInfoResponse_PluginInfo)(nil), // 26: buf.alpha.registry.v1alpha1.GetSDKInfoResponse.PluginInfo
+	(*v1alpha1.ModuleReference)(nil),      // 27: buf.alpha.module.v1alpha1.ModuleReference
+	(*v1alpha1.ModulePin)(nil),            // 28: buf.alpha.module.v1alpha1.ModulePin
+	(*LocalModuleReference)(nil),          // 29: buf.alpha.registry.v1alpha1.LocalModuleReference
+	(*LocalModulePin)(nil),                // 30: buf.alpha.registry.v1alpha1.LocalModulePin
+	(*timestamppb.Timestamp)(nil),         // 31: google.protobuf.Timestamp
 }
 var file_buf_alpha_registry_v1alpha1_resolve_proto_depIdxs = []int32{
 	27, // 0: buf.alpha.registry.v1alpha1.GetModulePinsRequest.module_references:type_name -> buf.alpha.module.v1alpha1.ModuleReference
@@ -2404,32 +2423,32 @@ var file_buf_alpha_registry_v1alpha1_resolve_proto_depIdxs = []int32{
 	29, // 22: buf.alpha.registry.v1alpha1.GetNugetVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
 	22, // 23: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
 	29, // 24: buf.alpha.registry.v1alpha1.GetCmakeVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	29, // 25: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
-	22, // 26: buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
-	25, // 27: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.module_info:type_name -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfo
-	26, // 28: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.plugin_info:type_name -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.PluginInfo
-	31, // 29: buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse.ModuleInfo.module_commit_create_time:type_name -> google.protobuf.Timestamp
+	29, // 25: buf.alpha.registry.v1alpha1.GetSDKInfoRequest.module_reference:type_name -> buf.alpha.registry.v1alpha1.LocalModuleReference
+	22, // 26: buf.alpha.registry.v1alpha1.GetSDKInfoRequest.plugin_reference:type_name -> buf.alpha.registry.v1alpha1.GetRemotePackageVersionPlugin
+	25, // 27: buf.alpha.registry.v1alpha1.GetSDKInfoResponse.module_info:type_name -> buf.alpha.registry.v1alpha1.GetSDKInfoResponse.ModuleInfo
+	26, // 28: buf.alpha.registry.v1alpha1.GetSDKInfoResponse.plugin_info:type_name -> buf.alpha.registry.v1alpha1.GetSDKInfoResponse.PluginInfo
+	31, // 29: buf.alpha.registry.v1alpha1.GetSDKInfoResponse.ModuleInfo.module_commit_create_time:type_name -> google.protobuf.Timestamp
 	1,  // 30: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:input_type -> buf.alpha.registry.v1alpha1.GetModulePinsRequest
-	6,  // 31: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:input_type -> buf.alpha.registry.v1alpha1.GetGoVersionRequest
-	12, // 32: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:input_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
-	8,  // 33: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:input_type -> buf.alpha.registry.v1alpha1.GetMavenVersionRequest
-	10, // 34: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:input_type -> buf.alpha.registry.v1alpha1.GetNPMVersionRequest
-	14, // 35: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:input_type -> buf.alpha.registry.v1alpha1.GetPythonVersionRequest
-	16, // 36: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:input_type -> buf.alpha.registry.v1alpha1.GetCargoVersionRequest
-	18, // 37: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:input_type -> buf.alpha.registry.v1alpha1.GetNugetVersionRequest
-	20, // 38: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:input_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
-	23, // 39: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:input_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionRequest
+	23, // 31: buf.alpha.registry.v1alpha1.ResolveService.GetSDKInfo:input_type -> buf.alpha.registry.v1alpha1.GetSDKInfoRequest
+	6,  // 32: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:input_type -> buf.alpha.registry.v1alpha1.GetGoVersionRequest
+	12, // 33: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:input_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionRequest
+	8,  // 34: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:input_type -> buf.alpha.registry.v1alpha1.GetMavenVersionRequest
+	10, // 35: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:input_type -> buf.alpha.registry.v1alpha1.GetNPMVersionRequest
+	14, // 36: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:input_type -> buf.alpha.registry.v1alpha1.GetPythonVersionRequest
+	16, // 37: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:input_type -> buf.alpha.registry.v1alpha1.GetCargoVersionRequest
+	18, // 38: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:input_type -> buf.alpha.registry.v1alpha1.GetNugetVersionRequest
+	20, // 39: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:input_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionRequest
 	3,  // 40: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:input_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsRequest
 	2,  // 41: buf.alpha.registry.v1alpha1.ResolveService.GetModulePins:output_type -> buf.alpha.registry.v1alpha1.GetModulePinsResponse
-	7,  // 42: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:output_type -> buf.alpha.registry.v1alpha1.GetGoVersionResponse
-	13, // 43: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:output_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
-	9,  // 44: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:output_type -> buf.alpha.registry.v1alpha1.GetMavenVersionResponse
-	11, // 45: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:output_type -> buf.alpha.registry.v1alpha1.GetNPMVersionResponse
-	15, // 46: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:output_type -> buf.alpha.registry.v1alpha1.GetPythonVersionResponse
-	17, // 47: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:output_type -> buf.alpha.registry.v1alpha1.GetCargoVersionResponse
-	19, // 48: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:output_type -> buf.alpha.registry.v1alpha1.GetNugetVersionResponse
-	21, // 49: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:output_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
-	24, // 50: buf.alpha.registry.v1alpha1.ResolveService.GetParsedSDKVersion:output_type -> buf.alpha.registry.v1alpha1.GetParsedSDKVersionResponse
+	24, // 42: buf.alpha.registry.v1alpha1.ResolveService.GetSDKInfo:output_type -> buf.alpha.registry.v1alpha1.GetSDKInfoResponse
+	7,  // 43: buf.alpha.registry.v1alpha1.ResolveService.GetGoVersion:output_type -> buf.alpha.registry.v1alpha1.GetGoVersionResponse
+	13, // 44: buf.alpha.registry.v1alpha1.ResolveService.GetSwiftVersion:output_type -> buf.alpha.registry.v1alpha1.GetSwiftVersionResponse
+	9,  // 45: buf.alpha.registry.v1alpha1.ResolveService.GetMavenVersion:output_type -> buf.alpha.registry.v1alpha1.GetMavenVersionResponse
+	11, // 46: buf.alpha.registry.v1alpha1.ResolveService.GetNPMVersion:output_type -> buf.alpha.registry.v1alpha1.GetNPMVersionResponse
+	15, // 47: buf.alpha.registry.v1alpha1.ResolveService.GetPythonVersion:output_type -> buf.alpha.registry.v1alpha1.GetPythonVersionResponse
+	17, // 48: buf.alpha.registry.v1alpha1.ResolveService.GetCargoVersion:output_type -> buf.alpha.registry.v1alpha1.GetCargoVersionResponse
+	19, // 49: buf.alpha.registry.v1alpha1.ResolveService.GetNugetVersion:output_type -> buf.alpha.registry.v1alpha1.GetNugetVersionResponse
+	21, // 50: buf.alpha.registry.v1alpha1.ResolveService.GetCmakeVersion:output_type -> buf.alpha.registry.v1alpha1.GetCmakeVersionResponse
 	5,  // 51: buf.alpha.registry.v1alpha1.LocalResolveService.GetLocalModulePins:output_type -> buf.alpha.registry.v1alpha1.GetLocalModulePinsResponse
 	41, // [41:52] is the sub-list for method output_type
 	30, // [30:41] is the sub-list for method input_type

--- a/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
+++ b/private/gen/proto/go/buf/alpha/registry/v1alpha1/resolve.pb.go
@@ -1926,7 +1926,7 @@ type GetSDKInfoResponse struct {
 	state                 protoimpl.MessageState         `protogen:"opaque.v1"`
 	xxx_hidden_ModuleInfo *GetSDKInfoResponse_ModuleInfo `protobuf:"bytes,1,opt,name=module_info,json=moduleInfo,proto3"`
 	xxx_hidden_PluginInfo *GetSDKInfoResponse_PluginInfo `protobuf:"bytes,2,opt,name=plugin_info,json=pluginInfo,proto3"`
-	xxx_hidden_Version    string                         `protobuf:"bytes,3,opt,name=version,proto3"`
+	xxx_hidden_SdkVersion string                         `protobuf:"bytes,3,opt,name=sdk_version,json=sdkVersion,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -1970,9 +1970,9 @@ func (x *GetSDKInfoResponse) GetPluginInfo() *GetSDKInfoResponse_PluginInfo {
 	return nil
 }
 
-func (x *GetSDKInfoResponse) GetVersion() string {
+func (x *GetSDKInfoResponse) GetSdkVersion() string {
 	if x != nil {
-		return x.xxx_hidden_Version
+		return x.xxx_hidden_SdkVersion
 	}
 	return ""
 }
@@ -1985,8 +1985,8 @@ func (x *GetSDKInfoResponse) SetPluginInfo(v *GetSDKInfoResponse_PluginInfo) {
 	x.xxx_hidden_PluginInfo = v
 }
 
-func (x *GetSDKInfoResponse) SetVersion(v string) {
-	x.xxx_hidden_Version = v
+func (x *GetSDKInfoResponse) SetSdkVersion(v string) {
+	x.xxx_hidden_SdkVersion = v
 }
 
 func (x *GetSDKInfoResponse) HasModuleInfo() bool {
@@ -2018,7 +2018,7 @@ type GetSDKInfoResponse_builder struct {
 	PluginInfo *GetSDKInfoResponse_PluginInfo
 	// The SDK version string. The format is based on the SDK registry supported by the
 	// provided plugin.
-	Version string
+	SdkVersion string
 }
 
 func (b0 GetSDKInfoResponse_builder) Build() *GetSDKInfoResponse {
@@ -2027,7 +2027,7 @@ func (b0 GetSDKInfoResponse_builder) Build() *GetSDKInfoResponse {
 	_, _ = b, x
 	x.xxx_hidden_ModuleInfo = b.ModuleInfo
 	x.xxx_hidden_PluginInfo = b.PluginInfo
-	x.xxx_hidden_Version = b.Version
+	x.xxx_hidden_SdkVersion = b.SdkVersion
 	return m0
 }
 
@@ -2319,13 +2319,14 @@ const file_buf_alpha_registry_v1alpha1_resolve_proto_rawDesc = "" +
 	"\x10module_reference\x18\x01 \x01(\v21.buf.alpha.registry.v1alpha1.LocalModuleReferenceR\x0fmoduleReference\x12e\n" +
 	"\x10plugin_reference\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetRemotePackageVersionPluginR\x0fpluginReference\x12\x1f\n" +
 	"\vsdk_version\x18\x03 \x01(\tR\n" +
-	"sdkVersion\"\x8b\x04\n" +
+	"sdkVersion\"\x92\x04\n" +
 	"\x12GetSDKInfoResponse\x12[\n" +
 	"\vmodule_info\x18\x01 \x01(\v2:.buf.alpha.registry.v1alpha1.GetSDKInfoResponse.ModuleInfoR\n" +
 	"moduleInfo\x12[\n" +
 	"\vplugin_info\x18\x02 \x01(\v2:.buf.alpha.registry.v1alpha1.GetSDKInfoResponse.PluginInfoR\n" +
-	"pluginInfo\x12\x18\n" +
-	"\aversion\x18\x03 \x01(\tR\aversion\x1a\xa5\x01\n" +
+	"pluginInfo\x12\x1f\n" +
+	"\vsdk_version\x18\x03 \x01(\tR\n" +
+	"sdkVersion\x1a\xa5\x01\n" +
 	"\n" +
 	"ModuleInfo\x12\x14\n" +
 	"\x05owner\x18\x01 \x01(\tR\x05owner\x12\x12\n" +

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -311,5 +311,5 @@ message GetSDKInfoResponse {
   PluginInfo plugin_info = 2;
   // The SDK version string. The format is based on the SDK registry supported by the
   // provided plugin.
-  string version = 3;
+  string sdk_version = 3;
 }

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -268,6 +268,7 @@ message GetRemotePackageVersionPlugin {
 message GetParsedSDKVersionRequest {
   LocalModuleReference module_reference = 1;
   GetRemotePackageVersionPlugin plugin_reference = 2;
+  string sdk_version = 3;
 }
 
 message GetParsedSDKVersionResponse {

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -18,6 +18,7 @@ package buf.alpha.registry.v1alpha1;
 
 import "buf/alpha/module/v1alpha1/module.proto";
 import "buf/alpha/registry/v1alpha1/module.proto";
+import "google/protobuf/timestamp.proto";
 
 // ResolveService is the resolve service.
 //
@@ -63,6 +64,12 @@ service ResolveService {
   }
   // GetCmakeVersion resolves the given plugin and module references to a version.
   rpc GetCmakeVersion(GetCmakeVersionRequest) returns (GetCmakeVersionResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  // GetSDKVersion takes a module reference, plugin identity, and SDK version string and returns
+  // a parsed SDK version that provides the plugin version, plugin revision, module commit,
+  // and module commit create time (optional).
+  rpc GetParsedSDKVersion(GetParsedSDKVersionRequest) returns (GetParsedSDKVersionResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 }
@@ -256,4 +263,26 @@ message GetRemotePackageVersionPlugin {
   // The revision of the plugin version.
   // example: 1
   uint32 revision = 4;
+}
+
+message GetParsedSDKVersionRequest {
+  LocalModuleReference module_reference = 1;
+  GetRemotePackageVersionPlugin plugin_reference = 2;
+}
+
+message GetParsedSDKVersionResponse {
+  message ParsedSDKVersion {
+    // The plugin version of the plugin used to generate the SDK version.
+    // This will always be valid semver.
+    string plugin_version = 1;
+    // The revision of the plugin version.
+    uint32 plugin_revision = 2;
+    // This is the short version of the module commit name, at least 12 char in length.
+    string module_commit_name = 3;
+    // This is the creation time of the module commit.
+    //
+    // This will always be in UTC. This may be empty.
+    google.protobuf.Timestamp module_commit_create_time = 4;
+  }
+  ParsedSDKVersion parsed_sdk_version = 1;
 }

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -34,6 +34,21 @@ service ResolveService {
   rpc GetModulePins(GetModulePinsRequest) returns (GetModulePinsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+  // GetSDKInfo takes a module, plugin, and optionally SDK version, and returns the SDK
+  // info. The SDK info includes the module, module commit, module commit create time, plugin,
+  // plugin version, plugin revision, and the SDK version string
+  // for the SDK.
+  //
+  // If the the module reference and/or plugin version is included, then the SDK at the
+  // specified version will be resolved. If the SDK version is included, then it will be
+  // validated with the module and plugin information provided.
+  //
+  // This replaces the need for all subsequent RPCs, which requirees the caller to resolve
+  // the registry type first. Instead, the registry type will be resolved based on the plugin
+  // information provided.
+  rpc GetSDKInfo(GetSDKInfoRequest) returns (GetSDKInfoResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   // GetGoVersion resolves the given plugin and module references to a version.
   rpc GetGoVersion(GetGoVersionRequest) returns (GetGoVersionResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
@@ -64,12 +79,6 @@ service ResolveService {
   }
   // GetCmakeVersion resolves the given plugin and module references to a version.
   rpc GetCmakeVersion(GetCmakeVersionRequest) returns (GetCmakeVersionResponse) {
-    option idempotency_level = NO_SIDE_EFFECTS;
-  }
-  // GetSDKVersion takes a module reference, plugin identity, and SDK version string and returns
-  // a parsed SDK version that provides the plugin version, plugin revision, module commit,
-  // and module commit create time (optional).
-  rpc GetParsedSDKVersion(GetParsedSDKVersionRequest) returns (GetParsedSDKVersionResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 }
@@ -265,16 +274,17 @@ message GetRemotePackageVersionPlugin {
   uint32 revision = 4;
 }
 
-message GetParsedSDKVersionRequest {
-  // The local module reference to parse.
+message GetSDKInfoRequest {
+  // The local module reference for the SDK.
   LocalModuleReference module_reference = 1;
-  // The plugin reference to parse.
+  // The plugin reference for the SDK.
   GetRemotePackageVersionPlugin plugin_reference = 2;
-  // The SDK version to parse.
+  // The SDK version string. If this is not provided, then it will be resolved using the module
+  // and plugin references provided.
   string sdk_version = 3;
 }
 
-message GetParsedSDKVersionResponse {
+message GetSDKInfoResponse {
   // ModuleInfo is the parsed module information for the SDK.
   message ModuleInfo {
     // The module owner name.
@@ -299,4 +309,7 @@ message GetParsedSDKVersionResponse {
   }
   ModuleInfo module_info = 1;
   PluginInfo plugin_info = 2;
+  // The SDK version string. The format is based on the SDK registry supported by the
+  // provided plugin.
+  string version = 3;
 }

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -39,7 +39,7 @@ service ResolveService {
   // plugin version, plugin revision, and the SDK version string
   // for the SDK.
   //
-  // If the the module reference and/or plugin version is included, then the SDK at the
+  // If the module reference and/or plugin version is included, then the SDK at the
   // specified version will be resolved. If the SDK version is included, then it will be
   // validated with the module and plugin information provided.
   //

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -266,24 +266,37 @@ message GetRemotePackageVersionPlugin {
 }
 
 message GetParsedSDKVersionRequest {
+  // The local module reference to parse.
   LocalModuleReference module_reference = 1;
+  // The plugin reference to parse.
   GetRemotePackageVersionPlugin plugin_reference = 2;
+  // The SDK version to parse.
   string sdk_version = 3;
 }
 
 message GetParsedSDKVersionResponse {
-  message ParsedSDKVersion {
-    // The plugin version of the plugin used to generate the SDK version.
-    // This will always be valid semver.
-    string plugin_version = 1;
-    // The revision of the plugin version.
-    uint32 plugin_revision = 2;
-    // This is the short version of the module commit name, at least 12 char in length.
-    string module_commit_name = 3;
-    // This is the creation time of the module commit.
-    //
-    // This will always be in UTC. This may be empty.
+  // ModuleInfo is the parsed module information for the SDK.
+  message ModuleInfo {
+    // The module owner name.
+    string owner = 1;
+    // The module name.
+    string name = 2;
+    // The module commit for the SDK.
+    string commit = 3;
+    // The module commit create time. This will always be in UTC.
     google.protobuf.Timestamp module_commit_create_time = 4;
   }
-  ParsedSDKVersion parsed_sdk_version = 1;
+  // PluginInfo is the parsed plugin information for the SDK.
+  message PluginInfo {
+    // The plugin owner.
+    string owner = 1;
+    // The plugin name.
+    string name = 2;
+    // The semver plugin version. This will always be valid semver.
+    string version = 3;
+    // The plugin revision.
+    uint32 plugin_revision = 4;
+  }
+  ModuleInfo module_info = 1;
+  PluginInfo plugin_info = 2;
 }

--- a/proto/buf/alpha/registry/v1alpha1/resolve.proto
+++ b/proto/buf/alpha/registry/v1alpha1/resolve.proto
@@ -43,7 +43,7 @@ service ResolveService {
   // specified version will be resolved. If the SDK version is included, then it will be
   // validated with the module and plugin information provided.
   //
-  // This replaces the need for all subsequent RPCs, which requirees the caller to resolve
+  // This replaces the need for all subsequent RPCs, which requires the caller to resolve
   // the registry type first. Instead, the registry type will be resolved based on the plugin
   // information provided.
   rpc GetSDKInfo(GetSDKInfoRequest) returns (GetSDKInfoResponse) {


### PR DESCRIPTION
This adds a `GetSDKInfo` rpc to the `ResolveService`.
This RPC will provide the SDK information based on the provided
module reference, plugin information, and optionally SDK version string.

If a specific module reference (commit or label) is and/or a plugin version
is specified, then the SDK for the specified information is resolved. If the
SDK version string is provided, then it will be validated with the module and
plugin information.

This allows us to replace the use of the subsequent RPCs in `buf registry sdk version`,
and make a single call to `GetSDKInfo` to resolve the SDK version information.
It also allows us to easily provide module commit and plugin version
information given the module, plugin, and SDK version string.