### PR TITLE
Add a prompt to `buf beta registry plugin delete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add relevant links from CEL LSP hover documentation to either <celbyexample.com> or <protovalidate.com>
 - Add OpenBSD and FreeBSD release binaries for amd64 and arm64.
 - Skip writing unchanged output files in `buf generate` to preserve modification times
+- Update `buf beta registry plugin delete` to prompt the user for deletion, matching the UX of the other deletion commands.
+  Use `--force` to restore the old behavior.
 
 ## [v1.66.1] - 2026-03-09
 

--- a/cmd/buf/internal/command/beta/registry/plugin/plugindelete/plugindelete.go
+++ b/cmd/buf/internal/command/beta/registry/plugin/plugindelete/plugindelete.go
@@ -49,13 +49,24 @@ func NewCommand(
 	}
 }
 
-type flags struct{}
+const forceFlagName = "force"
+
+type flags struct {
+	Force bool
+}
 
 func newFlags() *flags {
 	return &flags{}
 }
 
-func (f *flags) Bind(flagSet *pflag.FlagSet) {}
+func (f *flags) Bind(flagSet *pflag.FlagSet) {
+	flagSet.BoolVar(
+		&f.Force,
+		forceFlagName,
+		false,
+		"Force deletion without confirming. Use with caution",
+	)
+}
 
 func run(
 	ctx context.Context,
@@ -71,6 +82,11 @@ func run(
 	if version != "" {
 		if err := bufremotepluginref.ValidatePluginVersion(version); err != nil {
 			return appcmd.WrapInvalidArgumentError(err)
+		}
+	}
+	if !flags.Force {
+		if err := bufcli.PromptUserForDelete(container, "plugin", pluginIdentity.Plugin()); err != nil {
+			return err
 		}
 	}
 	clientConfig, err := bufcli.NewConnectClientConfig(container)
@@ -97,5 +113,6 @@ func run(
 		}
 		return err
 	}
-	return nil
+	_, err = fmt.Fprintf(container.Stdout(), "Deleted %s.\n", container.Arg(0))
+	return err
 }


### PR DESCRIPTION
To match the UX of the other `delete` commands. Adds the `--force` flag to restore the old behavior.