### PR TITLE
Respect comment ignores on proto2 group fields

### DIFF
--- a/private/bufpkg/bufcheck/client.go
+++ b/private/bufpkg/bufcheck/client.go
@@ -43,6 +43,7 @@ import (
 	"github.com/bufbuild/buf/private/pkg/protoversion"
 	"github.com/bufbuild/buf/private/pkg/syserror"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"pluginrpc.com/pluginrpc"
 )
 
@@ -822,18 +823,71 @@ func ignoreFileLocation(
 			return false, err
 		}
 		sourceLocations := protoreflectFileDescriptor.SourceLocations()
+		checkedSourcePathKeys := make(map[string]struct{}, len(associatedSourcePaths))
 		for _, associatedSourcePath := range associatedSourcePaths {
-			sourceLocation := sourceLocations.ByPath(associatedSourcePath)
-			if leadingComments := sourceLocation.LeadingComments; leadingComments != "" {
-				for _, line := range xstrings.SplitTrimLinesNoEmpty(leadingComments) {
-					if checkCommentLineForCheckIgnore(line, config.CommentIgnorePrefix, ruleID) {
-						return true, nil
-					}
+			if sourcePathHasCheckIgnore(sourceLocations, associatedSourcePath, checkedSourcePathKeys, config.CommentIgnorePrefix, ruleID) {
+				return true, nil
+			}
+			for _, siblingSourcePath := range sameSpanSiblingSourcePaths(sourceLocations, associatedSourcePath) {
+				if sourcePathHasCheckIgnore(sourceLocations, siblingSourcePath, checkedSourcePathKeys, config.CommentIgnorePrefix, ruleID) {
+					return true, nil
 				}
 			}
 		}
 	}
 	return false, nil
+}
+
+func sourcePathHasCheckIgnore(
+	sourceLocations protoreflect.SourceLocations,
+	sourcePath protoreflect.SourcePath,
+	checkedSourcePathKeys map[string]struct{},
+	commentIgnorePrefix string,
+	ruleID string,
+) bool {
+	sourcePathKey := sourcePath.String()
+	if _, ok := checkedSourcePathKeys[sourcePathKey]; ok {
+		return false
+	}
+	checkedSourcePathKeys[sourcePathKey] = struct{}{}
+	sourceLocation := sourceLocations.ByPath(sourcePath)
+	if sourceLocation.Path == nil {
+		return false
+	}
+	for _, line := range xstrings.SplitTrimLinesNoEmpty(sourceLocation.LeadingComments) {
+		if checkCommentLineForCheckIgnore(line, commentIgnorePrefix, ruleID) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameSpanSiblingSourcePaths(
+	sourceLocations protoreflect.SourceLocations,
+	sourcePath protoreflect.SourcePath,
+) []protoreflect.SourcePath {
+	sourceLocation := sourceLocations.ByPath(sourcePath)
+	if sourceLocation.Path == nil {
+		return nil
+	}
+	// Groups are modeled as both a field and a synthetic nested message that share a span.
+	// Checking sibling paths with the same span lets comment ignores attached to one view
+	// suppress annotations emitted on the other.
+	var siblingSourcePaths []protoreflect.SourcePath
+	sourcePathKey := sourceLocation.Path.String()
+	for i := range sourceLocations.Len() {
+		candidate := sourceLocations.Get(i)
+		if candidate.Path == nil || sourcePathKey == candidate.Path.String() {
+			continue
+		}
+		if sourceLocation.StartLine == candidate.StartLine &&
+			sourceLocation.StartColumn == candidate.StartColumn &&
+			sourceLocation.EndLine == candidate.EndLine &&
+			sourceLocation.EndColumn == candidate.EndColumn {
+			siblingSourcePaths = append(siblingSourcePaths, candidate.Path)
+		}
+	}
+	return siblingSourcePaths
 }
 
 // checkCommentLineForCheckIgnore checks that the comment line starts with the configured

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -402,6 +402,11 @@ func TestRunFieldNotRequired(t *testing.T) {
 	)
 }
 
+func TestRunFieldNotRequiredGroupCommentIgnore(t *testing.T) {
+	t.Parallel()
+	testLint(t, "field_not_required_group_comment_ignore")
+}
+
 func TestRunFileLowerSnakeCase(t *testing.T) {
 	t.Parallel()
 	testLint(

--- a/private/bufpkg/bufcheck/testdata/lint/field_not_required_group_comment_ignore/a.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/field_not_required_group_comment_ignore/a.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package foo;
+
+message Foo {
+  // buf:lint:ignore FIELD_NOT_REQUIRED
+  required group Metadata = 1 {
+    optional string id = 1;
+  }
+}

--- a/private/bufpkg/bufcheck/testdata/lint/field_not_required_group_comment_ignore/buf.yaml
+++ b/private/bufpkg/bufcheck/testdata/lint/field_not_required_group_comment_ignore/buf.yaml
@@ -1,0 +1,4 @@
+version: v2
+lint:
+  use:
+    - FIELD_NOT_REQUIRED


### PR DESCRIPTION
Fixes #4187

For proto2 group declarations, leading comments are attached to the synthetic nested message source location instead of the group field source location. That meant `// buf:lint:ignore FIELD_NOT_REQUIRED` on a required group declaration was still ignored even though the same comment worked on a normal required field.

This updates comment-ignore lookup to also check sibling source paths that share the same source span, which covers the field/synthetic-message pair for groups, and adds a regression test for the required-group case.

Validation:
- `go test ./private/bufpkg/bufcheck -run 'TestRunComments|TestRunFieldNotRequired(GroupCommentIgnore)?$' -count=1`\n- `go run ./cmd/buf lint /tmp/buf-group-ignore-eYGbo9 --error-format=json`