### PR TITLE
Fix usage formatting in webpages command

### DIFF
--- a/private/bufpkg/bufcobra/markdown.go
+++ b/private/bufpkg/bufcobra/markdown.go
@@ -262,7 +262,9 @@ func writeFlags(f *pflag.FlagSet, writer io.Writer) error {
 		}
 		p(" {#%s}", flag.Name)
 		p("\n")
-		p(usage)
+		// Skip fmt.Fprintf for usage, which may contain `%` format characters that aren't
+		// intended to be formatted. Instead, write the raw contents.
+		_, err = writer.Write([]byte(usage))
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
 			case "string":


### PR DESCRIPTION
Fixes a minor issue where usage containing `%` characters would be assumed to be a Go `fmt` format character. Instead, write out the raw contents and avoid any attempt at formatting (since we never provide args here).