### PR TITLE
LSP optimize start/end location offset lookups

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -616,9 +616,9 @@ func (f *file) IndexSymbols(ctx context.Context) {
 
 	// Finally, sort the symbols in position order, with shorter symbols sorting smaller.
 	slices.SortFunc(f.symbols, func(s1, s2 *symbol) int {
-		diff := s1.span.StartLoc().Offset - s2.span.StartLoc().Offset
+		diff := s1.span.Start - s2.span.Start
 		if diff == 0 {
-			return s1.span.EndLoc().Offset - s2.span.EndLoc().Offset
+			return s1.span.End - s2.span.End
 		}
 		return diff
 	})

--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -280,7 +280,7 @@ func getCommentsFromDef(def ast.DeclDef) string {
 	var comments []string
 	// We drop the other side of "Around" because we only care about the beginning -- we're
 	// traversing backwards for leading comemnts only.
-	_, start := def.Context().Stream().Around(def.Span().StartLoc().Offset)
+	_, start := def.Context().Stream().Around(def.Span().Start)
 	cursor := token.NewCursorAt(start)
 	t := cursor.PrevSkippable()
 	for !t.IsZero() {


### PR DESCRIPTION
This avoids calling StartLoc and EndLoc functions on lookup of start and end offsets.