### PR TITLE
Fix Windows test flake

### DIFF
--- a/private/buf/buffetch/internal/reader.go
+++ b/private/buf/buffetch/internal/reader.go
@@ -244,11 +244,14 @@ func (r *reader) getArchiveBucket(
 	targetPaths []string,
 	targetExcludePaths []string,
 	terminateFunc buftarget.TerminateFunc,
-) (ReadBucketCloser, buftarget.BucketTargeting, error) {
+) (_ ReadBucketCloser, _ buftarget.BucketTargeting, retErr error) {
 	readCloser, size, err := r.getFileReadCloserAndSize(ctx, container, archiveRef, false)
 	if err != nil {
 		return nil, nil, err
 	}
+	defer func() {
+		retErr = errors.Join(retErr, readCloser.Close())
+	}()
 	readWriteBucket := storagemem.NewReadWriteBucket()
 	switch archiveType := archiveRef.ArchiveType(); archiveType {
 	case ArchiveTypeTar:


### PR DESCRIPTION
Ref: https://github.com/bufbuild/buf/actions/runs/24255142265/attempts/1

`getArchiveBucket` opens a local archive file via `getFileReadCloserAndSize` but never closes the returned `io.ReadCloser` after extracting the contents into the in-memory bucket.

This fixes the issue by `defer` closing the readCloser right after opening it, so the handle is released as soon as extraction finishes regardless of codepath.