### PR TITLE
Add LSP CEL hovers for remaining extensions

### DIFF
--- a/private/buf/buflsp/cel.go
+++ b/private/buf/buflsp/cel.go
@@ -35,7 +35,7 @@ func celIsIdentChar(c byte) bool {
 func isCELKeyword(name string) bool {
 	switch name {
 	case "true", "false", "null", // literals
-		"this": // special identifier
+		"this", "now": // protovalidate special variables
 		return true
 	}
 	return false

--- a/private/buf/buflsp/hover_cel.go
+++ b/private/buf/buflsp/hover_cel.go
@@ -557,8 +557,11 @@ func formatCELHoverContent(info *celHoverInfo, celEnv *cel.Env) string {
 func celDocumentationLinks(kind celHoverKind, name string) string {
 	switch kind {
 	case celHoverKeyword:
-		if name == "this" {
+		switch name {
+		case "this":
 			return celProtovalidateLink("this")
+		case "now":
+			return celProtovalidateLink("now")
 		}
 	case celHoverOperator:
 		switch name {
@@ -642,6 +645,14 @@ func celDocumentationLinks(kind celHoverKind, name string) string {
 			return celProtovalidateLink("isuriref")
 		case "isHostAndPort":
 			return celProtovalidateLink("ishostandport")
+		// Protovalidate double extension functions
+		case "isNan":
+			return celProtovalidateLink("isnan")
+		case "isInf":
+			return celProtovalidateLink("isinf")
+		// Protovalidate list extension function
+		case "unique":
+			return celProtovalidateLink("unique")
 		}
 	case celHoverType:
 		switch name {
@@ -797,10 +808,13 @@ func getCELTypeString(t *types.Type) string {
 func getCELKeywordDocs(keyword string) string {
 	// Note: true, false, and null are ConstExpr nodes in the CEL AST (not IdentExpr),
 	// so only "this" can reach this function via celHoverKeyword.
-	if keyword == "this" {
+	switch keyword {
+	case "this":
 		return "**Special variable**\n\nRefers to the current message or field being validated.\n\n" +
 			"In field-level rules, `this` refers to the field value.\n" +
 			"In message-level rules, `this` refers to the entire message."
+	case "now":
+		return "**Special variable**\n\nThe current timestamp at the time of validation.\n\n**Type**: `google.protobuf.Timestamp`"
 	}
 	return ""
 }

--- a/private/buf/buflsp/hover_cel_test.go
+++ b/private/buf/buflsp/hover_cel_test.go
@@ -558,16 +558,54 @@ func TestCELHover(t *testing.T) {
 			expected: "**Operator**: `?`\n\nThe ternary operator tests a boolean predicate and returns the left-hand side (truthy) expression if true, or the right-hand side (falsy) expression if false\n\n**Overloads**:\n- `bool ? <T> : <T> -> <T>`\n\n[CEL by Example](https://celbyexample.com/ternary/)",
 		},
 
+		// Protovalidate special variable: now
+		// Line 372 (0-indexed): `    expression: "this < now"`
+		//                                                   ^--- now at column 24
+		{
+			name:     "variable: now",
+			line:     372,
+			char:     24,
+			expected: "**Special variable**\n\nThe current timestamp at the time of validation.\n\n**Type**: `google.protobuf.Timestamp`\n\n[Protovalidate CEL Extensions](https://protovalidate.com/reference/cel_extensions/#now)",
+		},
+
+		// Protovalidate double extension functions
+		// Line 378 (0-indexed): `    expression: "this.isNan()"`
+		//                                                ^--- isNan at column 22
+		{
+			name:     "function: isNan",
+			line:     378,
+			char:     22,
+			expected: "`isNan`\n\n**Overloads**:\n- `double.isNan() -> bool`\n\n[Protovalidate CEL Extensions](https://protovalidate.com/reference/cel_extensions/#isnan)",
+		},
+		// Line 383 (0-indexed): `    expression: "this.isInf()"`
+		//                                                ^--- isInf at column 22
+		{
+			name:     "function: isInf",
+			line:     383,
+			char:     22,
+			expected: "`isInf`\n\n**Overloads**:\n- `double.isInf() -> bool`\n- `double.isInf(int) -> bool`\n\n[Protovalidate CEL Extensions](https://protovalidate.com/reference/cel_extensions/#isinf)",
+		},
+
+		// Protovalidate list extension function
+		// Line 389 (0-indexed): `    expression: "this.unique()"`
+		//                                                 ^--- unique at column 22
+		{
+			name:     "function: unique",
+			line:     389,
+			char:     22,
+			expected: "`unique`\n\n**Overloads**:\n- `list(bool).unique() -> bool`\n- `list(int).unique() -> bool`\n- `list(uint).unique() -> bool`\n- `list(double).unique() -> bool`\n- `list(string).unique() -> bool`\n- `list(bytes).unique() -> bool`\n\n[Protovalidate CEL Extensions](https://protovalidate.com/reference/cel_extensions/#unique)",
+		},
+
 		// Message-level CEL rules
 		{
 			name:     "message-level: this",
-			line:     377,
+			line:     400,
 			char:     17,
 			expected: "**Special variable**\n\nRefers to the current message or field being validated.\n\nIn field-level rules, `this` refers to the field value.\nIn message-level rules, `this` refers to the entire message.\n\n[Protovalidate CEL Extensions](https://protovalidate.com/reference/cel_extensions/#this)",
 		},
 		{
 			name:     "message-level: &&",
-			line:     377,
+			line:     400,
 			char:     33,
 			expected: "**Operator**: `&&`\n\nlogically AND two boolean values. Errors and unknown values\nare valid inputs and will not halt evaluation.\n\n**Overloads**:\n- `bool && bool -> bool`\n\n[CEL by Example](https://celbyexample.com/logical-operators/#and)",
 		},
@@ -575,7 +613,7 @@ func TestCELHover(t *testing.T) {
 			// `this.name` in the message-level expression; hovering over `name` should
 			// resolve to CELMessageTest.name (string, field 1).
 			name:     "message-level: field access name",
-			line:     377,
+			line:     400,
 			char:     22, // `n` of `name` in `this.name != ''`
 			expected: "**Field**: `name`\n\n**Proto Field**: `test.cel.v1.CELMessageTest.name`\n\n**Field Number**: 1\n\n**Proto Type**: `string`\n\nencoded (hex): `0A` (1 byte)",
 		},
@@ -583,7 +621,7 @@ func TestCELHover(t *testing.T) {
 			// `this.value` in the message-level expression; hovering over `value` should
 			// resolve to CELMessageTest.value (int32, field 2).
 			name:     "message-level: field access value",
-			line:     377,
+			line:     400,
 			char:     41, // `v` of `value` in `this.value > 0`
 			expected: "**Field**: `value`\n\n**Proto Field**: `test.cel.v1.CELMessageTest.value`\n\n**Field Number**: 2\n\n**Proto Type**: `int32`\n\nencoded (hex): `10` (1 byte)",
 		},

--- a/private/buf/buflsp/testdata/hover/cel_comprehensive.proto
+++ b/private/buf/buflsp/testdata/hover/cel_comprehensive.proto
@@ -366,6 +366,29 @@ message CELTest {
     id: "test.escape"
     expression: "true\n? this : false"
   }];
+
+  // Protovalidate `now` variable (timestamp comparison)
+  google.protobuf.Timestamp test_now = 205 [(buf.validate.field).cel = {
+    id: "test.now"
+    expression: "this < now"
+  }];
+
+  // Protovalidate double extension functions
+  double test_isnan = 206 [(buf.validate.field).cel = {
+    id: "test.isnan"
+    expression: "this.isNan()"
+  }];
+
+  double test_isinf = 207 [(buf.validate.field).cel = {
+    id: "test.isinf"
+    expression: "this.isInf()"
+  }];
+
+  // Protovalidate list extension function
+  repeated double test_unique = 208 [(buf.validate.field).cel = {
+    id: "test.unique"
+    expression: "this.unique()"
+  }];
 }
 
 // Message-level CEL validation test


### PR DESCRIPTION
Missed a couple of our custom CEL extensions in the first pass; added the remaining ones here.

Ref: https://protovalidate.com/reference/cel_extensions/