### PR TITLE
Switch from x/crypto to stdlib sha3 hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	go.lsp.dev/protocol v0.12.0
 	go.lsp.dev/uri v0.3.0
 	go.uber.org/zap v1.27.1
-	golang.org/x/crypto v0.50.0
 	golang.org/x/mod v0.35.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.42.0
@@ -97,6 +96,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/private/pkg/shake256/shake256.go
+++ b/private/pkg/shake256/shake256.go
@@ -16,11 +16,10 @@
 package shake256
 
 import (
+	"crypto/sha3"
 	"fmt"
 	"io"
 	"slices"
-
-	"golang.org/x/crypto/sha3"
 )
 
 const shake256Length = 64
@@ -39,9 +38,7 @@ func NewDigest(value []byte) (Digest, error) {
 
 // NewDigestForContent returns a new Digest for the content read from the Reader.
 func NewDigestForContent(reader io.Reader) (Digest, error) {
-	shakeHash := sha3.NewShake256()
-	// TODO FUTURE: remove in the future, this should have no effect
-	shakeHash.Reset()
+	shakeHash := sha3.NewSHAKE256()
 	if _, err := io.Copy(shakeHash, reader); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Starting in Go 1.24, sha3 is now part of the stdlib. Switch to it instead of consuming via x/crypto.