### PR TITLE
Log LSP server version and attached clients

### DIFF
--- a/cmd/buf/internal/command/lsp/lspserve/lspserve.go
+++ b/cmd/buf/internal/command/lsp/lspserve/lspserve.go
@@ -120,6 +120,7 @@ func run(
 
 	conn, err := buflsp.Serve(
 		ctx,
+		bufcli.Version,
 		wktBucket,
 		container,
 		controller,

--- a/private/buf/buflsp/buflsp_test.go
+++ b/private/buf/buflsp/buflsp_test.go
@@ -124,6 +124,7 @@ func setupLSPServer(
 	go func() {
 		conn, err := buflsp.Serve(
 			ctx,
+			"test",
 			wktBucket,
 			appextContainer,
 			controller,

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -107,7 +107,7 @@ func (s *server) Initialize(
 
 	info := &protocol.ServerInfo{
 		Name:    serverName,
-		Version: s.lsp.version,
+		Version: s.lsp.bufVersion,
 	}
 
 	// The LSP protocol library doesn't actually provide SemanticTokensOptions


### PR DESCRIPTION
This adds some simple logging to the LSP that logs the startup of the server with the given `buf` version, and then also logs client information on initialization. This should help us further pinpoint issues in the LSP based on version (or give us the information that a user is on an older version of `buf` and direct them to upgrade).