### PR TITLE
Fix protovalidate predefined CEL rules variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for local bufplugins for `protoc-gen-buf-breaking` and `protoc-gen-buf-lint`.
 - Add RISC-V (64-bit) binaries for Linux to releases.
 - Fix type filtering on `buf generate` for empty files, files with no declared types.
+- Fix CEL check on `buf lint` for predefined `rules` variables.
 
 ## [v1.53.0] - 2025-04-21
 

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/predefined_rules.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/predefined_rules.go
@@ -93,6 +93,7 @@ func checkPredefinedRuleExtension(
 			celpv.RequiredEnvOptions(extensionDescriptor),
 			cel.Variable("rule", ruleType),
 			cel.Variable("this", thisType),
+			cel.Variable("rules", cel.ObjectType(string(extendedRuleFullName))),
 		)...,
 	)
 	if err != nil {

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/import/import.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/import/import.proto
@@ -5,7 +5,7 @@ package custom;
 import "buf/validate/validate.proto";
 
 extend buf.validate.StringRules {
-   optional string special_suffix = 1800 [(buf.validate.predefined).cel = {
+  optional string special_suffix = 1800 [(buf.validate.predefined).cel = {
     id: "string.special_suffix"
     expression: "!this.endsWith(rule + '_') ? \'value does not have suffix `%s`\'.format([rule + '_']) : \'\'"
   }];

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/proto/rules.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/proto/rules.proto
@@ -43,13 +43,3 @@ extend buf.validate.MapRules {
       ": 'this is required and must be ' + string(rule) + ' or fewer items but ' + string(rules.max_pairs)"
   }];
 }
-
-extend buf.validate.AnyRules {
-  optional string required_any_in = 18004 [(buf.validate.predefined).cel = {
-    id: "any.required.in"
-    expression:
-      "rules.in == this.required_any_in"
-      "? ''"
-      ": fail"
-  }];
-}

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/proto/rules.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/proto/rules.proto
@@ -1,0 +1,55 @@
+syntax = "proto2";
+
+package rules;
+
+import "buf/validate/validate.proto";
+
+extend buf.validate.StringRules {
+  optional int32 required_with_max = 80048954 [(buf.validate.predefined).cel = {
+    id: "string.required.max"
+    expression:
+      "(rules.min_len > 0 && rules.max_len > 0) || (this.size() > 0 && this.size() <= rule)"
+      "? ''"
+      ": 'this is required and must be ' + string(rule) + ' or fewer characters but ' + string(rules.max_len)"
+  }];
+}
+
+extend buf.validate.Int32Rules {
+  optional int32 required_lt = 18001 [(buf.validate.predefined).cel = {
+    id: "int32.required.lt"
+    expression:
+      "(rules.lt > 0)"
+      "? ''"
+      ": 'this is required and must be ' + string(rule)"
+  }];
+}
+
+extend buf.validate.RepeatedRules {
+  optional int32 required_max_items = 18002 [(buf.validate.predefined).cel = {
+    id: "repeated.required.max"
+    expression:
+      "(rules.min_items > 0 && rules.max_items > 0) || (this.size() > 0 && this.size() <= rule)"
+      "? ''"
+      ": 'this is required and must be ' + string(rule) + ' or fewer items but ' + string(rules.max_items)"
+  }];
+}
+
+extend buf.validate.MapRules {
+  optional int32 required_max_pairs = 18003 [(buf.validate.predefined).cel = {
+    id: "map.required.max"
+    expression:
+      "(rules.min_pairs > 0 && rules.max_pairs > 0) || (this.size() > 0 && this.size() <= rule)"
+      "? ''"
+      ": 'this is required and must be ' + string(rule) + ' or fewer items but ' + string(rules.max_pairs)"
+  }];
+}
+
+extend buf.validate.AnyRules {
+  optional string required_any_in = 18004 [(buf.validate.predefined).cel = {
+    id: "any.required.in"
+    expression:
+      "rules.in == this.required_any_in"
+      "? ''"
+      ": fail"
+  }];
+}

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/proto/test.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate_predefined/proto/test.proto
@@ -6,7 +6,7 @@ import "buf/validate/validate.proto";
 import "import.proto";
 
 extend buf.validate.StringRules {
-   optional string special_prefix = 1801 [(buf.validate.predefined).cel = {
+  optional string special_prefix = 1801 [(buf.validate.predefined).cel = {
     id: "string.special_prefix"
     expression: "!this.startsWith('_' + rule) ? \'value does not have prefix `%s`\'.format(['_' + rule]) : \'\'"
   }];


### PR DESCRIPTION
This adds the variable `rules` to the CEL environment for the predefined protovalidate rules.

Fixes #3824.