### PR TITLE
Fix format on missing field numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Update `PROTOVALIDATE` lint rule to check `IGNORE_IF_ZERO_VALUE` on fields that track presence.
+- Fix `buf format` on fields with missing field number tags.
 
 ## [v1.57.2] - 2025-09-16
 

--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -894,9 +894,13 @@ func (f *formatter) writeField(fieldNode *ast.FieldNode) {
 	f.Space()
 	f.writeInline(fieldNode.Name)
 	f.Space()
-	f.writeInline(fieldNode.Equals)
-	f.Space()
-	f.writeInline(fieldNode.Tag)
+	if fieldNode.Equals != nil {
+		f.writeInline(fieldNode.Equals)
+		f.Space()
+	}
+	if fieldNode.Tag != nil {
+		f.writeInline(fieldNode.Tag)
+	}
 	if fieldNode.Options != nil {
 		f.Space()
 		f.writeNode(fieldNode.Options)

--- a/private/buf/cmd/buf/testdata/format/invalid/invalid_field_number.proto
+++ b/private/buf/cmd/buf/testdata/format/invalid/invalid_field_number.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message FieldWithoutFieldNumber {
+	required string field; // missing field number
+	optional string withoptions [
+		(syntax) = true
+	];
+}


### PR DESCRIPTION
This fixes `buf format` when run on fields missing field number tags.

Fixes https://github.com/bufbuild/buf/issues/4028