### PR TITLE
Only set HTTP1 when HTTP/2 Prior Knowledge flag is false in `buf curl`

### DIFF
--- a/private/buf/cmd/buf/command/curl/curl.go
+++ b/private/buf/cmd/buf/command/curl/curl.go
@@ -1131,7 +1131,7 @@ func makeHTTPRoundTripper(f *flags, isSecure bool, authority string, printer ver
 		}
 	}
 	protocols := new(http.Protocols)
-	protocols.SetHTTP1(!f.HTTP2PriorKnowledge && !f.HTTP3)
+	protocols.SetHTTP1(!f.HTTP2PriorKnowledge)
 	protocols.SetHTTP2(true)
 	protocols.SetUnencryptedHTTP2(f.HTTP2PriorKnowledge && !isSecure)
 	return &http.Transport{


### PR DESCRIPTION
As of v1.57.2, calling `~/go/bin/buf curl -vvvvvv --debug --http2-prior-knowledge --protocol grpc http://127.0.0.1:55555 --list-methods` would result in the TLS handshake hanging. After bisecting down to v1.57.1 being the first bad tag, I found the regression here https://github.com/bufbuild/buf/commit/2d0ab7a0f731b8d06f1e764e775ec70b32c41b24#diff-05c240e5d4191f595d5b747c112c314cf14ee4d77505cee99aac9500eed39527L1135-R1144. I think there are lacking test cases for the buf curl command (unless you have some other acceptance test suite internally), so this was an easy miss. With this, we should be back to insecurely calling gRPC server methods 8).