### PR TITLE
Add concurrency checks for CI workflows

### DIFF
--- a/.github/workflows/buf-binary-size.yaml
+++ b/.github/workflows/buf-binary-size.yaml
@@ -8,6 +8,9 @@ on:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   MAKEFLAGS: "-j 2"
 jobs:

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
   pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   buf:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   MAKEFLAGS: "-j 2"
 jobs:

--- a/.github/workflows/previous.yaml
+++ b/.github/workflows/previous.yaml
@@ -8,6 +8,9 @@ on:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   MAKEFLAGS: "-j 2"
 jobs:

--- a/.github/workflows/verify-changelog.yaml
+++ b/.github/workflows/verify-changelog.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - "release/**"
       - "next/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -8,6 +8,9 @@ on:
 # Prevent writing to the repository using the CI token.
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
 permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     env:


### PR DESCRIPTION
Noticed that I was getting notifications about failing checks for previous commits. For basically all of our CI workflows, we can cancel running jobs if new commits are pushed, since the main thing we're concerned about are the checks on the final commit.