### PR TITLE
Clear stale LSP diagnostics when a file is closed or deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Increase check plugin WASM memory limits to 1GiB.
+- Fix LSP stale diagnostics persisting in the Problems panel after a file is closed or deleted.
 
 ## [v1.68.4] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Increase check plugin WASM memory limits to 1GiB.
-- Fix LSP stale diagnostics persisting in the Problems panel after a file is closed or deleted.
+- Fix LSP stale diagnostics persisting after a file is closed or deleted.
 
 ## [v1.68.4] - 2026-04-22
 

--- a/private/buf/buflsp/diagnostics_test.go
+++ b/private/buf/buflsp/diagnostics_test.go
@@ -511,6 +511,71 @@ func TestDiagnosticsNoTransitiveLeak(t *testing.T) {
 	})
 }
 
+// TestDiagnosticsClearedOnClose verifies that stale diagnostics are cleared from the
+// client when a file is closed, reproducing the scenario from
+// https://github.com/bufbuild/vscode-buf/issues/626 where lint errors on a deleted file
+// continued to show in the editor's Problems panel after the file was removed.
+func TestDiagnosticsClearedOnClose(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		// Use an existing testdata file with a known lint violation (IMPORT_USED)
+		// so the workspace is fully configured and RunChecks produces diagnostics.
+		protoPath, err := filepath.Abs("testdata/diagnostics/unused_import.proto")
+		require.NoError(t, err)
+
+		clientJSONConn, testURI, capture := setupLSPServerWithDiagnostics(t, protoPath)
+
+		ctx := t.Context()
+
+		initial := capture.wait(t, testURI, 10*time.Second, func(p *protocol.PublishDiagnosticsParams) bool {
+			return len(p.Diagnostics) > 0
+		})
+		require.NotEmpty(t, initial.Diagnostics, "expected lint diagnostics before close")
+
+		err = clientJSONConn.Notify(ctx, protocol.MethodTextDocumentDidClose, &protocol.DidCloseTextDocumentParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: testURI},
+		})
+		require.NoError(t, err)
+
+		cleared := capture.wait(t, testURI, 5*time.Second, func(p *protocol.PublishDiagnosticsParams) bool {
+			return len(p.Diagnostics) == 0
+		})
+		assert.Empty(t, cleared.Diagnostics, "stale diagnostics should be cleared after file close")
+	})
+}
+
+// TestDiagnosticsClearedOnDelete verifies that stale diagnostics are cleared when
+// the server receives a workspace/didDeleteFiles notification for a tracked file,
+// covering the case where the editor does not send textDocument/didClose first.
+func TestDiagnosticsClearedOnDelete(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		protoPath, err := filepath.Abs("testdata/diagnostics/unused_import.proto")
+		require.NoError(t, err)
+
+		clientJSONConn, testURI, capture := setupLSPServerWithDiagnostics(t, protoPath)
+
+		ctx := t.Context()
+
+		initial := capture.wait(t, testURI, 10*time.Second, func(p *protocol.PublishDiagnosticsParams) bool {
+			return len(p.Diagnostics) > 0
+		})
+		require.NotEmpty(t, initial.Diagnostics, "expected lint diagnostics before delete")
+
+		err = clientJSONConn.Notify(ctx, protocol.MethodDidDeleteFiles, &protocol.DeleteFilesParams{
+			Files: []protocol.FileDelete{{URI: string(testURI)}},
+		})
+		require.NoError(t, err)
+
+		cleared := capture.wait(t, testURI, 5*time.Second, func(p *protocol.PublishDiagnosticsParams) bool {
+			return len(p.Diagnostics) == 0
+		})
+		assert.Empty(t, cleared.Diagnostics, "stale diagnostics should be cleared after file delete")
+	})
+}
+
 // diagnosticsCapture captures publishDiagnostics notifications from the LSP server.
 type diagnosticsCapture struct {
 	mu          sync.Mutex

--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -101,15 +101,17 @@ func (f *file) Reset(ctx context.Context) {
 	// Evict the query key if there is a query cached on the file. We cache the [queries.File]
 	// query since this allows the executor to evict all dependent queries, e.g. AST and IR.
 	f.lsp.queryExecutor.Evict(f.queryFileKeys()...)
+	f.clearEditorState(ctx)
 	// Clear the file as nothing should use it after reset. This asserts that.
 	*f = file{}
 }
 
-// Close marks a file as closed.
-//
-// This will not necessarily evict the file, since there may be more than one user
-// for this file.
+// Close marks a file as closed by the editor. It clears the editor state
+// (cancels in-flight checks and publishes empty diagnostics) then decrements
+// the ref count. The file is only evicted when the ref count reaches zero,
+// since the workspace may hold additional references.
 func (f *file) Close(ctx context.Context) {
+	f.clearEditorState(ctx)
 	f.Manager().Close(ctx, f.uri)
 }
 
@@ -1080,6 +1082,26 @@ func (f *file) CancelChecks(ctx context.Context) {
 	}
 }
 
+// clearEditorState cancels in-flight checks, publishes empty diagnostics to clear
+// the client's Problems panel (only when diagnostics are non-empty, to avoid a
+// no-op network write), and marks the file as no longer open in the editor by
+// setting version=-1. Called while the LSP lock is held, before the editor ref
+// is decremented.
+//
+// The publish must happen before version is set to -1 because PublishDiagnostics
+// checks IsOpenInEditor (which returns f.version != -1) and returns early if false.
+func (f *file) clearEditorState(ctx context.Context) {
+	if !f.IsOpenInEditor() {
+		return
+	}
+	f.CancelChecks(ctx)
+	if len(f.diagnostics) > 0 {
+		f.diagnostics = nil
+		f.PublishDiagnostics(ctx)
+	}
+	f.version = -1
+}
+
 // RunChecks triggers the run of checks for this file. Diagnostics are published asynchronously.
 func (f *file) RunChecks(ctx context.Context) {
 	if f.IsWKT() || !f.IsOpenInEditor() {
@@ -1174,7 +1196,7 @@ func (f *file) RunChecks(ctx context.Context) {
 			// TODO: prefer diagnostics from the old compiler to the new compiler to remove duplicates from both.
 			f.diagnostics = diagnostics
 		}
-		f.appendAnnotations("buf lint", annotations)
+		f.appendAnnotations(lintSourceName, annotations)
 		f.PublishDiagnostics(ctx)
 	}()
 }

--- a/private/buf/buflsp/lint_ignore.go
+++ b/private/buf/buflsp/lint_ignore.go
@@ -46,7 +46,7 @@ func (s *server) getLintIgnoreCodeActions(
 	// Filter diagnostics to find lint errors that overlap with the requested range
 	for _, diagnostic := range file.diagnostics {
 		// Only handle lint diagnostics (not IR diagnostics)
-		if diagnostic.Source != "buf lint" {
+		if diagnostic.Source != lintSourceName {
 			continue
 		}
 

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	serverName = "buf-lsp"
+	serverName     = "buf-lsp"
+	lintSourceName = "buf lint"
 
 	maxSymbolResults = 1000
 )
@@ -377,6 +378,33 @@ func (s *server) DidClose(
 	}
 	if file := s.fileManager.Get(params.TextDocument.URI); file != nil {
 		file.Close(ctx)
+	}
+	return nil
+}
+
+// DidDeleteFiles is called when files are deleted on disk (e.g. via the OS or
+// IDE file explorer). For each deleted file we close the corresponding tracked
+// resource so stale diagnostics are cleared from the client.
+func (s *server) DidDeleteFiles(
+	ctx context.Context,
+	params *protocol.DeleteFilesParams,
+) error {
+	for _, deleted := range params.Files {
+		uri := protocol.URI(deleted.URI)
+		switch {
+		case isBufYAMLURI(uri):
+			s.bufYAMLManager.Close(ctx, uri)
+		case isBufGenYAMLURI(uri):
+			s.bufGenYAMLManager.Close(uri)
+		case isBufPolicyYAMLURI(uri):
+			s.bufPolicyYAMLManager.Close(uri)
+		case isBufLockURI(uri):
+			s.bufLockManager.Close(uri)
+		default:
+			if file := s.fileManager.Get(uri); file != nil {
+				file.Close(ctx)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When a file was closed or deleted, the LSP server never published empty diagnostics to clear the client's Problems panel.

Root cause: the workspace's `indexFiles` path calls `fileManager.Track` for every file in the module, so the ref count for an editor-open file is typically 2 (one from `DidOpen`, one from the workspace). When `DidClose` decremented the count to 1, `Reset` was never called and diagnostics were never cleared.

Fix by making `file.Close` call `clearEditorState` before decrementing the ref count. `clearEditorState` cancels in-flight lint checks, publishes empty diagnostics (only when non-empty, to skip the no-op network write), and sets `version=-1` so subsequent `RunChecks` won't re-publish lint diagnostics.

Also implement `DidDeleteFiles` (`workspace/didDeleteFiles`), previously a NYI stub, so files deleted from disk via the OS or IDE file explorer are handled the same way.

Also extract the `"buf lint"` diagnostic source string into a named constant `lintSourceName`.

Fixes https://github.com/bufbuild/vscode-buf/issues/626.