### PR TITLE
Add LSP filesystem path and proto type completions

### DIFF
--- a/private/buf/buflsp/buf_gen_yaml.go
+++ b/private/buf/buflsp/buf_gen_yaml.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -63,31 +64,65 @@ type bufGenYAMLFile struct {
 	refs                []bsrRef   // plugins[*].remote and inputs[*].module BSR references
 	versionedPluginRefs []bsrRef   // plugins[*].remote with an explicit version (for update checks)
 	pluginsKeyLine      uint32     // 0-indexed line of the "plugins:" key
+	workspace           *workspace // leased workspace for type completions, may be nil
 }
 
 // Track opens or refreshes a buf.gen.yaml file.
-func (m *bufGenYAMLManager) Track(uri protocol.URI, text string) {
+//
+// The workspace is leased on first Track and reused on subsequent Tracks for
+// the same URI; LeaseWorkspace's Refresh is too expensive to run per keystroke,
+// and proto file changes already refresh the workspace via their own Update path.
+func (m *bufGenYAMLManager) Track(ctx context.Context, uri protocol.URI, text string) {
 	normalized := normalizeURI(uri)
 	docNode := parseYAMLDoc(text)
 	allRefs, versionedPluginRefs, pluginsKeyLine := parseBufGenYAMLRefs(docNode)
+
+	m.mu.Lock()
+	existing := m.uriToFile[normalized]
+	m.mu.Unlock()
+
+	var ws *workspace
+	if existing != nil && existing.workspace != nil {
+		ws = existing.workspace
+	} else {
+		// LeaseWorkspace passes the URI to controller.GetWorkspace, which infers
+		// the input format from the path. A .yaml file isn't a valid input format,
+		// so use the parent directory URI instead.
+		workspaceURI := FilePathToURI(filepath.Dir(uri.Filename()))
+		var err error
+		ws, err = m.lsp.workspaceManager.LeaseWorkspace(ctx, workspaceURI)
+		if err != nil {
+			m.lsp.logger.DebugContext(ctx, "buf.gen.yaml: could not lease workspace",
+				slog.String("uri", string(uri)),
+				slog.String("error", err.Error()),
+			)
+			ws = nil
+		}
+	}
+
 	f := &bufGenYAMLFile{
 		text:                text,
 		docNode:             docNode,
 		refs:                allRefs,
 		versionedPluginRefs: versionedPluginRefs,
 		pluginsKeyLine:      pluginsKeyLine,
+		workspace:           ws,
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.uriToFile[normalized] = f
+	m.mu.Unlock()
 }
 
 // Close stops tracking a buf.gen.yaml file and clears any diagnostics it published.
 func (m *bufGenYAMLManager) Close(ctx context.Context, uri protocol.URI) {
 	normalized := normalizeURI(uri)
 	m.mu.Lock()
+	old := m.uriToFile[normalized]
 	delete(m.uriToFile, normalized)
 	m.mu.Unlock()
+	if old != nil && old.workspace != nil {
+		old.workspace.Release()
+	}
 	publishDiagnostics(ctx, m.lsp.client, normalized, nil)
 }
 
@@ -100,7 +135,7 @@ func (m *bufGenYAMLManager) GetCompletion(uri protocol.URI, pos protocol.Positio
 	if !ok {
 		return nil
 	}
-	return getBufGenYAMLCompletionItems(f.docNode, f.text, pos)
+	return getBufGenYAMLCompletionItems(f.docNode, f.text, pos, filepath.Dir(uri.Filename()), f.workspace)
 }
 
 // GetHover returns hover documentation for the buf.gen.yaml field at the given

--- a/private/buf/buflsp/buf_gen_yaml_completion.go
+++ b/private/buf/buflsp/buf_gen_yaml_completion.go
@@ -16,14 +16,42 @@ package buflsp
 
 import (
 	"maps"
+	"slices"
+	"strings"
 
+	"github.com/bufbuild/protocompile/experimental/ir"
 	"go.lsp.dev/protocol"
 	"gopkg.in/yaml.v3"
 )
 
+// bufGenYAMLPathValueKeys maps buf.gen.yaml value keys whose values are
+// filesystem paths to whether only directory entries should be offered.
+// out and directory are always directories.
+var bufGenYAMLPathValueKeys = map[string]bool{
+	"out":       true,
+	"directory": true,
+}
+
+// bufGenYAMLPathSequenceSections maps buf.gen.yaml section names whose
+// sequence items are filesystem paths to whether only directory entries
+// should be offered. paths and exclude_paths accept files or directories.
+var bufGenYAMLPathSequenceSections = map[string]bool{
+	"paths":         false,
+	"exclude_paths": false,
+}
+
+// bufGenYAMLTypeSequenceSections is the set of buf.gen.yaml section names
+// whose sequence items are fully-qualified proto type names.
+var bufGenYAMLTypeSequenceSections = map[string]bool{
+	"types": true, "exclude_types": true,
+}
+
 // getBufGenYAMLCompletionItems returns completion items for a buf.gen.yaml file
-// at the given cursor position.
-func getBufGenYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Position) []protocol.CompletionItem {
+// at the given cursor position. dirPath is the directory containing the
+// buf.gen.yaml file, used to resolve filesystem path completions; pass "" to
+// disable path completions (e.g. in tests). ws is the leased workspace for
+// proto type name completions; pass nil to disable type completions.
+func getBufGenYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Position, dirPath string, ws *workspace) []protocol.CompletionItem {
 	lines, prefix, ok := bufYAMLParseCursor(text, pos)
 	if !ok {
 		return nil
@@ -32,6 +60,9 @@ func getBufGenYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.
 	tokenStart := bufYAMLTokenStart(prefix)
 	editRange := bufYAMLEditRange(pos, tokenStart, lines[cursorLine])
 	if valueKey := bufYAMLValueKey(prefix); valueKey != "" {
+		if dirsOnly, ok := bufGenYAMLPathValueKeys[valueKey]; ok {
+			return bufYAMLPathItems(dirPath, prefix[tokenStart:], editRange, dirsOnly)
+		}
 		return bufGenYAMLValueItems(valueKey, editRange)
 	}
 	if tokenStart < len(prefix) && prefix[tokenStart] == '-' {
@@ -43,6 +74,12 @@ func getBufGenYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.
 		if bareKey := bufYAMLBareParentKey(lines, cursorLine); bufGenYAMLBareParentMappingKeys[bareKey] {
 			return bufYAMLPrependIndent(bufGenYAMLKeyItems(bareKey, editRange, nil))
 		}
+	}
+	if dirsOnly, ok := bufGenYAMLPathSequenceSections[section]; ok {
+		return bufYAMLPathItems(dirPath, prefix[tokenStart:], editRange, dirsOnly)
+	}
+	if bufGenYAMLTypeSequenceSections[section] {
+		return bufGenYAMLTypeItems(ws, prefix[tokenStart:], editRange)
 	}
 	existingKeys := bufYAMLASTExistingKeys(docNode, section, parentSection, cursorLine)
 	if existingKeys == nil {
@@ -250,4 +287,57 @@ var bufGenYAMLManagedKeys = []string{"enabled", "disable", "override"}
 // bufGenYAMLManagedRuleKeys lists keys valid within managed.disable[] and managed.override[] items.
 var bufGenYAMLManagedRuleKeys = []string{
 	"file_option", "field_option", "module", "path", "field", "value",
+}
+
+// bufGenYAMLTypeItems returns completion items for fully-qualified proto type names
+// (messages, enums, services) from the workspace. partialName is the text already
+// typed; items whose name does not have partialName as a prefix are excluded.
+// Returns nil when ws is nil or no symbols are indexed.
+//
+// Iterates each file's IR directly (rather than referenceableSymbols, which only
+// holds messages and enums) so services are included.
+func bufGenYAMLTypeItems(ws *workspace, partialName string, editRange protocol.Range) []protocol.CompletionItem {
+	if ws == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var items []protocol.CompletionItem
+	for _, wsFile := range ws.PathToFile() {
+		if wsFile.ir == nil {
+			continue
+		}
+		symbols := wsFile.ir.Symbols()
+		for i := range symbols.Len() {
+			sym := symbols.At(i)
+			switch sym.Kind() {
+			case ir.SymbolKindMessage:
+				if sym.AsType().IsMapEntry() {
+					continue
+				}
+			case ir.SymbolKindEnum, ir.SymbolKindService:
+			default:
+				continue
+			}
+			name := string(sym.FullName())
+			if partialName != "" && !strings.HasPrefix(name, partialName) {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			items = append(items, protocol.CompletionItem{
+				Label: name,
+				Kind:  protocol.CompletionItemKindValue,
+				TextEdit: &protocol.TextEdit{
+					Range:   editRange,
+					NewText: name,
+				},
+			})
+		}
+	}
+	slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+		return strings.Compare(a.Label, b.Label)
+	})
+	return items
 }

--- a/private/buf/buflsp/buf_gen_yaml_completion_test.go
+++ b/private/buf/buflsp/buf_gen_yaml_completion_test.go
@@ -15,6 +15,8 @@
 package buflsp
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -325,7 +327,7 @@ func TestGetBufGenYAMLCompletionItems(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			items := getBufGenYAMLCompletionItems(parseYAMLDoc(testCase.text), testCase.text, testCase.pos)
+			items := getBufGenYAMLCompletionItems(parseYAMLDoc(testCase.text), testCase.text, testCase.pos, "", nil)
 
 			if testCase.wantNilResult {
 				assert.Nil(t, items)
@@ -358,7 +360,7 @@ func TestGetBufGenYAMLCompletionItemsTextEdit(t *testing.T) {
 	t.Run("key_textEdit_includes_colon_space", func(t *testing.T) {
 		t.Parallel()
 		text := "plugins:\n  - \n"
-		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 1, Character: 4})
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 1, Character: 4}, "", nil)
 		require.NotNil(t, items)
 		for _, item := range items {
 			require.NotNil(t, item.TextEdit, "item %q has no TextEdit", item.Label)
@@ -371,7 +373,7 @@ func TestGetBufGenYAMLCompletionItemsTextEdit(t *testing.T) {
 		t.Parallel()
 		// "version: v" — cursor at character 10, token "v" starts at character 9.
 		text := "version: v\n"
-		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 0, Character: 10})
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 0, Character: 10}, "", nil)
 		require.NotNil(t, items)
 		for _, item := range items {
 			require.NotNil(t, item.TextEdit, "item %q has no TextEdit", item.Label)
@@ -380,5 +382,109 @@ func TestGetBufGenYAMLCompletionItemsTextEdit(t *testing.T) {
 			assert.Equal(t, uint32(10), item.TextEdit.Range.End.Character,
 				"item %q TextEdit range should end at cursor (col 10)", item.Label)
 		}
+	})
+}
+
+func TestGetBufGenYAMLCompletionItemsPathCompletions(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "gen", "go"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "proto"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "buf.yaml"), []byte("version: v2\n"), 0o600))
+
+	t.Run("out_value_empty_partial_dirs_only", func(t *testing.T) {
+		t.Parallel()
+		text := "plugins:\n  - remote: buf.build/foo/bar\n    out: \n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 9}, tmpDir, nil)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "gen/"), "expected label %q", "gen/")
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+		assert.False(t, slices.Contains(labels, "buf.yaml"), "out is a directory key — files should be excluded")
+	})
+
+	t.Run("out_value_partial", func(t *testing.T) {
+		t.Parallel()
+		text := "plugins:\n  - remote: buf.build/foo/bar\n    out: ge\n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 11}, tmpDir, nil)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "gen/"), "expected label %q", "gen/")
+		assert.False(t, slices.Contains(labels, "proto/"), "unexpected label %q", "proto/")
+	})
+
+	t.Run("directory_value", func(t *testing.T) {
+		t.Parallel()
+		// "  - directory: " — cursor at character 15, after the space following ":".
+		text := "inputs:\n  - directory: \n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 1, Character: 15}, tmpDir, nil)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+	})
+
+	t.Run("paths_sequence", func(t *testing.T) {
+		t.Parallel()
+		text := "inputs:\n  - directory: proto\n    paths:\n      - \n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 3, Character: 8}, tmpDir, nil)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+	})
+
+	t.Run("exclude_paths_sequence", func(t *testing.T) {
+		t.Parallel()
+		text := "inputs:\n  - directory: proto\n    exclude_paths:\n      - \n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 3, Character: 8}, tmpDir, nil)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+	})
+
+	t.Run("out_subdir", func(t *testing.T) {
+		t.Parallel()
+		text := "plugins:\n  - remote: buf.build/foo/bar\n    out: gen/\n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 14}, tmpDir, nil)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "gen/go/"), "expected label %q", "gen/go/")
+	})
+
+	t.Run("dirpath_empty_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		text := "plugins:\n  - remote: buf.build/foo/bar\n    out: \n"
+		items := getBufGenYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 9}, "", nil)
+		assert.Nil(t, items)
+	})
+}
+
+func TestGetBufGenYAMLCompletionItemsTypeCompletions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_workspace_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		text := "plugins:\n  - remote: buf.build/protocolbuffers/go\n    out: gen\n    types:\n      - \n"
+		items := getBufGenYAMLCompletionItems(
+			parseYAMLDoc(text),
+			text,
+			protocol.Position{Line: 4, Character: 6},
+			"",
+			nil,
+		)
+		assert.Nil(t, items)
+	})
+
+	t.Run("nil_workspace_returns_nil_exclude_types", func(t *testing.T) {
+		t.Parallel()
+		text := "inputs:\n  - directory: proto\n    exclude_types:\n      - \n"
+		items := getBufGenYAMLCompletionItems(
+			parseYAMLDoc(text),
+			text,
+			protocol.Position{Line: 3, Character: 6},
+			"",
+			nil,
+		)
+		assert.Nil(t, items)
 	})
 }

--- a/private/buf/buflsp/buf_gen_yaml_lsp_test.go
+++ b/private/buf/buflsp/buf_gen_yaml_lsp_test.go
@@ -16,6 +16,7 @@ package buflsp_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -794,4 +795,122 @@ func TestBufGenYAMLDiagnostics_ClearedOnClose(t *testing.T) {
 		require.NotNil(t, cleared)
 		assert.Empty(t, cleared.Diagnostics, "expected diagnostics to be cleared after close")
 	})
+}
+
+// TestBufGenYAMLTypeCompletions exercises the workspace lease wired up in
+// bufGenYAMLManager.Track and the symbol enumeration in bufGenYAMLTypeItems.
+// Opening buf.gen.yaml leases the workspace; opening the proto file alongside
+// triggers IR compilation so referenceableSymbols is populated. Completion at
+// the types/exclude_types cursor should then surface fully-qualified type
+// names from the workspace.
+func TestBufGenYAMLTypeCompletions(t *testing.T) {
+	t.Parallel()
+
+	bufGenPath, err := filepath.Abs("testdata/buf_gen_yaml/types_completion/buf.gen.yaml")
+	require.NoError(t, err)
+	protoPath := filepath.Join(filepath.Dir(bufGenPath), "proto", "acme", "test", "v1", "example.proto")
+
+	clientJSONConn, bufGenURI, _ := setupLSPServerForBufYAML(t, bufGenPath, nil, nil)
+	ctx := t.Context()
+
+	protoContent, err := os.ReadFile(protoPath)
+	require.NoError(t, err)
+	err = clientJSONConn.Notify(ctx, protocol.MethodTextDocumentDidOpen, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:        buflsp.FilePathToURI(protoPath),
+			LanguageID: "protobuf",
+			Version:    1,
+			Text:       string(protoContent),
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		line      uint32
+		character uint32
+	}{
+		// "      - acme." — cursor at character 13, right after the partial.
+		{"plugins_types", 5, 13},
+		{"inputs_exclude_types", 9, 13},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var list *protocol.CompletionList
+			_, err := clientJSONConn.Call(ctx, protocol.MethodTextDocumentCompletion, protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: bufGenURI},
+					Position:     protocol.Position{Line: tc.line, Character: tc.character},
+				},
+			}, &list)
+			require.NoError(t, err)
+
+			require.NotNil(t, list, "expected completions at (%d, %d)", tc.line, tc.character)
+			labels := make([]string, len(list.Items))
+			for i, item := range list.Items {
+				labels[i] = item.Label
+			}
+			assert.Contains(t, labels, "acme.test.v1.Foo", "expected message type")
+			assert.Contains(t, labels, "acme.test.v1.Status", "expected enum type")
+			assert.Contains(t, labels, "acme.test.v1.ExampleService", "expected service type")
+			assert.Contains(t, labels, "acme.test.v1.GreetRequest")
+			assert.Contains(t, labels, "acme.test.v1.GreetResponse")
+		})
+	}
+}
+
+// TestBufGenYAMLTypeCompletions_WorkspaceReuseOnDidChange verifies that the
+// workspace lease is reused across DidChange events: type completions still
+// work after the buf.gen.yaml is edited.
+func TestBufGenYAMLTypeCompletions_WorkspaceReuseOnDidChange(t *testing.T) {
+	t.Parallel()
+
+	bufGenPath, err := filepath.Abs("testdata/buf_gen_yaml/types_completion/buf.gen.yaml")
+	require.NoError(t, err)
+	protoPath := filepath.Join(filepath.Dir(bufGenPath), "proto", "acme", "test", "v1", "example.proto")
+
+	clientJSONConn, bufGenURI, _ := setupLSPServerForBufYAML(t, bufGenPath, nil, nil)
+	ctx := t.Context()
+
+	protoContent, err := os.ReadFile(protoPath)
+	require.NoError(t, err)
+	err = clientJSONConn.Notify(ctx, protocol.MethodTextDocumentDidOpen, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:        buflsp.FilePathToURI(protoPath),
+			LanguageID: "protobuf",
+			Version:    1,
+			Text:       string(protoContent),
+		},
+	})
+	require.NoError(t, err)
+
+	bufGenContent, err := os.ReadFile(bufGenPath)
+	require.NoError(t, err)
+	err = clientJSONConn.Notify(ctx, protocol.MethodTextDocumentDidChange, &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: bufGenURI},
+			Version:                2,
+		},
+		ContentChanges: []protocol.TextDocumentContentChangeEvent{{Text: string(bufGenContent)}},
+	})
+	require.NoError(t, err)
+
+	var list *protocol.CompletionList
+	_, err = clientJSONConn.Call(ctx, protocol.MethodTextDocumentCompletion, protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: bufGenURI},
+			Position:     protocol.Position{Line: 5, Character: 13},
+		},
+	}, &list)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+
+	labels := make([]string, len(list.Items))
+	for i, item := range list.Items {
+		labels[i] = item.Label
+	}
+	assert.Contains(t, labels, "acme.test.v1.Foo")
 }

--- a/private/buf/buflsp/buf_yaml.go
+++ b/private/buf/buflsp/buf_yaml.go
@@ -557,7 +557,7 @@ func (m *bufYAMLManager) GetCompletion(uri protocol.URI, pos protocol.Position) 
 	if !ok {
 		return nil
 	}
-	return getBufYAMLCompletionItems(f.docNode, f.text, pos)
+	return getBufYAMLCompletionItems(f.docNode, f.text, pos, filepath.Dir(uri.Filename()))
 }
 
 // GetHover returns hover documentation for the buf.yaml field or rule at the

--- a/private/buf/buflsp/buf_yaml_completion.go
+++ b/private/buf/buflsp/buf_yaml_completion.go
@@ -15,6 +15,9 @@
 package buflsp
 
 import (
+	"os"
+	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -23,8 +26,10 @@ import (
 )
 
 // getBufYAMLCompletionItems returns completion items for a buf.yaml file at
-// the given cursor position.
-func getBufYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Position) []protocol.CompletionItem {
+// the given cursor position. dirPath is the directory containing the buf.yaml
+// file, used to resolve filesystem path completions; pass "" to disable path
+// completions (e.g. in tests).
+func getBufYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Position, dirPath string) []protocol.CompletionItem {
 	lines, prefix, ok := bufYAMLParseCursor(text, pos)
 	if !ok {
 		return nil
@@ -33,6 +38,9 @@ func getBufYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Pos
 	tokenStart := bufYAMLTokenStart(prefix)
 	editRange := bufYAMLEditRange(pos, tokenStart, lines[cursorLine])
 	if valueKey := bufYAMLValueKey(prefix); valueKey != "" {
+		if dirsOnly, ok := bufYAMLPathValueKeys[valueKey]; ok {
+			return bufYAMLPathItems(dirPath, prefix[tokenStart:], editRange, dirsOnly)
+		}
 		return bufYAMLValueItems(valueKey, editRange)
 	}
 	if tokenStart < len(prefix) && prefix[tokenStart] == '-' {
@@ -48,6 +56,15 @@ func getBufYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Pos
 	if section == "use" || section == "except" {
 		return bufYAMLSequenceItems(parentSection, editRange)
 	}
+	if dirsOnly, ok := bufYAMLPathSequenceSections[section]; ok {
+		return bufYAMLPathItems(dirPath, prefix[tokenStart:], editRange, dirsOnly)
+	}
+	// ignore_only maps each rule ID to a list of file/directory paths.
+	// When the cursor is inside such a list, section is the rule ID itself
+	// (e.g., "STANDARD", "FILE_NO_DELETE"), and the immediate parent is "ignore_only".
+	if parentSection == "ignore_only" {
+		return bufYAMLPathItems(dirPath, prefix[tokenStart:], editRange, false)
+	}
 	existingKeys := bufYAMLASTExistingKeys(docNode, section, parentSection, cursorLine)
 	if existingKeys == nil {
 		existingKeys = bufYAMLExistingKeys(lines, cursorLine, currentIndent)
@@ -56,6 +73,69 @@ func getBufYAMLCompletionItems(docNode *yaml.Node, text string, pos protocol.Pos
 		return bufYAMLIgnoreOnlyKeyItems(parentSection, editRange, existingKeys)
 	}
 	return bufYAMLKeyItems(section, editRange, existingKeys)
+}
+
+// bufYAMLPathValueKeys maps buf.yaml value keys whose values are filesystem
+// paths to whether only directory entries should be offered.
+var bufYAMLPathValueKeys = map[string]bool{
+	"path": true,
+}
+
+// bufYAMLPathSequenceSections maps buf.yaml section names whose sequence items
+// are filesystem paths to whether only directory entries should be offered.
+// includes/excludes target subdirectories of a module; ignore accepts files
+// or directories.
+var bufYAMLPathSequenceSections = map[string]bool{
+	"ignore":   false,
+	"includes": true,
+	"excludes": true,
+}
+
+// bufYAMLPathItems returns completion items for filesystem paths relative to
+// dirPath. partialPath is the text the user has typed so far (may be empty).
+// When dirsOnly is true, file entries are excluded.
+// Returns nil when dirPath is empty or the search directory cannot be read.
+func bufYAMLPathItems(dirPath, partialPath string, editRange protocol.Range, dirsOnly bool) []protocol.CompletionItem {
+	if dirPath == "" {
+		return nil
+	}
+	dir, base := path.Split(partialPath)
+	searchDir := filepath.Join(dirPath, filepath.FromSlash(dir))
+	entries, err := os.ReadDir(searchDir)
+	if err != nil {
+		return nil
+	}
+	var items []protocol.CompletionItem
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if base != "" && !strings.HasPrefix(name, base) {
+			continue
+		}
+		var text string
+		var kind protocol.CompletionItemKind
+		if entry.IsDir() {
+			text = dir + name + "/"
+			kind = protocol.CompletionItemKindFolder
+		} else {
+			if dirsOnly {
+				continue
+			}
+			text = dir + name
+			kind = protocol.CompletionItemKindFile
+		}
+		items = append(items, protocol.CompletionItem{
+			Label: text,
+			Kind:  kind,
+			TextEdit: &protocol.TextEdit{
+				Range:   editRange,
+				NewText: text,
+			},
+		})
+	}
+	return items
 }
 
 // bufYAMLTokenStart returns the byte index in prefix where the current token begins.
@@ -202,14 +282,20 @@ func bufYAMLSequenceItems(parentSection string, editRange protocol.Range) []prot
 	}
 }
 
-// bufYAMLIgnoreOnlyKeyItems returns completion items for lint/breaking rule IDs
-// used as mapping keys under lint.ignore_only or breaking.ignore_only.
+// bufYAMLIgnoreOnlyKeyItems returns completion items for rule IDs used as
+// mapping keys under ignore_only blocks. policies[*].ignore_only can suppress
+// either lint or breaking rules, so both sets are offered there.
 func bufYAMLIgnoreOnlyKeyItems(parentSection string, editRange protocol.Range, existingKeys map[string]bool) []protocol.CompletionItem {
 	switch parentSection {
 	case "lint":
 		return makeCompletionKeyItems(bufYAMLLintRuleValues, bufYAMLLintRuleDocs, nil, editRange, existingKeys)
 	case "breaking":
 		return makeCompletionKeyItems(bufYAMLBreakingRuleValues, bufYAMLBreakingRuleDocs, nil, editRange, existingKeys)
+	case "policies":
+		// Lint and breaking rule names are disjoint, so the primary/fallback
+		// lookup in makeCompletionKeyItems unambiguously routes each rule to
+		// the right docs.
+		return makeCompletionKeyItems(bufYAMLAllRuleValues, bufYAMLLintRuleDocs, bufYAMLBreakingRuleDocs, editRange, existingKeys)
 	default:
 		return nil
 	}
@@ -299,6 +385,14 @@ var bufYAMLPolicyItemDocs = map[string]bufYAMLDoc{
 var bufYAMLLintRuleValues = bufYAMLSortedDocKeys(bufYAMLLintRuleDocs)
 
 var bufYAMLBreakingRuleValues = bufYAMLSortedDocKeys(bufYAMLBreakingRuleDocs)
+
+// bufYAMLAllRuleValues is the union of lint and breaking rule values, used for
+// policies[*].ignore_only completions where either kind of rule can be suppressed.
+var bufYAMLAllRuleValues = func() []string {
+	all := slices.Concat(bufYAMLLintRuleValues, bufYAMLBreakingRuleValues)
+	slices.Sort(all)
+	return all
+}()
 
 func bufYAMLSortedDocKeys(docs map[string]bufYAMLDoc) []string {
 	keys := make([]string, 0, len(docs))

--- a/private/buf/buflsp/buf_yaml_completion_test.go
+++ b/private/buf/buflsp/buf_yaml_completion_test.go
@@ -15,6 +15,8 @@
 package buflsp
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -216,6 +218,15 @@ func TestGetBufYAMLCompletionItems(t *testing.T) {
 			wantLabels: []string{"STANDARD", "FIELD_LOWER_SNAKE_CASE"},
 			wantKind:   protocol.CompletionItemKindField,
 		},
+		{
+			// policies[*].ignore_only is parented by "policies", and the rules a
+			// policy can ignore include both lint and breaking rule IDs.
+			name:       "policy_ignore_only_keys",
+			text:       "policies:\n  - policy: buf.build/foo/bar\n    ignore_only:\n      \n",
+			pos:        protocol.Position{Line: 3, Character: 6},
+			wantLabels: []string{"STANDARD", "FIELD_LOWER_SNAKE_CASE", "FILE", "FIELD_NO_DELETE"},
+			wantKind:   protocol.CompletionItemKindField,
+		},
 
 		// ── Sequence after existing items ─────────────────────────────────
 		{
@@ -294,9 +305,9 @@ func TestGetBufYAMLCompletionItems(t *testing.T) {
 			wantKind:         protocol.CompletionItemKindField,
 		},
 
-		// ── policies[].ignore sequence (no completions — file paths) ───────
+		// ── policies[].ignore sequence (no completions when dirPath is empty) ──
 		{
-			name:          "policy_ignore_no_completions",
+			name:          "policy_ignore_no_completions_empty_dir",
 			text:          "policies:\n  - policy: buf.build/foo/bar\n    ignore:\n      - \n",
 			pos:           protocol.Position{Line: 3, Character: 8},
 			wantNilResult: true,
@@ -422,7 +433,7 @@ func TestGetBufYAMLCompletionItems(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			items := getBufYAMLCompletionItems(parseYAMLDoc(testCase.text), testCase.text, testCase.pos)
+			items := getBufYAMLCompletionItems(parseYAMLDoc(testCase.text), testCase.text, testCase.pos, "")
 
 			if testCase.wantNilResult {
 				assert.Nil(t, items)
@@ -452,7 +463,7 @@ func TestGetBufYAMLCompletionItemsTextEdit(t *testing.T) {
 
 	t.Run("key_textEdit_includes_colon_space", func(t *testing.T) {
 		t.Parallel()
-		items := getBufYAMLCompletionItems(parseYAMLDoc("lint:\n  \n"), "lint:\n  \n", protocol.Position{Line: 1, Character: 2})
+		items := getBufYAMLCompletionItems(parseYAMLDoc("lint:\n  \n"), "lint:\n  \n", protocol.Position{Line: 1, Character: 2}, "")
 		require.NotNil(t, items)
 		for _, item := range items {
 			require.NotNil(t, item.TextEdit, "item %q has no TextEdit", item.Label)
@@ -469,6 +480,7 @@ func TestGetBufYAMLCompletionItemsTextEdit(t *testing.T) {
 			parseYAMLDoc(text),
 			text,
 			protocol.Position{Line: 2, Character: 10},
+			"",
 		)
 		require.NotNil(t, items)
 		for _, item := range items {
@@ -487,6 +499,7 @@ func TestGetBufYAMLCompletionItemsTextEdit(t *testing.T) {
 			parseYAMLDoc(text),
 			text,
 			protocol.Position{Line: 2, Character: 4},
+			"",
 		)
 		require.NotNil(t, items)
 		for _, item := range items {
@@ -500,7 +513,7 @@ func TestGetBufYAMLCompletionItemsTextEdit(t *testing.T) {
 		t.Parallel()
 		// After bare "breaking:", completion items should have "  " indent in NewText.
 		text := "breaking:\n"
-		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 1, Character: 0})
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 1, Character: 0}, "")
 		require.NotNil(t, items)
 		for _, item := range items {
 			require.NotNil(t, item.TextEdit, "item %q has no TextEdit", item.Label)
@@ -518,6 +531,7 @@ func TestGetBufYAMLCompletionItemsTextEdit(t *testing.T) {
 			parseYAMLDoc(text),
 			text,
 			protocol.Position{Line: 1, Character: 7},
+			"",
 		)
 		require.NotNil(t, items)
 		for _, item := range items {
@@ -535,12 +549,121 @@ func TestGetBufYAMLCompletionItemsTextEdit(t *testing.T) {
 		// still recognize "  - path: ." as having "path" at effective indent 4
 		// and filter it from the suggestions.
 		text := "modules:\n  - path: .\n    \n"
-		items := getBufYAMLCompletionItems(nil, text, protocol.Position{Line: 2, Character: 4})
+		items := getBufYAMLCompletionItems(nil, text, protocol.Position{Line: 2, Character: 4}, "")
 		require.NotNil(t, items)
 		labels := completionLabels(items)
 		assert.False(t, slices.Contains(labels, "path"),
 			"text fallback should filter already-present inline seq key %q", "path")
 		assert.True(t, slices.Contains(labels, "lint"),
 			"text fallback should still offer sibling keys like %q", "lint")
+	})
+}
+
+func TestGetBufYAMLCompletionItemsPathCompletions(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "proto", "api"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "vendor"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("hello"), 0o600))
+
+	t.Run("lint_ignore_empty_partial", func(t *testing.T) {
+		t.Parallel()
+		text := "lint:\n  ignore:\n    - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 6}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+		assert.True(t, slices.Contains(labels, "vendor/"), "expected label %q", "vendor/")
+		assert.True(t, slices.Contains(labels, "README.md"), "expected label %q", "README.md")
+	})
+
+	t.Run("lint_ignore_partial", func(t *testing.T) {
+		t.Parallel()
+		text := "lint:\n  ignore:\n    - pr\n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 8}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+		assert.False(t, slices.Contains(labels, "vendor/"), "unexpected label %q", "vendor/")
+	})
+
+	t.Run("modules_path_value_dirs_only", func(t *testing.T) {
+		t.Parallel()
+		text := "modules:\n  - path: \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 1, Character: 10}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+		assert.True(t, slices.Contains(labels, "vendor/"), "expected label %q", "vendor/")
+		assert.False(t, slices.Contains(labels, "README.md"), "path is a directory key — files should be excluded")
+	})
+
+	t.Run("lint_ignore_subdir", func(t *testing.T) {
+		t.Parallel()
+		text := "lint:\n  ignore:\n    - proto/\n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 12}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/api/"), "expected label %q", "proto/api/")
+	})
+
+	t.Run("dirpath_empty_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		text := "lint:\n  ignore:\n    - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 6}, "")
+		assert.Nil(t, items)
+	})
+
+	t.Run("folder_kind_and_file_kind", func(t *testing.T) {
+		t.Parallel()
+		text := "lint:\n  ignore:\n    - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 2, Character: 6}, tmpDir)
+		require.NotNil(t, items)
+		kindByLabel := make(map[string]protocol.CompletionItemKind)
+		for _, item := range items {
+			kindByLabel[item.Label] = item.Kind
+		}
+		assert.Equal(t, protocol.CompletionItemKindFolder, kindByLabel["proto/"],
+			"directory entries should have Folder kind")
+		assert.Equal(t, protocol.CompletionItemKindFile, kindByLabel["README.md"],
+			"file entries should have File kind")
+	})
+
+	t.Run("lint_ignore_only_path", func(t *testing.T) {
+		t.Parallel()
+		text := "lint:\n  ignore_only:\n    STANDARD:\n      - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 3, Character: 8}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+		assert.True(t, slices.Contains(labels, "README.md"), "expected label %q", "README.md")
+	})
+
+	t.Run("breaking_ignore_only_path", func(t *testing.T) {
+		t.Parallel()
+		text := "breaking:\n  ignore_only:\n    FILE:\n      - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 3, Character: 8}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+	})
+
+	t.Run("module_lint_ignore_only_path", func(t *testing.T) {
+		t.Parallel()
+		text := "modules:\n  - path: .\n    lint:\n      ignore_only:\n        STANDARD:\n          - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 5, Character: 12}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
+	})
+
+	t.Run("policy_ignore_only_path", func(t *testing.T) {
+		t.Parallel()
+		text := "policies:\n  - policy: buf.build/foo/bar\n    ignore_only:\n      STANDARD:\n        - \n"
+		items := getBufYAMLCompletionItems(parseYAMLDoc(text), text, protocol.Position{Line: 4, Character: 10}, tmpDir)
+		require.NotNil(t, items)
+		labels := completionLabels(items)
+		assert.True(t, slices.Contains(labels, "proto/"), "expected label %q", "proto/")
 	})
 }

--- a/private/buf/buflsp/server.go
+++ b/private/buf/buflsp/server.go
@@ -233,7 +233,7 @@ func (s *server) DidOpen(
 		return nil
 	}
 	if isBufGenYAMLURI(params.TextDocument.URI) {
-		s.bufGenYAMLManager.Track(params.TextDocument.URI, params.TextDocument.Text)
+		s.bufGenYAMLManager.Track(ctx, params.TextDocument.URI, params.TextDocument.Text)
 		return nil
 	}
 	if isBufPolicyYAMLURI(params.TextDocument.URI) {
@@ -262,7 +262,7 @@ func (s *server) DidChange(
 		return nil
 	}
 	if isBufGenYAMLURI(params.TextDocument.URI) {
-		s.bufGenYAMLManager.Track(params.TextDocument.URI, params.ContentChanges[0].Text)
+		s.bufGenYAMLManager.Track(ctx, params.TextDocument.URI, params.ContentChanges[0].Text)
 		return nil
 	}
 	if isBufPolicyYAMLURI(params.TextDocument.URI) {

--- a/private/buf/buflsp/testdata/buf_gen_yaml/completion/buf.gen.yaml
+++ b/private/buf/buflsp/testdata/buf_gen_yaml/completion/buf.gen.yaml
@@ -4,6 +4,6 @@ managed:
   enabled: true
 plugins:
   - remote: buf.build/protocolbuffers/go
-    out: gen/go
+    out: 
 inputs:
   - directory: proto

--- a/private/buf/buflsp/testdata/buf_gen_yaml/types_completion/buf.gen.yaml
+++ b/private/buf/buflsp/testdata/buf_gen_yaml/types_completion/buf.gen.yaml
@@ -1,0 +1,10 @@
+version: v2
+plugins:
+  - remote: buf.build/foo/bar
+    out: gen
+    types:
+      - acme.
+inputs:
+  - directory: proto
+    exclude_types:
+      - acme.

--- a/private/buf/buflsp/testdata/buf_gen_yaml/types_completion/buf.yaml
+++ b/private/buf/buflsp/testdata/buf_gen_yaml/types_completion/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: proto

--- a/private/buf/buflsp/testdata/buf_gen_yaml/types_completion/proto/acme/test/v1/example.proto
+++ b/private/buf/buflsp/testdata/buf_gen_yaml/types_completion/proto/acme/test/v1/example.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package acme.test.v1;
+
+message Foo {
+  string name = 1;
+}
+
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STATUS_OK = 1;
+}
+
+message GreetRequest {
+  string name = 1;
+}
+
+message GreetResponse {
+  string greeting = 1;
+}
+
+service ExampleService {
+  rpc Greet(GreetRequest) returns (GreetResponse);
+}


### PR DESCRIPTION
Quick follow-up to #4527.

Filesystem path completions for path-valued fields in `buf.yaml` (`modules[*].path`, `modules[*].includes`, `modules[*].excludes`, `lint.ignore`, `breaking.ignore`, `policies[*].ignore`, `{lint,breaking}.ignore_only.RULE_ID`) and `buf.gen.yaml` (`plugins[*].out`, `inputs[*].directory`, `inputs[*].paths`, `inputs[*].exclude_paths`). Reads the directory of the config file and offers matching files and directories, filtered by prefix. Directory- only keys (`path`, `out`, `directory`, `includes`, `excludes`) suppress file entries.

Proto type completions for `buf.gen.yaml` `types` and `exclude_types` sequences. Eagerly leases the workspace on first `Track` to make fully-qualified message, enum, and service names available; the lease is reused across subsequent `Track`s to avoid running `workspace.Refresh` on every keystroke.

Also offer rule ID completions for `policies[*].ignore_only` by adding a `"policies"` case to `bufYAMLIgnoreOnlyKeyItems` that returns the union of lint and breaking rule IDs, since a policy can suppress either kind.

This should make our completions better than what `yaml-language-server` could provide, as the JSONSchema has no way to designate a field as a "directory" or "file" for completions.