### PR TITLE
feat(bufformat): add comment spacing normalization

### DIFF
--- a/private/buf/bufformat/formatter.go
+++ b/private/buf/bufformat/formatter.go
@@ -2408,8 +2408,30 @@ func (f *formatter) writeComment(comment string) {
 		}
 	} else {
 		f.Indent(nil)
+		// Normalize comment spacing: ensure single-line comments have a space after //
+		if strings.HasPrefix(comment, "//") {
+			comment = normalizeCommentSpacing(comment)
+		}
 		f.WriteString(strings.TrimSpace(comment))
 	}
+}
+
+// normalizeCommentSpacing ensures that single-line comments have a space
+// after the // delimiter. Comments like //TODO: or //no-space are transformed
+// to // TODO: and // no-space respectively.
+func normalizeCommentSpacing(comment string) string {
+	lines := strings.Split(comment, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "//") {
+			after := strings.TrimPrefix(line, "//")
+			// If the content after // is non-empty and doesn't start with a space,
+			// add a single space.
+			if len(after) > 0 && after[0] != ' ' && after[0] != '\t' {
+				lines[i] = "// " + after
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func isCommentPrefix(ch byte) bool {

--- a/private/buf/bufformat/formatter_test.go
+++ b/private/buf/bufformat/formatter_test.go
@@ -61,6 +61,7 @@ func testFormatProto2(t *testing.T) {
 func testFormatProto3(t *testing.T) {
 	testFormatNoDiff(t, "testdata/proto3/all/v1")
 	testFormatNoDiff(t, "testdata/proto3/block/v1")
+	testFormatNoDiff(t, "testdata/proto3/comment_spacing")
 	testFormatNoDiff(t, "testdata/proto3/file/v1")
 	testFormatNoDiff(t, "testdata/proto3/header/v1")
 	testFormatNoDiff(t, "testdata/proto3/literal/v1")

--- a/private/buf/bufformat/testdata/proto3/comment_spacing/comment_spacing.golden
+++ b/private/buf/bufformat/testdata/proto3/comment_spacing/comment_spacing.golden
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package test.v1;
+
+// no space (should become "// no space")
+// one space (already correct)
+//  multiple spaces (should remain as-is per issue expectation)
+// TODO: should become "// TODO:"
+// FIXME: another common marker
+//     indented content (should remain as-is)
+
+message TestMessage {
+  // field comment without space
+  // field comment with one space
+  string name = 1;
+}

--- a/private/buf/bufformat/testdata/proto3/comment_spacing/comment_spacing.proto
+++ b/private/buf/bufformat/testdata/proto3/comment_spacing/comment_spacing.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package test.v1;
+
+//no space (should become "// no space")
+// one space (already correct)
+//  multiple spaces (should remain as-is per issue expectation)
+//TODO: should become "// TODO:"
+//FIXME: another common marker
+//     indented content (should remain as-is)
+
+message TestMessage {
+  //field comment without space
+  // field comment with one space
+  string name = 1;
+}


### PR DESCRIPTION
## Summary

This PR implements comment spacing normalization for `buf format` as requested in issue #4198.

## Changes

- Added `normalizeCommentSpacing` function in `formatter.go` that ensures single-line comments have a space after the `//` delimiter
- Added test case in `formatter_test.go` to verify the behavior
- Added test data files for the comment_spacing scenario

## Behavior

Comments without proper spacing are transformed:
- `//no space` → `// no space`
- `//TODO:` → `// TODO:`
- `//FIXME:` → `// FIXME:`

Comments with existing proper spacing (like `// one space` or `//  multiple spaces`) remain unchanged.

## Testing

Added test case `testFormatNoDiff(t, "testdata/proto3/comment_spacing")` which verifies:
1. Input file with various comment spacing scenarios
2. Output file with normalized spacing

## Related Issue

Closes #4198

---

*This implementation was created to address the feature request for consistent comment formatting in protobuf files.*