### PR TITLE
Check for newlines in parsing docs comments

### DIFF
--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -357,8 +357,16 @@ func (s *symbol) getDocsFromComments() string {
 		case token.Comment:
 			comments = append(comments, commentToMarkdown(t.Text()))
 		}
-		if !cursor.PeekPrevSkippable().Kind().IsSkippable() {
+		prev := cursor.PeekPrevSkippable()
+		if !prev.Kind().IsSkippable() {
 			break
+		}
+		if prev.Kind() == token.Space {
+			// Check if the whitespace contains a newline. If so, then we break. This is to prevent
+			// picking up comments that are not contiguous to the declaration.
+			if strings.Contains(prev.Text(), "\n") {
+				break
+			}
 		}
 		t = cursor.PrevSkippable()
 	}


### PR DESCRIPTION
This PR checks if a space token contains in a newline
when parsing the token stream for leading comments/docs.

This is to prevent picking up comments that are separated
from a declaration by some amount of whitespace
containing a newline, for example:

```
// This is just a random note

// Message Foo...
message Foo { ... }
```