### PR TITLE
Fix curated plugin latest fetching

### DIFF
--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -307,6 +307,22 @@ func run(
 			slog.String("name", pluginConfig.Name.IdentityString()),
 			slog.String("digest", plugin.ContainerImageDigest()),
 		)
+		if latestPluginResp == nil {
+			latestPluginResp, err = service.GetLatestCuratedPlugin(
+				ctx,
+				connect.NewRequest(
+					registryv1alpha1.GetLatestCuratedPluginRequest_builder{
+						Owner:    pluginConfig.Name.Owner(),
+						Name:     pluginConfig.Name.Plugin(),
+						Version:  pluginConfig.PluginVersion,
+						Revision: 0, // get latest revision for the plugin version.
+					}.Build(),
+				),
+			)
+			if err != nil {
+				return fmt.Errorf("unable to fetch latest plugin after AlreadyExists error: %w", err)
+			}
+		}
 		curatedPlugin = latestPluginResp.Msg.GetPlugin()
 	} else {
 		curatedPlugin = createPluginResp.Msg.GetConfiguration()

--- a/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/private/buf/cmd/buf/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -323,6 +323,10 @@ func run(
 				return fmt.Errorf("unable to fetch latest plugin after AlreadyExists error: %w", err)
 			}
 		}
+		// Ensure the image digest matches.
+		if latestPluginResp.Msg.GetPlugin().GetContainerImageDigest() != plugin.ContainerImageDigest() {
+			return fmt.Errorf("a plugin with the same name and version already exists, but with a different image digest (%s). If you want to push a new revision, please retry", latestPluginResp.Msg.GetPlugin().GetContainerImageDigest())
+		}
 		curatedPlugin = latestPluginResp.Msg.GetPlugin()
 	} else {
 		curatedPlugin = createPluginResp.Msg.GetConfiguration()


### PR DESCRIPTION
This fixes a panic on the edge case that the same plugin is uploaded multiple times at once. Also validation is added to ensure the image container digest match as this is not guaranteed by the error code alone (it could be from a conflict of revision number).