### PR TITLE
Fix color logging

### DIFF
--- a/private/pkg/slogapp/slogapp.go
+++ b/private/pkg/slogapp/slogapp.go
@@ -68,8 +68,8 @@ func getHandler(writer io.Writer, logLevel appext.LogLevel, logFormat appext.Log
 		return newConsoleHandler(writer, level, withConsoleColor(false)), nil
 	case appext.LogFormatColor:
 		// Use a custom console handler that formats log messages in a human-readable format.
-		// Color is enabled automatically if the writer is a TTY.
-		return newConsoleHandler(writer, level), nil
+		// Color is explicitly enabled since the user requested it (NO_COLOR still takes precedence).
+		return newConsoleHandler(writer, level, withConsoleColor(true)), nil
 	default:
 		return nil, fmt.Errorf("invalid logFormat: %v", logFormat)
 	}

--- a/private/pkg/slogapp/slogapp_test.go
+++ b/private/pkg/slogapp/slogapp_test.go
@@ -24,6 +24,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLogFormatColorEnablesColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	var sb strings.Builder
+	logger, err := NewLogger(&sb, appext.LogLevelInfo, appext.LogFormatColor)
+	require.NoError(t, err)
+	logger.Info("hello")
+	assert.Contains(t, sb.String(), "\x1b[")
+}
+
+func TestLogFormatColorRespectsNoColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var sb strings.Builder
+	logger, err := NewLogger(&sb, appext.LogLevelInfo, appext.LogFormatColor)
+	require.NoError(t, err)
+	logger.Info("hello")
+	assert.NotContains(t, sb.String(), "\x1b[")
+}
+
 func TestNoStack(t *testing.T) {
 	t.Parallel()
 	var sb strings.Builder


### PR DESCRIPTION
Noticed that `buf build --debug` or `buf build --debug --log-format color` (the default) were not logging with color in a TTY.

Looks like this originally broke in #4335.