### PR TITLE
Forward the input image resolver to protovalidate so it can support predefined rule

### DIFF
--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -751,7 +751,9 @@ func (c *controller) GetMessage(
 	}
 	var validator protoyaml.Validator
 	if functionOptions.messageValidation {
-		protovalidateValidator, err := protovalidate.New()
+		protovalidateValidator, err := protovalidate.New(
+			protovalidate.WithExtensionTypeResolver(schemaImage.Resolver()),
+		)
 		if err != nil {
 			return nil, 0, err
 		}


### PR DESCRIPTION
This simple change allow the `--validate` option of `buf convert` to locate custom rules (as documented in https://protovalidate.com/schemas/predefined-rules/) as long as they are included in the input (e.g. via a protoset).