### PR TITLE
LSP disable for cached files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix `buf lsp serve` to skip files in the buf cache directory to prevent workspace resolution
+  issues that could cause import paths to become unresolvable.
 
 ## [v1.59.0] - 2025-10-20
 


### PR DESCRIPTION
This PR disables the LSP on files within the buf cache directory. Files from the cache fail to resolve the correct workspace. The function `RefreshWorkspace` calls `controller.GetWorkspace` given the file URI. If the LSP closed this URI, it will then re-resolve the workspace. This may then poison the LSP file managers tracking of the import path. Then leading to file imports becoming unresolvable as the URI now points to a invalid path. To avoid this bug for now cached files are not supported. A follow up PR will correct this.