### PR TITLE
Use name of length rule rather than `const` for `PROTOVALIDATE` length checks

### DIFF
--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/field.go
@@ -1172,11 +1172,12 @@ func checkLenRules(
 				{ruleFieldNumber, minLenFieldNumber},
 				{ruleFieldNumber, maxLenFieldNumber},
 			},
-			"Field %q has equal %s and %s, use %s.const instead.",
+			"Field %q has equal %s and %s, use %s.%s instead.",
 			adder.fieldName(),
 			adder.getFieldRuleName(ruleFieldNumber, minLenFieldNumber),
 			maxLenFieldName,
 			adder.getFieldRuleName(ruleFieldNumber),
+			lenFieldName,
 		)
 	}
 	return nil


### PR DESCRIPTION
For better clarity, rather than recommending using `const` when
min/max length rules are set as the same, we should recommend
the use of the single length field instead.

Fixes #4252