### PR TITLE
Fix git test hang

### DIFF
--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestGitCloner(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	container, err := app.NewContainerForOS()
 	require.NoError(t, err)
 	originDir, workDir := createGitDirs(ctx, t, container)
@@ -463,7 +463,7 @@ func createGitDirs(
 	require.NoError(t, os.WriteFile(filepath.Join(originPath, "a.proto"), []byte("// commit 4"), 0600))
 	runCommand(ctx, t, container, "git", "-C", originPath, "add", "a.proto")
 	runCommand(ctx, t, container, "git", "-C", originPath, "commit", "-m", "commit 4")
-	runCommand(ctx, t, container, "git", "-C", originPath, "tag", "remote-tag")
+	runCommand(ctx, t, container, "git", "-C", originPath, "tag", "remote-tag", "--no-sign")
 	runCommand(ctx, t, container, "git", "-C", originPath, "tag", "-a", "remote-annotated-tag", "-m", "annotated tag")
 
 	runCommand(ctx, t, container, "git", "-C", workPath, "fetch", "origin")


### PR DESCRIPTION
For contributors who may have `tag.gpgSign` configured as a part of their local git configuration, this call will hang as it will open up `$EDITOR` to enter the message.

Also, use `t.Context` over `context.Background`.