### PR TITLE
LSP add goto definition on parent names

### DIFF
--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -371,9 +371,7 @@ func (s *server) definition(ctx context.Context, uri protocol.URI, position prot
 		return nil, nil
 	}
 
-	return []protocol.Location{
-		symbol.Definition(),
-	}, nil
+	return symbol.Definitions(position), nil
 }
 
 // References is the entry point for get-all-references.


### PR DESCRIPTION
This PR adds support for goto definition based on the cursor position in the fields FullName. For example: `google.protobuf.Timestamp` can go to both the type `Timestamp` or the package `google.protobuf` within the file `google/protobuf/timestamp.proto`. We may wish to extend this behaviour to also cover going to every file within the package `google.protobuf`.