### PR TITLE
Add disable_builtin for policy configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.24.0
 require (
 	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.36.8-20250718181942-e35f9b667443.1
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.8-20250717185734-6c6e0d3c608e.1
-	buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250819211657-a3dd0d3ea69b.1
-	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.8-20250819211657-a3dd0d3ea69b.1
+	buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1
+	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.8-20250903170917-c4be0f57e197.1
 	buf.build/go/app v0.1.0
 	buf.build/go/bufplugin v0.9.0
 	buf.build/go/protovalidate v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,12 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.8-2025071718573
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.8-20250717185734-6c6e0d3c608e.1/go.mod h1:8EQ5GzyGJQ5tEIwMSxCl8RKJYsjCpAwkdcENoioXT6g=
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250819211657-a3dd0d3ea69b.1 h1:zVrJGpnS4kG8ktXvtqsFTOobhBnh4SjNF9yQxHwPckE=
 buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250819211657-a3dd0d3ea69b.1/go.mod h1:b3AXX8gmI0mFMkxKIFYXyga6bTno5bhiHsB559j1WGg=
+buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1 h1:isqFuFhL6JRd7+KF/vivWqZGJMCaTuAccZIWwneCcqE=
+buf.build/gen/go/bufbuild/registry/connectrpc/go v1.18.1-20250903170917-c4be0f57e197.1/go.mod h1:eGjb9P6sl1irS46NKyXnxkyozT2aWs3BF4tbYWQuCsw=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.8-20250819211657-a3dd0d3ea69b.1 h1:tcK+tM1vPYPhO+h20m0gO9mAyhxeKKvpLmFBKQExeEg=
 buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.8-20250819211657-a3dd0d3ea69b.1/go.mod h1:00R1Pr0ukHuneWSlz7I3GpenOl0hcLpj6AV8HMypndk=
+buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.8-20250903170917-c4be0f57e197.1 h1:gQUlYMMWz8V8BmZlN/9mm66CD2ocG59izSKtl8VY/g8=
+buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.8-20250903170917-c4be0f57e197.1/go.mod h1:00R1Pr0ukHuneWSlz7I3GpenOl0hcLpj6AV8HMypndk=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1 h1:KuP+b+in6LGh2ukof5KgDCD8hPXotEq6EVOo13Wg1pE=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.8-20241007202033-cf42259fcbfc.1/go.mod h1:dV1Kz6zdmyXt7QWm5OXby44OFpyLemllUDBUG5HMLio=
 buf.build/go/app v0.1.0 h1:nlqD/h0rhIN73ZoiDElprrPiO2N6JV+RmNK34K29Ihg=

--- a/private/bufpkg/bufpolicy/bufpolicyapi/convert.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/convert.go
@@ -152,6 +152,7 @@ func getLintConfigForV1Beta1LintConfig(
 		lintConfigV1Beta1.GetRpcAllowGoogleProtobufEmptyRequests(),
 		lintConfigV1Beta1.GetRpcAllowGoogleProtobufEmptyResponses(),
 		lintConfigV1Beta1.GetServiceSuffix(),
+		lintConfigV1Beta1.GetDisableBuiltin(),
 	)
 }
 
@@ -162,6 +163,7 @@ func getBreakingConfigForV1Beta1BreakingConfig(
 		breakingConfigV1Beta1.GetUse(),
 		breakingConfigV1Beta1.GetExcept(),
 		breakingConfigV1Beta1.GetIgnoreUnstablePackages(),
+		breakingConfigV1Beta1.GetDisableBuiltin(),
 	)
 }
 

--- a/private/bufpkg/bufpolicy/bufpolicyconfig/buf_policy_yaml_file.go
+++ b/private/bufpkg/bufpolicy/bufpolicyconfig/buf_policy_yaml_file.go
@@ -200,7 +200,6 @@ func readBufPolicyYAMLFile(
 	if err := getUnmarshalStrict(allowJSON)(data, &externalBufPolicyYAMLFile); err != nil {
 		return nil, fmt.Errorf("invalid as version %v: %w", fileVersion, err)
 	}
-
 	var lintConfig bufpolicy.LintConfig
 	if !externalBufPolicyYAMLFile.Lint.isEmpty() {
 		lintConfig, err = getLintConfigForExternalLintV2(
@@ -295,7 +294,8 @@ func (el externalBufPolicyYAMLFileLintV2) isEmpty() bool {
 		!el.RPCAllowSameRequestResponse &&
 		!el.RPCAllowGoogleProtobufEmptyRequests &&
 		!el.RPCAllowGoogleProtobufEmptyResponses &&
-		el.ServiceSuffix == ""
+		el.ServiceSuffix == "" &&
+		!el.DisableBuiltin
 }
 
 // externalBufPolicyYAMLFileBreakingV2 represents breaking configuration within a v2 buf.policy.yaml file.
@@ -311,7 +311,8 @@ type externalBufPolicyYAMLFileBreakingV2 struct {
 func (eb externalBufPolicyYAMLFileBreakingV2) isEmpty() bool {
 	return len(eb.Use) == 0 &&
 		len(eb.Except) == 0 &&
-		!eb.IgnoreUnstablePackages
+		!eb.IgnoreUnstablePackages &&
+		!eb.DisableBuiltin
 }
 
 // externalBufPolicyYAMLFilePluginV2 represents a single plugin config in a v2 buf.yaml file.
@@ -329,6 +330,7 @@ func getLintConfigForExternalLintV2(externalLint externalBufPolicyYAMLFileLintV2
 		externalLint.RPCAllowGoogleProtobufEmptyRequests,
 		externalLint.RPCAllowGoogleProtobufEmptyResponses,
 		externalLint.ServiceSuffix,
+		externalLint.DisableBuiltin,
 	)
 }
 
@@ -351,6 +353,7 @@ func getBreakingConfigForExternalBreaking(externalBreaking externalBufPolicyYAML
 		externalBreaking.Use,
 		externalBreaking.Except,
 		externalBreaking.IgnoreUnstablePackages,
+		externalBreaking.DisableBuiltin,
 	)
 }
 
@@ -360,6 +363,7 @@ func getExternalBreakingForBreakingConfig(breakingConfig bufpolicy.BreakingConfi
 		Use:                    breakingConfig.UseIDsAndCategories(),
 		Except:                 breakingConfig.ExceptIDsAndCategories(),
 		IgnoreUnstablePackages: breakingConfig.IgnoreUnstablePackages(),
+		DisableBuiltin:         breakingConfig.DisableBuiltin(),
 	}
 }
 
@@ -474,6 +478,7 @@ func getDefaultLintConfigV2() (bufpolicy.LintConfig, error) {
 		false,
 		false,
 		"",
+		false,
 	)
 }
 
@@ -482,6 +487,7 @@ func getDefaultBreakingConfigV2() (bufpolicy.BreakingConfig, error) {
 	return bufpolicy.NewBreakingConfig(
 		nil,
 		nil,
+		false,
 		false,
 	)
 }

--- a/private/bufpkg/bufpolicy/bufpolicyconfig/buf_policy_yaml_file.go
+++ b/private/bufpkg/bufpolicy/bufpolicyconfig/buf_policy_yaml_file.go
@@ -285,6 +285,7 @@ type externalBufPolicyYAMLFileLintV2 struct {
 	RPCAllowGoogleProtobufEmptyRequests  bool   `json:"rpc_allow_google_protobuf_empty_requests,omitempty" yaml:"rpc_allow_google_protobuf_empty_requests,omitempty"`
 	RPCAllowGoogleProtobufEmptyResponses bool   `json:"rpc_allow_google_protobuf_empty_responses,omitempty" yaml:"rpc_allow_google_protobuf_empty_responses,omitempty"`
 	ServiceSuffix                        string `json:"service_suffix,omitempty" yaml:"service_suffix,omitempty"`
+	DisableBuiltin                       bool   `json:"disable_builtin,omitempty" yaml:"disable_builtin,omitempty"`
 }
 
 func (el externalBufPolicyYAMLFileLintV2) isEmpty() bool {
@@ -304,6 +305,7 @@ type externalBufPolicyYAMLFileBreakingV2 struct {
 	Use                    []string `json:"use,omitempty" yaml:"use,omitempty"`
 	Except                 []string `json:"except,omitempty" yaml:"except,omitempty"`
 	IgnoreUnstablePackages bool     `json:"ignore_unstable_packages,omitempty" yaml:"ignore_unstable_packages,omitempty"`
+	DisableBuiltin         bool     `json:"disable_builtin,omitempty" yaml:"disable_builtin,omitempty"`
 }
 
 func (eb externalBufPolicyYAMLFileBreakingV2) isEmpty() bool {
@@ -340,6 +342,7 @@ func getExternalLintForLintConfig(lintConfig bufpolicy.LintConfig) externalBufPo
 		RPCAllowGoogleProtobufEmptyRequests:  lintConfig.RPCAllowGoogleProtobufEmptyRequests(),
 		RPCAllowGoogleProtobufEmptyResponses: lintConfig.RPCAllowGoogleProtobufEmptyResponses(),
 		ServiceSuffix:                        lintConfig.ServiceSuffix(),
+		DisableBuiltin:                       lintConfig.DisableBuiltin(),
 	}
 }
 

--- a/private/bufpkg/bufpolicy/bufpolicyconfig/buf_policy_yaml_file_test.go
+++ b/private/bufpkg/bufpolicy/bufpolicyconfig/buf_policy_yaml_file_test.go
@@ -30,9 +30,17 @@ func TestReadWriteBufPolicyYAMLFileRoundTrip(t *testing.T) {
 		t,
 		// input
 		`version: v2
+lint:
+  disable_builtin: true
+breaking:
+  disable_builtin: true
 `,
 		// expected output
 		`version: v2
+lint:
+  disable_builtin: true
+breaking:
+  disable_builtin: true
 `,
 	)
 

--- a/private/bufpkg/bufpolicy/bufpolicyconfig/convert.go
+++ b/private/bufpkg/bufpolicy/bufpolicyconfig/convert.go
@@ -30,7 +30,7 @@ func LintConfigToBufConfig(lintConfig bufpolicy.LintConfig) (bufconfig.LintConfi
 		lintConfig.ExceptIDsAndCategories(),
 		nil,
 		nil,
-		false,
+		lintConfig.DisableBuiltin(),
 	)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func BreakingConfigToBufConfig(breakingConfig bufpolicy.BreakingConfig) (bufconf
 		breakingConfig.ExceptIDsAndCategories(),
 		nil,
 		nil,
-		false,
+		breakingConfig.DisableBuiltin(),
 	)
 	if err != nil {
 		return nil, err

--- a/private/bufpkg/bufpolicy/digest_test.go
+++ b/private/bufpkg/bufpolicy/digest_test.go
@@ -33,12 +33,14 @@ func TestO1Digest(t *testing.T) {
 		true,
 		true,
 		"serviceSuffix",
+		false,
 	)
 	require.NoError(t, err)
 	breakingConfig, err := newBreakingConfig(
 		[]string{"BREAKING_ID_1", "BREAKING_ID_2"},
 		nil,
 		true,
+		false,
 	)
 	require.NoError(t, err)
 	policyConfig, err := newPolicyConfig(lintConfig, breakingConfig, nil)

--- a/private/bufpkg/bufpolicy/policy_config.go
+++ b/private/bufpkg/bufpolicy/policy_config.go
@@ -362,6 +362,7 @@ func marshalPolicyConfigAsJSON(policyConfig PolicyConfig) ([]byte, error) {
 			RpcAllowGoogleProtobufEmptyRequests:  lintConfig.RPCAllowGoogleProtobufEmptyRequests(),
 			RpcAllowGoogleProtobufEmptyResponses: lintConfig.RPCAllowGoogleProtobufEmptyResponses(),
 			ServiceSuffix:                        lintConfig.ServiceSuffix(),
+			DisableBuiltin:                       lintConfig.DisableBuiltin(),
 		}
 	}
 	var breakingConfigV1Beta1 *policyV1Beta1PolicyConfig_BreakingConfig
@@ -370,6 +371,7 @@ func marshalPolicyConfigAsJSON(policyConfig PolicyConfig) ([]byte, error) {
 			Use:                    breakingConfig.UseIDsAndCategories(),
 			Except:                 breakingConfig.ExceptIDsAndCategories(),
 			IgnoreUnstablePackages: breakingConfig.IgnoreUnstablePackages(),
+			DisableBuiltin:         breakingConfig.DisableBuiltin(),
 		}
 	}
 	pluginConfigs, err := xslices.MapError(policyConfig.PluginConfigs(), func(pluginConfig PluginConfig) (*policyV1Beta1PolicyConfig_PluginConfig, error) {
@@ -499,6 +501,7 @@ type policyV1Beta1PolicyConfig_LintConfig struct {
 	RpcAllowGoogleProtobufEmptyRequests  bool     `json:"rpcAllowGoogleProtobufEmptyRequests,omitempty"`
 	RpcAllowGoogleProtobufEmptyResponses bool     `json:"rpcAllowGoogleProtobufEmptyResponses,omitempty"`
 	ServiceSuffix                        string   `json:"serviceSuffix,omitempty"`
+	DisableBuiltin                       bool     `json:"disableBuiltin,omitempty"`
 }
 
 // policyV1Beta1PolicyConfig_BreakingConfig is a stable JSON representation of the buf.registry.policy.v1beta1.PolicyConfig.BreakingConfig.
@@ -506,6 +509,7 @@ type policyV1Beta1PolicyConfig_BreakingConfig struct {
 	Use                    []string `json:"use,omitempty"`
 	Except                 []string `json:"except,omitempty"`
 	IgnoreUnstablePackages bool     `json:"ignoreUnstablePackages,omitempty"`
+	DisableBuiltin         bool     `json:"disableBuiltin,omitempty"`
 }
 
 // policyV1Beta1PolicyConfig_PluginConfig is a stable JSON representation of the buf.registry.policy.v1beta1.PolicyConfig.PluginConfig.


### PR DESCRIPTION
This adds the `disable_builtin` config handling to policies. Policies that set the `disable_builtin` will exclude all builtin rules and categories. Default builtins will not be run. Pulls in the latest registry API.