### PR TITLE
Add ppc64le architecture to release script

### DIFF
--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -84,7 +84,7 @@ mkdir -p "${RELEASE_DIR}"
 cd "${RELEASE_DIR}"
 
 for os in Darwin Linux Windows; do
-  for arch in x86_64 arm64 armv7; do
+  for arch in x86_64 arm64 armv7 ppc64le; do
     # our goal is to have the binaries be suffixed with $(uname -s)-$(uname -m)
     # on mac, this is arm64, on linux, this is aarch64, for historical reasons
     # this is a hacky way to not have to rewrite this loop (and others below)
@@ -108,6 +108,13 @@ for os in Darwin Linux Windows; do
         else
           continue
         fi 
+      elif [ "${arch}" == "ppc64le" ]; then
+        if [ "${os}" == "Linux" ]; then
+          CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
+            go build -a -ldflags "-s -w" -trimpath -buildvcs=false -o "${dir}/bin/${binary}${extension}" "${DIR}/cmd/${binary}"
+        else
+          continue
+        fi
       else
         CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
           go build -a -ldflags "-s -w" -trimpath -buildvcs=false -o "${dir}/bin/${binary}${extension}" "${DIR}/cmd/${binary}"
@@ -118,8 +125,11 @@ for os in Darwin Linux Windows; do
 done
 
 for os in Darwin Linux Windows; do
-  for arch in x86_64 arm64 armv7; do
+  for arch in x86_64 arm64 armv7 ppc64le; do
     if [ "${arch}" == "armv7" ] && [ "${os}" != "Linux" ]; then
+      continue
+    fi
+    if [ "${arch}" == "ppc64le" ] && [ "${os}" != "Linux" ]; then
       continue
     fi
     if [ "${os}" == "Linux" ] && [ "${arch}" == "arm64" ]; then
@@ -141,8 +151,11 @@ for os in Darwin Linux Windows; do
 done
 
 for os in Darwin Linux; do
-  for arch in x86_64 arm64 armv7; do
+  for arch in x86_64 arm64 armv7 ppc64le; do
     if [ "${arch}" == "armv7" ] && [ "${os}" != "Linux" ]; then
+      continue
+    fi
+    if [ "${arch}" == "ppc64le" ] && [ "${os}" != "Linux" ]; then
       continue
     fi
     if [ "${os}" == "Linux" ] && [ "${arch}" == "arm64" ]; then


### PR DESCRIPTION
Add ppc64le architecture to releases. This is necessary for the rules_buf bazel module to work properly on the ppc64le architecture as a binary release is required by the rules_buf_toolchains target.