### PR TITLE
Reduce allocations in protoencoding.ReparseExtensions, take 2

### DIFF
--- a/private/pkg/protoencoding/reparse_extensions.go
+++ b/private/pkg/protoencoding/reparse_extensions.go
@@ -80,6 +80,9 @@ func (r *reparser) reparseExtensions(reflectMessage protoreflect.Message) {
 		r.reflectMessage = reflectMessage
 
 		reflectMessage.Range(r.visitExt)
+		if r.err != nil {
+			return
+		}
 		if r.msgExts != nil {
 			options := proto.MarshalOptions{AllowPartial: true}
 			var err error
@@ -121,7 +124,6 @@ func (r *reparser) reparseExtensions(reflectMessage protoreflect.Message) {
 			return
 		}
 	}
-	return
 }
 
 func (r *reparser) reparseInMessageField(msg protoreflect.Message, field protoreflect.FieldDescriptor) {

--- a/private/pkg/protoencoding/reparse_extensions.go
+++ b/private/pkg/protoencoding/reparse_extensions.go
@@ -25,47 +25,68 @@ func ReparseExtensions(resolver Resolver, reflectMessage protoreflect.Message) e
 	if resolver == nil {
 		return nil
 	}
-	return reparseExtensions(
-		resolver,
-		map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor{},
-		reflectMessage,
-	)
+	rep := newReparser(resolver)
+	rep.reparseExtensions(reflectMessage)
+	return rep.err
 }
 
-// reparseExtensions implements ReparseExtensions with a shared cache of
-// recursion-worthy fields per descriptor. The cache lives for the duration of
-// the top-level call, so memory is bounded by the descriptor types visited in
-// this one call tree.
-func reparseExtensions(
-	resolver Resolver,
-	messageFieldsCache map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor,
-	reflectMessage protoreflect.Message,
-) error {
-	reparseBytes := reflectMessage.GetUnknown()
-	descriptor := reflectMessage.Descriptor()
-	hasExtensionRanges := descriptor.ExtensionRanges().Len() > 0
+type reparser struct {
+	resolver Resolver
 
-	if hasExtensionRanges {
+	// These fields hoist state up from reparseExtensions that could be local
+	// variables, but then would escape to the heap and result in many per-call
+	// allocations. So we allocate them once in this struct, which drastically
+	// improves the performance of the recursive calls by eliminating allocations.
+
+	reflectMessage protoreflect.Message
+	msgExts        protoreflect.Message
+	err            error
+
+	// visitExt refers to msgExts and reflectMessage, so those two fields
+	// must be reset prior to a Range call that uses visitExt.
+	visitExt      func(protoreflect.FieldDescriptor, protoreflect.Value) bool
+	visitMapEntry func(protoreflect.MapKey, protoreflect.Value) bool
+}
+
+func newReparser(resolver Resolver) *reparser {
+	result := &reparser{resolver: resolver}
+	result.visitExt = func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		if !field.IsExtension() {
+			return true
+		}
+		if result.msgExts == nil {
+			result.msgExts = result.reflectMessage.New()
+		}
+		result.msgExts.Set(field, value)
+		result.reflectMessage.Clear(field)
+		return true
+	}
+	result.visitMapEntry = func(_ protoreflect.MapKey, value protoreflect.Value) bool {
+		result.reparseExtensions(value.Message())
+		return result.err == nil
+	}
+	return result
+}
+
+func (r *reparser) reparseExtensions(reflectMessage protoreflect.Message) {
+	reparseBytes := reflectMessage.GetUnknown()
+
+	if reflectMessage.Descriptor().ExtensionRanges().Len() > 0 {
 		// Collect extensions into separate message so we can serialize
 		// *just* the extensions and then re-parse them below.
-		var msgExts protoreflect.Message
-		reflectMessage.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
-			if !field.IsExtension() {
-				return true
-			}
-			if msgExts == nil {
-				msgExts = reflectMessage.New()
-			}
-			msgExts.Set(field, value)
-			reflectMessage.Clear(field)
-			return true
-		})
-		if msgExts != nil {
+
+		// reset state for range
+		r.msgExts = nil
+		r.reflectMessage = reflectMessage
+
+		reflectMessage.Range(r.visitExt)
+		if r.msgExts != nil {
 			options := proto.MarshalOptions{AllowPartial: true}
 			var err error
-			reparseBytes, err = options.MarshalAppend(reparseBytes, msgExts.Interface())
+			reparseBytes, err = options.MarshalAppend(reparseBytes, r.msgExts.Interface())
 			if err != nil {
-				return err
+				r.err = err
+				return
 			}
 		}
 	}
@@ -73,109 +94,54 @@ func reparseExtensions(
 	if len(reparseBytes) > 0 {
 		reflectMessage.SetUnknown(nil)
 		options := proto.UnmarshalOptions{
-			Resolver: resolver,
+			Resolver: r.resolver,
 			Merge:    true,
 		}
 		if err := options.Unmarshal(reparseBytes, reflectMessage.Interface()); err != nil {
-			return err
+			r.err = err
+			return
 		}
 	}
-	// Recurse into populated message-valued non-extension fields using the
-	// call-scoped cache. Scalar-only message types get an empty slice and skip
-	// this loop, avoiding a Range closure allocation.
-	for _, fieldDescriptor := range messageTypeFields(messageFieldsCache, descriptor) {
-		if !reflectMessage.Has(fieldDescriptor) {
+	// Ideally, we'd use reflectMessage.Range here, but that allocates too much since it must
+	// allocate a wrapper for every repeated field that implements protoreflect.List. We don't
+	// care about visiting extensions (since we just resolved/reparsed those above), so we
+	// can iterate over the non-extension fields.
+	fields := reflectMessage.Descriptor().Fields()
+	for i := range fields.Len() {
+		field := fields.Get(i)
+		if field.Message() == nil {
+			// nothing to reparse if not a message
 			continue
 		}
-		if err := reparseInField(
-			resolver,
-			messageFieldsCache,
-			fieldDescriptor,
-			reflectMessage.Get(fieldDescriptor),
-		); err != nil {
-			return err
+		if !reflectMessage.Has(field) {
+			continue
+		}
+		r.reparseInMessageField(reflectMessage, field)
+		if r.err != nil {
+			return
 		}
 	}
-	// Extensions aren't in Fields(); use Range only when the schema allows them.
-	if hasExtensionRanges {
-		var err error
-		reflectMessage.Range(func(fieldDescriptor protoreflect.FieldDescriptor, value protoreflect.Value) bool {
-			if !fieldDescriptor.IsExtension() {
-				return true
-			}
-			err = reparseInField(resolver, messageFieldsCache, fieldDescriptor, value)
-			return err == nil
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return
 }
 
-// messageTypeFields returns the fields of descriptor that may hold a nested
-// message, using a call-scoped memoization map.
-func messageTypeFields(
-	cache map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor,
-	descriptor protoreflect.MessageDescriptor,
-) []protoreflect.FieldDescriptor {
-	if cached, ok := cache[descriptor]; ok {
-		return cached
-	}
-	var result []protoreflect.FieldDescriptor
-	fields := descriptor.Fields()
-	for i := range fields.Len() {
-		fieldDescriptor := fields.Get(i)
-		if fieldMayContainMessage(fieldDescriptor) {
-			result = append(result, fieldDescriptor)
-		}
-	}
-	cache[descriptor] = result
-	return result
-}
-
-// fieldMayContainMessage reports whether a field holds a message, group, or
-// map with a message/group value.
-func fieldMayContainMessage(fieldDescriptor protoreflect.FieldDescriptor) bool {
-	if fieldDescriptor.IsMap() {
-		valueKind := fieldDescriptor.MapValue().Kind()
-		return valueKind == protoreflect.MessageKind || valueKind == protoreflect.GroupKind
-	}
-	kind := fieldDescriptor.Kind()
-	return kind == protoreflect.MessageKind || kind == protoreflect.GroupKind
-}
-
-func reparseInField(
-	resolver Resolver,
-	messageFieldsCache map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor,
-	fieldDescriptor protoreflect.FieldDescriptor,
-	value protoreflect.Value,
-) error {
-	if fieldDescriptor.IsMap() {
-		valDesc := fieldDescriptor.MapValue()
-		if valDesc.Kind() != protoreflect.MessageKind && valDesc.Kind() != protoreflect.GroupKind {
+func (r *reparser) reparseInMessageField(msg protoreflect.Message, field protoreflect.FieldDescriptor) {
+	if field.IsMap() {
+		if field.MapValue().Message() == nil {
 			// nothing to reparse
-			return nil
+			return
 		}
-		var err error
-		value.Map().Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
-			err = reparseExtensions(resolver, messageFieldsCache, v.Message())
-			return err == nil
-		})
-		return err
+		msg.Get(field).Map().Range(r.visitMapEntry)
+		return
 	}
-	if fieldDescriptor.Kind() != protoreflect.MessageKind && fieldDescriptor.Kind() != protoreflect.GroupKind {
-		// nothing to reparse
-		return nil
-	}
-	if fieldDescriptor.IsList() {
-		list := value.List()
+	if field.IsList() {
+		list := msg.Get(field).List()
 		for i := range list.Len() {
-			if err := reparseExtensions(resolver, messageFieldsCache, list.Get(i).Message()); err != nil {
-				return err
+			r.reparseExtensions(list.Get(i).Message())
+			if r.err != nil {
+				return
 			}
 		}
-		return nil
+		return
 	}
-	return reparseExtensions(resolver, messageFieldsCache, value.Message())
+	r.reparseExtensions(msg.Get(field).Message())
 }

--- a/private/pkg/protoencoding/reparse_extensions.go
+++ b/private/pkg/protoencoding/reparse_extensions.go
@@ -25,9 +25,27 @@ func ReparseExtensions(resolver Resolver, reflectMessage protoreflect.Message) e
 	if resolver == nil {
 		return nil
 	}
-	reparseBytes := reflectMessage.GetUnknown()
+	return reparseExtensions(
+		resolver,
+		map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor{},
+		reflectMessage,
+	)
+}
 
-	if reflectMessage.Descriptor().ExtensionRanges().Len() > 0 {
+// reparseExtensions implements ReparseExtensions with a shared cache of
+// recursion-worthy fields per descriptor. The cache lives for the duration of
+// the top-level call, so memory is bounded by the descriptor types visited in
+// this one call tree.
+func reparseExtensions(
+	resolver Resolver,
+	messageFieldsCache map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor,
+	reflectMessage protoreflect.Message,
+) error {
+	reparseBytes := reflectMessage.GetUnknown()
+	descriptor := reflectMessage.Descriptor()
+	hasExtensionRanges := descriptor.ExtensionRanges().Len() > 0
+
+	if hasExtensionRanges {
 		// Collect extensions into separate message so we can serialize
 		// *just* the extensions and then re-parse them below.
 		var msgExts protoreflect.Message
@@ -36,7 +54,7 @@ func ReparseExtensions(resolver Resolver, reflectMessage protoreflect.Message) e
 				return true
 			}
 			if msgExts == nil {
-				msgExts = reflectMessage.Type().New()
+				msgExts = reflectMessage.New()
 			}
 			msgExts.Set(field, value)
 			reflectMessage.Clear(field)
@@ -62,16 +80,74 @@ func ReparseExtensions(resolver Resolver, reflectMessage protoreflect.Message) e
 			return err
 		}
 	}
-	var err error
-	reflectMessage.Range(func(fieldDescriptor protoreflect.FieldDescriptor, value protoreflect.Value) bool {
-		err = reparseInField(resolver, fieldDescriptor, value)
-		return err == nil
-	})
-	return err
+	// Recurse into populated message-valued non-extension fields using the
+	// call-scoped cache. Scalar-only message types get an empty slice and skip
+	// this loop, avoiding a Range closure allocation.
+	for _, fieldDescriptor := range messageTypeFields(messageFieldsCache, descriptor) {
+		if !reflectMessage.Has(fieldDescriptor) {
+			continue
+		}
+		if err := reparseInField(
+			resolver,
+			messageFieldsCache,
+			fieldDescriptor,
+			reflectMessage.Get(fieldDescriptor),
+		); err != nil {
+			return err
+		}
+	}
+	// Extensions aren't in Fields(); use Range only when the schema allows them.
+	if hasExtensionRanges {
+		var err error
+		reflectMessage.Range(func(fieldDescriptor protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+			if !fieldDescriptor.IsExtension() {
+				return true
+			}
+			err = reparseInField(resolver, messageFieldsCache, fieldDescriptor, value)
+			return err == nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// messageTypeFields returns the fields of descriptor that may hold a nested
+// message, using a call-scoped memoization map.
+func messageTypeFields(
+	cache map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor,
+	descriptor protoreflect.MessageDescriptor,
+) []protoreflect.FieldDescriptor {
+	if cached, ok := cache[descriptor]; ok {
+		return cached
+	}
+	var result []protoreflect.FieldDescriptor
+	fields := descriptor.Fields()
+	for i := range fields.Len() {
+		fieldDescriptor := fields.Get(i)
+		if fieldMayContainMessage(fieldDescriptor) {
+			result = append(result, fieldDescriptor)
+		}
+	}
+	cache[descriptor] = result
+	return result
+}
+
+// fieldMayContainMessage reports whether a field holds a message, group, or
+// map with a message/group value.
+func fieldMayContainMessage(fieldDescriptor protoreflect.FieldDescriptor) bool {
+	if fieldDescriptor.IsMap() {
+		valueKind := fieldDescriptor.MapValue().Kind()
+		return valueKind == protoreflect.MessageKind || valueKind == protoreflect.GroupKind
+	}
+	kind := fieldDescriptor.Kind()
+	return kind == protoreflect.MessageKind || kind == protoreflect.GroupKind
 }
 
 func reparseInField(
 	resolver Resolver,
+	messageFieldsCache map[protoreflect.MessageDescriptor][]protoreflect.FieldDescriptor,
 	fieldDescriptor protoreflect.FieldDescriptor,
 	value protoreflect.Value,
 ) error {
@@ -83,7 +159,7 @@ func reparseInField(
 		}
 		var err error
 		value.Map().Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
-			err = ReparseExtensions(resolver, v.Message())
+			err = reparseExtensions(resolver, messageFieldsCache, v.Message())
 			return err == nil
 		})
 		return err
@@ -95,11 +171,11 @@ func reparseInField(
 	if fieldDescriptor.IsList() {
 		list := value.List()
 		for i := range list.Len() {
-			if err := ReparseExtensions(resolver, list.Get(i).Message()); err != nil {
+			if err := reparseExtensions(resolver, messageFieldsCache, list.Get(i).Message()); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
-	return ReparseExtensions(resolver, value.Message())
+	return reparseExtensions(resolver, messageFieldsCache, value.Message())
 }

--- a/private/pkg/protoencoding/reparse_extensions_bench_test.go
+++ b/private/pkg/protoencoding/reparse_extensions_bench_test.go
@@ -1,0 +1,179 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoencoding
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
+	"buf.build/go/standard/xos/xexec"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// BenchmarkReparseExtensions_Synthetic exercises a hand-built FileDescriptorProto
+// that mirrors the shape of a validate-annotated proto file with an unrecognized
+// extension to force the reparse path.
+func BenchmarkReparseExtensions_Synthetic(b *testing.B) {
+	testFile, resolver := buildSyntheticInput(b)
+	data, err := proto.Marshal(testFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+	runReparseBench(b, resolver, data, func() proto.Message {
+		return &descriptorpb.FileDescriptorProto{}
+	})
+}
+
+// BenchmarkReparseExtensions_RealWorld builds a FileDescriptorSet from buf's
+// own protos at benchmark startup and exercises ReparseExtensions on it.
+func BenchmarkReparseExtensions_RealWorld(b *testing.B) {
+	raw := buildBufRepoDescriptorSet(b)
+	fdset := &descriptorpb.FileDescriptorSet{}
+	if err := proto.Unmarshal(raw, fdset); err != nil {
+		b.Fatal(err)
+	}
+	resolver, err := NewResolver(fdset.File...)
+	if err != nil {
+		b.Fatal(err)
+	}
+	runReparseBench(b, resolver, raw, func() proto.Message {
+		return &descriptorpb.FileDescriptorSet{}
+	})
+}
+
+func runReparseBench(
+	b *testing.B,
+	resolver Resolver,
+	data []byte,
+	newMessage func() proto.Message,
+) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		fresh := newMessage()
+		if err := proto.Unmarshal(data, fresh); err != nil {
+			b.Fatal(err)
+		}
+		if err := ReparseExtensions(resolver, fresh.ProtoReflect()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// buildBufRepoDescriptorSet invokes `go run ./cmd/buf build` against buf's
+// own protos, writing the result to a tempdir, then returns the bytes.
+func buildBufRepoDescriptorSet(b *testing.B) []byte {
+	b.Helper()
+	outputPath := filepath.Join(b.TempDir(), "buf_repo.binpb")
+	var stderr bytes.Buffer
+	err := xexec.Run(
+		b.Context(),
+		"go",
+		xexec.WithArgs("run", "./cmd/buf", "build", "-o", outputPath),
+		xexec.WithDir("../../.."), // relative to this package, this is the repo root.
+		xexec.WithEnv(os.Environ()),
+		xexec.WithStderr(&stderr),
+	)
+	if err != nil {
+		b.Skipf("buf build failed: %v\n%s", err, stderr.String())
+	}
+	raw, err := os.ReadFile(outputPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return raw
+}
+
+func buildSyntheticInput(b *testing.B) (*descriptorpb.FileDescriptorProto, Resolver) {
+	b.Helper()
+
+	descriptorFile := protodesc.ToFileDescriptorProto(descriptorpb.File_google_protobuf_descriptor_proto)
+	durationFile := protodesc.ToFileDescriptorProto(durationpb.File_google_protobuf_duration_proto)
+	timestampFile := protodesc.ToFileDescriptorProto(timestamppb.File_google_protobuf_timestamp_proto)
+	validateFile := protodesc.ToFileDescriptorProto(validate.File_buf_validate_validate_proto)
+
+	const customOptionNum = 54321
+	const customOptionVal = float32(3.14159)
+
+	newFieldOpts := func() *descriptorpb.FieldOptions {
+		fieldOpts := &descriptorpb.FieldOptions{}
+		fieldRules := &validate.FieldRules{
+			Required: proto.Bool(true),
+			Type: &validate.FieldRules_Int32{
+				Int32: &validate.Int32Rules{
+					GreaterThan: &validate.Int32Rules_Gt{Gt: 0},
+				},
+			},
+		}
+		proto.SetExtension(fieldOpts, validate.E_Field, fieldRules)
+		var unknownOption []byte
+		unknownOption = protowire.AppendTag(unknownOption, customOptionNum, protowire.Fixed32Type)
+		unknownOption = protowire.AppendFixed32(unknownOption, math.Float32bits(customOptionVal))
+		fieldOpts.ProtoReflect().SetUnknown(unknownOption)
+		return fieldOpts
+	}
+
+	const numMessages = 50
+	const fieldsPerMessage = 20
+	messages := make([]*descriptorpb.DescriptorProto, numMessages)
+	for m := range messages {
+		fields := make([]*descriptorpb.FieldDescriptorProto, fieldsPerMessage)
+		for f := range fields {
+			fields[f] = &descriptorpb.FieldDescriptorProto{
+				Name:     proto.String(fmt.Sprintf("field_%d", f)),
+				Number:   proto.Int32(int32(f + 1)),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum(),
+				JsonName: proto.String(fmt.Sprintf("field_%d", f)),
+				Options:  newFieldOpts(),
+			}
+		}
+		messages[m] = &descriptorpb.DescriptorProto{
+			Name:  proto.String(fmt.Sprintf("Msg%d", m)),
+			Field: fields,
+		}
+	}
+	testFile := &descriptorpb.FileDescriptorProto{
+		Name:        proto.String("test.proto"),
+		Syntax:      proto.String("proto3"),
+		Package:     proto.String("blah.blah"),
+		Dependency:  []string{"buf/validate/validate.proto", "google/protobuf/descriptor.proto"},
+		MessageType: messages,
+		Extension: []*descriptorpb.FieldDescriptorProto{
+			{
+				Extendee: proto.String(".google.protobuf.FieldOptions"),
+				Name:     proto.String("baz"),
+				Number:   proto.Int32(customOptionNum),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_FLOAT.Enum(),
+			},
+		},
+	}
+	resolver, err := NewResolver(descriptorFile, durationFile, timestampFile, validateFile, testFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return testFile, resolver
+}


### PR DESCRIPTION
This is an alternative solution to #4493. It improves the "RealWorld" benchmark by approximately the same amount (in both runtime and allocations), but is better on the "Synthetic" case. The value of the "Synthetic" case is that it has a shape more like small modules with fewer fields and/or modules where nearly all elements are annotated. For the former, this solution elides the map that caches relevant fields for all messages (whose cost to construct can outweight savings for small modules where there are fewer elements to amortize the cost of the cache). For the latter, it hoists the lambda and all accessed state up into a struct so it can be allocated once at the start of the operation instead of per-recursive-call (so if there are a very large number of extensions, we still beat the baseline in `main`).

Here's the output of `benchstat`:
```
goos: darwin
goarch: arm64
pkg: github.com/bufbuild/buf/private/pkg/protoencoding
cpu: Apple M1 Max
                               │ old_bench.txt │            new_bench.txt            │
                               │    sec/op     │    sec/op     vs base               │
ReparseExtensions_Synthetic-10    5.124m ± ∞ ¹   4.354m ± ∞ ¹  -15.03% (p=0.008 n=5)
ReparseExtensions_RealWorld-10    5.205m ± ∞ ¹   3.238m ± ∞ ¹  -37.80% (p=0.008 n=5)
geomean                           5.165m         3.755m        -27.30%
¹ need >= 6 samples for confidence interval at level 0.95

                               │ old_bench.txt │            new_bench.txt             │
                               │     B/op      │     B/op       vs base               │
ReparseExtensions_Synthetic-10   3.629Mi ± ∞ ¹   3.322Mi ± ∞ ¹   -8.47% (p=0.008 n=5)
ReparseExtensions_RealWorld-10   4.635Mi ± ∞ ¹   2.961Mi ± ∞ ¹  -36.12% (p=0.008 n=5)
geomean                          4.101Mi         3.136Mi        -23.53%
¹ need >= 6 samples for confidence interval at level 0.95

                               │ old_bench.txt │            new_bench.txt            │
                               │   allocs/op   │  allocs/op    vs base               │
ReparseExtensions_Synthetic-10    57.63k ± ∞ ¹   43.53k ± ∞ ¹  -24.47% (p=0.008 n=5)
ReparseExtensions_RealWorld-10   111.35k ± ∞ ¹   60.30k ± ∞ ¹  -45.84% (p=0.008 n=5)
geomean                           80.11k         51.24k        -36.04%
¹ need >= 6 samples for confidence interval at level 0.95
```