### PR TITLE
Add LSP completion for fully-qualified references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add LSP completion for fully-qualified type references.
 
 ## [v1.63.0] - 2026-01-06
 

--- a/private/buf/buflsp/completion_test.go
+++ b/private/buf/buflsp/completion_test.go
@@ -90,6 +90,13 @@ func TestCompletion(t *testing.T) {
 			character:        14, // After "  User user = "
 			expectedContains: []string{"20000"},
 		},
+		{
+			name:                "complete_absolute_type_reference",
+			line:                50, // Line with ".goo field_name = 1;"
+			character:           4,  // After ".goo"
+			expectedContains:    []string{".google.protobuf.Timestamp", ".google.protobuf.Duration", ".google.protobuf.Any"},
+			expectedNotContains: []string{".example.v1.User", ".example.v1.GetUserRequest"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/private/buf/buflsp/testdata/completion/test.proto
+++ b/private/buf/buflsp/testdata/completion/test.proto
@@ -46,3 +46,7 @@ message ProtobufReservedRangeTest {
 
   User user = ; // complete_field_number_skips_protobuf_reserved_range
 }
+
+message AbsoluteTypeReferenceTest {
+  .goo field_name = 1; // complete_absolute_type_reference
+}


### PR DESCRIPTION
It's valid for a type to be referred to as either e.g. "google.protobuf.Timestamp" or ".google.protobuf.Timestamp"; add the fully-qualified case to completions.

Ref: https://protobuf.com/docs/language-spec#fully-qualified-references