### PR TITLE
Add bufpolicyapi package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.24.2
 require (
 	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.36.6-20250121211742-6d880cc6cc8d.1
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1
-	buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250423175228-7edf8b09cc2c.1
-	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.6-20250423175228-7edf8b09cc2c.1
+	buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250424150516-e120136b05f7.1
+	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.6-20250424150516-e120136b05f7.1
 	buf.build/go/bufplugin v0.8.0
 	buf.build/go/protoyaml v0.3.2
 	buf.build/go/spdx v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.36.6-20250121211742-6d
 buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.36.6-20250121211742-6d880cc6cc8d.1/go.mod h1:rvbyamNtvJ4o3ExeCmaG5/6iHnu0vy0E+UQ+Ph0om8s=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1 h1:zgJPqo17m28+Lf5BW4xv3PvU20BnrmTcGYrog22lLIU=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
-buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250423175228-7edf8b09cc2c.1 h1:fK/q98JITrtqTKbhgE3vkpyyyncSbVo6H6NjFRvYM/4=
-buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250423175228-7edf8b09cc2c.1/go.mod h1:ChttLy3zSV2LCc5NkxHbz3uMQsWFSo8qrzCKw0Z3ktg=
-buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.6-20250423175228-7edf8b09cc2c.1 h1:fCVeN7ikFLE/pt0hjdr4D0MOmguIevtCQxbhWjoAqDE=
-buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.6-20250423175228-7edf8b09cc2c.1/go.mod h1:ee69ieBAzwc/oY/Vde0K4r6JWvrk093q4Z/FXexPMmA=
+buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250424150516-e120136b05f7.1 h1:cISjIL5A2z1FBxUhORVEdv5UPYnSR2thUJZMUcAmwRE=
+buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250424150516-e120136b05f7.1/go.mod h1:wHt1fEzVInGhwUJQJH4Kv9eBDRhJ/Kg74fk9+h0h1bQ=
+buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.6-20250424150516-e120136b05f7.1 h1:SWCy5KmaOVzPx7TSjQQMwfuqE5lCER9O223Q+QXws/8=
+buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.6-20250424150516-e120136b05f7.1/go.mod h1:ee69ieBAzwc/oY/Vde0K4r6JWvrk093q4Z/FXexPMmA=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.6-20241007202033-cf42259fcbfc.1 h1:trcsXBDm8exui7mvndZnvworCyBq1xuMnod2N0j79K8=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.6-20241007202033-cf42259fcbfc.1/go.mod h1:OUbhXurY+VHFGn9FBxcRy8UB7HXk9NvJ2qCgifOMypQ=
 buf.build/go/bufplugin v0.8.0 h1:YgR1+CNGmzR69jt85oRWTa5FioZoX/tOrHV+JxfNnnk=

--- a/private/bufpkg/bufpolicy/bufpolicyapi/bufpolicyapi.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/bufpolicyapi.go
@@ -1,0 +1,15 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpolicyapi

--- a/private/bufpkg/bufpolicy/bufpolicyapi/convert.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/convert.go
@@ -1,0 +1,66 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpolicyapi
+
+import (
+	"fmt"
+
+	policyv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1"
+	"github.com/bufbuild/buf/private/bufpkg/bufcas"
+	"github.com/bufbuild/buf/private/bufpkg/bufpolicy"
+)
+
+var (
+	v1beta1ProtoDigestTypeToDigestType = map[policyv1beta1.DigestType]bufpolicy.DigestType{
+		policyv1beta1.DigestType_DIGEST_TYPE_O1: bufpolicy.DigestTypeO1,
+	}
+)
+
+// V1Beta1ProtoToDigest converts the given proto Digest to a Digest.
+//
+// Validation is performed to ensure the DigestType is known, and the value
+// is a valid digest value for the given DigestType.
+func V1Beta1ProtoToDigest(protoDigest *policyv1beta1.Digest) (bufpolicy.Digest, error) {
+	digestType, err := v1beta1ProtoToDigestType(protoDigest.Type)
+	if err != nil {
+		return nil, err
+	}
+	bufcasDigest, err := bufcas.NewDigest(protoDigest.Value)
+	if err != nil {
+		return nil, err
+	}
+	return bufpolicy.NewDigest(digestType, bufcasDigest)
+}
+
+// *** PRIVATE ***
+
+func policyVisibilityToV1Beta1Proto(policyVisibility bufpolicy.PolicyVisibility) (policyv1beta1.PolicyVisibility, error) {
+	switch policyVisibility {
+	case bufpolicy.PolicyVisibilityPublic:
+		return policyv1beta1.PolicyVisibility_POLICY_VISIBILITY_PUBLIC, nil
+	case bufpolicy.PolicyVisibilityPrivate:
+		return policyv1beta1.PolicyVisibility_POLICY_VISIBILITY_PRIVATE, nil
+	default:
+		return 0, fmt.Errorf("unknown PolicyVisibility: %v", policyVisibility)
+	}
+}
+
+func v1beta1ProtoToDigestType(protoDigestType policyv1beta1.DigestType) (bufpolicy.DigestType, error) {
+	digestType, ok := v1beta1ProtoDigestTypeToDigestType[protoDigestType]
+	if !ok {
+		return 0, fmt.Errorf("unknown policyv1beta1.DigestType: %v", protoDigestType)
+	}
+	return digestType, nil
+}

--- a/private/bufpkg/bufpolicy/bufpolicyapi/policy_data_provider.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/policy_data_provider.go
@@ -1,0 +1,169 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpolicyapi
+
+import (
+	"context"
+	"log/slog"
+
+	policyv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/bufpkg/bufparse"
+	"github.com/bufbuild/buf/private/bufpkg/bufpolicy"
+	"github.com/bufbuild/buf/private/bufpkg/bufregistryapi/bufregistryapipolicy"
+	"github.com/bufbuild/buf/private/pkg/slicesext"
+	"github.com/bufbuild/buf/private/pkg/syserror"
+	"github.com/bufbuild/buf/private/pkg/uuidutil"
+	"github.com/google/uuid"
+)
+
+// NewPolicyDataProvider returns a new PolicyDataProvider for the given API client.
+//
+// A warning is printed to the logger if a given Policy is deprecated.
+func NewPolicyDataProvider(
+	logger *slog.Logger,
+	clientProvider interface {
+		bufregistryapipolicy.V1Beta1DownloadServiceClientProvider
+	},
+) bufpolicy.PolicyDataProvider {
+	return newPolicyDataProvider(logger, clientProvider)
+}
+
+// *** PRIVATE ***
+
+type policyDataProvider struct {
+	logger         *slog.Logger
+	clientProvider interface {
+		bufregistryapipolicy.V1Beta1DownloadServiceClientProvider
+	}
+}
+
+func newPolicyDataProvider(
+	logger *slog.Logger,
+	clientProvider interface {
+		bufregistryapipolicy.V1Beta1DownloadServiceClientProvider
+	},
+) *policyDataProvider {
+	return &policyDataProvider{
+		logger:         logger,
+		clientProvider: clientProvider,
+	}
+}
+
+func (p *policyDataProvider) GetPolicyDatasForPolicyKeys(
+	ctx context.Context,
+	policyKeys []bufpolicy.PolicyKey,
+) ([]bufpolicy.PolicyData, error) {
+	if len(policyKeys) == 0 {
+		return nil, nil
+	}
+	digestType, err := bufpolicy.UniqueDigestTypeForPolicyKeys(policyKeys)
+	if err != nil {
+		return nil, err
+	}
+	if digestType != bufpolicy.DigestTypeO1 {
+		return nil, syserror.Newf("unsupported digest type: %v", digestType)
+	}
+	if _, err := bufparse.FullNameStringToUniqueValue(policyKeys); err != nil {
+		return nil, err
+	}
+
+	registryToIndexedPolicyKeys := slicesext.ToIndexedValuesMap(
+		policyKeys,
+		func(policyKey bufpolicy.PolicyKey) string {
+			return policyKey.FullName().Registry()
+		},
+	)
+	indexedPolicyDatas := make([]slicesext.Indexed[bufpolicy.PolicyData], 0, len(policyKeys))
+	for registry, indexedPolicyKeys := range registryToIndexedPolicyKeys {
+		indexedRegistryPolicyDatas, err := p.getIndexedPolicyDatasForRegistryAndIndexedPolicyKeys(
+			ctx,
+			registry,
+			indexedPolicyKeys,
+		)
+		if err != nil {
+			return nil, err
+		}
+		indexedPolicyDatas = append(indexedPolicyDatas, indexedRegistryPolicyDatas...)
+	}
+	return slicesext.IndexedToSortedValues(indexedPolicyDatas), nil
+}
+
+func (p *policyDataProvider) getIndexedPolicyDatasForRegistryAndIndexedPolicyKeys(
+	ctx context.Context,
+	registry string,
+	indexedPolicyKeys []slicesext.Indexed[bufpolicy.PolicyKey],
+) ([]slicesext.Indexed[bufpolicy.PolicyData], error) {
+	values := slicesext.Map(indexedPolicyKeys, func(indexedPolicyKey slicesext.Indexed[bufpolicy.PolicyKey]) *policyv1beta1.DownloadRequest_Value {
+		return &policyv1beta1.DownloadRequest_Value{
+			ResourceRef: &policyv1beta1.ResourceRef{
+				Value: &policyv1beta1.ResourceRef_Id{
+					Id: uuidutil.ToDashless(indexedPolicyKey.Value.CommitID()),
+				},
+			},
+		}
+	})
+
+	policyResponse, err := p.clientProvider.V1Beta1DownloadServiceClient(registry).Download(
+		ctx,
+		connect.NewRequest(&policyv1beta1.DownloadRequest{
+			Values: values,
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	policyContents := policyResponse.Msg.Contents
+	if len(policyContents) != len(indexedPolicyKeys) {
+		return nil, syserror.New("did not get the expected number of policy datas")
+	}
+
+	commitIDToIndexedPolicyKeys, err := slicesext.ToUniqueValuesMapError(
+		indexedPolicyKeys,
+		func(indexedPolicyKey slicesext.Indexed[bufpolicy.PolicyKey]) (uuid.UUID, error) {
+			return indexedPolicyKey.Value.CommitID(), nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	indexedPolicyDatas := make([]slicesext.Indexed[bufpolicy.PolicyData], 0, len(indexedPolicyKeys))
+	for _, policyContent := range policyContents {
+		commitID, err := uuid.Parse(policyContent.Commit.Id)
+		if err != nil {
+			return nil, err
+		}
+		indexedPolicyKey, ok := commitIDToIndexedPolicyKeys[commitID]
+		if !ok {
+			return nil, syserror.Newf("did not get policy key from store with commitID %q", commitID)
+		}
+		getData := func() ([]byte, error) {
+			return policyContent.Content, nil
+		}
+		policyData, err := bufpolicy.NewPolicyData(ctx, indexedPolicyKey.Value, getData)
+		if err != nil {
+			return nil, err
+		}
+		indexedPolicyDatas = append(
+			indexedPolicyDatas,
+			slicesext.Indexed[bufpolicy.PolicyData]{
+				Value: policyData,
+				Index: indexedPolicyKey.Index,
+			},
+		)
+	}
+	return indexedPolicyDatas, nil
+}

--- a/private/bufpkg/bufpolicy/bufpolicyapi/policy_key_provider.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/policy_key_provider.go
@@ -1,0 +1,168 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpolicyapi
+
+import (
+	"context"
+	"log/slog"
+
+	policyv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/bufpkg/bufparse"
+	"github.com/bufbuild/buf/private/bufpkg/bufpolicy"
+	"github.com/bufbuild/buf/private/bufpkg/bufregistryapi/bufregistryapipolicy"
+	"github.com/bufbuild/buf/private/pkg/slicesext"
+	"github.com/bufbuild/buf/private/pkg/syserror"
+	"github.com/bufbuild/buf/private/pkg/uuidutil"
+)
+
+// NewPolicyKeyProvider returns a new PolicyKeyProvider for the given API clients.
+func NewPolicyKeyProvider(
+	logger *slog.Logger,
+	clientProvider interface {
+		bufregistryapipolicy.V1Beta1CommitServiceClientProvider
+		bufregistryapipolicy.V1Beta1PolicyServiceClientProvider
+	},
+) bufpolicy.PolicyKeyProvider {
+	return newPolicyKeyProvider(logger, clientProvider)
+}
+
+// *** PRIVATE ***
+
+type policyKeyProvider struct {
+	logger         *slog.Logger
+	clientProvider interface {
+		bufregistryapipolicy.V1Beta1CommitServiceClientProvider
+		bufregistryapipolicy.V1Beta1PolicyServiceClientProvider
+	}
+}
+
+func newPolicyKeyProvider(
+	logger *slog.Logger,
+	clientProvider interface {
+		bufregistryapipolicy.V1Beta1CommitServiceClientProvider
+		bufregistryapipolicy.V1Beta1PolicyServiceClientProvider
+	},
+) *policyKeyProvider {
+	return &policyKeyProvider{
+		logger:         logger,
+		clientProvider: clientProvider,
+	}
+}
+
+func (p *policyKeyProvider) GetPolicyKeysForPolicyRefs(
+	ctx context.Context,
+	policyRefs []bufparse.Ref,
+	digestType bufpolicy.DigestType,
+) ([]bufpolicy.PolicyKey, error) {
+	if len(policyRefs) == 0 {
+		return nil, nil
+	}
+	// Check unique policyRefs.
+	if _, err := slicesext.ToUniqueValuesMapError(
+		policyRefs,
+		func(policyRef bufparse.Ref) (string, error) {
+			return policyRef.String(), nil
+		},
+	); err != nil {
+		return nil, err
+	}
+	registryToIndexedPolicyRefs := slicesext.ToIndexedValuesMap(
+		policyRefs,
+		func(policyRef bufparse.Ref) string {
+			return policyRef.FullName().Registry()
+		},
+	)
+	indexedPolicyKeys := make([]slicesext.Indexed[bufpolicy.PolicyKey], 0, len(policyRefs))
+	for registry, indexedPolicyRefs := range registryToIndexedPolicyRefs {
+		indexedRegistryPolicyKeys, err := p.getIndexedPolicyKeysForRegistryAndIndexedPolicyRefs(
+			ctx,
+			registry,
+			indexedPolicyRefs,
+			digestType,
+		)
+		if err != nil {
+			return nil, err
+		}
+		indexedPolicyKeys = append(indexedPolicyKeys, indexedRegistryPolicyKeys...)
+	}
+	return slicesext.IndexedToSortedValues(indexedPolicyKeys), nil
+}
+
+func (p *policyKeyProvider) getIndexedPolicyKeysForRegistryAndIndexedPolicyRefs(
+	ctx context.Context,
+	registry string,
+	indexedPolicyRefs []slicesext.Indexed[bufparse.Ref],
+	digestType bufpolicy.DigestType,
+) ([]slicesext.Indexed[bufpolicy.PolicyKey], error) {
+	resourceRefs := slicesext.Map(indexedPolicyRefs, func(indexedPolicyRef slicesext.Indexed[bufparse.Ref]) *policyv1beta1.ResourceRef {
+		resourceRefName := &policyv1beta1.ResourceRef_Name{
+			Owner:  indexedPolicyRef.Value.FullName().Owner(),
+			Policy: indexedPolicyRef.Value.FullName().Name(),
+		}
+		if ref := indexedPolicyRef.Value.Ref(); ref != "" {
+			resourceRefName.Child = &policyv1beta1.ResourceRef_Name_Ref{
+				Ref: ref,
+			}
+		}
+		return &policyv1beta1.ResourceRef{
+			Value: &policyv1beta1.ResourceRef_Name_{
+				Name: resourceRefName,
+			},
+		}
+	})
+
+	policyResponse, err := p.clientProvider.V1Beta1CommitServiceClient(registry).GetCommits(
+		ctx,
+		connect.NewRequest(&policyv1beta1.GetCommitsRequest{
+			ResourceRefs: resourceRefs,
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	commits := policyResponse.Msg.Commits
+	if len(commits) != len(indexedPolicyRefs) {
+		return nil, syserror.New("did not get the expected number of policy datas")
+	}
+
+	indexedPolicyKeys := make([]slicesext.Indexed[bufpolicy.PolicyKey], len(commits))
+	for i, commit := range commits {
+		commitID, err := uuidutil.FromDashless(commit.Id)
+		if err != nil {
+			return nil, err
+		}
+		digest, err := V1Beta1ProtoToDigest(commit.Digest)
+		if err != nil {
+			return nil, err
+		}
+		policyKey, err := bufpolicy.NewPolicyKey(
+			// Note we don't have to resolve owner_name and policy_name since we already have them.
+			indexedPolicyRefs[i].Value.FullName(),
+			commitID,
+			func() (bufpolicy.Digest, error) {
+				return digest, nil
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		indexedPolicyKeys[i] = slicesext.Indexed[bufpolicy.PolicyKey]{
+			Value: policyKey,
+			Index: indexedPolicyRefs[i].Index,
+		}
+	}
+	return indexedPolicyKeys, nil
+}

--- a/private/bufpkg/bufpolicy/bufpolicyapi/uploader.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/uploader.go
@@ -1,0 +1,289 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufpolicyapi
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	ownerv1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/owner/v1"
+	policyv1beta1 "buf.build/gen/go/bufbuild/registry/protocolbuffers/go/buf/registry/policy/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/bufpkg/bufpolicy"
+	"github.com/bufbuild/buf/private/bufpkg/bufregistryapi/bufregistryapipolicy"
+	"github.com/bufbuild/buf/private/pkg/slicesext"
+	"github.com/bufbuild/buf/private/pkg/syserror"
+	"github.com/bufbuild/buf/private/pkg/uuidutil"
+)
+
+// NewUploader returns a new Uploader for the given API client.
+func NewUploader(
+	logger *slog.Logger,
+	policyClientProvider interface {
+		bufregistryapipolicy.V1Beta1PolicyServiceClientProvider
+		bufregistryapipolicy.V1Beta1UploadServiceClientProvider
+	},
+	options ...UploaderOption,
+) bufpolicy.Uploader {
+	return newUploader(logger, policyClientProvider, options...)
+}
+
+// UploaderOption is an option for a new Uploader.
+type UploaderOption func(*uploader)
+
+// *** PRIVATE ***
+
+type uploader struct {
+	logger               *slog.Logger
+	policyClientProvider interface {
+		bufregistryapipolicy.V1Beta1PolicyServiceClientProvider
+		bufregistryapipolicy.V1Beta1UploadServiceClientProvider
+	}
+}
+
+func newUploader(
+	logger *slog.Logger,
+	policyClientProvider interface {
+		bufregistryapipolicy.V1Beta1PolicyServiceClientProvider
+		bufregistryapipolicy.V1Beta1UploadServiceClientProvider
+	},
+	options ...UploaderOption,
+) *uploader {
+	uploader := &uploader{
+		logger:               logger,
+		policyClientProvider: policyClientProvider,
+	}
+	for _, option := range options {
+		option(uploader)
+	}
+	return uploader
+}
+
+func (u *uploader) Upload(
+	ctx context.Context,
+	policies []bufpolicy.Policy,
+	options ...bufpolicy.UploadOption,
+) ([]bufpolicy.Commit, error) {
+	uploadOptions, err := bufpolicy.NewUploadOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	registryToIndexedPolicyKeys := slicesext.ToIndexedValuesMap(
+		policies,
+		func(policy bufpolicy.Policy) string {
+			return policy.FullName().Registry()
+		},
+	)
+	indexedCommits := make([]slicesext.Indexed[bufpolicy.Commit], 0, len(policies))
+	for registry, indexedPolicyKeys := range registryToIndexedPolicyKeys {
+		indexedRegistryPolicyDatas, err := u.uploadIndexedPoliciesForRegistry(
+			ctx,
+			registry,
+			indexedPolicyKeys,
+			uploadOptions,
+		)
+		if err != nil {
+			return nil, err
+		}
+		indexedCommits = append(indexedCommits, indexedRegistryPolicyDatas...)
+	}
+	return slicesext.IndexedToSortedValues(indexedCommits), nil
+}
+
+func (u *uploader) uploadIndexedPoliciesForRegistry(
+	ctx context.Context,
+	registry string,
+	indexedPolicies []slicesext.Indexed[bufpolicy.Policy],
+	uploadOptions bufpolicy.UploadOptions,
+) ([]slicesext.Indexed[bufpolicy.Commit], error) {
+	if uploadOptions.CreateIfNotExist() {
+		// We must attempt to create each Policy one at a time, since CreatePolicies will return
+		// an `AlreadyExists` if any of the Policies we are attempting to create already exists,
+		// and no new Policies will be created.
+		for _, indexedPolicy := range indexedPolicies {
+			policy := indexedPolicy.Value
+			if _, err := u.createPolicyIfNotExist(
+				ctx,
+				registry,
+				policy,
+				uploadOptions.CreatePolicyVisibility(),
+			); err != nil {
+				return nil, err
+			}
+		}
+	}
+	contents, err := slicesext.MapError(indexedPolicies, func(indexedPolicy slicesext.Indexed[bufpolicy.Policy]) (*policyv1beta1.UploadRequest_Content, error) {
+		policy := indexedPolicy.Value
+		if !policy.IsLocal() {
+			return nil, syserror.New("expected local Policy in uploadIndexedPoliciesForRegistry")
+		}
+		if policy.FullName() == nil {
+			return nil, syserror.Newf("expected Policy name for local Policy: %s", policy.Description())
+		}
+		data, err := policy.Data()
+		if err != nil {
+			return nil, err
+		}
+		return &policyv1beta1.UploadRequest_Content{
+			PolicyRef: &policyv1beta1.PolicyRef{
+				Value: &policyv1beta1.PolicyRef_Name_{
+					Name: &policyv1beta1.PolicyRef_Name{
+						Owner:  policy.FullName().Owner(),
+						Policy: policy.FullName().Name(),
+					},
+				},
+			},
+			Content: data,
+			ScopedLabelRefs: slicesext.Map(uploadOptions.Labels(), func(label string) *policyv1beta1.ScopedLabelRef {
+				return &policyv1beta1.ScopedLabelRef{
+					Value: &policyv1beta1.ScopedLabelRef_Name{
+						Name: label,
+					},
+				}
+			}),
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	uploadResponse, err := u.policyClientProvider.V1Beta1UploadServiceClient(registry).Upload(
+		ctx,
+		connect.NewRequest(&policyv1beta1.UploadRequest{
+			Contents: contents,
+		}))
+	if err != nil {
+		return nil, err
+	}
+	policyCommits := uploadResponse.Msg.Commits
+	if len(policyCommits) != len(indexedPolicies) {
+		return nil, syserror.Newf("expected %d Commits, found %d", len(indexedPolicies), len(policyCommits))
+	}
+
+	indexedCommits := make([]slicesext.Indexed[bufpolicy.Commit], 0, len(indexedPolicies))
+	for i, policyCommit := range policyCommits {
+		policyFullName := indexedPolicies[i].Value.FullName()
+		commitID, err := uuidutil.FromDashless(policyCommit.Id)
+		if err != nil {
+			return nil, err
+		}
+		policyKey, err := bufpolicy.NewPolicyKey(
+			policyFullName,
+			commitID,
+			func() (bufpolicy.Digest, error) {
+				return V1Beta1ProtoToDigest(policyCommit.Digest)
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		commit := bufpolicy.NewCommit(
+			policyKey,
+			func() (time.Time, error) {
+				return policyCommit.CreateTime.AsTime(), nil
+			},
+		)
+		indexedCommits = append(
+			indexedCommits,
+			slicesext.Indexed[bufpolicy.Commit]{
+				Value: commit,
+				Index: i,
+			},
+		)
+	}
+	return indexedCommits, nil
+}
+
+func (u *uploader) createPolicyIfNotExist(
+	ctx context.Context,
+	primaryRegistry string,
+	policy bufpolicy.Policy,
+	createPolicyVisibility bufpolicy.PolicyVisibility,
+) (*policyv1beta1.Policy, error) {
+	v1Beta1ProtoCreatePolicyVisibility, err := policyVisibilityToV1Beta1Proto(createPolicyVisibility)
+	if err != nil {
+		return nil, err
+	}
+	response, err := u.policyClientProvider.V1Beta1PolicyServiceClient(primaryRegistry).CreatePolicies(
+		ctx,
+		connect.NewRequest(
+			&policyv1beta1.CreatePoliciesRequest{
+				Values: []*policyv1beta1.CreatePoliciesRequest_Value{
+					{
+						OwnerRef: &ownerv1.OwnerRef{
+							Value: &ownerv1.OwnerRef_Name{
+								Name: policy.FullName().Owner(),
+							},
+						},
+						Name:        policy.FullName().Name(),
+						Visibility:  v1Beta1ProtoCreatePolicyVisibility,
+						Description: policy.Description(),
+					},
+				},
+			},
+		),
+	)
+	if err != nil {
+		if connect.CodeOf(err) == connect.CodeAlreadyExists {
+			// If a policy already existed, then we check validate its contents.
+			policies, err := u.validatePoliciesExist(ctx, primaryRegistry, []bufpolicy.Policy{policy})
+			if err != nil {
+				return nil, err
+			}
+			if len(policies) != 1 {
+				return nil, syserror.Newf("expected 1 Policy, found %d", len(policies))
+			}
+			return policies[0], nil
+		}
+		return nil, err
+	}
+	if len(response.Msg.Policies) != 1 {
+		return nil, syserror.Newf("expected 1 Policy, found %d", len(response.Msg.Policies))
+	}
+	// Otherwise we return the policy we created.
+	return response.Msg.Policies[0], nil
+}
+
+func (u *uploader) validatePoliciesExist(
+	ctx context.Context,
+	primaryRegistry string,
+	policies []bufpolicy.Policy,
+) ([]*policyv1beta1.Policy, error) {
+	response, err := u.policyClientProvider.V1Beta1PolicyServiceClient(primaryRegistry).GetPolicies(
+		ctx,
+		connect.NewRequest(
+			&policyv1beta1.GetPoliciesRequest{
+				PolicyRefs: slicesext.Map(
+					policies,
+					func(policy bufpolicy.Policy) *policyv1beta1.PolicyRef {
+						return &policyv1beta1.PolicyRef{
+							Value: &policyv1beta1.PolicyRef_Name_{
+								Name: &policyv1beta1.PolicyRef_Name{
+									Owner:  policy.FullName().Owner(),
+									Policy: policy.FullName().Name(),
+								},
+							},
+						}
+					},
+				),
+			},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return response.Msg.Policies, nil
+}

--- a/private/bufpkg/bufpolicy/bufpolicyapi/usage.gen.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package bufpolicyapi
+
+import _ "github.com/bufbuild/buf/private/usage"

--- a/private/bufpkg/bufregistryapi/bufregistryapipolicy/bufregistryapipolicy.go
+++ b/private/bufpkg/bufregistryapi/bufregistryapipolicy/bufregistryapipolicy.go
@@ -1,0 +1,168 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufregistryapipolicy
+
+import (
+	"buf.build/gen/go/bufbuild/registry/connectrpc/go/buf/registry/policy/v1beta1/policyv1beta1connect"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
+)
+
+var (
+	// NopV1Beta1CommitServiceClientProvider is a V1Beta1CommitServiceClientProvider that provides unimplemented services for testing.
+	NopV1Beta1CommitServiceClientProvider V1Beta1CommitServiceClientProvider = nopClientProvider{}
+	// NopV1Beta1DownloadServiceClientProvider is a V1Beta1DownloadServiceClientProvider that provides unimplemented services for testing.
+	NopV1Beta1DownloadServiceClientProvider V1Beta1DownloadServiceClientProvider = nopClientProvider{}
+	// NopV1Beta1LabelServiceClientProvider is a V1Beta1LabelServiceClientProvider that provides unimplemented services for testing.
+	NopV1Beta1LabelServiceClientProvider V1Beta1LabelServiceClientProvider = nopClientProvider{}
+	// NopV1Beta1PolicyServiceClientProvider is a V1Beta1PolicyServiceClientProvider that provides unimplemented services for testing.
+	NopV1Beta1PolicyServiceClientProvider V1Beta1PolicyServiceClientProvider = nopClientProvider{}
+	// NopV1Beta1ResourceServiceClientProvider is a V1Beta1ResourceServiceClientProvider that provides unimplemented services for testing.
+	NopV1Beta1ResourceServiceClientProvider V1Beta1ResourceServiceClientProvider = nopClientProvider{}
+	// NopV1Beta1UploadServiceClientProvider is a V1Beta1UploadServiceClientProvider that provides unimplemented services for testing.
+	NopV1Beta1UploadServiceClientProvider V1Beta1UploadServiceClientProvider = nopClientProvider{}
+	// NopClientProvider is a ClientProvider that provides unimplemented services for testing.
+	NopClientProvider ClientProvider = nopClientProvider{}
+)
+
+// V1Beta1CommitServiceClientProvider provides CommitServiceClients.
+type V1Beta1CommitServiceClientProvider interface {
+	V1Beta1CommitServiceClient(registry string) policyv1beta1connect.CommitServiceClient
+}
+
+// V1Beta1DownloadServiceClientProvider provides DownloadServiceClients.
+type V1Beta1DownloadServiceClientProvider interface {
+	V1Beta1DownloadServiceClient(registry string) policyv1beta1connect.DownloadServiceClient
+}
+
+// V1Beta1LabelServiceClientProvider provides LabelServiceClients.
+type V1Beta1LabelServiceClientProvider interface {
+	V1Beta1LabelServiceClient(registry string) policyv1beta1connect.LabelServiceClient
+}
+
+// V1Beta1ResourceServiceClientProvider provides ResourceServiceClients.
+type V1Beta1ResourceServiceClientProvider interface {
+	V1Beta1ResourceServiceClient(registry string) policyv1beta1connect.ResourceServiceClient
+}
+
+// V1Beta1PolicyServiceClientProvider provides PolicyServiceClients.
+type V1Beta1PolicyServiceClientProvider interface {
+	V1Beta1PolicyServiceClient(registry string) policyv1beta1connect.PolicyServiceClient
+}
+
+// V1Beta1UploadServiceClientProvider provides UploadServiceClients.
+type V1Beta1UploadServiceClientProvider interface {
+	V1Beta1UploadServiceClient(registry string) policyv1beta1connect.UploadServiceClient
+}
+
+// ClientProvider provides API clients for BSR services.
+type ClientProvider interface {
+	V1Beta1CommitServiceClientProvider
+	V1Beta1DownloadServiceClientProvider
+	V1Beta1LabelServiceClientProvider
+	V1Beta1ResourceServiceClientProvider
+	V1Beta1PolicyServiceClientProvider
+	V1Beta1UploadServiceClientProvider
+}
+
+// NewClientProvider returns a new ClientProvider.
+func NewClientProvider(clientConfig *connectclient.Config) ClientProvider {
+	return newClientProvider(clientConfig)
+}
+
+// *** PRIVATE ***
+
+type clientProvider struct {
+	clientConfig *connectclient.Config
+}
+
+func newClientProvider(clientConfig *connectclient.Config) *clientProvider {
+	return &clientProvider{
+		clientConfig: clientConfig,
+	}
+}
+
+func (c *clientProvider) V1Beta1CommitServiceClient(registry string) policyv1beta1connect.CommitServiceClient {
+	return connectclient.Make(
+		c.clientConfig,
+		registry,
+		policyv1beta1connect.NewCommitServiceClient,
+	)
+}
+
+func (c *clientProvider) V1Beta1DownloadServiceClient(registry string) policyv1beta1connect.DownloadServiceClient {
+	return connectclient.Make(
+		c.clientConfig,
+		registry,
+		policyv1beta1connect.NewDownloadServiceClient,
+	)
+}
+
+func (c *clientProvider) V1Beta1LabelServiceClient(registry string) policyv1beta1connect.LabelServiceClient {
+	return connectclient.Make(
+		c.clientConfig,
+		registry,
+		policyv1beta1connect.NewLabelServiceClient,
+	)
+}
+
+func (c *clientProvider) V1Beta1ResourceServiceClient(registry string) policyv1beta1connect.ResourceServiceClient {
+	return connectclient.Make(
+		c.clientConfig,
+		registry,
+		policyv1beta1connect.NewResourceServiceClient,
+	)
+}
+
+func (c *clientProvider) V1Beta1PolicyServiceClient(registry string) policyv1beta1connect.PolicyServiceClient {
+	return connectclient.Make(
+		c.clientConfig,
+		registry,
+		policyv1beta1connect.NewPolicyServiceClient,
+	)
+}
+
+func (c *clientProvider) V1Beta1UploadServiceClient(registry string) policyv1beta1connect.UploadServiceClient {
+	return connectclient.Make(
+		c.clientConfig,
+		registry,
+		policyv1beta1connect.NewUploadServiceClient,
+	)
+}
+
+type nopClientProvider struct{}
+
+func (nopClientProvider) V1Beta1CommitServiceClient(registry string) policyv1beta1connect.CommitServiceClient {
+	return policyv1beta1connect.UnimplementedCommitServiceHandler{}
+}
+
+func (nopClientProvider) V1Beta1DownloadServiceClient(registry string) policyv1beta1connect.DownloadServiceClient {
+	return policyv1beta1connect.UnimplementedDownloadServiceHandler{}
+}
+
+func (nopClientProvider) V1Beta1LabelServiceClient(registry string) policyv1beta1connect.LabelServiceClient {
+	return policyv1beta1connect.UnimplementedLabelServiceHandler{}
+}
+
+func (nopClientProvider) V1Beta1ResourceServiceClient(registry string) policyv1beta1connect.ResourceServiceClient {
+	return policyv1beta1connect.UnimplementedResourceServiceHandler{}
+}
+
+func (nopClientProvider) V1Beta1PolicyServiceClient(registry string) policyv1beta1connect.PolicyServiceClient {
+	return policyv1beta1connect.UnimplementedPolicyServiceHandler{}
+}
+
+func (nopClientProvider) V1Beta1UploadServiceClient(registry string) policyv1beta1connect.UploadServiceClient {
+	return policyv1beta1connect.UnimplementedUploadServiceHandler{}
+}

--- a/private/bufpkg/bufregistryapi/bufregistryapipolicy/usage.gen.go
+++ b/private/bufpkg/bufregistryapi/bufregistryapipolicy/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package bufregistryapipolicy
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This PR adds the package `bufpolicyapi` for interacting with the BSR to upload and download policy data.