### PR TITLE
LSP fix goto definition for imports

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -475,6 +475,10 @@ func (f *file) RefreshIR(ctx context.Context) {
 	}
 	for i, file := range files {
 		file.ir = results[i].Value
+		if i > 0 {
+			// Update symbols for imports.
+			file.IndexSymbols(ctx)
+		}
 	}
 	diagnostics, err := xslices.MapError(
 		report.Diagnostics,


### PR DESCRIPTION
This fixes goto definition bug introduced in #4063. Imports must call the symbol index function after refresh.  