### PR TITLE
Fix lint error message for ignore option

### DIFF
--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
@@ -334,7 +334,6 @@ func checkFieldFlags(
 			adder.fieldName(),
 			adder.getFieldRuleName(ignoreFieldNumber),
 			validate.Ignore_IGNORE_IF_ZERO_VALUE,
-			adder.getFieldRuleName(),
 		)
 	}
 }


### PR DESCRIPTION
There was an extra argument passed to the format function.