### PR TITLE
Add CodeDescription link to `buf lint` rules

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -779,8 +779,11 @@ func (f *file) appendAnnotations(source string, annotations []bufanalysis.FileAn
 		endLocation := f.file.InverseLocation(annotation.EndLine(), annotation.EndColumn(), positionalEncoding)
 		protocolRange := reportLocationsToProtocolRange(startLocation, endLocation)
 		f.diagnostics = append(f.diagnostics, protocol.Diagnostic{
-			Range:    protocolRange,
-			Code:     annotation.Type(),
+			Range: protocolRange,
+			Code:  annotation.Type(),
+			CodeDescription: &protocol.CodeDescription{
+				Href: protocol.URI("https://buf.build/docs/lint/rules/#" + strings.ToLower(annotation.Type())),
+			},
 			Severity: protocol.DiagnosticSeverityWarning,
 			Source:   source,
 			Message:  annotation.Message(),


### PR DESCRIPTION
`buf lint` emits stable types that are described in the linked URL; add the link so clients can redirect users to find out more information.