### PR TITLE
Fix single directory traversal for normalpath

### DIFF
--- a/private/pkg/normalpath/normalpath.go
+++ b/private/pkg/normalpath/normalpath.go
@@ -37,8 +37,6 @@ const (
 	Absolute PathType = 2
 
 	stringOSPathSeparator = string(os.PathSeparator)
-	// This has to be with "/" instead of os.PathSeparator as we use this on normalized paths
-	normalizedRelPathJumpContextPrefix = "../"
 )
 
 var (
@@ -107,6 +105,28 @@ func (e *Error) Unwrap() error {
 // If the path is "" or ".", this returns ".".
 func Normalize(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
+}
+
+// NormalizeAndValidate normalizes and validates the given path.
+//
+// This calls Normalize on the path.
+// Returns Error if the path is not relative or jumps context.
+// This can be used to validate that paths are valid to use with Buckets.
+// The error message is safe to pass to users.
+func NormalizeAndValidate(path string) (string, error) {
+	normalizedPath := Normalize(path)
+	unnormalizedPath := Unnormalize(normalizedPath)
+	// Paths cannot be absolute.
+	if filepath.IsAbs(unnormalizedPath) {
+		return "", NewError(path, errNotRelative)
+	}
+	// Use IsLocal to validate the path is relative and does not jump context.
+	//
+	// The string ".." is not matched against, see https://github.com/bufbuild/buf/issues/51
+	if !filepath.IsLocal(unnormalizedPath) {
+		return "", NewError(path, errOutsideContextDir)
+	}
+	return normalizedPath, nil
 }
 
 // NormalizeAndAbsolute normalizes the path and makes it absolute.

--- a/private/pkg/normalpath/normalpath_unix.go
+++ b/private/pkg/normalpath/normalpath_unix.go
@@ -25,24 +25,6 @@ import (
 	"strings"
 )
 
-// NormalizeAndValidate normalizes and validates the given path.
-//
-// This calls Normalize on the path.
-// Returns Error if the path is not relative or jumps context.
-// This can be used to validate that paths are valid to use with Buckets.
-// The error message is safe to pass to users.
-func NormalizeAndValidate(path string) (string, error) {
-	normalizedPath := Normalize(path)
-	if filepath.IsAbs(normalizedPath) {
-		return "", NewError(path, errNotRelative)
-	}
-	// https://github.com/bufbuild/buf/issues/51
-	if strings.HasPrefix(normalizedPath, normalizedRelPathJumpContextPrefix) {
-		return "", NewError(path, errOutsideContextDir)
-	}
-	return normalizedPath, nil
-}
-
 // EqualsOrContainsPath returns true if the value is equal to or contains the path.
 //
 // The path and value are expected to be normalized and validated if Relative is used.

--- a/private/pkg/normalpath/normalpath_unix_test.go
+++ b/private/pkg/normalpath/normalpath_unix_test.go
@@ -47,6 +47,9 @@ func TestNormalizeAndValidate(t *testing.T) {
 
 	_, err = NormalizeAndValidate("../foo")
 	assert.Error(t, err)
+
+	_, err = NormalizeAndValidate("..")
+	assert.Error(t, err)
 }
 
 func TestNormalize(t *testing.T) {

--- a/private/pkg/normalpath/normalpath_windows.go
+++ b/private/pkg/normalpath/normalpath_windows.go
@@ -23,28 +23,6 @@ import (
 	"strings"
 )
 
-// NormalizeAndValidate normalizes and validates the given path.
-//
-// This calls Normalize on the path.
-// Returns Error if the path is not relative or jumps context.
-// This can be used to validate that paths are valid to use with Buckets.
-// The error message is safe to pass to users.
-func NormalizeAndValidate(path string) (string, error) {
-	normalizedPath := Normalize(path)
-	if filepath.IsAbs(normalizedPath) || (len(normalizedPath) > 0 && normalizedPath[0] == '/') {
-		// the stdlib implementation of `IsAbs` assumes that a volume name is required for a path to
-		// be absolute, however Windows treats a `/` (normalized) rooted path as absolute _within_ the current volume.
-		// In the context of validating that a path is _not_ relative, we need to reject a path that begins
-		// with `/`.
-		return "", NewError(path, errNotRelative)
-	}
-	// https://github.com/bufbuild/buf/issues/51
-	if strings.HasPrefix(normalizedPath, normalizedRelPathJumpContextPrefix) {
-		return "", NewError(path, errOutsideContextDir)
-	}
-	return normalizedPath, nil
-}
-
 // EqualsOrContainsPath returns true if the value is equal to or contains the path.
 // path is compared at each directory level to value for equivalency under simple unicode
 // codepoint folding. This means it is context and locale independent. This matching

--- a/private/pkg/normalpath/normalpath_windows_test.go
+++ b/private/pkg/normalpath/normalpath_windows_test.go
@@ -56,6 +56,9 @@ func TestNormalizeAndValidate(t *testing.T) {
 
 	_, err = NormalizeAndValidate("../foo")
 	assert.Error(t, err)
+
+	_, err = NormalizeAndValidate("..")
+	assert.Error(t, err)
 }
 
 func TestNormalize(t *testing.T) {


### PR DESCRIPTION
This fixes an edge case when validating normalpaths. A path consisting of just ".." is now rejected. The func filepath.IsLocal is used to assert the path is local. The func NormalizeAndValidate is now no longer OS specific.