### PR TITLE
Fix buf generate clean deleting files from nested plugin output directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `buf curl` URL path shell completions (service and method names) via
   server reflection, `--schema`, or the local buf module.
 - Add support for Edition 2024 syntax to `buf format`.
+- Fix `buf generate --clean` deleting files from nested plugin output directories.
 
 ## [v1.67.0] - 2026-04-01
 

--- a/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer.go
+++ b/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer.go
@@ -172,7 +172,8 @@ func (w *responseWriter) Close(ctx context.Context) error {
 	}
 	// Delete stale files and remove empty directories.
 	for outDirPath, retainPaths := range dirOutputPaths {
-		if err := w.deleteStaleFilesAndEmptyDirs(ctx, outDirPath, retainPaths); err != nil {
+		nestedOutDirs := nestedOutputDirs(outDirPath, dirOutputPaths)
+		if err := w.deleteStaleFilesAndEmptyDirs(ctx, outDirPath, retainPaths, nestedOutDirs); err != nil {
 			return err
 		}
 	}
@@ -385,10 +386,13 @@ func (w *responseWriter) copySkipUnchanged(
 
 // deleteStaleFilesAndEmptyDirs deletes files present in outDirPath that are
 // not in retainPaths, then removes any directories that are now empty.
+// Files under nestedOutDirs are skipped because they are managed by a
+// nested output directory's own clean pass.
 func (w *responseWriter) deleteStaleFilesAndEmptyDirs(
 	ctx context.Context,
 	outDirPath string,
 	retainPaths map[string]struct{},
+	nestedOutDirs map[string]struct{},
 ) error {
 	osReadWriteBucket, err := w.storageosProvider.NewReadWriteBucket(
 		outDirPath,
@@ -407,20 +411,45 @@ func (w *responseWriter) deleteStaleFilesAndEmptyDirs(
 	}
 	var deleteJobs []func(context.Context) error
 	for _, existingPath := range existingPaths {
-		if _, ok := retainPaths[existingPath]; !ok {
-			deleteJobs = append(deleteJobs, func(ctx context.Context) error {
-				w.logger.DebugContext(ctx, "deleting stale generated file", slog.String("path", existingPath))
-				if err := osReadWriteBucket.Delete(ctx, existingPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-					return err
-				}
-				return nil
-			})
+		if _, ok := retainPaths[existingPath]; ok {
+			continue
 		}
+		if normalpath.MapHasEqualOrContainingPath(nestedOutDirs, existingPath, normalpath.Relative) {
+			continue
+		}
+		deleteJobs = append(deleteJobs, func(ctx context.Context) error {
+			w.logger.DebugContext(ctx, "deleting stale generated file", slog.String("path", existingPath))
+			if err := osReadWriteBucket.Delete(ctx, existingPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return err
+			}
+			return nil
+		})
 	}
 	if err := thread.Parallelize(ctx, deleteJobs); err != nil {
 		return err
 	}
 	return removeEmptyDirs(outDirPath)
+}
+
+// nestedOutputDirs returns the set of relative directory paths for output
+// directories in dirOutputPaths that are nested under parentDir. Both
+// parentDir and the map keys are OS-native absolute paths; the returned
+// paths are normalized (forward slashes) for use with storage bucket paths.
+func nestedOutputDirs(parentDir string, dirOutputPaths map[string]map[string]struct{}) map[string]struct{} {
+	normalizedParent := normalpath.Normalize(parentDir)
+	nestedDirs := make(map[string]struct{})
+	for outDir := range dirOutputPaths {
+		normalizedOutDir := normalpath.Normalize(outDir)
+		if !normalpath.ContainsPath(normalizedParent, normalizedOutDir, normalpath.Absolute) {
+			continue
+		}
+		rel, err := normalpath.Rel(normalizedParent, normalizedOutDir)
+		if err != nil {
+			continue
+		}
+		nestedDirs[rel] = struct{}{}
+	}
+	return nestedDirs
 }
 
 // removeEmptyDirs recursively removes all empty directories under rootDir.

--- a/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer_test.go
+++ b/private/bufpkg/bufprotoplugin/bufprotopluginos/response_writer_test.go
@@ -307,6 +307,99 @@ func TestResponseWriterSmartCleanMultiplePluginsSameOutDir(t *testing.T) {
 	require.Equal(t, "package bar\n", string(barData))
 }
 
+func TestResponseWriterSmartCleanNestedPluginOutDirs(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	// Simulate two plugins: one outputs to outDir, the other to outDir/schema.
+	// The nested plugin's files should not be deleted by the parent's clean pass.
+	writer := NewResponseWriter(
+		slogtestext.NewLogger(t),
+		storageos.NewProvider(),
+		ResponseWriterWithCreateOutDirIfNotExists(),
+		ResponseWriterWithDeleteOuts(),
+	)
+	// Plugin 1 writes to the root outDir.
+	require.NoError(t, writer.AddResponse(
+		t.Context(),
+		&pluginpb.CodeGeneratorResponse{File: []*pluginpb.CodeGeneratorResponse_File{
+			newResponseFile("test_pb.d.ts", "export declare const Test: any;\n"),
+			newResponseFile("test_pb.js", "export const Test = {};\n"),
+		}},
+		outDir,
+	))
+	// Plugin 2 writes to outDir/schema (nested).
+	require.NoError(t, writer.AddResponse(
+		t.Context(),
+		&pluginpb.CodeGeneratorResponse{File: []*pluginpb.CodeGeneratorResponse_File{
+			newResponseFile("test.schema.json", `{"type":"object"}`+"\n"),
+		}},
+		filepath.Join(outDir, "schema"),
+	))
+	require.NoError(t, writer.Close(t.Context()))
+
+	// All files from both plugins must be present.
+	data, err := os.ReadFile(filepath.Join(outDir, "test_pb.d.ts"))
+	require.NoError(t, err)
+	require.Equal(t, "export declare const Test: any;\n", string(data))
+	data, err = os.ReadFile(filepath.Join(outDir, "test_pb.js"))
+	require.NoError(t, err)
+	require.Equal(t, "export const Test = {};\n", string(data))
+	data, err = os.ReadFile(filepath.Join(outDir, "schema", "test.schema.json"))
+	require.NoError(t, err)
+	require.Equal(t, `{"type":"object"}`+"\n", string(data))
+}
+
+func TestResponseWriterSmartCleanNestedPluginOutDirsStaleInParent(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	// Pre-populate the parent directory with a stale file that should still be cleaned.
+	stalePath := filepath.Join(outDir, "stale.go")
+	require.NoError(t, os.WriteFile(stalePath, []byte("package stale\n"), 0600))
+	// Pre-populate the nested dir with a stale file that should be cleaned by the nested pass.
+	require.NoError(t, os.MkdirAll(filepath.Join(outDir, "schema"), 0755))
+	nestedStalePath := filepath.Join(outDir, "schema", "old.json")
+	require.NoError(t, os.WriteFile(nestedStalePath, []byte("old\n"), 0600))
+
+	writer := NewResponseWriter(
+		slogtestext.NewLogger(t),
+		storageos.NewProvider(),
+		ResponseWriterWithCreateOutDirIfNotExists(),
+		ResponseWriterWithDeleteOuts(),
+	)
+	// Nested plugin first (order should not matter).
+	require.NoError(t, writer.AddResponse(
+		t.Context(),
+		&pluginpb.CodeGeneratorResponse{File: []*pluginpb.CodeGeneratorResponse_File{
+			newResponseFile("test.schema.json", `{"type":"object"}`+"\n"),
+		}},
+		filepath.Join(outDir, "schema"),
+	))
+	// Parent plugin second.
+	require.NoError(t, writer.AddResponse(
+		t.Context(),
+		&pluginpb.CodeGeneratorResponse{File: []*pluginpb.CodeGeneratorResponse_File{
+			newResponseFile("test_pb.js", "export const Test = {};\n"),
+		}},
+		outDir,
+	))
+	require.NoError(t, writer.Close(t.Context()))
+
+	// Nested plugin output preserved.
+	data, err := os.ReadFile(filepath.Join(outDir, "schema", "test.schema.json"))
+	require.NoError(t, err)
+	require.Equal(t, `{"type":"object"}`+"\n", string(data))
+	// Parent plugin output preserved.
+	data, err = os.ReadFile(filepath.Join(outDir, "test_pb.js"))
+	require.NoError(t, err)
+	require.Equal(t, "export const Test = {};\n", string(data))
+	// Stale file in parent deleted.
+	_, err = os.Stat(stalePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	// Stale file in nested dir deleted by the nested pass.
+	_, err = os.Stat(nestedStalePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func runResponseWriter(t *testing.T, outPath string, deleteOuts bool, files ...*pluginpb.CodeGeneratorResponse_File) {
 	t.Helper()
 	opts := []ResponseWriterOption{


### PR DESCRIPTION
FIx `buf generate --clean` when plugins have nested output directories. The smart clean pass for the parent directory walks into subdirectories and deletes files belonging to the nested plugin's output, treating them as stale. The stale file deletion phase now skips files under directories managed by other plugin outputs, using `normalpath.ContainsPath` and `normalpath.MapHasEqualOrContainingPath`.

Fixes https://github.com/bufbuild/buf/issues/4440