### PR TITLE
LSP add completion for service methods

### DIFF
--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -908,7 +908,8 @@ func isTokenParen(tok token.Token) bool {
 func isTokenTypeDelimiter(tok token.Token) bool {
 	kind := tok.Kind()
 	return (kind == token.Unrecognized && tok.IsZero()) ||
-		(kind == token.Space && strings.IndexByte(tok.Text(), '\n') != -1)
+		(kind == token.Space && strings.IndexByte(tok.Text(), '\n') != -1) ||
+		(kind == token.Comment)
 }
 
 // extractAroundOffset extracts the value around the offset by querying the token stream.


### PR DESCRIPTION
This adds completions to the LSP for service methods. The service keywords (`rpc`, `returns`) and its input and output types with a field modifier (`stream`) are all completed. Type completions are restricted to matching parenthesis to avoid parser ambiguities.