### PR TITLE
Add policy support to buf config commands 

### DIFF
--- a/private/buf/cmd/buf/command/config/internal/internal.go
+++ b/private/buf/cmd/buf/command/config/internal/internal.go
@@ -257,6 +257,7 @@ func lsRun(
 		}
 		configuredRuleOptions := []bufcheck.ConfiguredRulesOption{
 			bufcheck.WithPluginConfigs(bufYAMLFile.PluginConfigs()...),
+			bufcheck.WithPolicyConfigs(bufYAMLFile.PolicyConfigs()...),
 			bufcheck.WithRelatedCheckConfigs(allCheckConfigs...),
 		}
 		rules, err = checkClient.ConfiguredRules(
@@ -271,6 +272,7 @@ func lsRun(
 	} else {
 		allRulesOptions := []bufcheck.AllRulesOption{
 			bufcheck.WithPluginConfigs(bufYAMLFile.PluginConfigs()...),
+			bufcheck.WithPolicyConfigs(bufYAMLFile.PolicyConfigs()...),
 		}
 		rules, err = checkClient.AllRules(
 			ctx,

--- a/private/buf/cmd/buf/command/config/internal/internal.go
+++ b/private/buf/cmd/buf/command/config/internal/internal.go
@@ -283,6 +283,11 @@ func lsRun(
 		if err != nil {
 			return err
 		}
+		// Filter policy rules to only those that come from plugins. Each policy rule
+		// will match the default buf.yaml configuration.
+		rules = xslices.Filter(rules, func(rule bufcheck.Rule) bool {
+			return rule.PolicyName() == "" || rule.PluginName() != ""
+		})
 	}
 	return bufcli.PrintRules(
 		container.Stdout(),

--- a/private/bufpkg/bufcheck/bufcheck.go
+++ b/private/bufpkg/bufcheck/bufcheck.go
@@ -74,6 +74,12 @@ type Rule interface {
 	//
 	// Will be empty for Rules based on builtin plugins.
 	PluginName() string
+	// PolicyName returns the name of the policy that contains this Rule, if any.
+	//
+	// Names are freeform.
+	//
+	// Will be empty for Rules not based on policies.
+	PolicyName() string
 
 	isRule()
 	isRuleOrCategory()
@@ -91,6 +97,12 @@ type Category interface {
 	//
 	// Will be empty for Categorys based on builtin plugins.
 	PluginName() string
+	// PolicyName returns the name of the policy that contains this Category, if any.
+	//
+	// Names are freeform.
+	//
+	// Will be empty for Categorys not based on policies.
+	PolicyName() string
 
 	isCategory()
 	isRuleOrCategory()

--- a/private/bufpkg/bufcheck/category.go
+++ b/private/bufpkg/bufcheck/category.go
@@ -24,17 +24,23 @@ type category struct {
 	check.Category
 
 	pluginName string
+	policyName string
 }
 
-func newCategory(checkCategory check.Category, pluginName string) *category {
+func newCategory(checkCategory check.Category, pluginName string, policyName string) *category {
 	return &category{
 		Category:   checkCategory,
 		pluginName: pluginName,
+		policyName: policyName,
 	}
 }
 
 func (r *category) PluginName() string {
 	return r.pluginName
+}
+
+func (r *category) PolicyName() string {
+	return r.policyName
 }
 
 func (*category) isCategory()       {}

--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -413,6 +413,7 @@ func (c *client) ConfiguredRules(
 		if err != nil {
 			return nil, err
 		}
+		// Load the check config for the rule type.
 		var policyCheckConfig bufconfig.CheckConfig
 		switch ruleType {
 		case check.RuleTypeLint:
@@ -420,7 +421,7 @@ func (c *client) ConfiguredRules(
 		case check.RuleTypeBreaking:
 			policyCheckConfig, err = policyToBufConfigBreakingConfig(policy, policyConfig)
 		default:
-			return nil, fmt.Errorf("unknown RuleType: %v", ruleType)
+			return nil, fmt.Errorf("unknown check.RuleType: %v", ruleType)
 		}
 		if err != nil {
 			return nil, err

--- a/private/bufpkg/bufcheck/rule.go
+++ b/private/bufpkg/bufcheck/rule.go
@@ -27,12 +27,14 @@ type rule struct {
 	check.Rule
 
 	pluginName string
+	policyName string
 }
 
-func newRule(checkRule check.Rule, pluginName string) *rule {
+func newRule(checkRule check.Rule, pluginName string, policyName string) *rule {
 	return &rule{
 		Rule:       checkRule,
 		pluginName: pluginName,
+		policyName: policyName,
 	}
 }
 
@@ -40,13 +42,16 @@ func (r *rule) BufcheckCategories() []Category {
 	return xslices.Map(
 		r.Rule.Categories(),
 		func(checkCategory check.Category) Category {
-			return newCategory(checkCategory, r.pluginName)
+			return newCategory(checkCategory, r.pluginName, r.policyName)
 		},
 	)
 }
 
 func (r *rule) PluginName() string {
 	return r.pluginName
+}
+func (r *rule) PolicyName() string {
+	return r.policyName
 }
 
 func (*rule) isRule()           {}


### PR DESCRIPTION
This adds policy support to `buf config` commands `ls-breaking-rules` and `ls-lint-rules`. These now return the related policy rule configuration. When listing all rules (without `--configured-only` set) only the default rules for the main configuration are returned, as all policies are expected to match it. With `--configured-only` set, each policy will define the set of rules used.