### PR TITLE
Silence empty rules warn when policies are defined

### DIFF
--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -122,6 +122,7 @@ func (c *client) Lint(
 		lintOptions.pluginConfigs,
 		nil, // policyConfig.
 		lintOptions.relatedCheckConfigs,
+		len(lintOptions.policyConfigs) > 0, // hasPolicyConfigs.
 	)
 	if err != nil {
 		return err
@@ -148,7 +149,8 @@ func (c *client) Lint(
 			policyLintConfig,
 			pluginConfigs,
 			policyConfig,
-			nil, // relatedCheckConfigs.
+			nil,  // relatedCheckConfigs.
+			true, // hasPolicyConfigs.
 		)
 		if err != nil {
 			return err
@@ -175,6 +177,7 @@ func (c *client) lint(
 	pluginConfigs []bufconfig.PluginConfig,
 	policyConfig bufconfig.PolicyConfig,
 	relatedCheckConfigs []bufconfig.CheckConfig,
+	hasPolicyConfigs bool,
 ) ([]*annotation, error) {
 	if lintConfig.Disabled() {
 		return nil, nil
@@ -193,7 +196,7 @@ func (c *client) lint(
 	if err != nil {
 		return nil, err
 	}
-	logRulesConfig(c.logger, config.rulesConfig)
+	logRulesConfig(c.logger, config.rulesConfig, hasPolicyConfigs)
 	files, err := descriptor.FileDescriptorsForProtoFileDescriptors(imageToProtoFileDescriptors(image))
 	if err != nil {
 		// An Image may be invalid if it does not contain all of the required dependencies.
@@ -252,6 +255,7 @@ func (c *client) Breaking(
 		nil, // policyConfig.
 		breakingOptions.excludeImports,
 		breakingOptions.relatedCheckConfigs,
+		len(breakingOptions.policyConfigs) > 0, // hasPolicyConfigs.
 	)
 	if err != nil {
 		return err
@@ -280,7 +284,8 @@ func (c *client) Breaking(
 			pluginConfigs,
 			policyConfig,
 			breakingOptions.excludeImports,
-			nil, // relatedCheckConfigs.
+			nil,  // relatedCheckConfigs.
+			true, // hasPolicyConfigs.
 		)
 		if err != nil {
 			return err
@@ -309,6 +314,7 @@ func (c *client) breaking(
 	policyConfig bufconfig.PolicyConfig,
 	excludeImports bool,
 	relatedCheckConfigs []bufconfig.CheckConfig,
+	hasPolicyConfigs bool,
 ) ([]*annotation, error) {
 	if breakingConfig.Disabled() {
 		return nil, nil
@@ -333,7 +339,7 @@ func (c *client) breaking(
 	if err != nil {
 		return nil, err
 	}
-	logRulesConfig(c.logger, config.rulesConfig)
+	logRulesConfig(c.logger, config.rulesConfig, hasPolicyConfigs)
 	fileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(imageToProtoFileDescriptors(image))
 	if err != nil {
 		// An Image may be invalid if it does not contain all of the required dependencies.
@@ -400,7 +406,7 @@ func (c *client) ConfiguredRules(
 	if err != nil {
 		return nil, err
 	}
-	logRulesConfig(c.logger, rulesConfig)
+	logRulesConfig(c.logger, rulesConfig, len(configuredRulesOptions.policyConfigs) > 0)
 	return rulesForRuleIDs(allRules, rulesConfig.RuleIDs), nil
 }
 

--- a/private/bufpkg/bufcheck/rules_config.go
+++ b/private/bufpkg/bufcheck/rules_config.go
@@ -47,9 +47,9 @@ func rulesConfigForCheckConfig(
 	)
 }
 
-func logRulesConfig(logger *slog.Logger, rulesConfig *rulesConfig) {
+func logRulesConfig(logger *slog.Logger, rulesConfig *rulesConfig, hasPolicyConfigs bool) {
 	logger.Debug("rulesConfig", slog.Any("ruleIDs", rulesConfig.RuleIDs))
-	if len(rulesConfig.RuleIDs) == 0 {
+	if len(rulesConfig.RuleIDs) == 0 && !hasPolicyConfigs {
 		logger.Warn("No " + rulesConfig.RuleType.String() + " rules are configured.")
 	}
 	warnReferencedDeprecatedIDs(logger, rulesConfig)


### PR DESCRIPTION
This silences the warning message when running buf lint or breaking when no rules are specified but policies are.