### PR TITLE
Fix LSP CEL completion showing `in()` completion

### DIFF
--- a/private/buf/buflsp/completion_cel_test.go
+++ b/private/buf/buflsp/completion_cel_test.go
@@ -57,6 +57,7 @@ func TestCELCompletion(t *testing.T) {
 	// 206:  `    expression: "this.items[0]."`                                     (IndexAccessHolder — indexed into list, yields element fields)
 	// 210:  `    expression: "this.locations[\"key\"]."`                           (IndexAccessHolder — indexed into map, yields value fields)
 	// 222:  `    expression: "this.items.filter(item, item.zip_code > 0).all(addr, addr."` (ChainedComprehensionHolder)
+	// 232:  `    expression: "in"`                                                    (InOperatorHolder — "in" is an operator, not a function)
 	tests := []struct {
 		name                string
 		line                uint32
@@ -449,6 +450,15 @@ func TestCELCompletion(t *testing.T) {
 				"zip_code",
 			},
 			expectedNotContains: []string{"size", "all", "true", "false", "null"},
+		},
+		{
+			// Cursor at closing `"` of `"in"` — prefix "in".
+			// `in` is a CEL binary membership operator ("value in list"), not a
+			// callable function. It must NOT appear as a function completion "in()".
+			name:                "in_operator_not_function_completion",
+			line:                232,
+			character:           19, // closing `"` after `in`
+			expectedNotContains: []string{"in"},
 		},
 	}
 

--- a/private/buf/buflsp/testdata/hover/cel_completion.proto
+++ b/private/buf/buflsp/testdata/hover/cel_completion.proto
@@ -223,3 +223,13 @@ message ChainedComprehensionHolder {
     expression: "this.items.filter(item, item.zip_code > 0).all(addr, addr."
   };
 }
+
+// InOperatorHolder verifies that the "in" membership operator does not appear
+// as a callable function completion ("in()") when typed as a prefix.
+// "in" is a binary infix operator ("value in list"), not a function call.
+message InOperatorHolder {
+  option (buf.validate.message).cel = {
+    id: "in.operator"
+    expression: "in"
+  };
+}


### PR DESCRIPTION
[Caught][1] by @emcfarlane in #4358. Fixes the issue and adds a test.

[1]: https://github.com/bufbuild/buf/pull/4358#pullrequestreview-3867471988