### PR TITLE
Drop LSP notify non-error to debug

### DIFF
--- a/private/buf/buflsp/jsonrpc_wrappers.go
+++ b/private/buf/buflsp/jsonrpc_wrappers.go
@@ -95,7 +95,7 @@ func (c *connWrapper) Notify(
 			xslog.ErrorAttr(err),
 		)
 	} else {
-		c.logger.Warn(
+		c.logger.Debug(
 			"notify returned",
 			slog.String("method", method),
 		)


### PR DESCRIPTION
Similar to the calls above it; otherwise this is noisy with the default `buf lsp serve` configuration.