### PR TITLE
Fix bufplugin Plugin.Digest caclulation

### DIFF
--- a/private/bufpkg/bufplugin/plugin.go
+++ b/private/bufpkg/bufplugin/plugin.go
@@ -15,6 +15,7 @@
 package bufplugin
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"sync"
@@ -308,7 +309,7 @@ func newGetDigestFuncForPluginAndDigestType(plugin *plugin, digestType DigestTyp
 		if err != nil {
 			return nil, err
 		}
-		bufcasDigest, err := bufcas.NewDigest(data)
+		bufcasDigest, err := bufcas.NewDigestForContent(bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes the use of Plugin.Digest() method for calculating the plugin digest. Corrects the use of the bufcas digest to read from the plugin contents. Any current callers are expected to have failed using this method so no invalid digests should be seen.