### PR TITLE
LSP add workspace symbol queries

### DIFF
--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -517,10 +517,10 @@ func (s *server) Symbols(
 	query := strings.ToLower(params.Query)
 
 	var results []protocol.SymbolInformation
-	s.fileManager.uriToFile.Range(func(uri protocol.URI, file *file) bool {
+	for uri, file := range s.fileManager.uriToFile.Range {
 		if file.ir.IsZero() {
 			s.lsp.logger.DebugContext(ctx, fmt.Sprintf("workspace symbol: skipping file without IR: %s", uri))
-			return true
+			continue
 		}
 
 		// Search through all symbols in this file.
@@ -539,11 +539,10 @@ func (s *server) Symbols(
 			}
 			results = append(results, symbolInfo)
 			if len(results) >= maxResults {
-				return false // Stop iteration
+				break
 			}
 		}
-		return true
-	})
+	}
 
 	slices.SortFunc(results, func(a, b protocol.SymbolInformation) int {
 		if a.Name != b.Name {

--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -290,7 +290,7 @@ func (s *symbol) GetSymbolInformation() protocol.SymbolInformation {
 	case ir.SymbolKindExtension:
 		kind = protocol.SymbolKindField
 	case ir.SymbolKindOneof:
-		kind = protocol.SymbolKindField
+		kind = protocol.SymbolKindClass // Oneof are like classes
 	case ir.SymbolKindService:
 		kind = protocol.SymbolKindInterface // Services are like interfaces
 	case ir.SymbolKindMethod:


### PR DESCRIPTION
This adds basic support for workspace symbol queries. Symbols can be serached by name, with the parent listed as the container name. For example searching given a message type `buf.acme.User` with a field `name`. Searching for `user` returns `User` in the container `buf.acme`. Searching for `name` returns `name` in the container `buf.acme.User`.