### PR TITLE
Remove code owner for proto dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Protobuf changes
-/proto/ @bufdev


### PR DESCRIPTION
We no longer want to block changes to our `v1alpha1` APIs
on @bufdev reviews, removing the code owner config.