### PR TITLE
Run lints on open/save/change; remove breaking checks

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -52,9 +52,8 @@ import (
 //
 // Mutating a file is thread-safe.
 type file struct {
-	lsp       *lsp
-	uri       protocol.URI
-	checkWork chan<- struct{}
+	lsp *lsp
+	uri protocol.URI
 
 	file *report.File
 	// Version is an opaque version identifier given to us by the LSP client. This
@@ -120,10 +119,6 @@ func (f *file) Reset(ctx context.Context) {
 // for this file.
 func (f *file) Close(ctx context.Context) {
 	f.Manager().Close(ctx, f.uri)
-	if f.checkWork != nil {
-		close(f.checkWork)
-		f.checkWork = nil
-	}
 	if f.workspace != nil {
 		f.workspace.Release()
 		f.workspace = nil


### PR DESCRIPTION
This removes `RunChecks` and its background goroutine in favor of just running BuildImage and RunLints if the file is open in the editor. For now, this removes the breaking check entirely; we may add this back later as an LSP Code Action.