### PR TITLE
LSP fix file close

### DIFF
--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -337,7 +337,9 @@ func (s *server) DidClose(
 	ctx context.Context,
 	params *protocol.DidCloseTextDocumentParams,
 ) error {
-	s.fileManager.Close(ctx, params.TextDocument.URI)
+	if file := s.fileManager.Get(params.TextDocument.URI); file != nil {
+		file.Close(ctx)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This fixes close for files on DidClose notifications. Ensures the check go routine is stopped and any workspaces are released.