### PR TITLE
Avoid checking message constraints when there are none

### DIFF
--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/buflintvalidate.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/buflintvalidate.go
@@ -35,6 +35,9 @@ func CheckMessage(
 	if err != nil {
 		return err
 	}
+	if messageRules == nil {
+		return nil
+	}
 	return checkCELForMessage(
 		addAnnotationFunc,
 		messageRules,


### PR DESCRIPTION
We currently do this for field rules but not message rules.
This will avoid setting up the CEL environment, etc. which is a
very expensive operation, when there are no message constraints
to be checked.