### PR TITLE
Fix CompletionItem.Kind for package

### DIFF
--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -143,7 +143,7 @@ func completionItemsForPackage(ctx context.Context, file *file, syntaxPackage as
 	file.lsp.logger.DebugContext(ctx, "completion: package suggestion", slog.String("package", strings.Join(suggested, ".")))
 	return []protocol.CompletionItem{{
 		Label: strings.Join(suggested, ".") + ";",
-		Kind:  protocol.CompletionItemKindSnippet,
+		Kind:  protocol.CompletionItemKindModule,
 	}}
 }
 


### PR DESCRIPTION
Snippets are a separate thing in LSP-land that imply a bit of text that will be further edited by the user. Module seems to be the closest thing in meaning to a protobuf package.