### PR TITLE
protoc_builtin: Support `--rbs_out`

### DIFF
--- a/private/bufpkg/bufconfig/generate_plugin_config.go
+++ b/private/bufpkg/bufconfig/generate_plugin_config.go
@@ -70,6 +70,7 @@ var (
 		"python": {},
 		"pyi":    {},
 		"ruby":   {},
+		"rbs":    {},
 		"kotlin": {},
 		"rust":   {},
 	}


### PR DESCRIPTION
protoc v34.0 gained `--rbs_out`, type signature file for Ruby.

- https://github.com/protocolbuffers/protobuf/releases/tag/v34.0
- https://github.com/protocolbuffers/protobuf/pull/15633