### PR TITLE
Deprecate and hide the timeout flag

### DIFF
--- a/cmd/buf/buf.go
+++ b/cmd/buf/buf.go
@@ -636,6 +636,6 @@ func deprecatedMessage(newCommand, oldCommand string) string {
 func bindHiddenTimeoutFlag(flagSet *pflag.FlagSet) {
 	var timeout time.Duration
 	flagSet.DurationVar(&timeout, timeoutFlagName, 0, "This flag is deprecated and has no effect.")
-	_ = flagSet.MarkDeprecated(timeoutFlagName, "This flag is deprecated and has no effect.")
+	_ = flagSet.MarkDeprecated(timeoutFlagName, "this flag has no effect")
 	_ = flagSet.MarkHidden(timeoutFlagName)
 }


### PR DESCRIPTION
This PR deprecates and hides the global `--timeout` flag.

This specifically came up with `buf lsp serve`, where this command should not have a timeout. As such, we'd want to move `--timeout` to non-global anyways, but looking at the problem, it's not entirely clear what we're solving by having this flag in the first place. It was originally added because "all RPCs should have a timeout" but I'm not sure if this really desired or necessary.

As such, this just turns it into a no-op. You could theoretically argue that users expecting timeouts today will no longer get them, but this is generally how flags are deprecated, and you get a warning.