### PR TITLE
Update alpine image

### DIFF
--- a/Dockerfile.buf
+++ b/Dockerfile.buf
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
   go build -ldflags "-s -w" -trimpath -buildvcs=false -o /go/bin/buf ./cmd/buf
 
-FROM alpine:3.23.2
+FROM alpine:3.23.3
 
 RUN apk add --update --no-cache \
     ca-certificates \

--- a/private/bufpkg/bufremoteplugin/bufremoteplugindocker/testdata/success/Dockerfile
+++ b/private/bufpkg/bufremoteplugin/bufremoteplugindocker/testdata/success/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.23.2
+FROM alpine:3.23.3
 
 RUN echo "success"


### PR DESCRIPTION
This updates the alpine image version to 3.23.3.
Double checked that the golang alpine image is also up-to-date.