### PR TITLE
Use t.Output for slogtestext

### DIFF
--- a/private/pkg/slogtestext/slogtestext.go
+++ b/private/pkg/slogtestext/slogtestext.go
@@ -17,7 +17,6 @@ package slogtestext
 
 import (
 	"log/slog"
-	"os"
 	"testing"
 
 	"buf.build/go/app/appext"
@@ -31,7 +30,7 @@ func NewLogger(t testing.TB, options ...LoggerOption) *slog.Logger {
 	for _, option := range options {
 		option(loggerOptions)
 	}
-	logger, err := slogapp.NewLogger(os.Stderr, loggerOptions.logLevel, appext.LogFormatText)
+	logger, err := slogapp.NewLogger(t.Output(), loggerOptions.logLevel, appext.LogFormatText)
 	require.NoError(t, err)
 	return logger
 }


### PR DESCRIPTION
Only available in Go 1.25; it's designed for usages like this.

Ref: https://go.dev/doc/go1.25#testingpkgtesting