### PR TITLE
LSP fix IR file state

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -40,6 +40,7 @@ import (
 	"github.com/bufbuild/protocompile/experimental/ir"
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/bufbuild/protocompile/experimental/source"
 	"go.lsp.dev/protocol"
 )
 
@@ -243,11 +244,20 @@ func (f *file) RefreshIR(ctx context.Context) {
 		slog.Int("version", int(f.version)),
 	)
 
-	files := xslices.MapValuesToSlice(f.workspace.PathToFile())
+	// Opener creates a cached view of all files in the workspace.
+	pathToFiles := f.workspace.PathToFile()
+	files := make([]*file, 0, len(pathToFiles))
+	openerMap := make(map[string]string, len(pathToFiles))
+	for path, file := range pathToFiles {
+		openerMap[path] = file.file.Text()
+		files = append(files, file)
+	}
+	opener := source.NewMap(openerMap)
+
 	session := new(ir.Session)
 	queries := xslices.Map(files, func(file *file) incremental.Query[ir.File] {
 		return queries.IR{
-			Opener:  f.workspace,
+			Opener:  opener,
 			Path:    file.objectInfo.Path(),
 			Session: session,
 		}


### PR DESCRIPTION
Fixes an issue introduced in #4116 where the IR could become out of sync with file contents. The opener on the workspace is reverted to the static map. Additionally, a bug in tracking workspace files was fixed.