### PR TITLE
feat: add gitlab code quality output format for lint and breaking command

### DIFF
--- a/private/bufpkg/bufanalysis/bufanalysis.go
+++ b/private/bufpkg/bufanalysis/bufanalysis.go
@@ -34,6 +34,10 @@ const (
 	//
 	// See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message.
 	FormatGithubActions
+	// FormatGitlab is the Code Climate subformat for gitlab for FileAnnotations.
+	//
+	// See https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
+	FormatGitlab
 )
 
 var (
@@ -46,6 +50,7 @@ var (
 		"msvs",
 		"junit",
 		"github-actions",
+		"gitlab-code-quality",
 	}
 	// AllFormatStringsWithAliases is all format strings with aliases.
 	//
@@ -57,16 +62,18 @@ var (
 		"msvs",
 		"junit",
 		"github-actions",
+		"gitlab-code-quality",
 	}
 
 	stringToFormat = map[string]Format{
 		"text": FormatText,
 		// alias for text
-		"gcc":            FormatText,
-		"json":           FormatJSON,
-		"msvs":           FormatMSVS,
-		"junit":          FormatJUnit,
-		"github-actions": FormatGithubActions,
+		"gcc":                 FormatText,
+		"json":                FormatJSON,
+		"msvs":                FormatMSVS,
+		"junit":               FormatJUnit,
+		"github-actions":      FormatGithubActions,
+		"gitlab-code-quality": FormatGitlab,
 	}
 	formatToString = map[Format]string{
 		FormatText:          "text",
@@ -74,6 +81,7 @@ var (
 		FormatMSVS:          "msvs",
 		FormatJUnit:         "junit",
 		FormatGithubActions: "github-actions",
+		FormatGitlab:        "gitlab-code-quality",
 	}
 )
 
@@ -225,6 +233,8 @@ func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSe
 		return printAsJUnit(writer, fileAnnotationSet.FileAnnotations())
 	case FormatGithubActions:
 		return printAsGithubActions(writer, fileAnnotationSet.FileAnnotations())
+	case FormatGitlab:
+		return printAsCodeClimate(writer, fileAnnotationSet.FileAnnotations())
 	default:
 		return fmt.Errorf("unknown FileAnnotation Format: %v", format)
 	}

--- a/private/bufpkg/bufanalysis/bufanalysis.go
+++ b/private/bufpkg/bufanalysis/bufanalysis.go
@@ -234,7 +234,7 @@ func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSe
 	case FormatGithubActions:
 		return printAsGithubActions(writer, fileAnnotationSet.FileAnnotations())
 	case FormatGitlab:
-		return printAsCodeClimate(writer, fileAnnotationSet.FileAnnotations())
+		return printAsGitLabCodeQuality(writer, fileAnnotationSet.FileAnnotations())
 	default:
 		return fmt.Errorf("unknown FileAnnotation Format: %v", format)
 	}

--- a/private/bufpkg/bufanalysis/gitlab.go
+++ b/private/bufpkg/bufanalysis/gitlab.go
@@ -1,0 +1,35 @@
+package bufanalysis
+
+// CodeQualityReport represents a list of code quality violations.
+type CodeQualityReport []CodeQualityViolation
+
+// CodeQualityViolation describes a single violation in GitLab's code quality format.
+type CodeQualityViolation struct {
+	Description string              `json:"description"` // Human-readable message
+	CheckName   string              `json:"check_name"`  // Unique name of the rule or check
+	Fingerprint string              `json:"fingerprint"` // Unique identifier for the violation
+	Location    CodeQualityLocation `json:"location"`    // Location in source
+	Severity    string              `json:"severity"`    // One of: info, minor, major, critical, blocker
+}
+
+// CodeQualityLocation indicates where in the file the violation occurred.
+type CodeQualityLocation struct {
+	Path      string                    `json:"path"`                // Relative file path
+	Lines     *CodeQualityLineRange     `json:"lines,omitempty"`     // Optional line-based location
+	Positions *CodeQualityPositionRange `json:"positions,omitempty"` // Optional position-based location
+}
+
+// CodeQualityLineRange is used when only the line number is known.
+type CodeQualityLineRange struct {
+	Begin int `json:"begin"` // Line number where the issue starts
+}
+
+// CodeQualityPositionRange provides more precise location info.
+type CodeQualityPositionRange struct {
+	Begin CodeQualityPosition `json:"begin"` // Position (line/column)
+}
+
+// CodeQualityPosition identifies a character position in the file.
+type CodeQualityPosition struct {
+	Line int `json:"line"` // Line number (1-based)
+}

--- a/private/bufpkg/bufanalysis/print.go
+++ b/private/bufpkg/bufanalysis/print.go
@@ -326,7 +326,7 @@ func printEachAnnotationOnNewLine(
 	return nil
 }
 
-func printAsCodeClimate(writer io.Writer, fileAnnotations []FileAnnotation) error {
+func printAsGitLabCodeQuality(writer io.Writer, fileAnnotations []FileAnnotation) error {
 
 	var report []CodeQualityViolation
 


### PR DESCRIPTION
Dear team, 
I use the buf cli at work and I need the gitlab output format.
This is a rough MWE. Looking forward to your feedback !

Cheers from France.

Fixes #3926