### PR TITLE
Fix range over workspace files for WKTs

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -51,7 +51,6 @@ import (
 )
 
 const (
-	descriptorPath     = "google/protobuf/descriptor.proto"
 	checkRefreshPeriod = 3 * time.Second
 )
 
@@ -70,7 +69,7 @@ type file struct {
 	version int32
 	hasText bool // Whether this file has ever had text read into it.
 
-	workspace *workspace
+	workspace *workspace // May be nil.
 
 	againstStrategy againstStrategy
 	againstGitRef   string
@@ -393,7 +392,7 @@ func (f *file) IndexImports(ctx context.Context) {
 func (f *file) getWorkspaceFileInfos(ctx context.Context) ([]storage.ObjectInfo, error) {
 	seen := make(map[string]struct{})
 	var fileInfos []storage.ObjectInfo
-	for _, fileInfo := range f.workspace.fileNameToFileInfo {
+	for fileInfo := range f.workspace.FileInfo() {
 		fileInfos = append(fileInfos, fileInfo)
 		seen[fileInfo.Path()] = struct{}{}
 	}

--- a/private/buf/buflsp/workspace.go
+++ b/private/buf/buflsp/workspace.go
@@ -17,6 +17,7 @@ package buflsp
 import (
 	"context"
 	"fmt"
+	"iter"
 	"log/slog"
 
 	"buf.build/go/standard/xlog/xslog"
@@ -138,6 +139,9 @@ func (w *workspace) Release() int {
 
 // Refresh rebuilds the workspace and required context.
 func (w *workspace) Refresh(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
 	fileName := w.workspaceURI.Filename()
 	bufWorkspace, err := w.lsp.controller.GetWorkspace(ctx, fileName)
 	if err != nil {
@@ -167,6 +171,20 @@ func (w *workspace) Refresh(ctx context.Context) error {
 	w.fileNameToFileInfo = fileNameToFileInfo
 	w.checkClient = checkClient
 	return nil
+}
+
+// FileInfo returns an iterator over the files in the workspace.
+func (w *workspace) FileInfo() iter.Seq[bufmodule.FileInfo] {
+	return func(yield func(bufmodule.FileInfo) bool) {
+		if w == nil {
+			return
+		}
+		for _, fileInfo := range w.fileNameToFileInfo {
+			if !yield(fileInfo) {
+				return
+			}
+		}
+	}
 }
 
 // Workspace returns the buf Workspace.


### PR DESCRIPTION
This fixes resolving imports for WKTs where the workspace is unresolvable. Getters are used for the workspace to avoid nil dereferencing it.