### PR TITLE
Tighten up item kinds

### DIFF
--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -307,6 +307,8 @@ func (s *symbol) GetSymbolInformation() protocol.SymbolInformation {
 		kind = protocol.SymbolKindInterface // Services are like interfaces
 	case ir.SymbolKindMethod:
 		kind = protocol.SymbolKindMethod
+	case ir.SymbolKindScalar:
+		kind = protocol.SymbolKindConstant
 	default:
 		kind = protocol.SymbolKindVariable
 	}


### PR DESCRIPTION
* predeclared types (`string`, `int64`) are more like keywords than classes
* simplify typeReferencesToCompletionItems logic to only map types
* add scalar handling to symbols