### PR TITLE
Improve error message for not found keys

### DIFF
--- a/private/bufpkg/bufmodule/added_module.go
+++ b/private/bufpkg/bufmodule/added_module.go
@@ -115,7 +115,7 @@ func (a *addedModule) ToModule(
 				[]ModuleKey{a.remoteModuleKey},
 			)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("could not get module data for remote module %q: %w", a.remoteModuleKey.FullName().String(), err)
 			}
 			if len(moduleDatas) != 1 {
 				return nil, syserror.Newf("expected 1 ModuleData, got %d", len(moduleDatas))

--- a/private/bufpkg/bufmodule/bufmoduleapi/convert.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/convert.go
@@ -248,6 +248,45 @@ func moduleRefsToV1Beta1ProtoResourceRefs(moduleRefs []bufparse.Ref) []*modulev1
 	return xslices.Map(moduleRefs, moduleRefToV1Beta1ProtoResourceRef)
 }
 
+func moduleKeyToV1ProtoResourceRef(moduleKey bufmodule.ModuleKey) *modulev1.ResourceRef {
+	return &modulev1.ResourceRef{
+		Value: &modulev1.ResourceRef_Name_{
+			Name: &modulev1.ResourceRef_Name{
+				Owner:  moduleKey.FullName().Owner(),
+				Module: moduleKey.FullName().Name(),
+				Child: &modulev1.ResourceRef_Name_Ref{
+					Ref: uuidutil.ToDashless(moduleKey.CommitID()),
+				},
+			},
+		},
+	}
+}
+
+func moduleKeysToV1ProtoResourceRefs(moduleKeys []bufmodule.ModuleKey) []*modulev1.ResourceRef {
+	return xslices.Map(moduleKeys, moduleKeyToV1ProtoResourceRef)
+}
+
+func moduleKeyToV1Beta1ProtoGetGraphRequestResourceRef(moduleKey bufmodule.ModuleKey) *modulev1beta1.GetGraphRequest_ResourceRef {
+	return &modulev1beta1.GetGraphRequest_ResourceRef{
+		ResourceRef: &modulev1beta1.ResourceRef{
+			Value: &modulev1beta1.ResourceRef_Name_{
+				Name: &modulev1beta1.ResourceRef_Name{
+					Owner:  moduleKey.FullName().Owner(),
+					Module: moduleKey.FullName().Name(),
+					Child: &modulev1beta1.ResourceRef_Name_Ref{
+						Ref: uuidutil.ToDashless(moduleKey.CommitID()),
+					},
+				},
+			},
+		},
+		Registry: moduleKey.FullName().Registry(),
+	}
+}
+
+func moduleKeysToV1Beta1ProtoGetGraphRequestResourceRefs(moduleKeys []bufmodule.ModuleKey) []*modulev1beta1.GetGraphRequest_ResourceRef {
+	return xslices.Map(moduleKeys, moduleKeyToV1Beta1ProtoGetGraphRequestResourceRef)
+}
+
 // We have to make sure all the below is updated if a field is added.
 // This is enforced via exhaustruct using golangci-lint.
 // Search .golangci.yml for convert.go to see where this is enabled.

--- a/private/bufpkg/bufplugin/bufpluginapi/plugin_data_provider.go
+++ b/private/bufpkg/bufplugin/bufpluginapi/plugin_data_provider.go
@@ -111,8 +111,14 @@ func (p *pluginDataProvider) getIndexedPluginDatasForRegistryAndIndexedPluginKey
 	values := xslices.Map(indexedPluginKeys, func(indexedPluginKey xslices.Indexed[bufplugin.PluginKey]) *pluginv1beta1.DownloadRequest_Value {
 		return &pluginv1beta1.DownloadRequest_Value{
 			ResourceRef: &pluginv1beta1.ResourceRef{
-				Value: &pluginv1beta1.ResourceRef_Id{
-					Id: uuidutil.ToDashless(indexedPluginKey.Value.CommitID()),
+				Value: &pluginv1beta1.ResourceRef_Name_{
+					Name: &pluginv1beta1.ResourceRef_Name{
+						Owner:  indexedPluginKey.Value.FullName().Owner(),
+						Plugin: indexedPluginKey.Value.FullName().Name(),
+						Child: &pluginv1beta1.ResourceRef_Name_Ref{
+							Ref: uuidutil.ToDashless(indexedPluginKey.Value.CommitID()),
+						},
+					},
 				},
 			},
 		}


### PR DESCRIPTION
This improves the error message for Module and Plugin keys by including the full Ref, not just the Commit ID, in the request payload. Errors now include the owner and name for easier debugging.

This can occur when downloading dependencies for a Module. A valid ModuleKey may be reported as not found for a number of reasons:
- deleted module
- private module, without login to the registry
- private module, without access to the module

For example, given a private dependency where the authentication is not set the following error
```
Failure: resource with id "a224920f76a74104b0a88668cdda9214" was not found
```
is now reported as:
```
Failure: could not get module data for remote module "buf.build/owner/module": resource with name "owner/module:a224920f76a74104b0a88668cdda9214" was not found
```
We wrap the error with a "module data for remote" to aid debugging but do not attempt to hint as to why it was not found. The error structure doesn't currently allow to assert that a resource not found error came from a remote and an unauthorized client. We may also augment the not found error on the registry as a not found by unauthenticated client.