### PR TITLE
Add rule to check `IGNORE_IF_ZERO_VALUE` on fields that track presence

### DIFF
--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
@@ -215,7 +215,7 @@ func checkRulesForField(
 			adder.getFieldRuleName(requiredFieldNumber),
 		)
 	}
-	checkFieldFlags(adder, fieldRules)
+	checkFieldFlags(adder, fieldDescriptor, fieldRules)
 	if err := checkCELForField(
 		adder,
 		fieldRules,
@@ -296,6 +296,7 @@ func checkRulesForField(
 
 func checkFieldFlags(
 	adder *adder,
+	fieldDescriptor protoreflect.FieldDescriptor,
 	fieldRules *validate.FieldRules,
 ) {
 	var fieldCount int
@@ -324,6 +325,16 @@ func checkFieldFlags(
 			adder.getFieldRuleName(requiredFieldNumber),
 			adder.getFieldRuleName(ignoreFieldNumber),
 			validate.Ignore_IGNORE_IF_ZERO_VALUE,
+		)
+	}
+	if fieldRules.GetIgnore() == validate.Ignore_IGNORE_IF_ZERO_VALUE && fieldDescriptor.HasPresence() {
+		adder.addForPathf(
+			[]int32{ignoreFieldNumber},
+			"Field %q has %s=%v and tracks presence. This is the same the default and the ignore option can be removed.",
+			adder.fieldName(),
+			adder.getFieldRuleName(ignoreFieldNumber),
+			validate.Ignore_IGNORE_IF_ZERO_VALUE,
+			adder.getFieldRuleName(),
 		)
 	}
 }

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -660,6 +660,7 @@ func TestRunProtovalidate(t *testing.T) {
 		bufanalysistesting.NewFileAnnotation(t, "extension.proto", 45, 5, 45, 55, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "field.proto", 18, 5, 18, 41, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "field.proto", 19, 5, 19, 55, "PROTOVALIDATE"),
+		bufanalysistesting.NewFileAnnotation(t, "field.proto", 23, 52, 23, 102, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "map.proto", 24, 38, 24, 76, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "map.proto", 27, 5, 27, 43, "PROTOVALIDATE"),
 		bufanalysistesting.NewFileAnnotation(t, "map.proto", 29, 5, 29, 43, "PROTOVALIDATE"),

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/extension.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/extension.proto
@@ -9,7 +9,7 @@ message ExtensionTest {
     (buf.validate.field).string.min_len = 3,
     (buf.validate.field).required = true
   ];
-  optional string valid_ignore_empty = 2 [
+  string valid_ignore_empty = 2 [
     (buf.validate.field).string.min_len = 3,
     (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
@@ -24,9 +24,9 @@ message Extending {
       // required cannot be specified for extension
       (buf.validate.field).required = true
     ];
-    optional string invalid_ignore_empty = 14 [
+    string invalid_ignore_empty = 14 [
       (buf.validate.field).string.min_len = 3,
-      // ignore if unpopulated cannot be specified for extension
+      // ignore if zero value cannot be specified for extension
       (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
   }
@@ -39,9 +39,9 @@ extend ExtensionTest {
     // required cannot be specified for extension
     (buf.validate.field).required = true
   ];
-  optional string invalid_ignore_empty = 24 [
+  string invalid_ignore_empty = 24 [
     (buf.validate.field).string.min_len = 3,
-    // ignore if unpopulated cannot be specified for extension
+    // ignore if zero value cannot be specified for extension
     (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }

--- a/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/field.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/protovalidate/proto/field.proto
@@ -20,4 +20,5 @@ message FieldTest {
   ];
   // buf:lint:ignore PROTOVALIDATE
   int32 int32_validated_with_int64 = 4 [(buf.validate.field).int64.gt = 5];
+  optional string optional_zero_ignored_field = 5 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE];
 }


### PR DESCRIPTION
As [documented](https://buf.build/bufbuild/protovalidate/docs/main:buf.validate#buf.validate.Ignore), `IGNORE_IF_ZERO_VALUE` is a no-op on fields that track presence. We add a check to the existing `PROTOVALIDATE` rule.