### PR TITLE
Fix buf curl with HTTP/2 services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix buf curl for HTTP/2 services
 
 ## [v1.57.1] - 2025-09-16
 

--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -1132,7 +1132,7 @@ func makeHTTPRoundTripper(f *flags, isSecure bool, authority string, printer ver
 	}
 	protocols := new(http.Protocols)
 	protocols.SetHTTP1(true)
-	protocols.SetHTTP2(f.HTTP2PriorKnowledge)
+	protocols.SetHTTP2(true)
 	protocols.SetUnencryptedHTTP2(f.HTTP2PriorKnowledge && !isSecure)
 	return &http.Transport{
 		Proxy:             http.ProxyFromEnvironment,


### PR DESCRIPTION
This fixes buf curl commands with HTTP/2 services. Introduced in https://github.com/bufbuild/buf/pull/4011