### PR TITLE
Support multi-arch image manifests for image digest in `buf beta registry plugin push`

### DIFF
--- a/cmd/buf/internal/command/beta/registry/plugin/pluginpush/pluginpush.go
+++ b/cmd/buf/internal/command/beta/registry/plugin/pluginpush/pluginpush.go
@@ -495,19 +495,14 @@ func getImageIDAndDigestFromReference(
 				break
 			}
 		}
-		refNameWithoutDigest, _, ok := strings.Cut(ref.Name(), "@")
-		if !ok {
-			return "", "", fmt.Errorf("failed to parse reference name %q", ref)
-		}
-		repository, err := name.NewRepository(refNameWithoutDigest)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to construct repository %q: %w", refNameWithoutDigest, err)
+		if manifest.Digest.String() == "" {
+			return "", "", fmt.Errorf("no valid platform manifest found in image index for %q", ref)
 		}
 		// We resolved the image index to an image manifest digest, we can now call this function
 		// again to resolve the image manifest digest to an image config digest.
 		return getImageIDAndDigestFromReference(
 			ctx,
-			repository.Digest(manifest.Digest.String()),
+			ref.Context().Digest(manifest.Digest.String()),
 			options...,
 		)
 	case desc.MediaType.IsImage():


### PR DESCRIPTION
Use ref.Context() to get the repository instead of manually parsing the reference name with strings.Cut(). The previous approach only worked for digest references (repo@sha256:...) but failed for tag references (repo:tag) when resolving OCI image indexes to platform-specific manifests.

Also add validation to return a clear error when no valid platform manifest is found in an image index.