### PR TITLE
Fix LSP error diagnostics on build

### DIFF
--- a/private/buf/buflsp/image.go
+++ b/private/buf/buflsp/image.go
@@ -91,7 +91,7 @@ func buildImage(
 		}
 	}
 	if len(compiled) == 0 || compiled[0] == nil {
-		return nil, nil // Image failed to build.
+		return nil, diagnostics // Image failed to build.
 	}
 	compiledFile := compiled[0]
 


### PR DESCRIPTION
This fixes emitting diagnostics on image build failures. Avoid running checks but ensure any errors are captured.