### PR TITLE
Add document link support to buf.yaml deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add LSP document links for `buf.yaml` dep entries, making each dependency a clickable link to its BSR module page.
 - Add LSP code lenses for `buf.yaml` files to update all dependencies (`buf.dep.updateAll`) or check for available updates (`buf.dep.checkUpdates`).
 - Improve shell completions for `buf` flags with fixed value sets and file/directory arguments.
 - Add `buf curl` URL path shell completions (service and method names) via

--- a/private/buf/buflsp/buf_yaml.go
+++ b/private/buf/buflsp/buf_yaml.go
@@ -322,23 +322,20 @@ func (m *bufYAMLManager) GetDocumentLinks(uri protocol.URI) []protocol.DocumentL
 	if !ok {
 		return nil
 	}
-	var links []protocol.DocumentLink
+	links := make([]protocol.DocumentLink, 0, len(f.deps))
 	for _, dep := range f.deps {
 		ref, err := bufparse.ParseRef(dep.ref)
 		if err != nil {
 			continue
 		}
 		fullName := ref.FullName()
-		base := "https://" + fullName.Registry() + "/" + fullName.Owner() + "/" + fullName.Name()
-		var target string
+		url := "https://" + fullName.Registry() + "/" + fullName.Owner() + "/" + fullName.Name()
 		if ref.Ref() != "" {
-			target = base + "/docs/" + ref.Ref()
-		} else {
-			target = base
+			url += "/docs/" + ref.Ref()
 		}
 		links = append(links, protocol.DocumentLink{
 			Range:  dep.depRange,
-			Target: protocol.DocumentURI(target),
+			Target: protocol.DocumentURI(url),
 		})
 	}
 	return links

--- a/private/buf/buflsp/buf_yaml.go
+++ b/private/buf/buflsp/buf_yaml.go
@@ -311,6 +311,39 @@ func moduleKeysWithTransitiveDeps(
 	return all, nil
 }
 
+// GetDocumentLinks returns document links for all dep entries in the buf.yaml
+// file. If the dep has an explicit ref (e.g. "buf.build/acme/mod:v1.2.3"),
+// the link points to that specific label or commit on BSR. Otherwise it
+// points to the module root.
+func (m *bufYAMLManager) GetDocumentLinks(uri protocol.URI) []protocol.DocumentLink {
+	m.mu.Lock()
+	f, ok := m.uriToFile[normalizeURI(uri)]
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	var links []protocol.DocumentLink
+	for _, dep := range f.deps {
+		ref, err := bufparse.ParseRef(dep.ref)
+		if err != nil {
+			continue
+		}
+		fullName := ref.FullName()
+		base := "https://" + fullName.Registry() + "/" + fullName.Owner() + "/" + fullName.Name()
+		var target string
+		if ref.Ref() != "" {
+			target = base + "/docs/" + ref.Ref()
+		} else {
+			target = base
+		}
+		links = append(links, protocol.DocumentLink{
+			Range:  dep.depRange,
+			Target: protocol.DocumentURI(target),
+		})
+	}
+	return links
+}
+
 // parseBufYAMLDeps parses the top-level deps sequence from buf.yaml content.
 // It returns the 0-indexed line of the "deps:" key, the dep entries with their
 // source positions, and any parse error.

--- a/private/buf/buflsp/buf_yaml_lsp_test.go
+++ b/private/buf/buflsp/buf_yaml_lsp_test.go
@@ -440,6 +440,91 @@ func TestBufYAMLCheckUpdates_FileChange(t *testing.T) {
 	})
 }
 
+// TestBufYAMLDocumentLinks verifies that document links are returned for buf.yaml dep
+// entries. Links resolve to /docs/<ref> when the dep has an explicit ref, and to
+// the module root otherwise.
+func TestBufYAMLDocumentLinks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fixture   string
+		wantLinks []protocol.DocumentLink
+	}{
+		{
+			name:    "no_deps",
+			fixture: "testdata/buf_yaml/no_deps/buf.yaml",
+			// No deps, so no links.
+		},
+		{
+			name:    "invalid",
+			fixture: "testdata/buf_yaml/invalid/buf.yaml",
+			// Malformed YAML must not crash; returns no links.
+		},
+		{
+			// Deps without an explicit ref link to the module root.
+			name:    "with_deps",
+			fixture: "testdata/buf_yaml/with_deps/buf.yaml",
+			wantLinks: []protocol.DocumentLink{
+				{
+					// buf.build/bufbuild/protovalidate on line 2, cols 4–36.
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 4},
+						End:   protocol.Position{Line: 2, Character: 36},
+					},
+					Target: "https://buf.build/bufbuild/protovalidate",
+				},
+				{
+					// buf.build/googleapis/googleapis on line 3, cols 4–35.
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 4},
+						End:   protocol.Position{Line: 3, Character: 35},
+					},
+					Target: "https://buf.build/googleapis/googleapis",
+				},
+			},
+		},
+		{
+			// A dep with an explicit label ref links to /docs/<ref>.
+			name:    "deps_with_ref",
+			fixture: "testdata/buf_yaml/deps_with_ref/buf.yaml",
+			wantLinks: []protocol.DocumentLink{
+				{
+					// buf.build/bufbuild/protovalidate:v1.1.1 on line 2, cols 4–43.
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 4},
+						End:   protocol.Position{Line: 2, Character: 43},
+					},
+					Target: "https://buf.build/bufbuild/protovalidate/docs/v1.1.1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			absPath, err := filepath.Abs(tc.fixture)
+			require.NoError(t, err)
+
+			clientJSONConn, bufYAMLURI, _ := setupLSPServerForBufYAML(t, absPath, nil)
+			ctx := t.Context()
+
+			var links []protocol.DocumentLink
+			_, err = clientJSONConn.Call(ctx, protocol.MethodTextDocumentDocumentLink, &protocol.DocumentLinkParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: bufYAMLURI},
+			}, &links)
+			require.NoError(t, err)
+			require.Len(t, links, len(tc.wantLinks))
+			for i, want := range tc.wantLinks {
+				assert.Equal(t, want.Range, links[i].Range, "link %d range", i)
+				assert.Equal(t, want.Target, links[i].Target, "link %d target", i)
+			}
+		})
+	}
+}
+
 // mustParseUUID parses a UUID string for use in test data, failing the test on error.
 func mustParseUUID(t *testing.T, s string) uuid.UUID {
 	t.Helper()

--- a/private/buf/buflsp/buf_yaml_lsp_test.go
+++ b/private/buf/buflsp/buf_yaml_lsp_test.go
@@ -467,7 +467,6 @@ func TestBufYAMLDocumentLinks(t *testing.T) {
 			fixture: "testdata/buf_yaml/with_deps/buf.yaml",
 			wantLinks: []protocol.DocumentLink{
 				{
-					// buf.build/bufbuild/protovalidate on line 2, cols 4–36.
 					Range: protocol.Range{
 						Start: protocol.Position{Line: 2, Character: 4},
 						End:   protocol.Position{Line: 2, Character: 36},
@@ -475,7 +474,6 @@ func TestBufYAMLDocumentLinks(t *testing.T) {
 					Target: "https://buf.build/bufbuild/protovalidate",
 				},
 				{
-					// buf.build/googleapis/googleapis on line 3, cols 4–35.
 					Range: protocol.Range{
 						Start: protocol.Position{Line: 3, Character: 4},
 						End:   protocol.Position{Line: 3, Character: 35},
@@ -490,7 +488,6 @@ func TestBufYAMLDocumentLinks(t *testing.T) {
 			fixture: "testdata/buf_yaml/deps_with_ref/buf.yaml",
 			wantLinks: []protocol.DocumentLink{
 				{
-					// buf.build/bufbuild/protovalidate:v1.1.1 on line 2, cols 4–43.
 					Range: protocol.Range{
 						Start: protocol.Position{Line: 2, Character: 4},
 						End:   protocol.Position{Line: 2, Character: 43},

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -681,6 +681,9 @@ func (s *server) DocumentLink(
 	ctx context.Context,
 	params *protocol.DocumentLinkParams,
 ) ([]protocol.DocumentLink, error) {
+	if isBufYAMLURI(params.TextDocument.URI) {
+		return s.bufYAMLManager.GetDocumentLinks(params.TextDocument.URI), nil
+	}
 	file := s.fileManager.Get(params.TextDocument.URI)
 	if file == nil {
 		return nil, nil

--- a/private/buf/buflsp/testdata/buf_yaml/deps_with_ref/buf.yaml
+++ b/private/buf/buflsp/testdata/buf_yaml/deps_with_ref/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+deps:
+  - buf.build/bufbuild/protovalidate:v1.1.1


### PR DESCRIPTION
Simple follow-up to #4438, which adds LSP document link support to the `deps:` field in buf.yaml. If the value is pinned `:<label|commit>`, it'll link directly to `/docs/<label|commit>`. Otherwise, it'll link to just the module directly (even if the `buf.lock` is on a previous version).