### PR TITLE
Ensure pre-commit hooks are kept up-to-date

### DIFF
--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -204,8 +204,8 @@ newtodos:
 newtodofiles:
 	@bash make/buf/scripts/newtodos.bash | grep -v FUTURE | cut -f 1 -d : | sort | uniq
 
-.PHONY: checkprecommithooks
-checkprecommithooks:
-	@bash make/buf/scripts/checkprecommithooks.bash
+.PHONY: checkandupdateprecommithooks
+checkandupdateprecommithooks:
+	@bash make/buf/scripts/checkandupdateprecommithooks.bash
 
-postupgrade:: checkprecommithooks
+postupgrade:: checkandupdateprecommithooks

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -190,6 +190,7 @@ endif
 	$(SED_I) "s/golang:1\.[0-9][0-9]*/golang:$(GOVERSION)/g" $(shell git-ls-files-unstaged | grep Dockerfile)
 	$(SED_I) "s/golang:1\.[0-9][0-9]*/golang:$(GOVERSION)/g" $(shell git-ls-files-unstaged | grep \.mk$)
 	$(SED_I) "s/go-version: '1\.[0-9][0-9].x'/go-version: '$(GOVERSION).x'/g" $(shell git-ls-files-unstaged | grep \.github\/workflows | grep -v previous.yaml)
+	$(MAKE) checkandupdateprecommithooks
 
 .PHONY: bufimageutilupdateexpectations
 bufimageutilupdateexpectations:

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -207,3 +207,5 @@ newtodofiles:
 .PHONY: checkprecommithooks
 checkprecommithooks:
 	@bash make/buf/scripts/checkprecommithooks.bash
+
+postupgrade:: checkprecommithooks

--- a/make/buf/all.mk
+++ b/make/buf/all.mk
@@ -203,3 +203,7 @@ newtodos:
 .PHONY: newtodofiles
 newtodofiles:
 	@bash make/buf/scripts/newtodos.bash | grep -v FUTURE | cut -f 1 -d : | sort | uniq
+
+.PHONY: checkprecommithooks
+checkprecommithooks:
+	@bash make/buf/scripts/checkprecommithooks.bash

--- a/make/buf/scripts/checkandupdateprecommithooks.bash
+++ b/make/buf/scripts/checkandupdateprecommithooks.bash
@@ -11,11 +11,17 @@ function lesser_version() {
   echo -e "$1\n$2" | sort -V | head -n 1
 }
 
+function update_pre_commit_hooks() {
+  yq .[].language_version="${GO_VERSION}" .pre-commit-hooks.yaml > .pre-commit-hooks.yaml.tmp
+  mv .pre-commit-hooks.yaml.tmp .pre-commit-hooks.yaml
+}
+
 for version in $(yq ".[].language_version" .pre-commit-hooks.yaml)
 do
   LESSER_VERSION=$(lesser_version "${GO_VERSION}" "${version}")
   if [ ${version} == "${LESSER_VERSION}" ]; then
     echo "found lower pre-commit hook version ${version} compared to go.mod version ${GO_VERSION}"
-    exit 1
+    update_pre_commit_hooks
+    break
   fi
 done

--- a/make/buf/scripts/checkandupdateprecommithooks.bash
+++ b/make/buf/scripts/checkandupdateprecommithooks.bash
@@ -6,13 +6,18 @@ DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
 cd "${DIR}"
 
 GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+# If the version in go.mod does not include the patch version, e.g. go 1.24, for the
+# .pre-commit-hook.yaml configuration, we'll need to add a 0.
+if [[ ! "${GO_VERSION}" =~ '^([0-9]+\.){3}$' ]]; then
+  GO_VERSION="${GO_VERSION}.0"
+fi
 
 function lesser_version() {
   echo -e "$1\n$2" | sort -V | head -n 1
 }
 
 function update_pre_commit_hooks() {
-  yq .[].language_version="${GO_VERSION}" .pre-commit-hooks.yaml > .pre-commit-hooks.yaml.tmp
+  yq .[].language_version=\"${GO_VERSION}\" .pre-commit-hooks.yaml > .pre-commit-hooks.yaml.tmp
   mv .pre-commit-hooks.yaml.tmp .pre-commit-hooks.yaml
 }
 

--- a/make/buf/scripts/checkprecommithooks.bash
+++ b/make/buf/scripts/checkprecommithooks.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$(CDPATH= cd "$(dirname "${0}")/../../.." && pwd)"
+cd "${DIR}"
+
+GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+
+function lesser_version() {
+  echo -e "$1\n$2" | sort -V | head -n 1
+}
+
+for version in $(yq ".[].language_version" .pre-commit-hooks.yaml)
+do
+  LESSER_VERSION=$(lesser_version "${GO_VERSION}" "${version}")
+  if [ ${version} == "${LESSER_VERSION}" ]; then
+    echo "found lower pre-commit hook version ${version} compared to go.mod version ${GO_VERSION}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
This PR adds a script to check that pre-commit hooks are up-to-date
with `go.mod` versions and if not, update them, as a part of `make upgrade`.

Fixes #3882