### PR TITLE
LSP fix completion inside comments

### DIFF
--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -1516,7 +1516,7 @@ func isTokenParen(tok token.Token) bool {
 }
 
 // isTokenTypeDelimiter returns true if the token represents a delimiter for completion.
-// A delimiter is a newline or start of stream. This handles invalid partial tokens.
+// A delimiter is a newline or start of stream. This handles invalid partial declarations.
 func isTokenTypeDelimiter(tok token.Token) bool {
 	kind := tok.Kind()
 	return (kind == token.Unrecognized && tok.IsZero()) ||


### PR DESCRIPTION
This fixes completions in the LSP inside comments. A comment like `// buf` or `/*\nbuf.\n*/` no longer has any completion items. This was a bug in how the cursor identified the previous comment token as always having a newline. 