### PR TITLE
Use absolute link for buf logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![The Buf logo](./.github/buf-logo.svg)
+![The Buf logo](https://raw.githubusercontent.com/bufbuild/buf/main/.github/buf-logo.svg)
 
 # Buf
 


### PR DESCRIPTION
So that it renders correctly in places where we embed the README (buf.build, npm (seems to already render correctly...), pypi). Matches our other repositories (see referenced protovalidate PR).

Ref: bufbuild/protovalidate#208
Ref: https://buf.build/bufbuild/buf
Ref: https://www.npmjs.com/package/@bufbuild/buf
Ref: https://pypi.org/project/buf-bin/