### PR TITLE
Skip writing unchanged generated files to preserve mtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for `--rbs_out` as a `protoc_builtin` plugin (requires protoc v34.0+).
 - Add relevant links from CEL LSP hover documentation to either <celbyexample.com> or <protovalidate.com>
+- `buf generate` now skips writing output files when the content matches what's already on disk, preserving modification times for mtime-based build systems like cargo and make.
 
 ## [v1.66.1] - 2026-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add support for `--rbs_out` as a `protoc_builtin` plugin (requires protoc v34.0+).
 - Add relevant links from CEL LSP hover documentation to either <celbyexample.com> or <protovalidate.com>
-- `buf generate` now skips writing output files when the content matches what's already on disk, preserving modification times for mtime-based build systems like cargo and make.
+- Skip writing unchanged output files in `buf generate` to preserve modification times
 
 ## [v1.66.1] - 2026-03-09
 

--- a/cmd/buf/internal/command/generate/generate_test.go
+++ b/cmd/buf/internal/command/generate/generate_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"buf.build/go/app/appcmd"
 	"buf.build/go/app/appcmd/appcmdtesting"
@@ -369,6 +370,25 @@ func TestOutputFlag(t *testing.T) {
 		_, err := os.Stat(filepath.Join(tempDirPath, "java", "a", "v1", "A.java"))
 		require.NoError(t, err)
 	}
+}
+
+func TestSkipWriteWhenUnchanged(t *testing.T) {
+	t.Parallel()
+	tempDirPath := t.TempDir()
+	template := filepath.Join("testdata", "simple", "buf.gen.yaml")
+	input := filepath.Join("testdata", "simple")
+	outFile := filepath.Join(tempDirPath, "java", "a", "v1", "A.java")
+
+	testRunSuccess(t, "--output", tempDirPath, "--template", template, input)
+
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(outFile, past, past))
+
+	testRunSuccess(t, "--output", tempDirPath, "--template", template, input)
+
+	info, err := os.Stat(outFile)
+	require.NoError(t, err)
+	require.Equal(t, past.Truncate(time.Second), info.ModTime().Truncate(time.Second))
 }
 
 func TestProtoFileRefIncludePackageFiles(t *testing.T) {

--- a/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer.go
+++ b/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer.go
@@ -15,6 +15,7 @@
 package bufprotopluginos
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storagearchive"
 	"github.com/bufbuild/buf/private/pkg/storage/storagemem"
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
+	"github.com/bufbuild/buf/private/pkg/thread"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -284,12 +286,43 @@ func (w *responseWriter) writeDirectory(
 		if err != nil {
 			return err
 		}
-		if _, err := storage.Copy(ctx, readWriteBucket, osReadWriteBucket); err != nil {
-			return err
-		}
-		return nil
+		return w.copySkipUnchanged(ctx, readWriteBucket, osReadWriteBucket)
 	})
 	return nil
+}
+
+// copySkipUnchanged copies all paths from the source bucket to the destination,
+// skipping any path whose content already matches what is on disk. This preserves
+// mtimes for unchanged generated files so that mtime-based build systems do not
+// rebuild unnecessarily.
+func (w *responseWriter) copySkipUnchanged(
+	ctx context.Context,
+	from storage.ReadBucket,
+	to storage.ReadWriteBucket,
+) error {
+	paths, err := storage.AllPaths(ctx, from, "")
+	if err != nil {
+		return err
+	}
+	jobs := make([]func(context.Context) error, len(paths))
+	for i, path := range paths {
+		jobs[i] = func(ctx context.Context) error {
+			newData, err := storage.ReadPath(ctx, from, path)
+			if err != nil {
+				return err
+			}
+			existingData, err := storage.ReadPath(ctx, to, path)
+			if err == nil && bytes.Equal(existingData, newData) {
+				w.logger.DebugContext(ctx, "skipping unchanged generated file", slog.String("path", path))
+				return nil
+			}
+			// Not-exist, read error, or content differs: fall through to write.
+			// We intentionally swallow read errors here; this comparison is an
+			// optimization and must not cause generate to fail.
+			return storage.PutPath(ctx, to, path, newData)
+		}
+	}
+	return thread.Parallelize(ctx, jobs)
 }
 
 type responseWriterOptions struct {

--- a/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer_test.go
+++ b/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer_test.go
@@ -1,0 +1,131 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufprotopluginos
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bufbuild/buf/private/pkg/slogtestext"
+	"github.com/bufbuild/buf/private/pkg/storage/storageos"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+func TestResponseWriterSkipsUnchangedFile(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	content := "package foo\n"
+	filePath := filepath.Join(outDir, "foo.go")
+	require.NoError(t, os.WriteFile(filePath, []byte(content), 0600))
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(filePath, past, past))
+
+	runResponseWriter(t, outDir, newResponseFile("foo.go", content))
+
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	require.Equal(t, past.Truncate(time.Second), info.ModTime().Truncate(time.Second))
+}
+
+func TestResponseWriterWritesChangedFile(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	filePath := filepath.Join(outDir, "foo.go")
+	require.NoError(t, os.WriteFile(filePath, []byte("package old\n"), 0600))
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(filePath, past, past))
+
+	newContent := "package new\n"
+	runResponseWriter(t, outDir, newResponseFile("foo.go", newContent))
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, newContent, string(data))
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	require.Greater(t, info.ModTime(), past)
+}
+
+func TestResponseWriterWritesNewFile(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	content := "package foo\n"
+
+	runResponseWriter(t, outDir, newResponseFile("foo.go", content))
+
+	data, err := os.ReadFile(filepath.Join(outDir, "foo.go"))
+	require.NoError(t, err)
+	require.Equal(t, content, string(data))
+}
+
+func TestResponseWriterMixedFiles(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	unchangedContent := "package unchanged\n"
+	unchangedPath := filepath.Join(outDir, "unchanged.go")
+	changedPath := filepath.Join(outDir, "changed.go")
+	newPath := filepath.Join(outDir, "new.go")
+	require.NoError(t, os.WriteFile(unchangedPath, []byte(unchangedContent), 0600))
+	require.NoError(t, os.WriteFile(changedPath, []byte("package old\n"), 0600))
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(unchangedPath, past, past))
+	require.NoError(t, os.Chtimes(changedPath, past, past))
+
+	runResponseWriter(t, outDir,
+		newResponseFile("unchanged.go", unchangedContent),
+		newResponseFile("changed.go", "package changed\n"),
+		newResponseFile("new.go", "package new\n"),
+	)
+
+	unchangedInfo, err := os.Stat(unchangedPath)
+	require.NoError(t, err)
+	require.Equal(t, past.Truncate(time.Second), unchangedInfo.ModTime().Truncate(time.Second))
+
+	changedData, err := os.ReadFile(changedPath)
+	require.NoError(t, err)
+	require.Equal(t, "package changed\n", string(changedData))
+	changedInfo, err := os.Stat(changedPath)
+	require.NoError(t, err)
+	require.Greater(t, changedInfo.ModTime(), past)
+
+	newData, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+	require.Equal(t, "package new\n", string(newData))
+}
+
+func runResponseWriter(t *testing.T, outDir string, files ...*pluginpb.CodeGeneratorResponse_File) {
+	t.Helper()
+	writer := NewResponseWriter(
+		slogtestext.NewLogger(t),
+		storageos.NewProvider(),
+		ResponseWriterWithCreateOutDirIfNotExists(),
+	)
+	require.NoError(t, writer.AddResponse(
+		t.Context(),
+		&pluginpb.CodeGeneratorResponse{File: files},
+		outDir,
+	))
+	require.NoError(t, writer.Close())
+}
+
+func newResponseFile(name, content string) *pluginpb.CodeGeneratorResponse_File {
+	return &pluginpb.CodeGeneratorResponse_File{
+		Name:    &name,
+		Content: &content,
+	}
+}


### PR DESCRIPTION
Contributes towards #3126.

## Summary

`buf generate` previously wrote output files unconditionally, touching mtimes even when content was identical to what was already on disk. For mtime-based build systems (cargo, make, ninja, file-watching dev servers), a no-op `buf generate` would cascade into unnecessary downstream rebuilds.

The protoc plugin protocol gives plugins no visibility into the output directory—they emit `File{name, content}` on stdout and the invoking tool handles filesystem writes—so this fix lives in buf's write path rather than in individual plugins.

## Approach

Replaces the unconditional `storage.Copy` in the directory output path (`bufprotopluginos.writeDirectory`) with a compare-then-write loop. For each generated file:

- Read existing content from the OS bucket
- If it matches the new content, skip the write (mtime preserved)
- Otherwise write as before

Read errors during comparison (file doesn't exist, permissions, etc.) fall through to write, so worst-case behavior is identical to before.

## Scope

- **Directory output only.** zip/jar output continues to write unconditionally—comparing archive content would require unzip-compare-rezip, which isn't motivated by the use cases in #3126 and can be a follow-up if needed.
- **Default-on, no flag.** Per the discussion in #3126, this is backwards-compatible: it's never wrong to skip writing identical content, and the cost is one extra read per existing file (zero cost on first run).
- **`--clean` interaction is already correct.** Clean deletes first, so comparison finds nothing and writes everything.

## Testing

- 4 unit tests in `response_writer_test.go` covering unchanged/changed/new/mixed file scenarios
- 1 integration test in `generate_test.go` that runs `buf generate` twice and verifies the output mtime is preserved