### PR TITLE
Remove prefixes for field type ASTs

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -491,6 +491,8 @@ func (f *file) irToSymbols(irSymbol ir.Symbol) ([]*symbol, []*symbol) {
 		typ := &symbol{
 			ir:   irSymbol,
 			file: f,
+			// We remove prefixes from the type, since we want to exclude the prefix from the
+			// symbol, e.g. repeated string values = 1;, we want to capture the symbol for "string".
 			span: irSymbol.AsMember().TypeAST().RemovePrefixes().Span(),
 		}
 		kind, needsResolution := getKindForMember(irSymbol.AsMember())
@@ -600,6 +602,9 @@ func (f *file) irToSymbols(irSymbol ir.Symbol) ([]*symbol, []*symbol) {
 // getKindForMember takes a [ir.Member] and returns the symbol kind and whether or not the
 // symbol is currently resolved.
 func getKindForMember(member ir.Member) (kind, bool) {
+	// We remove prefixes to check for a predeclared type, e.g. repeated string values = 1;,
+	// "repeated string" would not be captured as a predeclared type. The corresponding symbol
+	// also excludes prefixes.
 	if member.TypeAST().RemovePrefixes().AsPath().AsPredeclared() != predeclared.Unknown {
 		return &builtin{
 			predeclared: member.TypeAST().RemovePrefixes().AsPath().AsPredeclared(),


### PR DESCRIPTION
This PR fixes an issue where we want to handle the field
type without prefixes.