### PR TITLE
Set check plugin memory limits to 1GiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Increase WASM memory limits to 1GiB.
+- Increase check plugin WASM memory limits to 1GiB.
 
 ## [v1.68.4] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Unbound WASM check plugin memory limits.
 
 ## [v1.68.4] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Unbound WASM check plugin memory limits.
+- Increase WASM memory limits to 1GiB.
 
 ## [v1.68.4] - 2026-04-22
 

--- a/private/buf/bufcli/cache.go
+++ b/private/buf/bufcli/cache.go
@@ -216,7 +216,11 @@ func NewWasmRuntime(ctx context.Context, container appext.Container) (wasm.Runti
 		return nil, err
 	}
 	fullCacheDirPath := normalpath.Join(container.CacheDirPath(), v3CacheWasmRuntimeRelDirPath)
-	wasmRuntime, err := wasm.NewRuntime(ctx, wasm.WithLocalCacheDir(fullCacheDirPath))
+	wasmRuntime, err := wasm.NewRuntime(
+		ctx,
+		wasm.WithLocalCacheDir(fullCacheDirPath),
+		wasm.WithMaxMemoryBytes(1<<32-1), // Max for unbounded size locally.
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/private/buf/bufcli/cache.go
+++ b/private/buf/bufcli/cache.go
@@ -216,11 +216,7 @@ func NewWasmRuntime(ctx context.Context, container appext.Container) (wasm.Runti
 		return nil, err
 	}
 	fullCacheDirPath := normalpath.Join(container.CacheDirPath(), v3CacheWasmRuntimeRelDirPath)
-	wasmRuntime, err := wasm.NewRuntime(
-		ctx,
-		wasm.WithLocalCacheDir(fullCacheDirPath),
-		wasm.WithMaxMemoryBytes(1<<32-1), // Max for unbounded size locally.
-	)
+	wasmRuntime, err := wasm.NewRuntime(ctx, wasm.WithLocalCacheDir(fullCacheDirPath))
 	if err != nil {
 		return nil, err
 	}

--- a/private/pkg/wasm/runtime.go
+++ b/private/pkg/wasm/runtime.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// defaultMaxMemoryBytes is the maximum memory size in bytes.
-	defaultMaxMemoryBytes = 1 << 29 // 512 MiB
+	defaultMaxMemoryBytes = 1 << 30 // 1 GiB
 	// wasmPageSize is the page size in bytes.
 	wasmPageSize = 1 << 16 // 64 KiB
 )

--- a/private/pkg/wasm/wasm.go
+++ b/private/pkg/wasm/wasm.go
@@ -59,7 +59,7 @@ type RuntimeOption func(*runtimeOptions)
 
 // WithMaxMemoryBytes sets the maximum memory size in bytes.
 //
-// The maximuim memory size is limited to 4 GiB. The default is 512 MiB. Sizes
+// The maximuim memory size is limited to 4 GiB. The default is 1 GiB. Sizes
 // less then the page size (64 KiB) are truncated.
 func WithMaxMemoryBytes(maxMemoryBytes uint32) RuntimeOption {
 	return func(runtimeOptions *runtimeOptions) {


### PR DESCRIPTION
This sets the max memory to 1GiB for WASM check plugins.