### PR TITLE
Remove extra space when writing first hunk when outside of context

### DIFF
--- a/private/pkg/diff/diffmyers/diffmyers.go
+++ b/private/pkg/diff/diffmyers/diffmyers.go
@@ -144,8 +144,10 @@ func Print(from, to [][]byte, edits []Edit) ([]byte, error) {
 	var buffer bytes.Buffer
 	buffer.Grow(bufferSize)
 	for _, line := range out {
-		if line.hunk && len(line.line) > 0 {
-			buffer.Write(line.line)
+		if line.hunk {
+			if len(line.line) > 0 {
+				buffer.Write(line.line)
+			}
 			continue
 		}
 		switch line.EditKind {

--- a/private/pkg/diff/diffmyers/diffmyers_test.go
+++ b/private/pkg/diff/diffmyers/diffmyers_test.go
@@ -201,6 +201,32 @@ The door of all subtleties!
 		)
 		testPrint(t, lao, tzu, edits, "lao-tzu")
 	})
+
+	t.Run("first-line-prefix", func(t *testing.T) {
+		t.Parallel()
+		from := "syntax = \"proto3\";\n\npackage test;\n\nmessage Foo {\n  string field1 = 1;\n  string field2 = 2;\n  string field3 = 3;\n  string field4 = 4;\n  string field5 = 5;\n}\n"
+		to := "syntax = \"proto3\";\n\npackage test;\n\nmessage Foo {\n  string field1 = 1;\n  string field2 = 2;\n  string field3 = 3;\n  string field4 = 4;\n  int32 field5 = 5;\n}\n"
+		expectedFirstLineOfOutput := " syntax = \"proto3\";"
+		fromLines := splitLines(from)
+		toLines := splitLines(to)
+		edits := diffmyers.Diff(
+			fromLines,
+			toLines,
+		)
+		diff, err := diffmyers.Print(
+			fromLines,
+			toLines,
+			edits,
+		)
+		require.NoError(t, err)
+		firstLineEnd := bytes.Index(diff, []byte("\n"))
+
+		firstLine := diff[:firstLineEnd]
+		actualFirstLine := string(firstLine)
+		require.Equal(t, expectedFirstLineOfOutput, actualFirstLine,
+			"First line of diff output should match expected format (single space prefix, no double space)")
+		testPrint(t, from, to, edits, "first-line-prefix")
+	})
 }
 
 func testPrint(t *testing.T, from, to string, edits []diffmyers.Edit, golden string) {

--- a/private/pkg/diff/diffmyers/testdata/first-line-prefix
+++ b/private/pkg/diff/diffmyers/testdata/first-line-prefix
@@ -1,0 +1,13 @@
+ syntax = "proto3";
+ 
+ package test;
+ 
+ message Foo {
+   string field1 = 1;
+   string field2 = 2;
+   string field3 = 3;
+   string field4 = 4;
+@@ -10,1 +10,1 @@
+-  string field5 = 5;
++  int32 field5 = 5;
+ }


### PR DESCRIPTION
When the first lines are outside of the change header, there was an extra space being injected in the first line. Fixed the conditions slightly to ensure that we don't get an extra space.