### PR TITLE
Handle files that have not completed lowering in LSP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/otelconnect v0.9.0
-	github.com/bufbuild/protocompile v0.14.2-0.20260406184405-b06501d51312
+	github.com/bufbuild/protocompile v0.14.2-0.20260409171342-5665f7ecc74e
 	github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1
 	github.com/cli/browser v1.3.0
 	github.com/gofrs/flock v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/otelconnect v0.9.0
-	github.com/bufbuild/protocompile v0.14.2-0.20260409171342-5665f7ecc74e
+	github.com/bufbuild/protocompile v0.14.2-0.20260409205102-f58612be4b0a
 	github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1
 	github.com/cli/browser v1.3.0
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
-github.com/bufbuild/protocompile v0.14.2-0.20260409171342-5665f7ecc74e h1:z//Rw7dhM8RH+QzNljv9b826m3Qj4Kau45l0idVy+ls=
-github.com/bufbuild/protocompile v0.14.2-0.20260409171342-5665f7ecc74e/go.mod h1:DhgqsRznX/F0sGkUYtTQJRP+q8xMReQRQ3qr+n1opWU=
+github.com/bufbuild/protocompile v0.14.2-0.20260409205102-f58612be4b0a h1:mtZZcNBraTXNE1e/UG7Odlw8314ucNtRgnB2muW0/cs=
+github.com/bufbuild/protocompile v0.14.2-0.20260409205102-f58612be4b0a/go.mod h1:DhgqsRznX/F0sGkUYtTQJRP+q8xMReQRQ3qr+n1opWU=
 github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1 h1:V1xulAoqLqVg44rY97xOR+mQpD2N+GzhMHVwJ030WEU=
 github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1/go.mod h1:c5D8gWRIZ2HLWO3gXYTtUfw/hbJyD8xikv2ooPxnklQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
-github.com/bufbuild/protocompile v0.14.2-0.20260406184405-b06501d51312 h1:Cp7oCRZIqSsBrsi3GJSYzTgQNz70PJv5J+6hoXGyD2k=
-github.com/bufbuild/protocompile v0.14.2-0.20260406184405-b06501d51312/go.mod h1:DhgqsRznX/F0sGkUYtTQJRP+q8xMReQRQ3qr+n1opWU=
+github.com/bufbuild/protocompile v0.14.2-0.20260409171342-5665f7ecc74e h1:z//Rw7dhM8RH+QzNljv9b826m3Qj4Kau45l0idVy+ls=
+github.com/bufbuild/protocompile v0.14.2-0.20260409171342-5665f7ecc74e/go.mod h1:DhgqsRznX/F0sGkUYtTQJRP+q8xMReQRQ3qr+n1opWU=
 github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1 h1:V1xulAoqLqVg44rY97xOR+mQpD2N+GzhMHVwJ030WEU=
 github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1/go.mod h1:c5D8gWRIZ2HLWO3gXYTtUfw/hbJyD8xikv2ooPxnklQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/private/buf/buflsp/deprecate.go
+++ b/private/buf/buflsp/deprecate.go
@@ -42,8 +42,8 @@ func (s *server) getDeprecateCodeAction(
 		slog.Uint64("line", uint64(params.Range.Start.Line)),
 		slog.Uint64("char", uint64(params.Range.Start.Character)),
 	)
-	if file.workspace == nil || file.ir == nil {
-		s.logger.DebugContext(ctx, "deprecate: no workspace or IR")
+	if file.workspace == nil || file.ir == nil || !file.ir.Lowered() {
+		s.logger.DebugContext(ctx, "deprecate: no workspace or valid IR")
 		return nil
 	}
 
@@ -62,7 +62,7 @@ func (s *server) getDeprecateCodeAction(
 	checker := newFullNameMatcher(fqnPrefix)
 	edits := make(map[protocol.DocumentURI][]protocol.TextEdit)
 	for _, wsFile := range file.workspace.PathToFile() {
-		if wsFile.ir == nil {
+		if wsFile.ir == nil || !wsFile.ir.Lowered() {
 			continue
 		}
 		fileEdits := generateDeprecationEdits(wsFile, checker)
@@ -191,7 +191,7 @@ func generateDeprecationEdits(file *file, checker *fullNameMatcher) []protocol.T
 
 // getPackageFQN extracts the package FQN components from a file.
 func getPackageFQN(file *file) ir.FullName {
-	if file.ir == nil {
+	if file.ir == nil || !file.ir.Lowered() {
 		return ""
 	}
 	return file.ir.Package()

--- a/private/buf/buflsp/diagnostic.go
+++ b/private/buf/buflsp/diagnostic.go
@@ -17,6 +17,8 @@
 package buflsp
 
 import (
+	"strings"
+
 	"github.com/bufbuild/protocompile/experimental/report"
 	"github.com/bufbuild/protocompile/experimental/report/rtags"
 	"github.com/bufbuild/protocompile/experimental/source/length"
@@ -41,10 +43,16 @@ var reportLevelToDiagnosticSeverity = map[report.Level]protocol.DiagnosticSeveri
 func reportDiagnosticToProtocolDiagnostic(
 	reportDiagnostic report.Diagnostic,
 ) protocol.Diagnostic {
+	message := reportDiagnostic.Message()
+	if reportDiagnostic.Level() == report.ICE {
+		// Include notes for ICE
+		notes := append([]string{message}, reportDiagnostic.Notes()...)
+		message = strings.Join(notes, " ")
+	}
 	diagnostic := protocol.Diagnostic{
 		Source:   serverName,
 		Severity: reportLevelToDiagnosticSeverity[reportDiagnostic.Level()],
-		Message:  reportDiagnostic.Message(),
+		Message:  message,
 	}
 	if primary := reportDiagnostic.Primary(); !primary.IsZero() {
 		startLocation := primary.Location(primary.Start, positionalEncoding)

--- a/private/buf/buflsp/diagnostics_test.go
+++ b/private/buf/buflsp/diagnostics_test.go
@@ -192,11 +192,11 @@ func TestDiagnostics(t *testing.T) {
 				{
 					Range: protocol.Range{
 						Start: protocol.Position{Line: 8, Character: 0},
-						End:   protocol.Position{Line: 8, Character: 0},
+						End:   protocol.Position{Line: 8, Character: 1},
 					},
 					Severity: protocol.DiagnosticSeverityError,
 					Source:   "buf-lsp",
-					Message:  "syntax error: expecting ';'",
+					Message:  "unexpected `}` after definition",
 				},
 			},
 		},
@@ -226,12 +226,12 @@ func TestDiagnostics(t *testing.T) {
 			expectedDiagnostics: []protocol.Diagnostic{
 				{
 					Range: protocol.Range{
-						Start: protocol.Position{Line: 5, Character: 7},
-						End:   protocol.Position{Line: 5, Character: 28},
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 30},
 					},
 					Severity: protocol.DiagnosticSeverityError,
 					Source:   "buf-lsp",
-					Message:  `does/not/exist.proto: file does not exist`,
+					Message:  "imported file does not exist",
 				},
 			},
 		},

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -57,6 +57,8 @@ type file struct {
 	// diagnostics or symbols an operating refers to.
 	version int32
 	hasText bool // Whether this file has ever had text read into it.
+	// The local path of the descriptor.proto file used for compilation. This is stored for diagnostics.
+	descriptorProtoLocalPath string
 
 	workspace  *workspace         // May be nil.
 	objectInfo storage.ObjectInfo // Info in the context of the workspace.
@@ -240,7 +242,7 @@ func (f *file) RefreshIR(ctx context.Context) {
 	for path, file := range pathToFiles {
 		current := openerMap[path]
 		// If there is no entry for the current path or if the file content has changed, we
-		// update the opener and set a new query.
+		// update the opener and evict stale [queries.File] queries.
 		if current == nil || current.Text() != file.file.Text() {
 			openerMap[path] = file.file
 			if current != nil {
@@ -250,6 +252,7 @@ func (f *file) RefreshIR(ctx context.Context) {
 		}
 		files = append(files, file)
 	}
+
 	// Remove paths that are no longer in the current workspace and evict stale query keys.
 	for path := range openerMap {
 		if _, ok := pathToFiles[path]; !ok {
@@ -276,21 +279,30 @@ func (f *file) RefreshIR(ctx context.Context) {
 		)
 		return
 	}
+
 	for i, file := range files {
 		file.ir = results[i].Value
+		if file.objectInfo.Path() == "google/protobuf/descriptor.proto" {
+			// Set local path for the descriptor.proto file used for diagnostics.
+			f.descriptorProtoLocalPath = file.objectInfo.LocalPath()
+		}
 		if f != file {
 			// Update symbols for imports.
 			file.IndexSymbols(ctx)
 		}
 	}
+
 	// Store the IR report for code actions
 	f.irReport = diagnosticReport
 
-	// Only hold on to diagnostics where the primary span is for this path.
+	// Only hold on to diagnostics where the primary span is for this file.
 	fileDiagnostics := xslices.Filter(diagnosticReport.Diagnostics, func(d report.Diagnostic) bool {
-		return d.Primary().Path() == f.objectInfo.Path()
+		// We avoid returning warnings from the compiler for now, since these may conflate with
+		// lint checks.
+		return d.Primary().Path() == f.objectInfo.LocalPath() && d.Level() < report.Warning
 	})
 	f.diagnostics = xslices.Map(fileDiagnostics, reportDiagnosticToProtocolDiagnostic)
+
 	f.lsp.logger.DebugContext(
 		ctx, "ir diagnostic(s)",
 		slog.String("uri", f.uri.Filename()),
@@ -338,8 +350,23 @@ func (f *file) queryFileKeys() []any {
 // This operation requires RefreshIR.
 func (f *file) IndexSymbols(ctx context.Context) {
 	defer xslog.DebugProfile(f.lsp.logger, slog.String("uri", string(f.uri)))()
-	// We cannot index symbols without the IR, so we keep the symbols as-is.
+
 	if f.ir == nil {
+		return
+	}
+
+	// The file has not completed lowering, so we cannot continue with symbol indexing here.
+	// To help the user better understand/diagnose this problem, we surface an additional
+	// diagnostic here.
+	if !f.ir.Lowered() {
+		f.diagnostics = append(f.diagnostics, protocol.Diagnostic{
+			Source:   serverName,
+			Severity: protocol.DiagnosticSeverityError,
+			Message: fmt.Sprintf(`the symbols for this file have not been fully resolved due to an invalid version of descriptor.proto located at: %q.
+this is likely due to a vendored descriptor.proto.`,
+				f.descriptorProtoLocalPath,
+			),
+		})
 		return
 	}
 

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -362,8 +362,8 @@ func (f *file) IndexSymbols(ctx context.Context) {
 		f.diagnostics = append(f.diagnostics, protocol.Diagnostic{
 			Source:   serverName,
 			Severity: protocol.DiagnosticSeverityError,
-			Message: fmt.Sprintf(`the symbols for this file have not been fully resolved due to an invalid version of descriptor.proto located at: %q.
-this is likely due to a vendored descriptor.proto.`,
+			Message: fmt.Sprintf(`The symbols for this file have not been fully resolved due to an invalid version of descriptor.proto located at: %q.
+This is likely due to a vendored descriptor.proto.`,
 				f.descriptorProtoLocalPath,
 			),
 		})
@@ -921,7 +921,7 @@ func (f *file) messageToSymbolsHelper(msg ir.MessageValue, index int, parents []
 		// each path component.
 		for element := range seq.Values(field.Elements()) {
 			key := field.KeyASTs().At(element.ValueNodeIndex())
-			components := slices.Collect(key.AsPath().Components)
+			components := slices.Collect(key.AsPath().Components())
 			// If there are no path components for an element, then we skip it, since there are
 			// no symbols to track.
 			if len(components) == 0 {

--- a/private/buf/buflsp/folding_range.go
+++ b/private/buf/buflsp/folding_range.go
@@ -26,7 +26,7 @@ import (
 // foldingRange generates folding ranges for a file.
 // It finds messages, services, enums, and multi-line comment blocks.
 func (s *server) foldingRange(file *file) []protocol.FoldingRange {
-	if file.ir == nil {
+	if file.ir == nil || !file.ir.Lowered() {
 		return nil
 	}
 


### PR DESCRIPTION
This implements more graceful behaviour in the LSP for when
a file is unable to go through the full lowering process, and therefore
cannot/does not have fully resolved symbols for LSP functionality, and
attempts to return the most helpful possible diagnostic to the user to
communicate this.

Fixes #4434