### PR TITLE
Skip adding links in LSP diagnostics for check plugins / policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix LSP not skipping `buf.build/docs` links for lint rules from check plugins and policies.
 - Fix `buf dep graph --format json` silently dropping dependencies when a dependency was already seen.
 - Add support for `--rbs_out` as a `protoc_builtin` plugin (requires protoc v34.0+).
 - Add relevant links from CEL LSP hover documentation to either <celbyexample.com> or <protovalidate.com>

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -1147,14 +1147,18 @@ func (f *file) appendAnnotations(source string, annotations []bufanalysis.FileAn
 		endLocation := f.file.InverseLocation(annotation.EndLine(), annotation.EndColumn(), positionalEncoding)
 		protocolRange := reportLocationsToProtocolRange(startLocation, endLocation)
 		diagnostic := protocol.Diagnostic{
-			Range: protocolRange,
-			Code:  annotation.Type(),
-			CodeDescription: &protocol.CodeDescription{
-				Href: protocol.URI("https://buf.build/docs/lint/rules/#" + strings.ToLower(annotation.Type())),
-			},
+			Range:    protocolRange,
+			Code:     annotation.Type(),
 			Severity: protocol.DiagnosticSeverityWarning,
 			Source:   source,
 			Message:  annotation.Message(),
+		}
+		// Only link to buf.build/docs for built-in rules. Plugin and policy
+		// rules have their own documentation, so we skip the link entirely.
+		if annotation.PluginName() == "" && annotation.PolicyName() == "" {
+			diagnostic.CodeDescription = &protocol.CodeDescription{
+				Href: protocol.URI("https://buf.build/docs/lint/rules/#" + strings.ToLower(annotation.Type())),
+			}
 		}
 		if annotation.Type() == "IMPORT_USED" {
 			diagnostic.Tags = []protocol.DiagnosticTag{


### PR DESCRIPTION
These docs only make sense for our built-in lint rules.

I didn't add tests for these because we already have tests for our built-in lint rules, and I didn't feel that we needed to wire up a check plugin / policy to our LSP tests.

Towards #4422.