### PR TITLE
Expand testcase for FIELD_CARDINALITY_SAME with optionals

### DIFF
--- a/private/bufpkg/bufcheck/breaking_test.go
+++ b/private/bufpkg/bufcheck/breaking_test.go
@@ -231,6 +231,7 @@ func TestRunBreakingFieldSameCardinality(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 44, 5, 44, 20, "FIELD_SAME_CARDINALITY"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 45, 5, 45, 19, "FIELD_SAME_CARDINALITY"),
 		bufanalysistesting.NewFileAnnotation(t, "1.proto", 48, 5, 48, 19, "FIELD_SAME_CARDINALITY"),
+		bufanalysistesting.NewFileAnnotation(t, "1.proto", 54, 5, 54, 30, "FIELD_SAME_CARDINALITY"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 6, 3, 6, 26, "FIELD_SAME_CARDINALITY"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 13, 3, 13, 26, "FIELD_SAME_CARDINALITY"),
 		bufanalysistesting.NewFileAnnotation(t, "2.proto", 14, 3, 14, 24, "FIELD_SAME_CARDINALITY"),

--- a/private/bufpkg/bufcheck/testdata/breaking/current/breaking_field_same_cardinality/1.proto
+++ b/private/bufpkg/bufcheck/testdata/breaking/current/breaking_field_same_cardinality/1.proto
@@ -51,5 +51,8 @@ message Three {
     repeated One four = 4;
     map<int32, int32> five = 5;
     map<int32, One> six = 6;
+    optional int32 seven = 7;
+    Eight eight = 8;
+    optional Eight nine = 9;
   }
 }

--- a/private/bufpkg/bufcheck/testdata/breaking/previous/breaking_field_same_cardinality/1.proto
+++ b/private/bufpkg/bufcheck/testdata/breaking/previous/breaking_field_same_cardinality/1.proto
@@ -54,6 +54,9 @@ message Three {
     repeated One four = 4;
     map<int32, int32> five = 5;
     map<int32, One> six = 6;
+    int32 seven = 7;
+    optional Eight eight = 8;
+    Eight nine = 9;
   }
 }
 


### PR DESCRIPTION
This is a small PR to expand the testcase for proto3 optional behaviour on message cardinality. `optional` does not affect messages and there is no change in behaviour. The new testcases confirm this.