### PR TITLE
Add LSP completion for CEL expressions

### DIFF
--- a/private/buf/buflsp/cel.go
+++ b/private/buf/buflsp/cel.go
@@ -23,6 +23,13 @@ import (
 	"github.com/google/cel-go/common/operators"
 )
 
+// celIsIdentChar reports whether c is a valid CEL identifier character:
+// ASCII letter, digit, or underscore. This mirrors the CEL spec's IDENT token
+// rule; there is no public API for this in cel-go.
+func celIsIdentChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
 // isCELKeyword returns true if the identifier is a CEL reserved keyword.
 // See https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax
 func isCELKeyword(name string) bool {

--- a/private/buf/buflsp/completion_cel.go
+++ b/private/buf/buflsp/completion_cel.go
@@ -1,0 +1,850 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements CEL expression completion support for the LSP.
+// CEL expressions appear in protovalidate (buf.validate) options.
+
+package buflsp
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/bufbuild/protocompile/experimental/ast/predeclared"
+	"github.com/bufbuild/protocompile/experimental/ir"
+	"github.com/bufbuild/protocompile/experimental/seq"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types"
+	"go.lsp.dev/protocol"
+)
+
+// celKeywords are CEL literal keywords, the protovalidate "this" special variable,
+// and the "now" runtime variable (google.protobuf.Timestamp) declared by protovalidate.
+var celKeywords = []string{"true", "false", "null", "this", "now"}
+
+// getCELCompletionItems returns completion items if the cursor is inside a CEL expression.
+// Returns nil if the position is not inside a CEL expression.
+func getCELCompletionItems(
+	file *file,
+	position protocol.Position,
+	celEnv *cel.Env,
+) []protocol.CompletionItem {
+	byteOffset := positionToOffset(file, position)
+
+	for _, symbol := range file.symbols {
+		for _, exprInfo := range extractCELExpressions(file, symbol) {
+			if byteOffset < exprInfo.span.Start || byteOffset >= exprInfo.span.End {
+				continue
+			}
+
+			celOffset := fileByteOffsetToCELOffset(byteOffset, exprInfo.span)
+			if celOffset < 0 {
+				// Cursor is at the closing quote or inside an empty string literal;
+				// treat as end-of-expression for completion purposes.
+				celOffset = len(exprInfo.expression)
+			}
+			if celOffset > len(exprInfo.expression) {
+				continue
+			}
+
+			celContent := exprInfo.expression[:celOffset]
+
+			// If the cursor is surrounded by identifier characters on both sides,
+			// it is placed inside an existing token — do not offer completions.
+			// Checking both sides avoids suppressing completions at the start of
+			// an expression (where celContent is empty) when the next char happens
+			// to be an identifier (e.g. cursor before "this.").
+			if celOffset < len(exprInfo.expression) && len(celContent) > 0 {
+				next := exprInfo.expression[celOffset]
+				prev := celContent[len(celContent)-1]
+				if celIsIdentChar(next) && celIsIdentChar(prev) {
+					return nil
+				}
+			}
+
+			// Determine the content to analyze for member access by stripping outer
+			// context layers: comprehension bodies first (to capture the iter var type),
+			// then has() macro arguments.
+			memberAccessContent := celContent
+			iterVarTypes := map[string]ir.Type{}
+
+			// Peel comprehension layers from outermost to innermost.
+			// Each iteration resolves the range expression (using all known variables
+			// accumulated so far) to bind the iteration variable, then advances
+			// memberAccessContent into the body expression for the next pass.
+			//
+			// lastRangeType tracks the element type from the previous layer. In chained
+			// comprehensions (e.g. "list.filter(x, pred).all(y, y."), the inner macro's
+			// range candidate is the predicate expression "pred" which cannot be resolved
+			// as a type. In that case we fall back to the previous element type because
+			// filter/map/all preserve the element type of the input list.
+			var lastRangeType ir.Type
+			for {
+				rangeExpr, iterVar, body, inBody := celParseIteratorBody(memberAccessContent)
+				if !inBody {
+					break
+				}
+				vars := map[string]ir.Type{}
+				if !exprInfo.thisIRType.IsZero() {
+					vars["this"] = exprInfo.thisIRType
+				}
+				maps.Copy(vars, iterVarTypes)
+				rangeType, _ := celResolveExprType(rangeExpr, vars)
+				if rangeType.IsZero() {
+					rangeType = lastRangeType
+				}
+				if !rangeType.IsZero() {
+					iterVarTypes[iterVar] = rangeType
+					lastRangeType = rangeType
+				}
+				memberAccessContent = body
+			}
+
+			// has() macro argument context: strip "has(" so the inner select
+			// expression is handled by the regular member access path below.
+			// E.g. "has(this.f" → memberAccessContent = "this.f".
+			if innerContent, inHasArg := celParseHasArg(memberAccessContent); inHasArg {
+				memberAccessContent = innerContent
+			}
+
+			// Member access context: cursor immediately after a dot or typing
+			// a member name. Handles both "this." and "this.ci" (prefix "ci").
+			if receiverExpr, memberPrefix, ok := celParseMemberAccess(memberAccessContent); ok {
+				var items []protocol.CompletionItem
+
+				// Try CEL compile to determine receiver type (works for variables like "now").
+				var receiverCELType *types.Type
+				if ast, iss := celEnv.Compile(receiverExpr); iss.Err() == nil {
+					receiverCELType = ast.OutputType()
+				}
+
+				// Resolve via proto IR for field names and type mapping.
+				// Build a variable map from "this" and any comprehension iteration variables.
+				var isListOrMapReceiver bool
+				if !exprInfo.thisIRType.IsZero() || len(iterVarTypes) > 0 {
+					vars := map[string]ir.Type{}
+					if !exprInfo.thisIRType.IsZero() {
+						vars["this"] = exprInfo.thisIRType
+					}
+					maps.Copy(vars, iterVarTypes)
+					irType, isCollection := celResolveExprType(receiverExpr, vars)
+					if !irType.IsZero() {
+						// For the direct "this" receiver, use irMember cardinality:
+						// thisIRType is already the element type so cardinality is not in vars.
+						if receiverExpr == "this" && !exprInfo.irMember.IsZero() {
+							if exprInfo.irMember.IsMap() {
+								if receiverCELType == nil {
+									receiverCELType = celMapEntryToCELType(irType)
+								}
+								irType = ir.Type{}
+								isListOrMapReceiver = true
+							} else if exprInfo.irMember.IsRepeated() {
+								if receiverCELType == nil {
+									receiverCELType = types.NewListType(celProtoTypeToExprType(irType))
+								}
+								irType = ir.Type{}
+								isListOrMapReceiver = true
+							}
+						} else if isCollection {
+							// Path through a repeated or map field (e.g., "this.items."):
+							// offer collection methods rather than element field names.
+							if receiverCELType == nil {
+								if irType.IsMessage() && irType.IsMapEntry() {
+									receiverCELType = celMapEntryToCELType(irType)
+								} else {
+									receiverCELType = types.NewListType(celProtoTypeToExprType(irType))
+								}
+							}
+							irType = ir.Type{}
+							isListOrMapReceiver = true
+						}
+						if !irType.IsZero() {
+							if receiverCELType == nil {
+								receiverCELType = celProtoTypeToExprType(irType)
+							}
+							if irType.IsMessage() {
+								items = append(items, celProtoFieldCompletionItems(irType)...)
+							}
+						}
+					}
+				}
+
+				items = append(items, celMemberCompletionItems(celEnv, receiverCELType)...)
+				if isListOrMapReceiver {
+					items = append(items, celMemberMacroCompletionItems()...)
+				}
+				return celFilterByPrefix(items, memberPrefix)
+			}
+
+			// Extract the identifier prefix being typed at the end of celContent
+			// so that operator context detection works on the preceding content.
+			prefix := celCurrentPrefix(celContent)
+			contentBeforePrefix := celContent[:len(celContent)-len(prefix)]
+
+			// Detect unary NOT or binary operator context to narrow expected type.
+			var expectedType *types.Type
+			trimmed := strings.TrimRight(contentBeforePrefix, " \t\r\n")
+			if strings.HasSuffix(trimmed, "!") {
+				// After logical NOT, the operand must be bool.
+				expectedType = types.BoolType
+			} else {
+				expectedType = celExpectedTypeAfterOperator(contentBeforePrefix, celEnv)
+			}
+
+			var items []protocol.CompletionItem
+			items = append(items, celGlobalCompletionItems(celEnv, expectedType)...)
+			items = append(items, celMacroCompletionItems(celEnv)...)
+			items = append(items, celKeywordCompletionItems(celEnv, expectedType)...)
+			return celFilterByPrefix(items, prefix)
+		}
+	}
+
+	return nil
+}
+
+// celParseMemberAccess detects if celContent is in a member access context:
+// either right after a dot ("this.") or typing a member name ("this.ci").
+// Returns the receiver expression, the typed prefix (possibly empty), and ok=true.
+// Examples:
+//   - "this."     → ("this", "", true)
+//   - "this.ci"   → ("this", "ci", true)
+//   - "size("     → ("", "", false)
+//   - "si"        → ("", "", false)
+func celParseMemberAccess(celContent string) (receiverExpr, memberPrefix string, ok bool) {
+	// Peel off the identifier being typed at the end of celContent.
+	wordStart := len(celContent)
+	for wordStart > 0 && celIsIdentChar(celContent[wordStart-1]) {
+		wordStart--
+	}
+	beforeWord := celContent[:wordStart]
+	prefix := celContent[wordStart:]
+
+	// Member access requires a dot immediately before the current word (or cursor).
+	trimmed := strings.TrimRight(beforeWord, " \t\r\n")
+	if len(trimmed) == 0 || trimmed[len(trimmed)-1] != '.' {
+		return "", "", false
+	}
+
+	// Receiver expression is everything before the dot.
+	receiver := strings.TrimRight(trimmed[:len(trimmed)-1], " \t\r\n")
+	if receiver == "" {
+		return "", "", false
+	}
+	return receiver, prefix, true
+}
+
+// celParseHasArg detects if the cursor is inside the argument of a has() macro call.
+// The has() macro takes a single select expression: has(receiver.field).
+// Returns the content after the last unqualified "has(" when the cursor is still
+// within the argument (i.e. no closing paren or comma has been written yet).
+// "Unqualified" means has( is not preceded by an identifier character or dot —
+// which would make it a method call (e.g. "foo.has(") rather than the macro.
+// Examples:
+//   - "has(this."    → ("this.", true)
+//   - "has(this.f"   → ("this.f", true)
+//   - "!has(this.f"  → ("this.f", true)
+//   - "has(this.f)"  → ("", false)  — already closed
+//   - "foo.has(this." → ("", false)  — method call, not the macro
+func celParseHasArg(celContent string) (innerContent string, ok bool) {
+	idx := strings.LastIndex(celContent, "has(")
+	if idx < 0 {
+		return "", false
+	}
+	// Reject method calls: "expr.has(" or "ident.has(" — the char before "has(" is a
+	// dot or identifier character, indicating this is a method call, not the macro.
+	if idx > 0 && (celIsIdentChar(celContent[idx-1]) || celContent[idx-1] == '.') {
+		return "", false
+	}
+	inner := celContent[idx+4:]
+	// If we have already passed a closing paren or argument separator, we are
+	// no longer inside the has() argument.
+	if strings.ContainsAny(inner, "),") {
+		return "", false
+	}
+	return inner, true
+}
+
+// celIteratorMacros are the CEL comprehension macros that bind an iteration variable.
+var celIteratorMacros = []string{"all", "exists", "exists_one", "filter", "map"}
+
+// celParseIteratorBody detects if the cursor is inside the body expression of a CEL
+// comprehension macro call (all, exists, filter, map, etc.).
+// It finds the leftmost (outermost) such macro in celContent so that callers can
+// process comprehension layers from outer to inner by calling it in a loop.
+// Returns the range expression, the iteration variable name, and the body content
+// (the expression fragment after the separating comma), or ok=false if not matched.
+// Examples:
+//
+//	"this.items.filter(addr, addr."  → ("this.items", "addr", "addr.", true)
+//	"items.all(x, x.name"            → ("items", "x", "x.name", true)
+//	"this.filter("                   → ("", "", "", false)  — no comma yet
+func celParseIteratorBody(celContent string) (rangeExpr, iterVar, bodyContent string, ok bool) {
+	// Find the leftmost occurrence of any comprehension macro pattern.
+	bestIdx := -1
+	bestMacro := ""
+	for _, macro := range celIteratorMacros {
+		pattern := "." + macro + "("
+		if idx := strings.Index(celContent, pattern); idx >= 0 {
+			if bestIdx < 0 || idx < bestIdx {
+				bestIdx = idx
+				bestMacro = macro
+			}
+		}
+	}
+	if bestIdx < 0 {
+		return "", "", "", false
+	}
+	pattern := "." + bestMacro + "("
+	afterParen := celContent[bestIdx+len(pattern):]
+	beforeComma, afterComma, hasComma := strings.Cut(afterParen, ",")
+	if !hasComma {
+		return "", "", "", false
+	}
+	candidate := strings.TrimSpace(beforeComma)
+	if candidate == "" {
+		return "", "", "", false
+	}
+	// Iteration variable must be a plain identifier with no operators or parens.
+	for i := 0; i < len(candidate); i++ {
+		if !celIsIdentChar(candidate[i]) {
+			return "", "", "", false
+		}
+	}
+	body := strings.TrimLeft(afterComma, " \t\r\n")
+	rangeCandidate := strings.TrimRight(celContent[:bestIdx], " \t\r\n")
+	// Strip unbalanced trailing closing parens. These appear when this expression
+	// is itself the body of an outer comprehension that was already peeled — e.g.
+	// "this.items.filter(item, item.addresses).all(addr, addr." yields a range
+	// candidate of "item.addresses)" with one unmatched ")".
+	opens := strings.Count(rangeCandidate, "(")
+	closes := strings.Count(rangeCandidate, ")")
+	for closes > opens && strings.HasSuffix(rangeCandidate, ")") {
+		rangeCandidate = strings.TrimRight(rangeCandidate[:len(rangeCandidate)-1], " \t\r\n")
+		closes--
+	}
+	return rangeCandidate, candidate, body, true
+}
+
+// celCurrentPrefix extracts the identifier being typed at the end of celContent.
+// Returns an empty string if celContent ends with a non-identifier character.
+func celCurrentPrefix(celContent string) string {
+	i := len(celContent)
+	for i > 0 && celIsIdentChar(celContent[i-1]) {
+		i--
+	}
+	return celContent[i:]
+}
+
+// celFilterByPrefix filters completion items to those whose label starts with prefix.
+// Returns the full list unchanged when prefix is empty.
+func celFilterByPrefix(items []protocol.CompletionItem, prefix string) []protocol.CompletionItem {
+	if prefix == "" {
+		return items
+	}
+	filtered := make([]protocol.CompletionItem, 0, len(items))
+	for _, item := range items {
+		if strings.HasPrefix(item.Label, prefix) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+// celResolveExprType resolves a CEL expression to its ir.Type, supporting both
+// dot access ("this.field.sub") and bracket-index notation ("this.items[0]" or
+// "this.locations[\"key\"]"). The second return value is true when the final
+// navigation step traverses a repeated or map field, indicating the returned type
+// is the element type of a list or map (so callers can offer collection methods
+// rather than individual field names).
+//
+// Examples (with vars = {"this": LocationType, "addr": AddressType}):
+//
+//	"this.address.city"          → (string, false)
+//	"this.items"                 → (Address, true)   // repeated field
+//	"this.items[0]"              → (Address, false)  // element after indexing
+//	"this.locations[\"home\"]" → (Address, false)  // map-value after indexing
+//	"addr.zip_code"              → (int32, false)
+func celResolveExprType(expr string, vars map[string]ir.Type) (ir.Type, bool) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return ir.Type{}, false
+	}
+
+	// Handle bracket-index access: receiver[expr].
+	// After indexing, the result is always a single element (not a collection).
+	if strings.HasSuffix(expr, "]") {
+		bracketOpen := strings.LastIndex(expr, "[")
+		if bracketOpen < 0 {
+			return ir.Type{}, false
+		}
+		receiverType, _ := celResolveExprType(expr[:bracketOpen], vars)
+		if receiverType.IsZero() {
+			return ir.Type{}, false
+		}
+		if receiverType.IsMessage() && receiverType.IsMapEntry() {
+			// Map indexing: return the map value element type.
+			_, valueMember := receiverType.EntryFields()
+			if valueMember.IsZero() {
+				return ir.Type{}, false
+			}
+			return valueMember.Element(), false
+		}
+		// List indexing: the receiver is already the element type.
+		return receiverType, false
+	}
+
+	// Handle dot access: split on the last dot.
+	dotIdx := strings.LastIndex(expr, ".")
+	if dotIdx < 0 {
+		// Simple root variable lookup.
+		t, ok := vars[expr]
+		if !ok {
+			return ir.Type{}, false
+		}
+		return t, false
+	}
+
+	fieldName := strings.TrimSpace(expr[dotIdx+1:])
+	receiverExpr := expr[:dotIdx]
+	if fieldName == "" {
+		return ir.Type{}, false
+	}
+
+	receiverType, _ := celResolveExprType(receiverExpr, vars)
+	if receiverType.IsZero() || !receiverType.IsMessage() {
+		return ir.Type{}, false
+	}
+
+	member := receiverType.MemberByName(fieldName)
+	if member.IsZero() {
+		return ir.Type{}, false
+	}
+
+	// Return element type and whether this step crosses a collection boundary.
+	return member.Element(), member.IsRepeated() || member.IsMap()
+}
+
+// celProtoTypeToExprType maps a proto ir.Type to the corresponding CEL *types.Type.
+// Returns nil if the type cannot be mapped.
+func celProtoTypeToExprType(irType ir.Type) *types.Type {
+	if irType.IsZero() {
+		return nil
+	}
+	if irType.IsMessage() {
+		return types.NewObjectType(string(irType.FullName()))
+	}
+	if irType.IsEnum() {
+		return types.IntType // enums are integers in CEL
+	}
+	if !irType.IsPredeclared() {
+		return nil
+	}
+	switch irType.Predeclared() {
+	case predeclared.Bool:
+		return types.BoolType
+	case predeclared.String:
+		return types.StringType
+	case predeclared.Bytes:
+		return types.BytesType
+	case predeclared.Float, predeclared.Double:
+		return types.DoubleType
+	case predeclared.UInt32, predeclared.UInt64, predeclared.Fixed32, predeclared.Fixed64:
+		return types.UintType
+	case predeclared.Int32, predeclared.Int64,
+		predeclared.SInt32, predeclared.SInt64,
+		predeclared.SFixed32, predeclared.SFixed64:
+		return types.IntType
+	default:
+		return nil
+	}
+}
+
+// celMapEntryToCELType converts a map-entry ir.Type to the corresponding CEL map type.
+// Map fields in proto are represented internally as repeated MapEntry messages;
+// this function extracts the key and value types to produce a CEL map type.
+// Returns nil if irType is not a valid map entry.
+func celMapEntryToCELType(irType ir.Type) *types.Type {
+	if irType.IsZero() || !irType.IsMessage() || !irType.IsMapEntry() {
+		return nil
+	}
+	keyMember, valueMember := irType.EntryFields()
+	if keyMember.IsZero() || valueMember.IsZero() {
+		return nil
+	}
+	keyType := celProtoTypeToExprType(keyMember.Element())
+	valueType := celProtoTypeToExprType(valueMember.Element())
+	if keyType == nil || valueType == nil {
+		return nil
+	}
+	return types.NewMapType(keyType, valueType)
+}
+
+// celProtoFieldCompletionItems returns completion items for the fields of a proto message type.
+func celProtoFieldCompletionItems(irType ir.Type) []protocol.CompletionItem {
+	if irType.IsZero() || !irType.IsMessage() {
+		return nil
+	}
+	var items []protocol.CompletionItem
+	for member := range seq.Values(irType.Members()) {
+		if member.IsSynthetic() || member.IsZero() {
+			continue
+		}
+		fieldType := member.Element()
+		detail := ""
+		if !fieldType.IsZero() {
+			detail = string(fieldType.FullName())
+		}
+		_, isDeprecated := member.Deprecated().AsBool()
+		var documentation any
+		if doc := leadingDocComments(member.AST()); doc != "" {
+			documentation = &protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: doc,
+			}
+		}
+		items = append(items, protocol.CompletionItem{
+			Label:         member.Name(),
+			Kind:          protocol.CompletionItemKindField,
+			Detail:        detail,
+			Documentation: documentation,
+			Deprecated:    isDeprecated,
+		})
+	}
+	slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+		return cmp.Compare(a.Label, b.Label)
+	})
+	return items
+}
+
+// celBinaryOperatorSymbols returns a map from display symbol (e.g. "&&") to
+// cel-go internal name (e.g. "_&&_") for all binary operators in the environment.
+func celBinaryOperatorSymbols(celEnv *cel.Env) map[string]string {
+	result := make(map[string]string)
+	for name := range celEnv.Functions() {
+		display, ok := operators.FindReverseBinaryOperator(name)
+		if ok && display != "" {
+			if _, exists := result[display]; !exists {
+				result[display] = name
+			}
+		}
+	}
+	return result
+}
+
+// celExpectedTypeAfterOperator checks if celContent ends with a binary operator and
+// returns the expected type for the right-hand operand. Returns nil if no binary
+// operator context is detected or the expected type cannot be determined.
+func celExpectedTypeAfterOperator(celContent string, celEnv *cel.Env) *types.Type {
+	before := strings.TrimRight(celContent, " \t\r\n")
+	if before == "" {
+		return nil
+	}
+
+	opSymbols := celBinaryOperatorSymbols(celEnv)
+
+	// Sort display symbols longest-first so multi-character operators (e.g. "&&")
+	// are matched before single-character ones (e.g. ">").
+	symbols := make([]string, 0, len(opSymbols))
+	for sym := range opSymbols {
+		symbols = append(symbols, sym)
+	}
+	slices.SortFunc(symbols, func(a, b string) int {
+		return cmp.Compare(len(b), len(a))
+	})
+
+	// Find the binary operator at the end of the trimmed content.
+	var celOp, leftExpr string
+	for _, sym := range symbols {
+		if strings.HasSuffix(before, sym) {
+			candidate := strings.TrimRight(before[:len(before)-len(sym)], " \t\r\n")
+			if candidate == "" {
+				continue
+			}
+			celOp = opSymbols[sym]
+			leftExpr = candidate
+			break
+		}
+	}
+	if celOp == "" {
+		return nil
+	}
+
+	// Compile the left-hand expression to determine its type.
+	leftAst, iss := celEnv.Compile(leftExpr)
+	if iss.Err() != nil {
+		return nil
+	}
+	leftType := leftAst.OutputType()
+
+	// Find operator overloads accepting leftType and collect the expected right-hand types.
+	fn, ok := celEnv.Functions()[celOp]
+	if !ok {
+		return nil
+	}
+
+	rightTypes := make(map[string]*types.Type)
+	for _, o := range fn.OverloadDecls() {
+		args := o.ArgTypes()
+		if len(args) != 2 {
+			continue
+		}
+		if !args[0].IsAssignableType(leftType) && !leftType.IsAssignableType(args[0]) {
+			continue
+		}
+		right := args[1]
+		if celIsTypeParam(right) {
+			right = leftType
+		}
+		rightTypes[right.String()] = right
+	}
+
+	// Only narrow the type if there is exactly one expected type.
+	if len(rightTypes) == 1 {
+		for _, t := range rightTypes {
+			return t
+		}
+	}
+	return nil
+}
+
+// celIsTypeParam returns true if t is a type parameter (e.g. <A>).
+func celIsTypeParam(t *types.Type) bool {
+	s := t.String()
+	return strings.HasPrefix(s, "<") && strings.HasSuffix(s, ">")
+}
+
+// celTypeMatches returns true if resultType is compatible with expectedType.
+// If expectedType is nil, all types match.
+func celTypeMatches(expectedType, resultType *types.Type) bool {
+	if expectedType == nil {
+		return true
+	}
+	return expectedType.IsAssignableType(resultType)
+}
+
+// celMemberCompletionItems returns completion items for member (receiver-style) functions.
+// If receiverType is non-nil, only functions whose first argument is assignable from
+// receiverType are included. If nil, all member functions are returned.
+func celMemberCompletionItems(celEnv *cel.Env, receiverType *types.Type) []protocol.CompletionItem {
+	var items []protocol.CompletionItem
+	for name, fn := range celEnv.Functions() {
+		if celIsOperatorOrInternal(name) {
+			continue
+		}
+
+		var matchingOverloads []*decls.OverloadDecl
+		for _, o := range fn.OverloadDecls() {
+			if !o.IsMemberFunction() {
+				continue
+			}
+			if receiverType != nil && len(o.ArgTypes()) > 0 {
+				recvType := o.ArgTypes()[0]
+				if !recvType.IsAssignableType(receiverType) {
+					continue
+				}
+			}
+			matchingOverloads = append(matchingOverloads, o)
+		}
+		if len(matchingOverloads) == 0 {
+			continue
+		}
+
+		items = append(items, protocol.CompletionItem{
+			Label:            name,
+			Kind:             protocol.CompletionItemKindMethod,
+			Detail:           celFormatOverloadSignature(fn.Name(), matchingOverloads[0]),
+			Documentation:    fn.Description(),
+			InsertText:       name + "($1)",
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+		})
+	}
+	slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+		return cmp.Compare(a.Label, b.Label)
+	})
+	return items
+}
+
+// celMemberMacroCompletionItems returns completion items for CEL comprehension macros
+// (all, exists, filter, map, exists_one) invoked in member-access style on list and
+// map receivers (e.g. myList.filter(x, pred)). These macros are not regular functions
+// in cel-go's function registry, so celMemberCompletionItems does not include them.
+func celMemberMacroCompletionItems() []protocol.CompletionItem {
+	items := make([]protocol.CompletionItem, 0, len(celIteratorMacros))
+	for _, name := range celIteratorMacros {
+		items = append(items, protocol.CompletionItem{
+			Label:            name,
+			Kind:             protocol.CompletionItemKindMethod,
+			Detail:           "macro",
+			InsertText:       name + "($1, $2)",
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+		})
+	}
+	return items
+}
+
+// celGlobalCompletionItems returns completion items for global (non-receiver) functions
+// and type conversions. If expectedType is non-nil, only functions that can return a
+// compatible type are included.
+func celGlobalCompletionItems(celEnv *cel.Env, expectedType *types.Type) []protocol.CompletionItem {
+	var items []protocol.CompletionItem
+	for name, fn := range celEnv.Functions() {
+		if celIsOperatorOrInternal(name) {
+			continue
+		}
+
+		hasMatchingGlobal := false
+		for _, o := range fn.OverloadDecls() {
+			if o.IsMemberFunction() {
+				continue
+			}
+			if celTypeMatches(expectedType, o.ResultType()) {
+				hasMatchingGlobal = true
+				break
+			}
+		}
+		if !hasMatchingGlobal {
+			continue
+		}
+
+		items = append(items, protocol.CompletionItem{
+			Label:            name,
+			Kind:             protocol.CompletionItemKindFunction,
+			Detail:           celGlobalFunctionDetail(fn),
+			Documentation:    fn.Description(),
+			InsertText:       name + "($1)",
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+		})
+	}
+	slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+		return cmp.Compare(a.Label, b.Label)
+	})
+	return items
+}
+
+// celMacroCompletionItems returns completion items for CEL macros derived from
+// cel-go's env.Macros(). Macros are not filtered by expectedType since they do
+// not carry return type information in cel-go.
+func celMacroCompletionItems(celEnv *cel.Env) []protocol.CompletionItem {
+	seen := make(map[string]bool)
+	var items []protocol.CompletionItem
+	for _, m := range celEnv.Macros() {
+		name := m.Function()
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		items = append(items, protocol.CompletionItem{
+			Label:            name,
+			Kind:             protocol.CompletionItemKindFunction,
+			Detail:           "macro",
+			InsertText:       name + "($1)",
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+		})
+	}
+	slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+		return cmp.Compare(a.Label, b.Label)
+	})
+	return items
+}
+
+// celKeywordCompletionItems returns completion items for CEL literal keywords and
+// protovalidate runtime variables ("this", "now"). If expectedType is non-nil, only
+// keywords whose compiled type is compatible with it are included.
+// "this" is always included when there is no expected type constraint.
+// "now" is included when its timestamp type is compatible with expectedType.
+func celKeywordCompletionItems(celEnv *cel.Env, expectedType *types.Type) []protocol.CompletionItem {
+	var items []protocol.CompletionItem
+	for _, kw := range celKeywords {
+		if kw == "this" {
+			// "this" is the protovalidate special variable bound at eval time;
+			// it cannot be compiled in the static environment. Always include it
+			// unless the caller has narrowed to a specific expected type (in that
+			// case its type is unknown so we cannot confirm compatibility).
+			if expectedType == nil {
+				items = append(items, protocol.CompletionItem{
+					Label:  kw,
+					Kind:   protocol.CompletionItemKindVariable,
+					Detail: "protovalidate: current message or field",
+				})
+			}
+			continue
+		}
+		ast, iss := celEnv.Compile(kw)
+		if iss.Err() != nil {
+			continue
+		}
+		kwType := ast.OutputType()
+		if !celTypeMatches(expectedType, kwType) {
+			continue
+		}
+		kind := protocol.CompletionItemKindKeyword
+		detail := kwType.String()
+		if kw == "now" {
+			// "now" is a protovalidate runtime variable, not a literal keyword.
+			kind = protocol.CompletionItemKindVariable
+			detail = "protovalidate: current evaluation timestamp"
+		}
+		items = append(items, protocol.CompletionItem{
+			Label:  kw,
+			Kind:   kind,
+			Detail: detail,
+		})
+	}
+	return items
+}
+
+// celIsOperatorOrInternal returns true if name represents an operator or internal
+// function that should not appear as a user-visible completion item.
+func celIsOperatorOrInternal(name string) bool {
+	if _, ok := operators.FindReverse(name); ok {
+		return true
+	}
+	return strings.HasPrefix(name, "@") || strings.HasPrefix(name, "_")
+}
+
+// celGlobalFunctionDetail returns a short detail string for the first global
+// (non-member) overload of fn.
+func celGlobalFunctionDetail(fn *decls.FunctionDecl) string {
+	for _, o := range fn.OverloadDecls() {
+		if o.IsMemberFunction() {
+			continue
+		}
+		return celFormatOverloadSignature(fn.Name(), o)
+	}
+	return ""
+}
+
+// celFormatOverloadSignature formats a single overload as "name(args...) -> result".
+// For member functions, the format is "receiver.name(args...) -> result".
+func celFormatOverloadSignature(name string, o *decls.OverloadDecl) string {
+	args := o.ArgTypes()
+	var parts []string
+	start := 0
+	prefix := ""
+	if o.IsMemberFunction() && len(args) > 0 {
+		prefix = args[0].String() + "."
+		start = 1
+	}
+	for _, a := range args[start:] {
+		parts = append(parts, a.String())
+	}
+	result := o.ResultType().String()
+	return fmt.Sprintf("%s%s(%s) -> %s", prefix, name, strings.Join(parts, ", "), result)
+}

--- a/private/buf/buflsp/completion_cel_test.go
+++ b/private/buf/buflsp/completion_cel_test.go
@@ -1,0 +1,542 @@
+// Copyright 2020-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buflsp_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+)
+
+func TestCELCompletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	testProtoPath, err := filepath.Abs("testdata/hover/cel_completion.proto")
+	require.NoError(t, err)
+
+	clientJSONConn, testURI := setupLSPServer(t, testProtoPath)
+
+	// File contents (0-indexed lines):
+	//  26:  `    expression: "this."`                                              (dot context; also used for expression-start)
+	//  32:  `    expression: ""`                                                   (empty expression)
+	//  39:  `    expression: "1 > "`                                               (operator, no narrowing)
+	//  46:  `    expression: "true == "`                                           (operator, narrowed to bool)
+	//  53:  `    expression: "th"`                                                 (prefix "th", completes to "this")
+	//  60:  `    expression: "size(this) > 0"`                                     (mid-token cursor, no completions)
+	//  65:  `  string test_cel_expr = 7 [(buf.validate.field).cel_expression = "this."];`
+	//  71:  `    expression: "this."`                                              (message-typed field)
+	//  77:  `    expression: "!"`                                                  (unary NOT, narrowed to bool)
+	//  84:  `    expression: "this.address.ci"`                                    (nested path; prefix "ci")
+	//  91:  `    expression: "has(this."`                                          (has() arg completions)
+	//  98:  `    expression: "has(this.address.ci"`                                (has() nested path; prefix "ci")
+	// 105:  `    expression: "now."`                                               (Timestamp methods via "now" variable)
+	// 112:  `    expression: "this."`                                              (repeated field; list methods and macros)
+	// 119:  `    expression: "this."`                                              (map field; map methods)
+	// 127:  `    expression: "this."`                                              (message-level CEL)
+	// 138:  `    expression: "this.items.filter(addr, addr."`                      (comprehension iter var)
+	// 155:  `    expression: "this.items.filter(item, item.addresses.filter(addr, addr."` (nested comprehension iter var)
+	// 165:  `    expression: "this."`                                              (WKTHolder.created_at — Timestamp field)
+	// 175:  `    expression: "this."`                                              (OneofHolder message-level — oneof member fields)
+	// 193:  `    expression: "this.items."`                                        (RepeatedPathHolder — list receiver, not element fields)
+	// 206:  `    expression: "this.items[0]."`                                     (IndexAccessHolder — indexed into list, yields element fields)
+	// 210:  `    expression: "this.locations[\"key\"]."`                           (IndexAccessHolder — indexed into map, yields value fields)
+	// 222:  `    expression: "this.items.filter(item, item.zip_code > 0).all(addr, addr."` (ChainedComprehensionHolder)
+	tests := []struct {
+		name                string
+		line                uint32
+		character           uint32
+		noCompletions       bool // expect nil or empty completion list
+		expectedContains    []string
+		expectedNotContains []string
+		expectedDocs        map[string]string // maps item label → expected documentation substring
+		expectedDeprecated  []string          // item labels expected to have Deprecated: true
+	}{
+		{
+			// Cursor at closing `"` of `"this."` — isDotContext sees `this.`
+			// and returns member completions filtered to string methods.
+			name:      "dot_context_member_completions",
+			line:      26,
+			character: 22, // position of closing `"` after `this.`
+			expectedContains: []string{
+				"contains",
+				"endsWith",
+				"matches",
+				"size",
+				"startsWith",
+			},
+			// Keywords and global-only functions are not included in member completion.
+			expectedNotContains: []string{"true", "false", "null"},
+		},
+		{
+			// Cursor at closing `"` of `""` — empty expression, return all completions.
+			name:      "empty_expression_all_completions",
+			line:      32,
+			character: 17, // position of closing `"` in empty string
+			expectedContains: []string{
+				// CEL keywords / protovalidate special variables
+				"true",
+				"false",
+				"null",
+				"this",
+				"now", // protovalidate runtime timestamp variable
+				// Standard global functions
+				"size",
+				// Standard macros
+				"all",
+				"exists",
+				"filter",
+				"has",
+				"map",
+			},
+		},
+		{
+			// Cursor at closing `"` of `"1 > "` — inside a CEL expression after an operator.
+			// The `>` operator has mixed-type overloads (int, double, uint on the right),
+			// so type narrowing does not apply and all CEL completions are returned.
+			name:      "operator_context_cel_completions",
+			line:      39,
+			character: 21, // position of closing `"` after `1 > `
+			expectedContains: []string{
+				"size",
+				"all",
+				"exists",
+				"true",
+				"false",
+				"null",
+				"this",
+				"now",
+			},
+		},
+		{
+			// Cursor at closing `"` of `"true == "`.
+			// `==` has a single type-param overload; with bool on the left, expectedType
+			// narrows to bool. Only bool-compatible completions are returned.
+			name:      "operator_context_type_narrowed_to_bool",
+			line:      46,
+			character: 25, // position of closing `"` after `true == `
+			expectedContains: []string{
+				// bool keywords match the expected type
+				"true",
+				"false",
+			},
+			// size() returns int, not bool — excluded by type narrowing.
+			// "this" is excluded because expectedType is non-nil.
+			// "null" has type "value", not bool — excluded.
+			// "now" is timestamp, not bool — excluded.
+			expectedNotContains: []string{"size", "this", "null", "now"},
+		},
+		{
+			// Cursor at char 17 (first character of `this` in `"this."`).
+			// celContent="" so all completions are returned, just like the empty expression case.
+			name:      "expression_start_all_completions",
+			line:      26,
+			character: 17, // char of `t` — celOffset=0, celContent=""
+			expectedContains: []string{
+				"true",
+				"false",
+				"null",
+				"this",
+				"now",
+				"size",
+				"all",
+				"exists",
+			},
+		},
+		{
+			// Cursor at closing `"` of `"th"` — prefix "th" filters completions
+			// to items starting with "th". The only standard CEL item is "this".
+			name:      "prefix_th_completes_this",
+			line:      53,
+			character: 19, // closing `"` of `"th"`, celContent="th"
+			expectedContains: []string{
+				"this",
+			},
+			// Items not starting with "th" are all filtered out.
+			expectedNotContains: []string{"true", "false", "null", "size", "all", "now"},
+		},
+		{
+			// Cursor at char 18 of `    expression: "size(this) > 0"`.
+			// char 18 = `i`, so the next character after the cursor is an identifier
+			// character — the cursor is inside a completed token. No completions offered.
+			name:          "no_completions_mid_token",
+			line:          60,
+			character:     18, // `i` in `size`, next char is also identifier
+			noCompletions: true,
+		},
+		{
+			// `cel_expression` field — a direct repeated-string field on FieldRules,
+			// not wrapped in a Rule message. Cursor at char 72 = closing `"` after `this.`.
+			name:      "cel_expression_field_dot_completions",
+			line:      65,
+			character: 72, // closing `"` of `"this."` in the inline option
+			expectedContains: []string{
+				"contains",
+				"endsWith",
+				"matches",
+				"size",
+				"startsWith",
+			},
+			expectedNotContains: []string{"true", "false", "null"},
+		},
+		{
+			// Message-typed field: cursor at closing `"` of `"this."`.
+			// Should return proto field names (city, country, zip_code) from Address,
+			// not string member functions.
+			name:      "message_field_dot_completions",
+			line:      71,
+			character: 22, // closing `"` of `"this."` for Address-typed field
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			// String member functions and keywords are excluded.
+			expectedNotContains: []string{"contains", "startsWith", "true", "false", "null"},
+			// Verify that field doc comments are surfaced in completion documentation.
+			expectedDocs: map[string]string{
+				"city":     "The city name.",
+				"country":  "The country code.",
+				"zip_code": "The ZIP or postal code.",
+			},
+			// zip_code is marked deprecated = true in the proto.
+			expectedDeprecated: []string{"zip_code"},
+		},
+		{
+			// Unary NOT context: cursor at closing `"` of `"!"`.
+			// After `!`, the operand must be bool, so completions narrow to bool-typed items.
+			name:      "unary_not_bool_narrowing",
+			line:      77,
+			character: 18, // closing `"` of `"!"`
+			expectedContains: []string{
+				"true",
+				"false",
+			},
+			// Non-bool items are excluded.
+			expectedNotContains: []string{"size", "null", "this", "now"},
+		},
+		{
+			// Nested path: cursor at end of `"this.address.ci"` on a Location-typed field.
+			// `this` is Location, `this.address` is Address, prefix "ci" narrows to city.
+			name:      "nested_path_completions",
+			line:      84,
+			character: 32, // closing `"` after `this.address.ci`
+			expectedContains: []string{
+				"city",
+			},
+			// Other Address fields don't start with "ci"; keywords and methods excluded.
+			expectedNotContains: []string{"country", "zip_code", "contains", "true", "false", "null"},
+		},
+		{
+			// has() macro argument: cursor at closing `"` of `"has(this."` on an Address field.
+			// The inner `this.` selects Address fields.
+			name:      "has_arg_dot_completions",
+			line:      91,
+			character: 26, // closing `"` after `has(this.`
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			expectedNotContains: []string{"contains", "true", "false", "null"},
+		},
+		{
+			// has() with a nested path: cursor at end of `"has(this.address.ci"`.
+			// has() strips to "this.address.ci"; member access resolves to Address
+			// via the nested path; prefix "ci" filters to only city.
+			name:      "has_arg_nested_path_completions",
+			line:      98,
+			character: 36, // closing `"` after `has(this.address.ci`
+			expectedContains: []string{
+				"city",
+			},
+			expectedNotContains: []string{"country", "zip_code", "contains", "true", "false", "null"},
+		},
+		{
+			// now. completions: cursor at closing `"` of `"now."`.
+			// `now` is protovalidate's runtime Timestamp variable; "now." should yield
+			// Timestamp methods from the CEL environment.
+			name:      "now_dot_completions",
+			line:      105,
+			character: 21, // closing `"` after `now.`
+			expectedContains: []string{
+				"getFullYear",
+				"getHours",
+				"getMonth",
+			},
+			// Proto field names and keywords are not Timestamp methods.
+			expectedNotContains: []string{"city", "name", "true", "false", "null"},
+		},
+		{
+			// Repeated field: cursor at closing `"` of `"this."` on a `repeated Address` field.
+			// CEL treats repeated proto fields as lists; `size` (list member function) and
+			// comprehension macros (filter, all, exists, etc.) should be offered.
+			// Address field names (city, etc.) should NOT appear since this is a list.
+			name:      "repeated_field_dot_completions",
+			line:      112,
+			character: 22, // closing `"` after `this.`
+			expectedContains: []string{
+				"size",
+				"filter",
+				"all",
+				"exists",
+			},
+			expectedNotContains: []string{"city", "country", "zip_code"},
+		},
+		{
+			// Map field: cursor at closing `"` of `"this."` on a `map<string, string>` field.
+			// CEL treats map fields as maps; `size` should be offered.
+			// String field names should NOT appear.
+			name:      "map_field_dot_completions",
+			line:      119,
+			character: 22, // closing `"` after `this.`
+			expectedContains: []string{
+				"size",
+			},
+			expectedNotContains: []string{"city", "country", "true", "false", "null"},
+		},
+		{
+			// Message-level CEL rule: `(buf.validate.message).cel`.
+			// Cursor at char 22 = closing `"` after `this.` in the message option.
+			// `this` refers to CELCompletionMsg itself, so field completions yield `name`.
+			name:      "message_level_dot_completions",
+			line:      127,
+			character: 22,
+			expectedContains: []string{
+				"name",
+			},
+			// String member functions and keywords are not proto fields — excluded.
+			expectedNotContains: []string{"contains", "startsWith", "true", "false", "null"},
+		},
+		{
+			// Comprehension iteration variable: cursor at closing `"` of
+			// `"this.items.filter(addr, addr."`. The range `this.items` is a repeated
+			// Address field; `addr` is bound to Address elements. Completions should
+			// yield Address field names.
+			name:      "iter_var_dot_completions",
+			line:      138,
+			character: 46, // closing `"` after `this.items.filter(addr, addr.`
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			// List methods and keywords are not Address fields.
+			expectedNotContains: []string{"size", "all", "true", "false", "null"},
+		},
+		{
+			// Nested comprehension iteration variable: cursor at closing `"` of
+			// `"this.items.filter(item, item.addresses.filter(addr, addr."`.
+			// The outer range `this.items` is a repeated Item field; `item` is bound to Item.
+			// The inner range `item.addresses` is a repeated Address field; `addr` is bound
+			// to Address elements. Completions should yield Address field names.
+			name:      "iter_nested_var_completions",
+			line:      155,
+			character: 74, // closing `"` after `this.items.filter(item, item.addresses.filter(addr, addr.`
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			// List methods, Item fields, and keywords are not Address fields.
+			expectedNotContains: []string{"size", "all", "label", "true", "false", "null"},
+		},
+		{
+			// Well-known type field: cursor at closing `"` of `"this."` on a
+			// google.protobuf.Timestamp field. The proto fields (seconds, nanos)
+			// and CEL Timestamp methods (getFullYear, getHours, etc.) should be offered.
+			// This exercises the IR path for WKT completions, which is distinct from
+			// the `now.` test that resolves Timestamp via the CEL static environment.
+			name:      "wkt_timestamp_field_dot_completions",
+			line:      165,
+			character: 22, // closing `"` after `this.`
+			expectedContains: []string{
+				"seconds",
+				"nanos",
+				"getFullYear",
+				"getHours",
+				"getMonth",
+			},
+			expectedNotContains: []string{"city", "country", "zip_code"},
+		},
+		{
+			// Oneof field completions: cursor at closing `"` of `"this."` in a
+			// message-level CEL rule. The oneof member fields (text, code, location)
+			// are non-synthetic members in the proto IR and must appear as completions.
+			name:      "oneof_field_dot_completions",
+			line:      175,
+			character: 22, // closing `"` after `this.`
+			expectedContains: []string{
+				"text",
+				"code",
+				"location",
+			},
+			expectedNotContains: []string{"true", "false", "null", "contains", "startsWith"},
+		},
+		{
+			// Repeated path: cursor at closing `"` of `"this.items."` in a message-level
+			// CEL rule on RepeatedPathHolder. `this.items` is a repeated Address field,
+			// so the receiver is a list — list methods and comprehension macros should be
+			// offered, not Address field names.
+			name:      "repeated_path_dot_completions",
+			line:      193,
+			character: 28, // closing `"` after `this.items.`
+			expectedContains: []string{
+				"size",
+				"filter",
+				"all",
+				"exists",
+			},
+			expectedNotContains: []string{"city", "country", "zip_code"},
+		},
+		{
+			// Index access (list): cursor at closing `"` of `"this.items[0]."` in a
+			// message-level CEL rule on IndexAccessHolder. After indexing into the
+			// repeated Address field, the receiver is an Address element — Address
+			// field names should be offered.
+			name:      "index_access_list_completions",
+			line:      206,
+			character: 31, // closing `"` after `this.items[0].`
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			expectedNotContains: []string{"size", "all", "true", "false"},
+		},
+		{
+			// Index access (map): cursor at closing `"` of `"this.locations["key"]."` in a
+			// message-level CEL rule on IndexAccessHolder. After indexing into the
+			// map<string, Address> field, the receiver is an Address value — Address
+			// field names should be offered, not map methods.
+			name:      "index_access_map_completions",
+			line:      210,
+			character: 41, // closing `"` after `this.locations["key"].`
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			expectedNotContains: []string{"size", "all", "true", "false"},
+		},
+		{
+			// Chained comprehension: cursor at closing `"` of
+			// `"this.items.filter(item, item.zip_code > 0).all(addr, addr."`.
+			// The outer filter's result is a list of Address elements; `addr` in the
+			// inner all() is bound to those elements. Address field names must appear
+			// even though the range expression has a trailing `)` from the outer call.
+			name:      "chained_comprehension_iter_var",
+			line:      222,
+			character: 75, // closing `"` after `...all(addr, addr.`
+			expectedContains: []string{
+				"city",
+				"country",
+				"zip_code",
+			},
+			expectedNotContains: []string{"size", "all", "true", "false", "null"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var completionList *protocol.CompletionList
+			_, err := clientJSONConn.Call(ctx, protocol.MethodTextDocumentCompletion, protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{
+						URI: testURI,
+					},
+					Position: protocol.Position{
+						Line:      tt.line,
+						Character: tt.character,
+					},
+				},
+			}, &completionList)
+			require.NoError(t, err)
+
+			if tt.noCompletions {
+				assert.True(t,
+					completionList == nil || len(completionList.Items) == 0,
+					"expected no completions mid-token, got %v",
+					func() []string {
+						if completionList == nil {
+							return nil
+						}
+						labels := make([]string, len(completionList.Items))
+						for i, item := range completionList.Items {
+							labels[i] = item.Label
+						}
+						return labels
+					}(),
+				)
+				return
+			}
+
+			require.NotNil(t, completionList, "expected completion list to be non-nil")
+
+			labels := make([]string, 0, len(completionList.Items))
+			for _, item := range completionList.Items {
+				labels = append(labels, item.Label)
+			}
+			for _, expected := range tt.expectedContains {
+				assert.Contains(t, labels, expected, "expected completion list to contain %q", expected)
+			}
+			for _, notExpected := range tt.expectedNotContains {
+				assert.NotContains(t, labels, notExpected, "expected completion list to not contain %q", notExpected)
+			}
+			for label, wantDoc := range tt.expectedDocs {
+				var found bool
+				for _, item := range completionList.Items {
+					if item.Label != label {
+						continue
+					}
+					found = true
+					var docStr string
+					switch doc := item.Documentation.(type) {
+					case string:
+						docStr = doc
+					case *protocol.MarkupContent:
+						docStr = doc.Value
+					case map[string]any:
+						// After JSON round-trip through the LSP JSON-RPC layer,
+						// *protocol.MarkupContent is decoded as a generic map.
+						if v, ok := doc["value"].(string); ok {
+							docStr = v
+						}
+					}
+					assert.Contains(t, docStr, wantDoc, "item %q: expected documentation to contain %q", label, wantDoc)
+					break
+				}
+				assert.True(t, found, "item %q not found in completion list for doc check", label)
+			}
+			for _, label := range tt.expectedDeprecated {
+				var found bool
+				for _, item := range completionList.Items {
+					if item.Label != label {
+						continue
+					}
+					found = true
+					assert.True(t, item.Deprecated, "item %q: expected Deprecated to be true", label)
+					break
+				}
+				assert.True(t, found, "item %q not found in completion list for deprecated check", label)
+			}
+		})
+	}
+}

--- a/private/buf/buflsp/hover_cel.go
+++ b/private/buf/buflsp/hover_cel.go
@@ -550,13 +550,13 @@ func formatCELHoverContent(info *celHoverInfo, celEnv *cel.Env) string {
 // resolveCELFieldAccess resolves a CEL SelectExpr to a proto field/member.
 // Handles expressions like `this.fieldName` or `this.address.city`.
 func resolveCELFieldAccess(sel ast.SelectExpr, exprInfo celExpressionInfo) ir.Member {
-	if sel == nil || exprInfo.irMember.IsZero() {
+	if sel == nil || exprInfo.thisIRType.IsZero() {
 		return ir.Member{}
 	}
 
-	// Start from the context field (the field being validated)
-	// For field-level validation, exprInfo.irMember is the field
-	currentType := exprInfo.irMember.Element()
+	// Start from the `this` type: the field's element type for field-level rules,
+	// or the message type itself for message-level rules.
+	currentType := exprInfo.thisIRType
 
 	// Build the field path by walking up the select chain
 	var fieldPath []string

--- a/private/buf/buflsp/hover_cel_test.go
+++ b/private/buf/buflsp/hover_cel_test.go
@@ -571,6 +571,22 @@ func TestCELHover(t *testing.T) {
 			char:     33,
 			expected: "**Operator**: `&&`\n\nlogically AND two boolean values. Errors and unknown values\nare valid inputs and will not halt evaluation.\n\n**Overloads**:\n- `bool && bool -> bool`",
 		},
+		{
+			// `this.name` in the message-level expression; hovering over `name` should
+			// resolve to CELMessageTest.name (string, field 1).
+			name:     "message-level: field access name",
+			line:     377,
+			char:     22, // `n` of `name` in `this.name != ''`
+			expected: "**Field**: `name`\n\n**Proto Field**: `test.cel.v1.CELMessageTest.name`\n\n**Field Number**: 1\n\n**Proto Type**: `string`\n\nencoded (hex): `0A` (1 byte)",
+		},
+		{
+			// `this.value` in the message-level expression; hovering over `value` should
+			// resolve to CELMessageTest.value (int32, field 2).
+			name:     "message-level: field access value",
+			line:     377,
+			char:     41, // `v` of `value` in `this.value > 0`
+			expected: "**Field**: `value`\n\n**Proto Field**: `test.cel.v1.CELMessageTest.value`\n\n**Field Number**: 2\n\n**Proto Type**: `int32`\n\nencoded (hex): `10` (1 byte)",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -439,6 +439,13 @@ func (s *server) Completion(
 	if file == nil {
 		return nil, nil
 	}
+
+	// First, try CEL completion when the cursor is inside a protovalidate expression.
+	if celItems := getCELCompletionItems(file, params.Position, s.celEnv); celItems != nil {
+		return &protocol.CompletionList{Items: celItems}, nil
+	}
+
+	// Fall back to proto-level completions.
 	items := getCompletionItems(ctx, file, params.Position)
 	if len(items) == 0 {
 		return nil, nil

--- a/private/buf/buflsp/testdata/hover/cel_completion.proto
+++ b/private/buf/buflsp/testdata/hover/cel_completion.proto
@@ -1,0 +1,225 @@
+syntax = "proto3";
+
+package test.celcompletion.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+// Address is used for testing message-field completions.
+message Address {
+  // The city name.
+  string city = 1;
+  // The country code.
+  string country = 2;
+  // The ZIP or postal code.
+  int32 zip_code = 3 [deprecated = true];
+}
+
+// Location wraps Address for testing nested path completions.
+message Location {
+  Address address = 1;
+}
+
+message CELCompletion {
+  // test_dot: cursor after "this." should yield member completions.
+  string test_dot = 1 [(buf.validate.field).cel = {
+    id: "test.dot"
+    expression: "this."
+  }];
+
+  // test_empty: cursor inside "" should yield all (global, macro, keyword) completions.
+  string test_empty = 2 [(buf.validate.field).cel = {
+    id: "test.empty"
+    expression: ""
+  }];
+
+  // test_operator: cursor after "1 > " — inside CEL expression after operator.
+  // The `>` operator has mixed-type overloads so type narrowing does not apply.
+  string test_operator = 3 [(buf.validate.field).cel = {
+    id: "test.operator"
+    expression: "1 > "
+  }];
+
+  // test_eq: cursor after "true == " — `==` has a single type-param overload.
+  // With bool left side, expectedType narrows to bool, filtering out int-return functions.
+  bool test_eq = 4 [(buf.validate.field).cel = {
+    id: "test.eq"
+    expression: "true == "
+  }];
+
+  // test_prefix: cursor at closing `"` of `"th"` — prefix "th" filters completions
+  // to only items starting with "th", which is "this".
+  string test_prefix = 5 [(buf.validate.field).cel = {
+    id: "test.prefix"
+    expression: "th"
+  }];
+
+  // test_midword: cursor placed mid-token inside a fully written expression.
+  // No completion should be offered since the token is already complete.
+  string test_midword = 6 [(buf.validate.field).cel = {
+    id: "test.midword"
+    expression: "size(this) > 0"
+  }];
+
+  // test_cel_expr: the cel_expression field is a direct string (not a Rule message).
+  // Cursor after "this." should yield member completions via the alternate extraction path.
+  string test_cel_expr = 7 [(buf.validate.field).cel_expression = "this."];
+
+  // test_msg_dot: cursor after "this." on a message-typed field should yield
+  // the fields of Address as completions.
+  Address test_msg = 8 [(buf.validate.field).cel = {
+    id: "test.msg.dot"
+    expression: "this."
+  }];
+
+  // test_not: cursor after "!" should narrow completions to bool-returning items.
+  bool test_not = 9 [(buf.validate.field).cel = {
+    id: "test.not"
+    expression: "!"
+  }];
+
+  // test_nested: cursor at end of "this.address.ci" — nested path through a message-typed
+  // field. Prefix "ci" should yield only city from Address.
+  Location test_nested = 10 [(buf.validate.field).cel = {
+    id: "test.nested"
+    expression: "this.address.ci"
+  }];
+
+  // test_has: cursor after "has(this." — inside the has() macro argument.
+  // Should yield Address field completions (city, country, zip_code).
+  Address test_has = 11 [(buf.validate.field).cel = {
+    id: "test.has"
+    expression: "has(this."
+  }];
+
+  // test_has_nested: has() with a nested path "has(this.address.ci".
+  // Prefix "ci" filters to only the city field from Address.
+  Location test_has_nested = 12 [(buf.validate.field).cel = {
+    id: "test.has.nested"
+    expression: "has(this.address.ci"
+  }];
+
+  // test_now_dot: cursor after "now." — now is protovalidate's Timestamp variable.
+  // Timestamp methods (getFullYear, getHours, etc.) should be offered.
+  string test_now_dot = 13 [(buf.validate.field).cel = {
+    id: "test.now.dot"
+    expression: "now."
+  }];
+
+  // test_repeated_dot: cursor after "this." on a repeated Address field.
+  // CEL treats repeated proto fields as lists; list methods should be offered.
+  repeated Address test_repeated = 14 [(buf.validate.field).cel = {
+    id: "test.repeated.dot"
+    expression: "this."
+  }];
+
+  // test_map_dot: cursor after "this." on a map<string, string> field.
+  // CEL treats map fields as maps; map methods (e.g. size) should be offered.
+  map<string, string> test_map = 15 [(buf.validate.field).cel = {
+    id: "test.map.dot"
+    expression: "this."
+  }];
+}
+
+// CELCompletionMsg exercises message-level CEL rules.
+message CELCompletionMsg {
+  option (buf.validate.message).cel = {
+    id: "test.msg"
+    expression: "this."
+  };
+  string name = 1;
+}
+
+// CELCompletionIter exercises iteration variable completions in comprehension macros.
+message CELCompletionIter {
+  repeated Address items = 1;
+
+  option (buf.validate.message).cel = {
+    id: "test.iter"
+    expression: "this.items.filter(addr, addr."
+  };
+}
+
+// Item is used for testing nested comprehension completions.
+message Item {
+  string label = 1;
+  repeated Address addresses = 2;
+}
+
+// CELCompletionIterNested exercises nested comprehension iteration variable completions.
+// The inner iter var `addr` is bound to Address elements from `item.addresses`.
+message CELCompletionIterNested {
+  repeated Item items = 1;
+
+  option (buf.validate.message).cel = {
+    id: "test.iter.nested"
+    expression: "this.items.filter(item, item.addresses.filter(addr, addr."
+  };
+}
+
+// WKTHolder exercises completions on well-known-type fields.
+// Completing `this.` on a google.protobuf.Timestamp field should offer both
+// the proto fields (seconds, nanos) and CEL Timestamp methods (getFullYear, etc.).
+message WKTHolder {
+  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).cel = {
+    id: "wkt.created_at"
+    expression: "this."
+  }];
+}
+
+// OneofHolder exercises completions on messages that contain oneof fields.
+// Oneof member fields are regular (non-synthetic) members in the proto IR
+// and must appear in `this.` completions.
+message OneofHolder {
+  option (buf.validate.message).cel = {
+    id: "oneof.rule"
+    expression: "this."
+  };
+
+  oneof payload {
+    string text = 1;
+    int32 code = 2;
+    Address location = 3;
+  }
+}
+
+// RepeatedPathHolder exercises completions when the cursor is after a
+// repeated-field path (e.g. "this.items."). The receiver `this.items` is a
+// list, so list methods and macros should be offered — not Address fields.
+message RepeatedPathHolder {
+  repeated Address items = 1;
+
+  option (buf.validate.message).cel = {
+    id: "repeated.path"
+    expression: "this.items."
+  };
+}
+
+// IndexAccessHolder exercises completions after bracket-index expressions.
+// - "this.items[0]."     → Address fields (list element access)
+// - "this.locations["key"]." → Address fields (map value access)
+message IndexAccessHolder {
+  repeated Address items = 1;
+  map<string, Address> locations = 2;
+
+  option (buf.validate.message).cel = {
+    id: "index.list"
+    expression: "this.items[0]."
+  };
+  option (buf.validate.message).cel = {
+    id: "index.map"
+    expression: "this.locations[\"key\"]."
+  };
+}
+
+// ChainedComprehensionHolder exercises completions in chained comprehension macros.
+// A filter result is piped into all(); the inner iter var `addr` is bound to
+// Address elements from the outer filter and must yield Address field completions.
+message ChainedComprehensionHolder {
+  repeated Address items = 1;
+
+  option (buf.validate.message).cel = {
+    id: "chained.comp"
+    expression: "this.items.filter(item, item.zip_code > 0).all(addr, addr."
+  };
+}


### PR DESCRIPTION
This adds contextual completion for CEL expressions for protovalidate, in the same spirit as our completion approach for protobuf.

I strongly suggest reviewing this by also installing this branch locally and trying out the completion in the testcases, to see how it feels to use locally.