### PR TITLE
Remove unused //go:build tag

### DIFF
--- a/private/buf/buflsp/diagnostics_test.go
+++ b/private/buf/buflsp/diagnostics_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.25
-
 package buflsp_test
 
 import (


### PR DESCRIPTION
Now that we're on 1.25 by default, we don't need this any more.

Ref: #4333