### PR TITLE
Fix several issues with import completion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,11 +184,6 @@ linters:
         path: private/buf/buflsp/symbol.go
         text: 'G115:'
       - linters:
-          - gosec
-        # G115 checks for use of truncating conversions.
-        path: private/buf/buflsp/completion.go
-        text: 'G115'
-      - linters:
           - containedctx
         # Type must implement an interface whose methods do not accept context. But this
         # implementation makes RPC calls, which need a context. So we allow creator of the

--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -247,11 +247,12 @@ func completionItemsForImport(ctx context.Context, file *file, declImport ast.De
 				// We're in a situation where we have `import goo`, in which case we want to make sure that
 				// we fix the entire import to be wrapped in quotes.
 				// Send an AdditionalTextEdit to add the front quote.
-				if len(currentImportPathText) > math.MaxUint32 {
+				importPathLength := len(currentImportPathText)
+				if importPathLength < 0 || importPathLength > math.MaxUint32 {
 					file.lsp.logger.DebugContext(ctx, "completion: current import path text > math.MaxUint32")
 					return nil
 				}
-				characterForInsert := position.Character - uint32(len(currentImportPathText))
+				characterForInsert := position.Character - uint32(importPathLength)
 				positionForInsert := protocol.Position{
 					Line:      position.Line,
 					Character: characterForInsert,


### PR DESCRIPTION
* Removes an extra space we were inserting during completion
* Supports filtering on the existing import "prefix" in the text
* Avoids adding a `;` when inserting path within quotes (but will send an AdditionalTextEdit to add the `;` at the end of line, if it doesn't exist)
* Removes unnecessary sorting (this is done by LSP clients)
* Avoids an error in clients on attempting completion with a nil return