### PR TITLE
Add `s390x` build to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following is a breakdown of the binaries by CPU architecture and operating s
 | ARMv7 (32-bit) | ✅ | ❌ | ❌ |
 | RISC-V (64-bit) | ✅ | ❌ | ❌ |
 | ppc64le | ✅ | ❌ | ❌ |
+| s390x | ✅ | ❌ | ❌ |
 
 ## Community
 


### PR DESCRIPTION
This adds the new `s390x` binary (introduced in #3900) to the README
for the next release.