### PR TITLE
Skip adding import for symbols in same file

### DIFF
--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -680,7 +680,7 @@ func typeReferencesToCompletionItems(
 			symbolFile := symbol.ir.File().Path()
 			_, hasImport := currentImportPaths[symbolFile]
 			var additionalTextEdits []protocol.TextEdit
-			if !hasImport {
+			if !hasImport && symbolFile != current.ir.Path() {
 				additionalTextEdits = append(additionalTextEdits, protocol.TextEdit{
 					NewText: "import " + `"` + symbolFile + `";` + "\n",
 					Range: protocol.Range{


### PR DESCRIPTION
Otherwise, we'll get circular imports by trying to import ourselves 😸.