### PR TITLE
Add s390x binaries for Linux to releases and fix ppc64le release binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Add `buf export --all` flag to include non-proto source files.
+- Add s390x binaries for Linux to releases.
+- Fix ppc64le binaries for Linux released as x86_64 binaries.
 
 ## [v1.55.1] - 2025-06-17
 

--- a/make/buf/scripts/release.bash
+++ b/make/buf/scripts/release.bash
@@ -18,7 +18,7 @@ goos() {
     Darwin) echo darwin ;;
     Linux) echo linux ;;
     Windows) echo windows ;;
-    *) return 1 ;;
+    *) echo "unsupported"; return 1 ;;
   esac
 }
 
@@ -29,7 +29,9 @@ goarch() {
     arm64) echo arm64 ;;
     aarch64) echo arm64 ;;
     armv7) echo arm ;;
-    *) return 1 ;;
+    ppc64le) echo ppc64le ;;
+    s390x) echo s390x ;;
+    *) echo "unsupported"; return 1 ;;
   esac
 }
 
@@ -85,7 +87,7 @@ mkdir -p "${RELEASE_DIR}"
 cd "${RELEASE_DIR}"
 
 for os in Darwin Linux Windows; do
-  for arch in x86_64 riscv64 arm64 armv7 ppc64le; do
+  for arch in x86_64 riscv64 arm64 armv7 ppc64le s390x; do
     # our goal is to have the binaries be suffixed with $(uname -s)-$(uname -m)
     # on mac, this is arm64, on linux, this is aarch64, for historical reasons
     # this is a hacky way to not have to rewrite this loop (and others below)
@@ -118,7 +120,7 @@ for os in Darwin Linux Windows; do
 done
 
 for os in Darwin Linux Windows; do
-  for arch in x86_64 riscv64 arm64 armv7 ppc64le; do
+  for arch in x86_64 riscv64 arm64 armv7 ppc64le s390x; do
     if [[ ! "${arch}" =~ x86_64|arm64 ]] && [ "${os}" != "Linux" ]; then
       continue
     fi
@@ -141,7 +143,7 @@ for os in Darwin Linux Windows; do
 done
 
 for os in Darwin Linux; do
-  for arch in x86_64 riscv64 arm64 armv7 ppc64le; do
+  for arch in x86_64 riscv64 arm64 armv7 ppc64le s390x; do
     if [[ ! "${arch}" =~ x86_64|arm64 ]] && [ "${os}" != "Linux" ]; then
       continue
     fi

--- a/make/go/dep_protoc.mk
+++ b/make/go/dep_protoc.mk
@@ -32,7 +32,11 @@ endif
 endif
 ifeq ($(UNAME_OS),Linux)
 PROTOC_OS = linux
+ifeq ($(UNAME_ARCH),s390x)
+PROTOC_ARCH := s390_64
+else
 PROTOC_ARCH := $(UNAME_ARCH)
+endif
 endif
 
 PROTOC := $(CACHE_VERSIONS)/protoc/$(PROTOC_VERSION)


### PR DESCRIPTION
Add s390x binaries for Linux to releases.

@doriable and @Jenkins-J I also fixed the ppc64le binaries which are being released as x86_64 binaries since I needed to change the same code. In a previous PR #3840 the bash function `goarch()` wasn't updated with the `ppc64le` value so the default `x86_64` ended up being used. 

Note that the `goarch()` function returns 1 if the arch wasn't found but since `goarch()` is only executed in a subshell, it doesn't fail and exit the script which I think was the intent. So I also made the `goarch()` and `goos()` functions return the string `"unsupported"` if the arch or os is not found so that the script will fail and exit. I'm happy to provide more details if you have more questions on this. It took me a while to figure out exactly what was going on.
