### PR TITLE
Add cas.BucketToDigest

### DIFF
--- a/private/pkg/cas/manifest.go
+++ b/private/pkg/cas/manifest.go
@@ -121,8 +121,8 @@ func ManifestToBlob(manifest Manifest) (Blob, error) {
 // ManifestToDigest converts the string representation of the given Manifest into a Digest.
 //
 // The Manifest is assumed to be non-nil.
-func ManifestToDigest(manifest Manifest, options ...DigestOption) (Digest, error) {
-	return NewDigestForContent(strings.NewReader(manifest.String()), options...)
+func ManifestToDigest(manifest Manifest, digestType DigestType) (Digest, error) {
+	return NewDigestForContent(strings.NewReader(manifest.String()), DigestWithDigestType(digestType))
 }
 
 // BlobToManifest converts the given Blob representing the string representation of a Manifest into a Manifest.

--- a/private/pkg/cas/storage.go
+++ b/private/pkg/cas/storage.go
@@ -1,0 +1,52 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cas
+
+import (
+	"context"
+
+	"github.com/bufbuild/buf/private/pkg/storage"
+)
+
+// BucketToDigest converts the files in the bucket to a digest.
+//
+// This uses the specified DigestType for the file and manifest digests.
+func BucketToDigest(ctx context.Context, bucket storage.ReadBucket, digestType DigestType) (Digest, error) {
+	var fileNodes []FileNode
+	if err := storage.WalkReadObjects(
+		ctx,
+		bucket,
+		"",
+		func(readObject storage.ReadObject) error {
+			digest, err := NewDigestForContent(readObject, DigestWithDigestType(digestType))
+			if err != nil {
+				return err
+			}
+			fileNode, err := NewFileNode(readObject.Path(), digest)
+			if err != nil {
+				return err
+			}
+			fileNodes = append(fileNodes, fileNode)
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+	manifest, err := NewManifest(fileNodes)
+	if err != nil {
+		return nil, err
+	}
+	return ManifestToDigest(manifest, digestType)
+}


### PR DESCRIPTION
This is a safety mechanism (if used) to make sure the right thing is repeatedly done with the `DigestType`. It also changes `ManifestToDigest` to not use an option (only added in previous PR).