### PR TITLE
Add support for `--rbs_out`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Add support for `--rbs_out` as a `protoc_builtin` plugin (requires protoc v34.0+).
 
 ## [v1.66.1] - 2026-03-09
 

--- a/private/buf/bufprotopluginexec/protoc_proxy_handler.go
+++ b/private/buf/bufprotopluginexec/protoc_proxy_handler.go
@@ -88,6 +88,9 @@ func (h *protocProxyHandler) Handle(
 	if h.pluginName == "rust" && !getRustSupportedAsBuiltin(protocVersion) {
 		return fmt.Errorf("rust is not supported for protoc version %s", versionString(protocVersion))
 	}
+	if h.pluginName == "rbs" && !getRbsSupportedAsBuiltin(protocVersion) {
+		return fmt.Errorf("rbs is not supported for protoc version %s", versionString(protocVersion))
+	}
 	// When we create protocProxyHandlers in NewHandler, we always prefer protoc-gen-.* plugins
 	// over builtin plugins, so we only get here if we did not find protoc-gen-js, so this
 	// is an error

--- a/private/buf/bufprotopluginexec/version.go
+++ b/private/buf/bufprotopluginexec/version.go
@@ -150,6 +150,15 @@ func getRustSupportedAsBuiltin(version *pluginpb.Version) bool {
 	return true
 }
 
+// Is rbs supported as a builtin plugin?
+func getRbsSupportedAsBuiltin(version *pluginpb.Version) bool {
+	if version.GetSuffix() == "buf" {
+		return true
+	}
+	// rbs was added in protoc v34.0
+	return version.GetMajor() >= 34
+}
+
 // Is js supported as a builtin plugin?
 func getJSSupportedAsBuiltin(version *pluginpb.Version) bool {
 	if version.GetSuffix() == "buf" {

--- a/private/buf/bufprotopluginexec/version_test.go
+++ b/private/buf/bufprotopluginexec/version_test.go
@@ -75,6 +75,15 @@ func TestGetRustSupportedAsBuiltin(t *testing.T) {
 	assert.False(t, getRustSupportedAsBuiltin(newVersion(3, 14, 1, "")))
 }
 
+func TestGetRbsSupportedAsBuiltin(t *testing.T) {
+	t.Parallel()
+	assert.True(t, getRbsSupportedAsBuiltin(newVersion(3, 11, 1, "buf")))
+	assert.True(t, getRbsSupportedAsBuiltin(newVersion(34, 0, 0, "")))
+	assert.True(t, getRbsSupportedAsBuiltin(newVersion(35, 0, 0, "")))
+	assert.False(t, getRbsSupportedAsBuiltin(newVersion(33, 5, 0, "")))
+	assert.False(t, getRbsSupportedAsBuiltin(newVersion(21, 1, 0, "")))
+}
+
 func TestGetJSSupportedAsBuiltin(t *testing.T) {
 	t.Parallel()
 	assert.False(t, getJSSupportedAsBuiltin(newVersion(2, 11, 1, "")))

--- a/private/bufpkg/bufconfig/generate_plugin_config.go
+++ b/private/bufpkg/bufconfig/generate_plugin_config.go
@@ -70,6 +70,7 @@ var (
 		"python": {},
 		"pyi":    {},
 		"ruby":   {},
+		"rbs":    {},
 		"kotlin": {},
 		"rust":   {},
 	}


### PR DESCRIPTION
Originally in #4361, but we need to add our typical version checks and testing.

Ref: https://github.com/protocolbuffers/protobuf/releases/tag/v34.0
Ref: protocolbuffers/protobuf#15633

Supersedes #4361.