### PR TITLE
Add deprecation status to SymbolInformation

### DIFF
--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -299,11 +299,17 @@ func (s *symbol) GetSymbolInformation() protocol.SymbolInformation {
 	default:
 		kind = protocol.SymbolKindVariable
 	}
+	var isDeprecated bool
+	if _, ok := s.ir.Deprecated().AsBool(); ok {
+		isDeprecated = true
+	}
 	return protocol.SymbolInformation{
 		Name:          name,
 		Kind:          kind,
 		Location:      location,
 		ContainerName: containerName,
+		// TODO: Use Tags with a protocol.CompletionItemTagDeprecated if the client supports tags.
+		Deprecated: isDeprecated,
 	}
 }
 


### PR DESCRIPTION
In editors, this tends to be rendered as a strikethrough (to signal against using the symbol); `gopls` does this for `Deprecated: ` APIs.

For example, in VS Code, the third `ListCommitsRequest` here is marked as deprecated:

<img width="646" height="148" alt="image" src="https://github.com/user-attachments/assets/944784c8-b45d-456c-8ecd-8c026a02a948" />
