### PR TITLE
Add `ppc64le` Linux binary to releases and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ Once you've installed `buf`, we recommend completing the [CLI tutorial][cli-tuto
 
 After completing the tour, check out the remainder of the [docs] for your specific areas of interest.
 
+## Builds
+
+The following is a breakdown of the binaries by CPU architecture and operating system available through our [releases]:
+
+|  | Linux | MacOS | Windows |
+| --- | --- | --- | --- |
+| x86 (64-bit) | ✅ | ✅ | ✅ |
+| ARM (64-bit) | ✅ | ✅ | ✅ |
+| ARMv7 (32-bit) | ✅ | ❌ | ❌ |
+| RISC-V (64-bit) | ✅ | ❌ | ❌ |
+| ppc64le | ✅ | ❌ | ❌ |
+
 ## Community
 
 For help and discussion around Protobuf, best practices, and more, join us on [Slack][badges_slack].

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -85,7 +85,7 @@ mkdir -p "${RELEASE_DIR}"
 cd "${RELEASE_DIR}"
 
 for os in Darwin Linux Windows; do
-  for arch in x86_64 riscv64 arm64 armv7; do
+  for arch in x86_64 riscv64 arm64 armv7 ppc64le; do
     # our goal is to have the binaries be suffixed with $(uname -s)-$(uname -m)
     # on mac, this is arm64, on linux, this is aarch64, for historical reasons
     # this is a hacky way to not have to rewrite this loop (and others below)
@@ -118,7 +118,7 @@ for os in Darwin Linux Windows; do
 done
 
 for os in Darwin Linux Windows; do
-  for arch in x86_64 riscv64 arm64 armv7; do
+  for arch in x86_64 riscv64 arm64 armv7 ppc64le; do
     if [[ ! "${arch}" =~ x86_64|arm64 ]] && [ "${os}" != "Linux" ]; then
       continue
     fi
@@ -141,7 +141,7 @@ for os in Darwin Linux Windows; do
 done
 
 for os in Darwin Linux; do
-  for arch in x86_64 riscv64 arm64 armv7; do
+  for arch in x86_64 riscv64 arm64 armv7 ppc64le; do
     if [[ ! "${arch}" =~ x86_64|arm64 ]] && [ "${os}" != "Linux" ]; then
       continue
     fi


### PR DESCRIPTION
This adds a `ppc64le` binary to our builds for release and
a README summary of the binaries available in our releases.

Supersedes #3811