### PR TITLE
Prevent LSP renaming symbols in non-local files

### DIFF
--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -499,6 +499,15 @@ func (s *server) PrepareRename(ctx context.Context, params *protocol.PrepareRena
 	}
 	switch symbol.kind.(type) {
 	case *referenceable, *static, *reference:
+		// Don't allow renaming symbols defined in non-local files (e.g., WKTs from ~/.cache)
+		// Check the definition if available, otherwise check the symbol's own file
+		defFile := symbol.file
+		if symbol.def != nil && symbol.def.file != nil {
+			defFile = symbol.def.file
+		}
+		if defFile != nil && !defFile.IsLocal() {
+			return nil, fmt.Errorf("cannot rename a symbol in a non-local file")
+		}
 		rnge := reportSpanToProtocolRange(symbol.span)
 		return &rnge, nil
 	}
@@ -513,6 +522,15 @@ func (s *server) Rename(
 	symbol := s.getSymbol(ctx, params.TextDocument.URI, params.Position)
 	if symbol == nil {
 		return nil, nil
+	}
+	// Don't allow renaming symbols defined in non-local files (e.g., WKTs from ~/.cache)
+	// Check the definition if available, otherwise check the symbol's own file
+	defFile := symbol.file
+	if symbol.def != nil && symbol.def.file != nil {
+		defFile = symbol.def.file
+	}
+	if defFile != nil && !defFile.IsLocal() {
+		return nil, fmt.Errorf("cannot rename a symbol in a non-local file")
 	}
 	return symbol.Rename(params.NewName)
 }

--- a/private/buf/buflsp/testdata/rename/wkt.proto
+++ b/private/buf/buflsp/testdata/rename/wkt.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package rename.v1;
+
+import "google/protobuf/timestamp.proto";
+
+message Event {
+  google.protobuf.Timestamp created_at = 1;
+}


### PR DESCRIPTION
We shouldn't be allowing renames in non-local files (i.e., files that are in the cache).