### PR TITLE
Fix IMPORT_USED false positives for leading-dot type references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Revert the use of the new compiler report format and properly ungate Editions 2024 features.
+- Fix absolute imports (leading-dot) marked unused in diagnostics.
 
 ## [v1.68.0] - 2026-04-14
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/otelconnect v0.9.0
-	github.com/bufbuild/protocompile v0.14.2-0.20260414151636-6b2e7e07d2a7
+	github.com/bufbuild/protocompile v0.14.2-0.20260414204819-0b1a6cd46bcb
 	github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b
 	github.com/cli/browser v1.3.0
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
-github.com/bufbuild/protocompile v0.14.2-0.20260414151636-6b2e7e07d2a7 h1:FIwB0ceZhxe3WXW2rnF11tki9nNEGGwZOp48yhYVYaU=
-github.com/bufbuild/protocompile v0.14.2-0.20260414151636-6b2e7e07d2a7/go.mod h1:DhgqsRznX/F0sGkUYtTQJRP+q8xMReQRQ3qr+n1opWU=
+github.com/bufbuild/protocompile v0.14.2-0.20260414204819-0b1a6cd46bcb h1:jdS2S8gfhRe0KGzvVbysqIsobREx4dDq9e1hppy4a6A=
+github.com/bufbuild/protocompile v0.14.2-0.20260414204819-0b1a6cd46bcb/go.mod h1:DhgqsRznX/F0sGkUYtTQJRP+q8xMReQRQ3qr+n1opWU=
 github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b h1:b7wvo9ZhjLzCp7tGbOUMvgtYTnd33zGSAmMxcdxMnhQ=
 github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b/go.mod h1:c5D8gWRIZ2HLWO3gXYTtUfw/hbJyD8xikv2ooPxnklQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -184,6 +184,16 @@ func TestRunImportUsed(t *testing.T) {
 	)
 }
 
+func TestRunImportUsedLeadingDot(t *testing.T) {
+	t.Parallel()
+	// Leading-dot fully-qualified type references (e.g. .shared.location.v1.USAddress)
+	// must be recognized as using the import. No violations expected.
+	testLint(
+		t,
+		"import_used_leading_dot",
+	)
+}
+
 func TestRunEnumFirstValueZero(t *testing.T) {
 	t.Parallel()
 	testLint(

--- a/private/bufpkg/bufcheck/testdata/lint/import_used_leading_dot/a.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/import_used_leading_dot/a.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package a;
+
+import "shared/location/v1/location.proto";
+
+// Uses a leading-dot fully-qualified reference to a type from a
+// different top-level package. The leading dot is required for
+// cross-top-level-package resolution. This import should be
+// considered used.
+message MyMessage {
+  .shared.location.v1.USAddress address = 1;
+}

--- a/private/bufpkg/bufcheck/testdata/lint/import_used_leading_dot/buf.yaml
+++ b/private/bufpkg/bufcheck/testdata/lint/import_used_leading_dot/buf.yaml
@@ -1,0 +1,4 @@
+version: v1
+lint:
+  use:
+    - IMPORT_USED

--- a/private/bufpkg/bufcheck/testdata/lint/import_used_leading_dot/shared/location/v1/location.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/import_used_leading_dot/shared/location/v1/location.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package shared.location.v1;
+
+message USAddress {
+  string street = 1;
+  string city = 2;
+  string state = 3;
+  string zip = 4;
+}


### PR DESCRIPTION
Fix a regression where the `IMPORT_USED` lint rule incorrectly flagged imports as unused when the imported types were referenced with leading-dot fully-qualified names (e.g., `.shared.location.v1.USAddress`).