### PR TITLE
Remove hidden parallelism flag from app

### DIFF
--- a/private/pkg/app/appext/builder.go
+++ b/private/pkg/app/appext/builder.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/bufbuild/buf/private/pkg/app"
-	"github.com/bufbuild/buf/private/pkg/thread"
 	"github.com/pkg/profile"
 	"github.com/spf13/pflag"
 )
@@ -39,8 +38,6 @@ type builder struct {
 	profileLoops      int
 	profileType       string
 	profileAllowError bool
-
-	parallelism int
 
 	timeout time.Duration
 
@@ -82,8 +79,6 @@ func (b *builder) BindRoot(flagSet *pflag.FlagSet) {
 	// We do not officially support this flag, this is for testing, where we need warnings turned off.
 	flagSet.BoolVar(&b.noWarn, "no-warn", false, "Turn off warn logging")
 	_ = flagSet.MarkHidden("no-warn")
-	flagSet.IntVar(&b.parallelism, "parallelism", 0, "Manually control the parallelism")
-	_ = flagSet.MarkHidden("parallelism")
 
 	// We used to have this as a global flag, so we still need to not error when it is called.
 	var verbose bool
@@ -125,10 +120,6 @@ func (b *builder) run(
 		return err
 	}
 	container := newContainer(nameContainer, logger)
-
-	if b.parallelism > 0 {
-		thread.SetParallelism(b.parallelism)
-	}
 
 	var cancel context.CancelFunc
 	if !b.profile && b.timeout != 0 {


### PR DESCRIPTION
To my knowledge, this hasn't been used since circa 2020. This removes a dependency on the `thread` package.