### PR TITLE
Consolidate CEL compilation errors to single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix CEL compilation error messages in `buf lint` to use the structured error API instead of parsing cel-go's text output.
 
 ## [v1.68.1] - 2026-04-14
 

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/cel.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/cel.go
@@ -237,13 +237,13 @@ func checkCEL(
 		}
 		if compileIssues.Err() != nil {
 			allCelExpressionsCompile = false
-			for _, parsedIssue := range parseCelIssuesText(compileIssues.Err().Error()) {
+			for _, celErr := range compileIssues.Errors() {
 				add(
 					i,
 					"%s on %s fails to compile: %s",
 					expressionField,
 					parentName,
-					parsedIssue,
+					strings.TrimPrefix(celErr.Message, "Syntax error: "),
 				)
 			}
 		}
@@ -263,35 +263,4 @@ func checkCEL(
 		}
 	}
 	return allCelExpressionsCompile
-}
-
-// this depends on the undocumented behavior of cel-go's error message
-//
-// maps a string in this form:
-// "ERROR: <input>:1:6: found no matching overload for '_+_' applied to '(int, string)'
-// | this + 'xyz' > (this * 'xyz')
-// | .....^
-// ERROR: <input>:1:22: found no matching overload for '_*_' applied to '(int, string)'
-// | this + 'xyz' > (this * 'xyz')
-// | .....................^"
-// to a string slice:
-// [ "found no matching overload for '_+_' applied to '(int, string)'
-// | this + 'xyz' > (this * 'xyz')
-// | .....^",
-// "found no matching overload for '_*_' applied to '(int, string)'
-// | this + 'xyz' > (this * 'xyz')
-// | .....................^"]
-func parseCelIssuesText(issuesText string) []string {
-	issues := strings.Split(issuesText, "ERROR: <input>:")
-	parsedIssues := make([]string, 0, len(issues)-1)
-	for _, issue := range issues {
-		issue = strings.TrimSpace(issue)
-		if len(issue) == 0 {
-			continue
-		}
-		// now issue looks like 1:2:<error message>
-		parts := strings.SplitAfterN(issue, ":", 3)
-		parsedIssues = append(parsedIssues, strings.TrimSpace(parts[len(parts)-1]))
-	}
-	return parsedIssues
 }

--- a/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/cel_test.go
+++ b/private/bufpkg/bufcheck/bufcheckserver/internal/buflintvalidate/cel_test.go
@@ -21,48 +21,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCelIssuesErrorTextMatch(t *testing.T) {
+func TestCelIssuesErrors(t *testing.T) {
 	t.Parallel()
 	celEnv, err := cel.NewEnv()
 	require.NoError(t, err)
-	t.Run("parse_single_issue", func(t *testing.T) {
+	t.Run("single_issue", func(t *testing.T) {
 		t.Parallel()
 		_, issues := celEnv.Compile("1 / 'a'")
-		expectedErrorText := `ERROR: <input>:1:3: found no matching overload for '_/_' applied to '(int, string)'
- | 1 / 'a'
- | ..^`
-		require.Equal(t, expectedErrorText, issues.Err().Error())
-		expectedParsedTexts := []string{
-			`found no matching overload for '_/_' applied to '(int, string)'
- | 1 / 'a'
- | ..^`,
-		}
-		require.Equal(t, expectedParsedTexts, parseCelIssuesText(issues.Err().Error()))
+		require.Error(t, issues.Err())
+		errs := issues.Errors()
+		require.Len(t, errs, 1)
+		require.Equal(t, "found no matching overload for '_/_' applied to '(int, string)'", errs[0].Message)
 	})
-	t.Run("parse_multiple_issues", func(t *testing.T) {
+	t.Run("multiple_issues", func(t *testing.T) {
 		t.Parallel()
 		_, issues := celEnv.Compile("(1 / 'a') * (1 - 'a') * (1 * 'a')")
-		expectedErrorText := `ERROR: <input>:1:4: found no matching overload for '_/_' applied to '(int, string)'
- | (1 / 'a') * (1 - 'a') * (1 * 'a')
- | ...^
-ERROR: <input>:1:16: found no matching overload for '_-_' applied to '(int, string)'
- | (1 / 'a') * (1 - 'a') * (1 * 'a')
- | ...............^
-ERROR: <input>:1:28: found no matching overload for '_*_' applied to '(int, string)'
- | (1 / 'a') * (1 - 'a') * (1 * 'a')
- | ...........................^`
-		require.Equal(t, expectedErrorText, issues.Err().Error())
-		expectedParsedTexts := []string{
-			`found no matching overload for '_/_' applied to '(int, string)'
- | (1 / 'a') * (1 - 'a') * (1 * 'a')
- | ...^`,
-			`found no matching overload for '_-_' applied to '(int, string)'
- | (1 / 'a') * (1 - 'a') * (1 * 'a')
- | ...............^`,
-			`found no matching overload for '_*_' applied to '(int, string)'
- | (1 / 'a') * (1 - 'a') * (1 * 'a')
- | ...........................^`,
-		}
-		require.Equal(t, expectedParsedTexts, parseCelIssuesText(issues.Err().Error()))
+		require.Error(t, issues.Err())
+		errs := issues.Errors()
+		require.Len(t, errs, 3)
+		require.Equal(t, "found no matching overload for '_/_' applied to '(int, string)'", errs[0].Message)
+		require.Equal(t, "found no matching overload for '_-_' applied to '(int, string)'", errs[1].Message)
+		require.Equal(t, "found no matching overload for '_*_' applied to '(int, string)'", errs[2].Message)
+	})
+	t.Run("invalid_escape_in_string_literal", func(t *testing.T) {
+		t.Parallel()
+		// Reproduces the CEL parse failure from using \. (invalid escape) inside a CEL string
+		// literal. This arises when a proto field like:
+		//   expression: "this.matches('(^|.*/)[^/]+\\.lock($|/.*)')"
+		// is used — the proto string \\ becomes a single \ in the CEL expression, and CEL does
+		// not recognize \. as a valid escape sequence.
+		stringEnv, err := celEnv.Extend(cel.Variable("this", cel.StringType))
+		require.NoError(t, err)
+		_, issues := stringEnv.Compile("this == '' || !this.matches('(^|.*/)[^/]+\\.lock($|/.*)')")
+		require.Error(t, issues.Err())
+		errs := issues.Errors()
+		require.Len(t, errs, 6)
+		// These are the raw messages from cel-go — the "Syntax error: " prefix is stripped
+		// by checkCEL before being reported to the user.
+		require.Equal(t, "Syntax error: token recognition error at: ''(^|.*/)[^/]+\\.'", errs[0].Message)
+		require.Equal(t, "Syntax error: token recognition error at: '$'", errs[1].Message)
+		require.Equal(t, "Syntax error: token recognition error at: '|/'", errs[2].Message)
+		require.Equal(t, "Syntax error: no viable alternative at input '.*'", errs[3].Message)
+		require.Equal(t, "Syntax error: mismatched input ')' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}", errs[4].Message)
+		require.Equal(t, "Syntax error: token recognition error at: '')'", errs[5].Message)
 	})
 }


### PR DESCRIPTION
Matching our default `buf lint` format. Still, when cel-go reports multiple issues, we'll include all of them. Also strips out the leading "Syntax error: ", which IMO seems superfluous.