### PR TITLE
Disable colorized logs in non-TTYs

### DIFF
--- a/private/pkg/slogapp/console_test.go
+++ b/private/pkg/slogapp/console_test.go
@@ -19,12 +19,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsWriterTTY(t *testing.T) {
+	t.Parallel()
+
+	// A bytes.Buffer has no Fd method, so it's not a TTY.
+	var buf bytes.Buffer
+	assert.False(t, isWriterTTY(&buf))
+
+	// An os.Pipe is never a TTY even though it has an Fd method.
+	_, w, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+	assert.False(t, isWriterTTY(w))
+}
 
 func TestConsoleLogOutput(t *testing.T) {
 	t.Parallel()

--- a/private/pkg/slogapp/slogapp.go
+++ b/private/pkg/slogapp/slogapp.go
@@ -65,10 +65,11 @@ func getHandler(writer io.Writer, logLevel appext.LogLevel, logFormat appext.Log
 		}), nil
 	case appext.LogFormatText:
 		// Use a custom console handler that formats log messages in a human-readable format.
-		return newConsoleHandler(writer, level), nil
+		return newConsoleHandler(writer, level, withConsoleColor(false)), nil
 	case appext.LogFormatColor:
-		// Use a custom console handler that formats log messages in a human-readable format, with colors.
-		return newConsoleHandler(writer, level, withConsoleColor(true)), nil
+		// Use a custom console handler that formats log messages in a human-readable format.
+		// Color is enabled automatically if the writer is a TTY.
+		return newConsoleHandler(writer, level), nil
 	default:
 		return nil, fmt.Errorf("invalid logFormat: %v", logFormat)
 	}


### PR DESCRIPTION
In clients where we embed the LSP, we commonly need to specifically request `log-format=text` over the default of `color`, because we're running in a non-TTY environment (where OSC escape codes clog up the output). Instead of requiring setting that everywhere, we ought to detect that we're in a non-TTY environment and disable colors ourselves.

To keep the tests working as-is (i.e., with colorized output against a non-terminal output (bytes.Buffer)), this slightly refactors the way `withConsoleColor` works, so at the callsite we explicitly pass `false` for `text`, but pass no value for the color case, so that we can auto-detect based on if the output is a terminal.

Ref: bufbuild/intellij-buf#420
Ref: https://github.com/neovim/nvim-lspconfig/blob/44acfe887d4056f704ccc4f17513ed41c9e2b2e6/lsp/buf_ls.lua#L10
Ref: https://github.com/bufbuild/vscode-buf/blob/a5a0feb5bab06a82b79213adb309c8c2039f5e2b/src/state.ts#L465