### PR TITLE
Revert the use of the new report format and properly ungate Editions 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Revert the use of the new compiler report format and properly ungate Editions 2024 features.
 
 ## [v1.68.0] - 2026-04-14
 

--- a/cmd/buf/internal/command/breaking/breaking.go
+++ b/cmd/buf/internal/command/breaking/breaking.go
@@ -181,7 +181,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 		bufctl.WithFileAnnotationsToStdout(),
 	)
 	if err != nil {
@@ -369,7 +368,7 @@ func run(
 		}
 	}
 	if len(allFileAnnotations) > 0 {
-		allFileAnnotationSet := bufanalysis.NewFileAnnotationSet(nil, allFileAnnotations...)
+		allFileAnnotationSet := bufanalysis.NewFileAnnotationSet(allFileAnnotations...)
 		if err := bufanalysis.PrintFileAnnotationSet(
 			container.Stdout(),
 			allFileAnnotationSet,

--- a/cmd/buf/internal/command/build/build.go
+++ b/cmd/buf/internal/command/build/build.go
@@ -152,7 +152,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return err

--- a/cmd/buf/internal/command/convert/convert.go
+++ b/cmd/buf/internal/command/convert/convert.go
@@ -174,7 +174,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return err

--- a/cmd/buf/internal/command/dep/depgraph/depgraph.go
+++ b/cmd/buf/internal/command/dep/depgraph/depgraph.go
@@ -155,7 +155,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return err

--- a/cmd/buf/internal/command/format/format.go
+++ b/cmd/buf/internal/command/format/format.go
@@ -296,7 +296,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return err

--- a/cmd/buf/internal/command/generate/generate.go
+++ b/cmd/buf/internal/command/generate/generate.go
@@ -534,7 +534,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return err

--- a/cmd/buf/internal/command/lint/lint.go
+++ b/cmd/buf/internal/command/lint/lint.go
@@ -120,7 +120,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(controllerErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 		bufctl.WithFileAnnotationsToStdout(),
 	)
 	if err != nil {
@@ -173,7 +172,7 @@ func run(
 		}
 	}
 	if len(allFileAnnotations) > 0 {
-		allFileAnnotationSet := bufanalysis.NewFileAnnotationSet(nil, allFileAnnotations...)
+		allFileAnnotationSet := bufanalysis.NewFileAnnotationSet(allFileAnnotations...)
 		if flags.ErrorFormat == "config-ignore-yaml" {
 			if err := bufcli.PrintFileAnnotationSetLintConfigIgnoreYAMLV1(
 				container.Stdout(),

--- a/cmd/buf/internal/command/push/push.go
+++ b/cmd/buf/internal/command/push/push.go
@@ -312,7 +312,6 @@ func getBuildableWorkspace(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/buf/internal/command/source/sourceedit/sourceeditdeprecate/sourceeditdeprecate.go
+++ b/cmd/buf/internal/command/source/sourceedit/sourceeditdeprecate/sourceeditdeprecate.go
@@ -183,7 +183,6 @@ func run(
 		container,
 		bufctl.WithDisableSymlinks(flags.DisableSymlinks),
 		bufctl.WithFileAnnotationErrorFormat(flags.ErrorFormat),
-		bufctl.WithColorizedFileAnnotationSetDiagnosticReport(container.LogFormat() == appext.LogFormatColor),
 	)
 	if err != nil {
 		return err

--- a/private/buf/bufctl/controller.go
+++ b/private/buf/bufctl/controller.go
@@ -22,7 +22,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"os"
 	"slices"
 	"sort"
 
@@ -54,7 +53,6 @@ import (
 	"github.com/bufbuild/buf/private/pkg/storage/storageos"
 	"github.com/bufbuild/buf/private/pkg/syserror"
 	"github.com/bufbuild/buf/private/pkg/wasm"
-	"golang.org/x/term"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -215,11 +213,10 @@ type controller struct {
 	policyDataProvider bufpolicy.PolicyDataProvider
 	wktStore           bufwktstore.Store
 
-	disableSymlinks                            bool
-	fileAnnotationErrorFormat                  string
-	fileAnnotationsToStdout                    bool
-	colorizedFileAnnotationSetDiagnosticReport bool
-	copyToInMemory                             bool
+	disableSymlinks           bool
+	fileAnnotationErrorFormat string
+	fileAnnotationsToStdout   bool
+	copyToInMemory            bool
 
 	storageosProvider           storageos.Provider
 	buffetchRefParser           buffetch.RefParser
@@ -1368,26 +1365,15 @@ func (c *controller) handleFileAnnotationSetRetError(retErrAddr *error) {
 		return
 	}
 	var fileAnnotationSet bufanalysis.FileAnnotationSet
-	var printDiagnosticReport bool
 	if errors.As(*retErrAddr, &fileAnnotationSet) {
 		writer := c.container.Stderr()
 		if c.fileAnnotationsToStdout {
 			writer = c.container.Stdout()
-		} else {
-			// When writing to stderr, check if the input is TTY, if so, allow printing the
-			// diagnostic report.
-			//
-			// HACK: We need to check os.Stderr rather than writer, since c.container.Stderr()
-			// returns wrapped writer, which only implements io.Writer. A fix needs to be made
-			// upstream in order to address this.
-			printDiagnosticReport = term.IsTerminal(int(os.Stderr.Fd()))
 		}
 		if err := bufanalysis.PrintFileAnnotationSet(
 			writer,
 			fileAnnotationSet,
 			c.fileAnnotationErrorFormat,
-			bufanalysis.WithPrintDiagnosticReport(printDiagnosticReport),
-			bufanalysis.WithRenderColorizedDiagnosticReport(c.colorizedFileAnnotationSetDiagnosticReport),
 		); err != nil {
 			*retErrAddr = err
 			return

--- a/private/buf/bufctl/option.go
+++ b/private/buf/bufctl/option.go
@@ -42,14 +42,6 @@ func WithFileAnnotationsToStdout() ControllerOption {
 	}
 }
 
-// WithColorizedFileAnnotationSetDiagnosticReport returns a new ControllerOptions that sets
-// whether or not to render a colorized diagnostic report for the FileAnnotationSet.
-func WithColorizedFileAnnotationSetDiagnosticReport(colorizedFileAnnotationSetDiagnosticReport bool) ControllerOption {
-	return func(controller *controller) {
-		controller.colorizedFileAnnotationSetDiagnosticReport = colorizedFileAnnotationSetDiagnosticReport
-	}
-}
-
 // WithCopyToInMemory returns a new ControllerOption that copies to memory.
 func WithCopyToInMemory() ControllerOption {
 	return func(controller *controller) {

--- a/private/bufpkg/bufanalysis/bufanalysis.go
+++ b/private/bufpkg/bufanalysis/bufanalysis.go
@@ -19,8 +19,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-
-	"github.com/bufbuild/protocompile/experimental/report"
 )
 
 const (
@@ -209,59 +207,18 @@ type FileAnnotationSet interface {
 	// These will be deduplicated and sorted.
 	FileAnnotations() []FileAnnotation
 
-	// diagnosticReport returns the diagnostic [report.Report] for the [FileAnnotationSet],
-	// if set.
-	//
-	// This may be nil. If non-nil, it will be used as the output for
-	// [PrintFileAnnotationSet] when the format is set to "text", rendered
-	// with a [report.Renderer] configured by the given print options.
-	diagnosticReport() *report.Report
-
 	isFileAnnotationSet()
 }
 
 // NewFileAnnotationSet returns a new FileAnnotationSet.
 //
 // If len(fileAnnotations) is 0, this returns nil.
-//
-// The diagnosticReport is the [report.Report] from the compiler, if available.
-// If non-nil, it will be rendered by [PrintFileAnnotationSet] when the format
-// is "text". Otherwise, the individual file annotations will be used, same as
-// all other print formats.
-func NewFileAnnotationSet(diagnosticReport *report.Report, fileAnnotations ...FileAnnotation) FileAnnotationSet {
-	return newFileAnnotationSet(diagnosticReport, fileAnnotations)
-}
-
-// PrintFileAnnotationSetOption is an option for printing the FileAnnotationSet.
-type PrintFileAnnotationSetOption func(*printFileAnnotationSetOptions)
-
-// WithPrintDiagnosticReport returns a new PrintFileAnnotationSetOption that sets whether
-// or not to print the diagnostic report.
-//
-// The diagnostic report is only use for text outputs.
-func WithPrintDiagnosticReport(printDiagnosticReport bool) PrintFileAnnotationSetOption {
-	return func(options *printFileAnnotationSetOptions) {
-		options.printDiagnosticReport = printDiagnosticReport
-	}
-}
-
-// WithRenderColorizedDiagnosticReport returns a new PrintFileAnnotationSetOption that sets
-// whether or not to render a colorized diagnostic report.
-//
-// The diagnostic report is only use for text outputs.
-func WithRenderColorizedDiagnosticReport(colorizedDiagnosticReport bool) PrintFileAnnotationSetOption {
-	return func(options *printFileAnnotationSetOptions) {
-		options.colorizedDiagnosticReport = colorizedDiagnosticReport
-	}
+func NewFileAnnotationSet(fileAnnotations ...FileAnnotation) FileAnnotationSet {
+	return newFileAnnotationSet(fileAnnotations)
 }
 
 // PrintFileAnnotationSet prints the file annotations separated by newlines.
-func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSet, formatString string, options ...PrintFileAnnotationSetOption) error {
-	opts := &printFileAnnotationSetOptions{}
-	for _, option := range options {
-		option(opts)
-	}
-
+func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSet, formatString string) error {
 	format, err := ParseFormat(formatString)
 	if err != nil {
 		return err
@@ -269,17 +226,6 @@ func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSe
 
 	switch format {
 	case FormatText:
-		if diagnosticReport := fileAnnotationSet.diagnosticReport(); diagnosticReport != nil && opts.printDiagnosticReport {
-			// TODO: There is a follow-up effort to organize the way compiler warnings are
-			// handled vs. lint/breaking change rules. For now, only render the errors and
-			// suppress compiler warnings.
-			diagnosticReport.Options.SuppressWarnings = true
-			renderer := report.Renderer{
-				Colorize: opts.colorizedDiagnosticReport,
-			}
-			_, _, err := renderer.Render(diagnosticReport, writer)
-			return err
-		}
 		return printAsText(writer, fileAnnotationSet.FileAnnotations())
 	case FormatJSON:
 		return printAsJSON(writer, fileAnnotationSet.FileAnnotations())
@@ -294,9 +240,4 @@ func PrintFileAnnotationSet(writer io.Writer, fileAnnotationSet FileAnnotationSe
 	default:
 		return fmt.Errorf("unknown FileAnnotation Format: %v", format)
 	}
-}
-
-type printFileAnnotationSetOptions struct {
-	printDiagnosticReport     bool
-	colorizedDiagnosticReport bool
 }

--- a/private/bufpkg/bufanalysis/bufanalysistesting/bufanalysistesting_test.go
+++ b/private/bufpkg/bufanalysis/bufanalysistesting/bufanalysistesting_test.go
@@ -49,7 +49,7 @@ func TestBasic(t *testing.T) {
 		),
 	}
 	sb := &strings.Builder{}
-	err := bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(nil, fileAnnotations...), "text")
+	err := bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(fileAnnotations...), "text")
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -59,7 +59,7 @@ path/to/file.proto:2:1:Hello. (buf-plugin-foo)
 		sb.String(),
 	)
 	sb.Reset()
-	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(nil, fileAnnotations...), "json")
+	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(fileAnnotations...), "json")
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -69,7 +69,7 @@ path/to/file.proto:2:1:Hello. (buf-plugin-foo)
 		sb.String(),
 	)
 	sb.Reset()
-	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(nil, fileAnnotations...), "msvs")
+	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(fileAnnotations...), "msvs")
 	require.NoError(t, err)
 	assert.Equal(t,
 		`path/to/file.proto(1,1) : error FOO : Hello.
@@ -78,7 +78,7 @@ path/to/file.proto(2,1) : error FOO : Hello. (buf-plugin-foo)
 		sb.String(),
 	)
 	sb.Reset()
-	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(nil, fileAnnotations...), "junit")
+	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(fileAnnotations...), "junit")
 	require.NoError(t, err)
 	assert.Equal(t,
 		`<testsuites>
@@ -98,7 +98,6 @@ path/to/file.proto(2,1) : error FOO : Hello. (buf-plugin-foo)
 	err = bufanalysis.PrintFileAnnotationSet(
 		sb,
 		bufanalysis.NewFileAnnotationSet(
-			nil,
 			append(
 				fileAnnotations,
 				newFileAnnotation(
@@ -136,7 +135,7 @@ path/to/file.proto(2,1) : error FOO : Hello. (buf-plugin-foo)
 		sb.String(),
 	)
 	sb.Reset()
-	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(nil, fileAnnotations...), "gitlab-code-quality")
+	err = bufanalysis.PrintFileAnnotationSet(sb, bufanalysis.NewFileAnnotationSet(fileAnnotations...), "gitlab-code-quality")
 	require.NoError(t, err)
 	assert.Equal(t,
 		`[{"description":"Hello.","check_name":"FOO","fingerprint":"7fa769d9df9f6db3b793316aa485c307df262ece452189a1c434e77480e9a6a26759f7616faf70c654639075b2fd170d3b66eef686ad402c72b550305883a7b7","location":{"path":"path/to/file.proto","positions":{"begin":{"line":1},"end":{"line":1}}},"severity":"minor"},{"description":"Hello.","check_name":"FOO","fingerprint":"60eab160b8308bb2c5fb823e200a54d58749513e2f2ad28447584f7223812f106a746ab7bf5fa5493e2e320163f86b46d098cb398f1795715617a825665e2a89","location":{"path":"path/to/file.proto","positions":{"begin":{"line":2,"column":1},"end":{"line":2,"column":1}}},"severity":"minor"}]

--- a/private/bufpkg/bufanalysis/file_annotation_set.go
+++ b/private/bufpkg/bufanalysis/file_annotation_set.go
@@ -19,22 +19,18 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/bufbuild/protocompile/experimental/report"
 )
 
 type fileAnnotationSet struct {
 	fileAnnotations []FileAnnotation
-	report          *report.Report
 }
 
-func newFileAnnotationSet(diagnosticReport *report.Report, fileAnnotations []FileAnnotation) *fileAnnotationSet {
+func newFileAnnotationSet(fileAnnotations []FileAnnotation) *fileAnnotationSet {
 	if len(fileAnnotations) == 0 {
 		return nil
 	}
 	return &fileAnnotationSet{
 		fileAnnotations: deduplicateAndSortFileAnnotations(fileAnnotations),
-		report:          diagnosticReport,
 	}
 }
 
@@ -51,10 +47,6 @@ func (f *fileAnnotationSet) String() string {
 		}
 	}
 	return sb.String()
-}
-
-func (f *fileAnnotationSet) diagnosticReport() *report.Report {
-	return f.report
 }
 
 func (f *fileAnnotationSet) Error() string {

--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -163,7 +163,6 @@ func (c *client) Lint(
 		return nil
 	}
 	return bufanalysis.NewFileAnnotationSet(
-		nil,
 		annotationsToFileAnnotations(
 			imageToPathToExternalPath(
 				image,
@@ -303,7 +302,6 @@ func (c *client) Breaking(
 		return nil
 	}
 	return bufanalysis.NewFileAnnotationSet(
-		nil,
 		annotationsToFileAnnotations(
 			imageToPathToExternalPath(
 				image,

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -152,7 +152,7 @@ func compileImage(
 		)
 	}
 	if len(fileAnnotations) > 0 {
-		return nil, bufanalysis.NewFileAnnotationSet(diagnostics, fileAnnotations...)
+		return nil, bufanalysis.NewFileAnnotationSet(fileAnnotations...)
 	}
 
 	// Validate that there is a single result for all files

--- a/private/bufpkg/bufprotocompile/bufprotocompile.go
+++ b/private/bufpkg/bufprotocompile/bufprotocompile.go
@@ -111,7 +111,7 @@ func FileAnnotationSetForErrorsWithPos(
 	if err != nil {
 		return nil, err
 	}
-	return bufanalysis.NewFileAnnotationSet(nil, fileAnnotations...), nil
+	return bufanalysis.NewFileAnnotationSet(fileAnnotations...), nil
 }
 
 // FileAnnotationOption is an option when creating a FileAnnotation.

--- a/private/pkg/protodescriptor/protodescriptor.go
+++ b/private/pkg/protodescriptor/protodescriptor.go
@@ -29,7 +29,7 @@ const (
 	// MinSupportedEdition is the earliest edition supported by this repo.
 	MinSupportedEdition = descriptorpb.Edition_EDITION_2023
 	// MaxSupportedEdition is the latest edition supported by this repo.
-	MaxSupportedEdition = descriptorpb.Edition_EDITION_2023
+	MaxSupportedEdition = descriptorpb.Edition_EDITION_2024
 )
 
 // FileDescriptor is an interface that matches the methods on a *descriptorpb.FileDescriptorProto.

--- a/private/pkg/protodescriptor/protodescriptor.go
+++ b/private/pkg/protodescriptor/protodescriptor.go
@@ -139,14 +139,11 @@ func ValidateFileDescriptor(fileDescriptor FileDescriptor) error {
 	}
 	if fileDescriptor.GetSyntax() == "editions" {
 		edition := fileDescriptor.GetEdition()
-		// protocompile should support the same editions as buf (or possibly a superset at
-		// some point in the future, like while support for a new edition is being implemented),
-		// but we check with it just in case.
-		if !protocompile.IsEditionSupported(edition) ||
-			edition < MinSupportedEdition ||
-			edition > MaxSupportedEdition {
-			return fmt.Errorf("%s uses unsupported edition %s",
-				fileDescriptor.GetName(), edition)
+		// Removed the check against [protocompile.IsEditionSupported], since we are using the
+		// new compiler now. Just checking against the local editions settings.
+		if edition < MinSupportedEdition || edition > MaxSupportedEdition {
+			return fmt.Errorf("%s uses unsupported edition %s %v",
+				fileDescriptor.GetName(), edition, protocompile.IsEditionSupported(edition))
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR removes the use of the new report format
and properly ungate Editions 2024 features.