### PR TITLE
Add import of missing file on completion

### DIFF
--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -642,7 +642,6 @@ func typeReferencesToCompletionItems(
 		case !current.ir.AST().Syntax().IsZero():
 			line = current.ir.AST().Syntax().Span().EndLoc().Line
 		default:
-			// We won't add an import in this case.
 			line = 0
 		}
 		if line < 0 || line > math.MaxUint32 {
@@ -697,8 +696,7 @@ func typeReferencesToCompletionItems(
 			symbolFile := symbol.ir.File().Path()
 			_, hasImport := currentImportPaths[symbolFile]
 			var additionalTextEdits []protocol.TextEdit
-			var zero protocol.Position
-			if !hasImport && insertPosition != zero {
+			if !hasImport {
 				additionalTextEdits = append(additionalTextEdits, protocol.TextEdit{
 					NewText: "import " + `"` + symbolFile + `";` + "\n",
 					Range: protocol.Range{


### PR DESCRIPTION
If the completion item is not currently imported in the file, this will add the missing import.

We can't necessarily assume that the file is already formatted by `buf format`, so instead, we just either shove the import directly after any existing imports (which will be reordered by `buf format`, if used); if no imports, right after `package`; if no package, right after `syntax`, and otherwise just balk.