### PR TITLE
Handle LSP no data for semantic tokens

### DIFF
--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -525,6 +525,9 @@ func (s *server) SemanticTokensFull(
 			}
 		}
 	}
+	if len(encoded) == 0 {
+		return nil, nil
+	}
 	return &protocol.SemanticTokens{Data: encoded}, nil
 }
 


### PR DESCRIPTION
In the case that we can't compute semantic tokens (from an error), we want to avoid sending back a non-nil response with nil data.