### PR TITLE
Add URI normalisation improvements to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Add LSP comment ignore code action to add comment ignores for lint errors.
 - Fix buf breaking module comparison when adding new modules.
-- Add LSP hover support for protovalidate CEL expressions
-- Fixed offset handling in CEL semantic tokens for non-ASCII content and proto escape sequences in multi-line string literal expressions
+- Add LSP hover support for protovalidate CEL expressions.
+- Fixed offset handling in CEL semantic tokens for non-ASCII content and proto escape sequences in multi-line string literal expressions.
+- Improve URI normalization for the LSP.
 
 ## [v1.65.0] - 2026-02-03
 


### PR DESCRIPTION
Prepping the changelog for release to include the fixes
from #4345 and #4346.