### PR TITLE
Implement `buf registry sdk info` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Promote `buf beta stats` to `buf stats`.
 - Update built-in Well-Known Types to Protobuf v31.1.
+- Add `buf registry sdk info` command.
 
 ## [v1.54.0] - 2025-05-12
 

--- a/private/buf/bufprint/bufprint.go
+++ b/private/buf/bufprint/bufprint.go
@@ -322,6 +322,16 @@ func NewStatsPrinter(writer io.Writer) StatsPrinter {
 	return newStatsPrinter(writer)
 }
 
+// SDKInfoPrinter is a printer for SDK info.
+type SDKInfoPrinter interface {
+	PrintSDKInfo(ctx context.Context, format Format, sdkInfo *registryv1alpha1.GetSDKInfoResponse) error
+}
+
+// NewSDKInfoPrinter returns a new SDKInfoPrinter.
+func NewSDKInfoPrinter(writer io.Writer) SDKInfoPrinter {
+	return newSDKInfoPrinter(writer)
+}
+
 // TabWriter is a tab writer.
 type TabWriter interface {
 	Write(values ...string) error

--- a/private/buf/bufprint/sdk_info_printer.go
+++ b/private/buf/bufprint/sdk_info_printer.go
@@ -1,0 +1,120 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufprint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
+)
+
+type sdkInfoPrinter struct {
+	writer io.Writer
+}
+
+func newSDKInfoPrinter(writer io.Writer) *sdkInfoPrinter {
+	return &sdkInfoPrinter{
+		writer: writer,
+	}
+}
+
+func (p *sdkInfoPrinter) PrintSDKInfo(
+	ctx context.Context,
+	format Format,
+	sdkInfo *registryv1alpha1.GetSDKInfoResponse,
+) error {
+	output := newOutputSDKInfo(sdkInfo)
+	switch format {
+	case FormatText:
+		if _, err := fmt.Fprintf(
+			p.writer,
+			`Module
+Owner:  %s
+Name:   %s
+Commit: %s
+
+`,
+			output.ModuleInfo.Owner,
+			output.ModuleInfo.Name,
+			output.ModuleInfo.Commit,
+		); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(
+			p.writer,
+			`Plugin
+Owner:    %s
+Name:     %s
+Version:  %s
+Revision: %d
+
+`,
+			output.PluginInfo.Owner,
+			output.PluginInfo.Name,
+			output.PluginInfo.Version,
+			output.PluginInfo.Revision,
+		); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintf(p.writer, "Version: %s\n", output.Version)
+		return err
+	case FormatJSON:
+		return json.NewEncoder(p.writer).Encode(output)
+	default:
+		return fmt.Errorf("unknown format: %v", format)
+	}
+}
+
+type outputSDKInfo struct {
+	ModuleInfo outputSDKModuleInfo `json:"module,omitempty"`
+	PluginInfo outputSDKPluginInfo `json:"plugin,omitempty"`
+	Version    string              `json:"version,omitempty"`
+}
+
+type outputSDKModuleInfo struct {
+	Owner            string    `json:"owner,omitempty"`
+	Name             string    `json:"name,omitempty"`
+	Commit           string    `json:"commit,omitempty"`
+	CommitCreateTime time.Time `json:"commit_create_time,omitempty"`
+}
+
+type outputSDKPluginInfo struct {
+	Owner    string `json:"owner,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Revision uint32 `json:"revision,omitempty"`
+}
+
+func newOutputSDKInfo(sdkInfo *registryv1alpha1.GetSDKInfoResponse) outputSDKInfo {
+	return outputSDKInfo{
+		ModuleInfo: outputSDKModuleInfo{
+			Owner:            sdkInfo.GetModuleInfo().GetOwner(),
+			Name:             sdkInfo.GetModuleInfo().GetName(),
+			Commit:           sdkInfo.GetModuleInfo().GetCommit(),
+			CommitCreateTime: sdkInfo.GetModuleInfo().GetModuleCommitCreateTime().AsTime(),
+		},
+		PluginInfo: outputSDKPluginInfo{
+			Owner:    sdkInfo.GetPluginInfo().GetOwner(),
+			Name:     sdkInfo.GetPluginInfo().GetName(),
+			Version:  sdkInfo.GetPluginInfo().GetVersion(),
+			Revision: sdkInfo.GetPluginInfo().GetPluginRevision(),
+		},
+		Version: sdkInfo.GetSdkVersion(),
+	}
+}

--- a/private/buf/cmd/buf/buf.go
+++ b/private/buf/cmd/buf/buf.go
@@ -101,6 +101,7 @@ import (
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/registrycc"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/registrylogin"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/registrylogout"
+	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/sdk/sdkinfo"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/sdk/version"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/registry/whoami"
 	"github.com/bufbuild/buf/private/buf/cmd/buf/command/stats"
@@ -221,6 +222,7 @@ func NewRootCommand(name string) *appcmd.Command {
 						Short: "Manage Generated SDKs",
 						SubCommands: []*appcmd.Command{
 							version.NewCommand("version", builder),
+							sdkinfo.NewCommand("info", builder),
 						},
 					},
 					{

--- a/private/buf/cmd/buf/command/registry/sdk/sdkinfo/sdkinfo.go
+++ b/private/buf/cmd/buf/command/registry/sdk/sdkinfo/sdkinfo.go
@@ -53,9 +53,9 @@ In order to resolve the SDK information, a module and plugin must be specified.
 Examples:
 
 To get the SDK information for the latest commit of a module and latest version of a plugin, you only need to specify the module and plugin.
-The following will resolve the SDK information for the latest commit of the bufbuild/eliza module and the latest version of the bufbuild/es plugin:
+The following will resolve the SDK information for the latest commit of the connectrpc/eliza module and the latest version of the bufbuild/es plugin:
 
-    $ buf registry sdk info --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es
+    $ buf registry sdk info --module=buf.build/connectrpc/eliza --plugin=buf.build/connectrpc/es
     Module
     Owner:  connectrpc
     Name:   eliza
@@ -70,7 +70,7 @@ The following will resolve the SDK information for the latest commit of the bufb
     Version: <SDK version for the resolved module commit and plugin version>
 
 To get the SDK information for a specific commit of a module and/or a specific version of a plugin, you can specify the commit with the module and/or the version with the plugin.
-The following will resolve the SDK information for the specified commit of the bufbuild/eliza module and specified version of the bufbuild/es plugin:
+The following will resolve the SDK information for the specified commit of the connectrpc/eliza module and specified version of the bufbuild/es plugin:
 
     $ buf registry sdk info --module=buf.build/connectrpc/eliza:d8fbf2620c604277a0ece1ff3a26f2ff --plugin=buf.build/bufbuild/es:v1.2.1
     Module
@@ -87,7 +87,7 @@ The following will resolve the SDK information for the specified commit of the b
     Version: 1.2.1-20230727062025-d8fbf2620c60.1
 
 If you have a SDK version and want to know the corresponding module commit and plugin version information for the SDK, you can specify the module and plugin with the version string.
-The following will resolve the SDK information for the specified SDK version of the bufbuild/eliza module and bufbuild/es plugin.
+The following will resolve the SDK information for the specified SDK version of the connectrpc/eliza module and bufbuild/es plugin.
 
     $ buf registry sdk --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es --version=1.2.1-20230727062025-d8fbf2620c60.1
     Module

--- a/private/buf/cmd/buf/command/registry/sdk/sdkinfo/sdkinfo.go
+++ b/private/buf/cmd/buf/command/registry/sdk/sdkinfo/sdkinfo.go
@@ -1,0 +1,106 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdkinfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"buf.build/go/app/appcmd"
+	"buf.build/go/app/appext"
+	"github.com/bufbuild/buf/private/buf/bufprint"
+	"github.com/spf13/pflag"
+)
+
+const (
+	formatFlagName  = "format"
+	moduleFlagName  = "module"
+	pluginFlagName  = "plugin"
+	versionFlagName = "version"
+)
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	// TODO: should we use an example other than eliza?
+	return &appcmd.Command{
+		Use:   name + " --module=<remote/owner/repository[:ref]> --plugin=<remote/owner/plugin[:version]>",
+		Short: "Get SDK information for the given module, plugin, and optionally version.",
+		// TODO: complete examples
+		Long: `This command returns the version information for a Generated SDK based on the specified information.
+In order to resolve the SDK information, a module and plugin must be specified.
+
+Examples:
+
+To get the SDK information for of the latest commit of the eliza module and the latest version of the Go plugin:
+    $ buf registry sdk info --module=buf.build/connectrpc/eliza --plugin=buf.build/protocolbuffers/go
+    <TODO: return value>
+
+To get the SDK information for a specific commit of the eliza module and a specific version of the Go plugin:
+    $ buf registry sdk info --module=buf.build/connectrpc/eliza:<TODO: commit> --plugin=buf.build/protocolbuffers/go:v1.32.0
+    <TODO: return value>
+
+If you have a SDK version and you want to know the module commit and plugin version information for the SDK:
+    $ buf registry sdk --module=buf.build/connectrpc/eliza --plugin=buf.build/protocolbuffers/go --version=<TODO: version string>
+    <TODO: return value>
+
+If a module reference and/or plugin version are specified along with the SDK version flag, --version, then the SDK version
+will be validated against the provided module reference and/or plugin version. If there is a mismatch, this command will error.`,
+		Args: appcmd.NoArgs,
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct {
+	Format  string
+	Module  string
+	Plugin  string
+	Version string
+}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(
+		&f.Format,
+		formatFlagName,
+		bufprint.FormatText.String(),
+		fmt.Sprintf("The output format to use. Must be one of %s", bufprint.AllFormatsString),
+	)
+	flagSet.StringVar(&f.Module, moduleFlagName, "", "The module reference for the SDK.")
+	flagSet.StringVar(&f.Plugin, pluginFlagName, "", "The plugin reference for the SDK.")
+	flagSet.StringVar(&f.Version, versionFlagName, "", "The version of the SDK.")
+	_ = appcmd.MarkFlagRequired(flagSet, moduleFlagName)
+	_ = appcmd.MarkFlagRequired(flagSet, pluginFlagName)
+}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	return errors.New("unimplemented")
+}

--- a/private/buf/cmd/buf/command/registry/sdk/sdkinfo/sdkinfo.go
+++ b/private/buf/cmd/buf/command/registry/sdk/sdkinfo/sdkinfo.go
@@ -16,12 +16,18 @@ package sdkinfo
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"buf.build/go/app/appcmd"
 	"buf.build/go/app/appext"
+	"connectrpc.com/connect"
+	"github.com/bufbuild/buf/private/buf/bufcli"
 	"github.com/bufbuild/buf/private/buf/bufprint"
+	"github.com/bufbuild/buf/private/bufpkg/bufparse"
+	"github.com/bufbuild/buf/private/bufpkg/bufremoteplugin/bufremotepluginref"
+	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
+	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
+	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/spf13/pflag"
 )
 
@@ -38,30 +44,77 @@ func NewCommand(
 	builder appext.SubCommandBuilder,
 ) *appcmd.Command {
 	flags := newFlags()
-	// TODO: should we use an example other than eliza?
 	return &appcmd.Command{
 		Use:   name + " --module=<remote/owner/repository[:ref]> --plugin=<remote/owner/plugin[:version]>",
 		Short: "Get SDK information for the given module, plugin, and optionally version.",
-		// TODO: complete examples
 		Long: `This command returns the version information for a Generated SDK based on the specified information.
 In order to resolve the SDK information, a module and plugin must be specified.
 
 Examples:
 
-To get the SDK information for of the latest commit of the eliza module and the latest version of the Go plugin:
-    $ buf registry sdk info --module=buf.build/connectrpc/eliza --plugin=buf.build/protocolbuffers/go
-    <TODO: return value>
+To get the SDK information for the latest commit of a module and latest version of a plugin, you only need to specify the module and plugin.
+The following will resolve the SDK information for the latest commit of the bufbuild/eliza module and the latest version of the bufbuild/es plugin:
 
-To get the SDK information for a specific commit of the eliza module and a specific version of the Go plugin:
-    $ buf registry sdk info --module=buf.build/connectrpc/eliza:<TODO: commit> --plugin=buf.build/protocolbuffers/go:v1.32.0
-    <TODO: return value>
+    $ buf registry sdk info --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es
+    Module
+    Owner:  connectrpc
+    Name:   eliza
+    Commit: <latest commit on default label>
 
-If you have a SDK version and you want to know the module commit and plugin version information for the SDK:
-    $ buf registry sdk --module=buf.build/connectrpc/eliza --plugin=buf.build/protocolbuffers/go --version=<TODO: version string>
-    <TODO: return value>
+    Plugin
+    Owner:    bufbuild
+    Name:     es
+    Version:  <latest version of plugin>
+    Revision: <latest revision of the plugin version>
 
-If a module reference and/or plugin version are specified along with the SDK version flag, --version, then the SDK version
-will be validated against the provided module reference and/or plugin version. If there is a mismatch, this command will error.`,
+    Version: <SDK version for the resolved module commit and plugin version>
+
+To get the SDK information for a specific commit of a module and/or a specific version of a plugin, you can specify the commit with the module and/or the version with the plugin.
+The following will resolve the SDK information for the specified commit of the bufbuild/eliza module and specified version of the bufbuild/es plugin:
+
+    $ buf registry sdk info --module=buf.build/connectrpc/eliza:d8fbf2620c604277a0ece1ff3a26f2ff --plugin=buf.build/bufbuild/es:v1.2.1
+    Module
+    Owner:  connectrpc
+    Name:   eliza
+    Commit: d8fbf2620c604277a0ece1ff3a26f2ff
+
+    Plugin
+    Owner:    bufbuild
+    Name:     es
+    Version:  v1.2.1
+    Revision: 1
+
+    Version: 1.2.1-20230727062025-d8fbf2620c60.1
+
+If you have a SDK version and want to know the corresponding module commit and plugin version information for the SDK, you can specify the module and plugin with the version string.
+The following will resolve the SDK information for the specified SDK version of the bufbuild/eliza module and bufbuild/es plugin.
+
+    $ buf registry sdk --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es --version=1.2.1-20230727062025-d8fbf2620c60.1
+    Module
+    Owner:  connectrpc
+    Name:   eliza
+    Commit: d8fbf2620c604277a0ece1ff3a26f2ff
+
+    Plugin
+    Owner:    bufbuild
+    Name:     es
+    Version:  v1.2.1
+    Revision: 1
+
+    Version: 1.2.1-20230727062025-d8fbf2620c60.1
+
+The module commit and plugin version information are resolved based on the specified SDK version string.
+
+If a module reference and/or plugin version are specified along with the SDK version, then the SDK version will be validated against the specified module reference and/or plugin version.
+If there is a mismatch, this command will error.
+
+    $ buf registry sdk info  \
+        --module=buf.build/connectrpc/eliza:8b8b971d6fde4dc8ba5d96f9fda7d53c   \
+        --plugin=buf.build/bufbuild/es  \
+        --version=1.2.1-20230727062025-d8fbf2620c60.1
+    Failure: invalid_argument: invalid SDK version v1.2.1-20230727062025-d8fbf2620c60.1 with module short commit d8fbf2620c60 for resolved module reference connectrpc/eliza:8b8b971d6fde4dc8ba5d96f9fda7d53c
+
+In this case, the SDK version provided resolves to a different commit than the commit provided for the module.`,
 		Args: appcmd.NoArgs,
 		Run: builder.NewRunFunc(
 			func(ctx context.Context, container appext.Container) error {
@@ -102,5 +155,52 @@ func run(
 	container appext.Container,
 	flags *flags,
 ) error {
-	return errors.New("unimplemented")
+	moduleRef, err := bufparse.ParseRef(flags.Module)
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	pluginIdentity, pluginVersion, err := bufremotepluginref.ParsePluginIdentityOptionalVersion(flags.Plugin)
+	if err != nil {
+		return appcmd.WrapInvalidArgumentError(err)
+	}
+	if moduleRef.FullName().Registry() != pluginIdentity.Remote() {
+		return appcmd.NewInvalidArgumentError("module and plugin must be from the same BSR instance")
+	}
+	clientConfig, err := bufcli.NewConnectClientConfig(container)
+	if err != nil {
+		return err
+	}
+	resolveServiceClient := connectclient.Make(
+		clientConfig,
+		moduleRef.FullName().Registry(),
+		registryv1alpha1connect.NewResolveServiceClient,
+	)
+	res, err := resolveServiceClient.GetSDKInfo(
+		ctx,
+		connect.NewRequest(registryv1alpha1.GetSDKInfoRequest_builder{
+			ModuleReference: registryv1alpha1.LocalModuleReference_builder{
+				Owner:      moduleRef.FullName().Owner(),
+				Repository: moduleRef.FullName().Name(),
+				Reference:  moduleRef.Ref(),
+			}.Build(),
+			PluginReference: registryv1alpha1.GetRemotePackageVersionPlugin_builder{
+				Owner:   pluginIdentity.Owner(),
+				Name:    pluginIdentity.Plugin(),
+				Version: pluginVersion,
+			}.Build(),
+			SdkVersion: flags.Version,
+		}.Build()),
+	)
+	if err != nil {
+		return err
+	}
+	format, err := bufprint.ParseFormat(flags.Format)
+	if err != nil {
+		return err
+	}
+	return bufprint.NewSDKInfoPrinter(container.Stdout()).PrintSDKInfo(
+		ctx,
+		format,
+		res.Msg,
+	)
 }

--- a/private/buf/cmd/buf/command/registry/sdk/sdkinfo/usage.gen.go
+++ b/private/buf/cmd/buf/command/registry/sdk/sdkinfo/usage.gen.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated. DO NOT EDIT.
+
+package sdkinfo
+
+import _ "github.com/bufbuild/buf/private/usage"


### PR DESCRIPTION
This PR implements a new command, `buf registry sdk info`. This command is
used for resolving SDK information. It always requires the user to provide the module
and plugin information.

This commands expands on `buf registry sdk version`, allowing the user to resolve
the SDK information based on the version string for the module and plugin. For example,
the user knows the SDK version string, they could provide the following to resolve the module
commit and plugin information for the SDK given version string:

```
$ buf registry sdk --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es --version=1.2.1-20230727062025-d8fbf2620c60.1
Module
Owner:  connectrpc
Name:   eliza
Commit: d8fbf2620c604277a0ece1ff3a26f2ff

Plugin
Owner:    bufbuild
Name:     es
Version:  v1.2.1
Revision: 1

Version: 1.2.1-20230727062025-d8fbf2620c60.1
```

If the user would like to resolve the SDK information for the latest commit on the default
label and latest version of the plugin:

```
$ buf registry sdk info --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es
Module
Owner:  connectrpc
Name:   eliza
Commit: <latest commit on default label>

Plugin
Owner:    bufbuild
Name:     es
Version:  <latest version of plugin>
Revision: <latest revision of the plugin version>

Version: <SDK version string for the resolved module commit and plugin version>
```

If the user would like to resolve the SDK information for a specific module commit and/or plugin version:

```
$ buf registry sdk --module=buf.build/connectrpc/eliza --plugin=buf.build/bufbuild/es --version=1.2.1-20230727062025-d8fbf2620c60.1
Module
Owner:  connectrpc
Name:   eliza
Commit: d8fbf2620c604277a0ece1ff3a26f2ff

Plugin
Owner:    bufbuild
Name:     es
Version:  v1.2.1
Revision: 1

Version: 1.2.1-20230727062025-d8fbf2620c60.1
```

If the SDK version and module commit and/or plugin version are provided, the SDK version string will be
resolved and validated against the provided module commit and/or plugin version. If there is a mismatch,
the command will error:

```
$ buf registry sdk info  \
    --module=buf.build/connectrpc/eliza:8b8b971d6fde4dc8ba5d96f9fda7d53c   \
    --plugin=buf.build/bufbuild/es  \
    --version=1.2.1-20230727062025-d8fbf2620c60.1
Failure: invalid_argument: invalid SDK version v1.2.1-20230727062025-d8fbf2620c60.1 with module short commit d8fbf2620c60 for resolved module reference connectrpc/eliza:8b8b971d6fde4dc8ba5d96f9fda7d53c
```

Fixes #3485