### PR TITLE
Line up comments due to different LSP client behaviours

### DIFF
--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -462,7 +462,7 @@ func lineUpComments(comments []string) []string {
 			return !unicode.IsSpace(r)
 		}) {
 			// We are only checking for " " and do not count nbsp's.
-			if strings.Index(comment, " ") != 0 {
+			if !strings.HasPrefix(comment, " ") {
 				return comments
 			}
 			linedUp[i] = strings.TrimPrefix(comment, " ")


### PR DESCRIPTION
There is an issue where different LSP clients handle leading
whitespaces in rendered documentation differently. We don't
trim leading whitespace unilaterally because Commonmark
indented code blocks depend on them. Instead we will apply
a heuristic where if all lines containing one or more non-space
characters all begin with a leading space character, we trim it.

This PR also applies a nice simplification for collecting the comment
tokens from https://github.com/bufbuild/buf/pull/4164#discussion_r2519520004