### PR TITLE
Add buf beta registry cargo credential provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add LSP completion for `buf.gen.yaml`, `buf.yaml`, and `buf.policy.yaml` files.
 - Add error for when a dependency is added to `buf.yaml` and is missing from `buf.lock`.
+- Add `buf beta registry cargo` subcommand that acts as a Cargo `cargo:token-from-stdout` credential provider for BSR-hosted Cargo registries.
 
 ## [v1.69.0] - 2026-04-29
 

--- a/cmd/buf/buf.go
+++ b/cmd/buf/buf.go
@@ -36,6 +36,7 @@ import (
 	"github.com/bufbuild/buf/cmd/buf/internal/command/beta/price"
 	betaplugindelete "github.com/bufbuild/buf/cmd/buf/internal/command/beta/registry/plugin/plugindelete"
 	betapluginpush "github.com/bufbuild/buf/cmd/buf/internal/command/beta/registry/plugin/pluginpush"
+	"github.com/bufbuild/buf/cmd/buf/internal/command/beta/registry/registrycargo"
 	"github.com/bufbuild/buf/cmd/buf/internal/command/beta/registry/webhook/webhookcreate"
 	"github.com/bufbuild/buf/cmd/buf/internal/command/beta/registry/webhook/webhookdelete"
 	"github.com/bufbuild/buf/cmd/buf/internal/command/beta/registry/webhook/webhooklist"
@@ -415,6 +416,7 @@ func newRootCommand(name string) *appcmd.Command {
 						Use:   "registry",
 						Short: "Manage assets on the Buf Schema Registry",
 						SubCommands: []*appcmd.Command{
+							registrycargo.NewCommand("cargo", builder),
 							{
 								Use:   "webhook",
 								Short: "Manage webhooks for a repository on the Buf Schema Registry",

--- a/cmd/buf/internal/command/beta/registry/registrycargo/registrycargo.go
+++ b/cmd/buf/internal/command/beta/registry/registrycargo/registrycargo.go
@@ -1,0 +1,208 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registrycargo implements the "buf beta registry cargo" command,
+// which acts as a Cargo "cargo:token-from-stdout" credential provider for
+// BSR-hosted Cargo registries.
+package registrycargo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"slices"
+	"strings"
+
+	"buf.build/go/app/appcmd"
+	"buf.build/go/app/appext"
+	"github.com/bufbuild/buf/private/bufpkg/bufconnect"
+	"github.com/bufbuild/buf/private/pkg/netrc"
+	"github.com/spf13/pflag"
+)
+
+// errSilent is returned to exit with a non-zero status without printing a
+// "Failure: ..." line to stderr. The top-level wrapError in cmd/buf/buf.go
+// returns errors whose Error() is "" unchanged, bypassing the failure
+// wrapping. This is the same mechanism used by other commands that need a
+// silent non-zero exit (see private/pkg/bandeps/cmd/bandeps/main.go).
+var errSilent = errors.New("")
+
+// NewCommand returns a new Command.
+func NewCommand(
+	name string,
+	builder appext.SubCommandBuilder,
+) *appcmd.Command {
+	flags := newFlags()
+	return &appcmd.Command{
+		Use:   name + " [host...]",
+		Short: "Cargo credential provider for BSR-hosted Cargo registries",
+		Long: `This command implements Cargo's "cargo:token-from-stdout" credential-provider protocol for BSR-hosted Cargo registries.
+
+Add the following to your ~/.cargo/config.toml to make Cargo use buf as its credential provider for the public BSR at buf.build:
+
+    [registry]
+    global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo"]
+
+To opt in to a different set of hosts (for example, an Enterprise BSR instance), list them as positional arguments. The positional arguments replace the default; buf.build is not implicitly included. Ports in positional arguments are stripped before matching, so the allow-list operates at the hostname level only:
+
+    [registry]
+    global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo bsr.example.com"]
+
+Multiple hosts are supported:
+
+    [registry]
+    global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo buf.build bsr.example.com"]
+
+Tokens are looked up using the existing buf authentication chain: the BUF_TOKEN environment variable, then ~/.netrc. Manage tokens with "buf registry login".
+
+Failure behavior:
+
+  - If the host extracted from CARGO_REGISTRY_INDEX_URL is not in the allow-list (or no host can be extracted, or CARGO_REGISTRY_INDEX_URL is unset), the command exits non-zero with no output so Cargo can fall through to its next configured credential provider.
+  - If the host is in the allow-list but no token resolves, the command writes a "Failure:" message to stderr pointing at "buf registry login" and exits non-zero.
+
+Pass --debug to log host-resolution and token-lookup steps.`,
+		Args: appcmd.ArbitraryArgs,
+		Run: builder.NewRunFunc(
+			func(ctx context.Context, container appext.Container) error {
+				return run(ctx, container, flags)
+			},
+		),
+		BindFlags: flags.Bind,
+	}
+}
+
+type flags struct{}
+
+func newFlags() *flags {
+	return &flags{}
+}
+
+func (f *flags) Bind(flagSet *pflag.FlagSet) {}
+
+func run(
+	ctx context.Context,
+	container appext.Container,
+	flags *flags,
+) error {
+	logger := container.Logger()
+
+	rawURL := container.Env("CARGO_REGISTRY_INDEX_URL")
+	if rawURL == "" {
+		logger.Debug("CARGO_REGISTRY_INDEX_URL not set; nothing to do")
+		return errSilent
+	}
+	host := hostFromCargoRegistryURL(rawURL)
+	if host == "" {
+		logger.Debug(
+			"no host could be extracted from CARGO_REGISTRY_INDEX_URL",
+			"url", rawURL,
+		)
+		return errSilent
+	}
+
+	allowedHosts := effectiveAllowedHosts(container)
+	if !slices.Contains(allowedHosts, host) {
+		logger.Debug(
+			"host not in allow-list; falling through to next cargo credential provider",
+			"host", host,
+			"allowed_hosts", allowedHosts,
+		)
+		return errSilent
+	}
+
+	envTokenProvider, err := bufconnect.NewTokenProviderFromContainer(container)
+	if err != nil {
+		// Deliberately do not include err in the user-visible message:
+		// bufconnect.NewTokenProviderFromContainer formats the raw BUF_TOKEN
+		// value into its errors (see newMultipleTokenProvider in
+		// static_token_provider.go), which would echo the user's secret to
+		// stderr. The full error is available at --debug.
+		logger.Debug("BUF_TOKEN failed to parse", "error", err.Error())
+		return fmt.Errorf(
+			`the %[1]s environment variable could not be parsed. Either unset %[1]s, or run "buf registry login %[2]s" to populate ~/.netrc instead. Run with --debug for parser details`,
+			bufconnect.TokenEnvKey, host,
+		)
+	}
+	netrcTokenProvider := bufconnect.NewNetrcTokenProvider(container, netrc.GetMachineForName)
+
+	for _, provider := range []bufconnect.TokenProvider{envTokenProvider, netrcTokenProvider} {
+		if token := provider.RemoteToken(host); token != "" {
+			if _, err := fmt.Fprintf(container.Stdout(), "Bearer %s\n", token); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	logger.Debug("no token found for host", "host", host)
+	return fmt.Errorf(
+		`no token found for %[1]s. Run "buf registry login %[1]s", using a Buf API token as the password. For details, visit https://buf.build/docs/bsr/authentication`,
+		host,
+	)
+}
+
+// hostFromCargoRegistryURL returns the host extracted from a Cargo registry
+// index URL, or "" if no host can be determined.
+//
+// It strips a leading "sparse+" prefix and parses the remainder as a URL.
+// The returned host has any port stripped and is lowercased so the allow-
+// list comparison in run() is case-insensitive (DNS hosts are
+// case-insensitive but net/url preserves the original case).
+func hostFromCargoRegistryURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	trimmed := strings.TrimPrefix(rawURL, "sparse+")
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(parsed.Hostname())
+}
+
+// effectiveAllowedHosts returns the positional host allow-list, normalized
+// (lowercased, port stripped) for case-insensitive comparison against the
+// URL host. If no positional arguments were supplied, returns the default
+// [buf.build].
+func effectiveAllowedHosts(container appext.Container) []string {
+	numArgs := container.NumArgs()
+	if numArgs == 0 {
+		return []string{bufconnect.DefaultRemote}
+	}
+	hosts := make([]string, numArgs)
+	for i := range numArgs {
+		hosts[i] = normalizeHost(container.Arg(i))
+	}
+	return hosts
+}
+
+// normalizeHost lowercases s and strips an optional port. It accepts
+// "host", "host:port", and "[host]:port" forms; if splitting fails (e.g.
+// the input is a bare hostname with no port), the lowercased input is
+// returned unchanged. This makes positional-arg allow-list entries
+// comparable to URL-extracted hosts, which url.URL.Hostname() also
+// returns without a port.
+//
+// Bare IPv6 literals (e.g. "::1") trip net.SplitHostPort's "too many
+// colons" check and fall through to the unchanged-input branch, matching
+// what url.URL.Hostname() returns for "[::1]" hosts.
+func normalizeHost(s string) string {
+	lower := strings.ToLower(s)
+	if host, _, err := net.SplitHostPort(lower); err == nil {
+		return host
+	}
+	return lower
+}

--- a/cmd/buf/internal/command/beta/registry/registrycargo/registrycargo_test.go
+++ b/cmd/buf/internal/command/beta/registry/registrycargo/registrycargo_test.go
@@ -1,0 +1,461 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registrycargo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"buf.build/go/app/appcmd"
+	"buf.build/go/app/appcmd/appcmdtesting"
+	"buf.build/go/app/appext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostFromCargoRegistryURL(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "sparse_https_root",
+			input:    "sparse+https://buf.build/gen/cargo/",
+			expected: "buf.build",
+		},
+		{
+			name:     "sparse_https_subpath",
+			input:    "sparse+https://buf.build/gen/cargo/index/co/nn/connectrpc_eliza_community_neoeinstein-prost",
+			expected: "buf.build",
+		},
+		{
+			name:     "sparse_http",
+			input:    "sparse+http://buf.build/gen/cargo/",
+			expected: "buf.build",
+		},
+		{
+			name:     "https_no_sparse_prefix",
+			input:    "https://buf.build/",
+			expected: "buf.build",
+		},
+		{
+			name:     "sparse_https_with_port",
+			input:    "sparse+https://buf.build:8443/gen/cargo/",
+			expected: "buf.build",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "scheme_only",
+			input:    "sparse+https://",
+			expected: "",
+		},
+		{
+			name:     "path_only_no_scheme",
+			input:    "buf.build/gen/cargo/",
+			expected: "",
+		},
+		{
+			name:     "sparse_plus_path_only",
+			input:    "sparse+buf.build/gen/cargo/",
+			expected: "",
+		},
+		{
+			name:     "uppercase_host_lowercased",
+			input:    "sparse+https://BUF.BUILD/gen/cargo/",
+			expected: "buf.build",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, hostFromCargoRegistryURL(tc.input))
+		})
+	}
+}
+
+func TestNormalizeHost(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "bare", input: "buf.build", expected: "buf.build"},
+		{name: "with_port", input: "buf.build:8443", expected: "buf.build"},
+		{name: "uppercase", input: "BUF.BUILD", expected: "buf.build"},
+		{name: "uppercase_with_port", input: "BUF.BUILD:8443", expected: "buf.build"},
+		{name: "ipv6_with_port", input: "[::1]:8443", expected: "::1"},
+		{name: "empty", input: "", expected: ""},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, normalizeHost(tc.input))
+		})
+	}
+}
+
+const cargoIndexBufBuild = "sparse+https://buf.build/gen/cargo/"
+
+// runSilent invokes the command and asserts a silent exit 1: stderr must be
+// empty (no "Failure:" line). Use for paths where the URL is missing, no
+// host can be extracted, or the host isn't in the allow-list.
+func runSilent(
+	t *testing.T,
+	envOverrides map[string]string,
+	args ...string,
+) {
+	t.Helper()
+	runCargo(
+		t,
+		envOverrides,
+		1,
+		"",
+		nil,
+		nil,
+		args...,
+	)
+}
+
+// runSuccess invokes the command and asserts exit 0 with the given stdout.
+func runSuccess(
+	t *testing.T,
+	envOverrides map[string]string,
+	expectedStdout string,
+	args ...string,
+) {
+	t.Helper()
+	runCargo(
+		t,
+		envOverrides,
+		0,
+		expectedStdout,
+		nil,
+		nil,
+		args...,
+	)
+}
+
+// runLoud invokes the command and asserts exit 1 with stderr containing each
+// of the given substrings. Use for paths where the host *is* in the
+// allow-list but no token resolves.
+func runLoud(
+	t *testing.T,
+	envOverrides map[string]string,
+	stderrSubstrings []string,
+	args ...string,
+) {
+	t.Helper()
+	require.NotEmpty(t, stderrSubstrings, "loud failure tests must assert at least one stderr substring")
+	runCargo(
+		t,
+		envOverrides,
+		1,
+		"",
+		stderrSubstrings,
+		nil,
+		args...,
+	)
+}
+
+// runCargo is the underlying harness. The interceptor mirrors the subset of
+// cmd/buf/buf.go's wrapError that this command actually exercises: empty-
+// message non-Connect errors pass through unchanged (silent failure), and
+// any other error gets the "Failure: " prefix. wrapError has additional
+// handling for *connect.Error, syserror, ImportNotExistError, etc. that the
+// real binary applies in production but this command never produces, so the
+// interceptor does not replicate them.
+//
+// expectedStderrPartials: nil means assert stderr is empty; a non-nil slice
+// means assert each substring is present.
+//
+// forbiddenStderrSubstrings: any substring listed here must NOT appear in
+// stderr. Used for leak-prevention assertions (e.g. that a wrapped error
+// does not echo a sensitive value from the underlying cause).
+func runCargo(
+	t *testing.T,
+	envOverrides map[string]string,
+	expectedExitCode int,
+	expectedStdout string,
+	expectedStderrPartials []string,
+	forbiddenStderrSubstrings []string,
+	args ...string,
+) {
+	t.Helper()
+	var stderrBuf *bytes.Buffer
+	options := []appcmdtesting.RunOption{
+		appcmdtesting.WithEnv(func(string) map[string]string {
+			env := map[string]string{
+				"PATH": os.Getenv("PATH"),
+			}
+			maps.Copy(env, envOverrides)
+			return env
+		}),
+		appcmdtesting.WithExpectedExitCode(expectedExitCode),
+		appcmdtesting.WithExpectedStdout(expectedStdout),
+		appcmdtesting.WithArgs(args...),
+	}
+	if len(forbiddenStderrSubstrings) > 0 {
+		stderrBuf = &bytes.Buffer{}
+		options = append(options, appcmdtesting.WithStderr(stderrBuf))
+	}
+	if expectedStderrPartials == nil {
+		options = append(options, appcmdtesting.WithExpectedStderrPartials())
+	} else {
+		options = append(options, appcmdtesting.WithExpectedStderrPartials(expectedStderrPartials...))
+	}
+	appcmdtesting.Run(
+		t,
+		func(name string) *appcmd.Command {
+			return NewCommand(
+				name,
+				appext.NewBuilder(
+					name,
+					appext.BuilderWithInterceptor(
+						func(next func(context.Context, appext.Container) error) func(context.Context, appext.Container) error {
+							return func(ctx context.Context, container appext.Container) error {
+								err := next(ctx, container)
+								if err == nil {
+									return nil
+								}
+								if err.Error() == "" {
+									return err
+								}
+								return fmt.Errorf("Failure: %w", err)
+							}
+						},
+					),
+				),
+			)
+		},
+		options...,
+	)
+	if stderrBuf != nil {
+		stderrText := stderrBuf.String()
+		for _, forbidden := range forbiddenStderrSubstrings {
+			assert.NotContains(t, stderrText, forbidden, "stderr leaked forbidden substring")
+		}
+	}
+}
+
+// writeNetrc writes a netrc file with a single machine entry and returns its
+// path.
+func writeNetrc(t *testing.T, machine, login, password string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".netrc")
+	contents := fmt.Sprintf("machine %s\n  login %s\n  password %s\n", machine, login, password)
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestCargo_UnsetURL_SilentExit1(t *testing.T) {
+	t.Parallel()
+	runSilent(t, map[string]string{})
+}
+
+func TestCargo_NoArgs_DefaultAllowList_BufBuild_UnscopedToken(t *testing.T) {
+	t.Parallel()
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "plain-token",
+		},
+		"Bearer plain-token",
+	)
+}
+
+func TestCargo_NoArgs_DefaultAllowList_OtherHost_SilentExit1(t *testing.T) {
+	t.Parallel()
+	runSilent(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": "sparse+https://other.example.com/gen/cargo/",
+			"BUF_TOKEN":                "plain-token",
+		},
+	)
+}
+
+func TestCargo_ExplicitHost_Matches(t *testing.T) {
+	t.Parallel()
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": "sparse+https://bsr.example.com/gen/cargo/",
+			"BUF_TOKEN":                "plain-token",
+		},
+		"Bearer plain-token",
+		"bsr.example.com",
+	)
+}
+
+func TestCargo_PositionalHostWithPort_MatchesURL(t *testing.T) {
+	t.Parallel()
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": "sparse+https://bsr.example.com:8443/gen/cargo/",
+			"BUF_TOKEN":                "plain-token",
+		},
+		"Bearer plain-token",
+		"bsr.example.com:8443",
+	)
+}
+
+func TestCargo_PositionalHostUppercase_MatchesURL(t *testing.T) {
+	t.Parallel()
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": "sparse+https://bsr.example.com/gen/cargo/",
+			"BUF_TOKEN":                "plain-token",
+		},
+		"Bearer plain-token",
+		"BSR.example.com",
+	)
+}
+
+func TestCargo_ExplicitHost_DoesNotIncludeDefault_BufBuild_Silent(t *testing.T) {
+	t.Parallel()
+	runSilent(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "plain-token",
+		},
+		"bsr.example.com",
+	)
+}
+
+func TestCargo_MultipleExplicitHosts_RequestMatchesOne(t *testing.T) {
+	t.Parallel()
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "plain-token",
+		},
+		"Bearer plain-token",
+		"a.example.com", "buf.build",
+	)
+}
+
+func TestCargo_ScopedToken_Match(t *testing.T) {
+	t.Parallel()
+	runSuccess(t,
+		map[string]string{ //nolint:gosec // G101: BUF_TOKEN literals are synthetic env fixtures for contract tests.
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "scoped-tok@buf.build",
+		},
+		"Bearer scoped-tok",
+	)
+}
+
+func TestCargo_MalformedBufToken_LoudFailureMentionsBufToken(t *testing.T) {
+	t.Parallel()
+	const secret = "supersecret-do-not-leak"
+	runCargo(
+		t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			// Duplicate remote triggers newMultipleTokenProvider's
+			// "repeated remote address" error, which embeds the raw token.
+			"BUF_TOKEN": secret + "@buf.build," + secret + "@buf.build",
+		},
+		1,
+		"",
+		[]string{
+			"Failure:",
+			"BUF_TOKEN environment variable could not be parsed",
+			"buf registry login buf.build",
+			"unset BUF_TOKEN",
+		},
+		// The wrapped error must NOT echo the raw token; the parser-level
+		// detail is debug-only.
+		[]string{secret},
+	)
+}
+
+func TestCargo_ScopedToken_NoMatchForHost_LoudFailure(t *testing.T) {
+	t.Parallel()
+	runLoud(t,
+		map[string]string{ //nolint:gosec // G101: BUF_TOKEN literals are synthetic env fixtures for contract tests.
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "scoped-tok@elsewhere.example.com",
+		},
+		[]string{
+			"Failure:",
+			"no token found for buf.build",
+			"\"buf registry login buf.build\"",
+		},
+	)
+}
+
+func TestCargo_NetrcMatch(t *testing.T) {
+	t.Parallel()
+	netrcPath := writeNetrc(t, "buf.build", "user", "netrc-secret")
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"NETRC":                    netrcPath,
+		},
+		"Bearer netrc-secret",
+	)
+}
+
+func TestCargo_ScopedTokenNoMatch_FallsThroughToNetrc(t *testing.T) {
+	t.Parallel()
+	netrcPath := writeNetrc(t, "buf.build", "user", "netrc-secret")
+	runSuccess(t,
+		map[string]string{ //nolint:gosec // G101: BUF_TOKEN literals are synthetic env fixtures for contract tests.
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "scoped-tok@elsewhere.example.com",
+			"NETRC":                    netrcPath,
+		},
+		"Bearer netrc-secret",
+	)
+}
+
+func TestCargo_BufTokenWinsOverNetrc(t *testing.T) {
+	t.Parallel()
+	netrcPath := writeNetrc(t, "buf.build", "user", "netrc-loses")
+	runSuccess(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"BUF_TOKEN":                "env-wins",
+			"NETRC":                    netrcPath,
+		},
+		"Bearer env-wins",
+	)
+}
+
+func TestCargo_NetrcMiss_NoEnvVar_LoudFailure(t *testing.T) {
+	t.Parallel()
+	emptyNetrc := writeNetrc(t, "other.example.com", "user", "irrelevant")
+	runLoud(t,
+		map[string]string{
+			"CARGO_REGISTRY_INDEX_URL": cargoIndexBufBuild,
+			"NETRC":                    emptyNetrc,
+		},
+		[]string{
+			"Failure:",
+			"no token found for buf.build",
+		},
+	)
+}


### PR DESCRIPTION
## Summary

Adds a new `buf beta registry cargo` subcommand that implements Cargo's [`cargo:token-from-stdout` credential-provider protocol](https://doc.rust-lang.org/cargo/reference/registry-authentication.html#cargotoken-from-stdout). With this in place, Cargo can resolve a Bearer token for a BSR-hosted Cargo registry by shelling out to `buf`, instead of users having to copy a token into `~/.cargo/credentials.toml` and keep two copies in sync.

The command is registered under `beta` so we have room to iterate on the UX before promoting it.

## Motivation

Today, a developer pulling crates from a BSR-hosted Cargo registry has to:

1. Run `buf registry login buf.build` to authenticate `buf`.
2. Separately store the same token in `~/.cargo/credentials.toml` (or `cargo login`) so Cargo can use it.

Two stores for one secret, two places to rotate, two places to leak. This change lets users delegate the second step to `buf`:

```toml
# ~/.cargo/config.toml
[registry]
global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo"]
```

Now any `cargo` operation against a BSR-hosted registry invokes `buf beta registry cargo`, which resolves the token from the same chain `buf` already uses (`BUF_TOKEN` env var, then `~/.netrc`).

## Configuration

Default — public BSR at `buf.build`:

```toml
[registry]
global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo"]
```

Enterprise BSR (positional args replace the default; `buf.build` is **not** implicitly included):

```toml
[registry]
global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo bsr.example.com"]
```

Multiple hosts:

```toml
[registry]
global-credential-providers = ["cargo:token-from-stdout buf beta registry cargo buf.build bsr.example.com"]
```

Token management continues to flow through `buf registry login <host>`; no Cargo-specific login is required.

## How it works

On each invocation Cargo sets `CARGO_REGISTRY_INDEX_URL` (and other env vars per the spec) and reads a single line from stdout. The command:

1. Extracts the host from `CARGO_REGISTRY_INDEX_URL` (strips an optional `sparse+` prefix, parses as a URL, lowercases, drops any port).
2. Checks the host against the positional-argument allow-list (default `[buf.build]`). Allow-list entries are also lowercased and port-stripped so `bsr.example.com:8443` matches `sparse+https://bsr.example.com:8443/...`.
3. Looks up a token via `bufconnect.NewTokenProviderFromContainer` (the `BUF_TOKEN` env var) and falls through to `bufconnect.NewNetrcTokenProvider` (`~/.netrc`).
4. On success, writes `Bearer <token>\n` to stdout and exits `0`.

No Connect clients are constructed and no network calls are made — credential providers are on the hot path of every dependency resolution.

## Failure semantics

| Situation | Behavior | Why |
|---|---|---|
| `CARGO_REGISTRY_INDEX_URL` unset, unparseable, or host not in the allow-list | Exit non-zero with empty stdout/stderr | Lets Cargo fall through to its next configured credential provider |
| Host in the allow-list but no token resolves | Exit non-zero; stderr says `Failure: no token found for <host>. Run "buf registry login <host>" ...` | The user opted in to this host but `buf` has no credentials for it — surface a fix |
| `BUF_TOKEN` is malformed | Exit non-zero; stderr says `Failure: the BUF_TOKEN environment variable could not be parsed. Either unset BUF_TOKEN, or run "buf registry login <host>" ...`. Underlying parser error is debug-only | The underlying `bufconnect` parse error embeds the raw token value, so the user-visible message is deliberately redacted |

Pass `--debug` to log host extraction, allow-list matching, and (when present) the raw `BUF_TOKEN` parser error.

## Out of scope

- No `cargo login` / `cargo logout` support — the `cargo:token-from-stdout` protocol explicitly doesn't support them.
- No changes to `bufconnect` or any existing authentication primitive; this is a thin orchestrator over what's already there.

## Test plan

- [x] `go test -race ./cmd/buf/internal/command/beta/registry/registrycargo/...` (15 unit + command-level tests covering the contract matrix: unset URL, default and explicit allow-lists, scoped vs unscoped `BUF_TOKEN`, scoped-miss → netrc fallthrough, env-wins-over-netrc, netrc match + miss, uppercase URL host, uppercase positional, positional `host:port`, malformed `BUF_TOKEN` with leak-prevention `NotContains` assertion).
- [x] `golangci-lint run ./cmd/buf/internal/command/beta/registry/registrycargo/...` — 0 issues.
- [x] `go build ./...` and `go vet ./...` clean.
- [x] Manual smoke tests against the built binary:
  - Silent fallback for a non-allow-listed `CARGO_REGISTRY_INDEX_URL`.
  - Success path returns `Bearer <token>` and exits 0.
  - Loud failure with full advice when no token resolves for an allow-listed host.
  - `--debug` surfaces structured logs and (only with `--debug`) the raw `BUF_TOKEN` parser error.
  - `BUF_TOKEN=secret@host,secret@host` → user-facing stderr does **not** contain `secret`; only the debug log does.

## Notes for review

- Single new package: `cmd/buf/internal/command/beta/registry/registrycargo`. The only touches outside it are a 2-line wiring change in `cmd/buf/buf.go` and a 1-line `CHANGELOG.md` entry.
- The command uses the empty-message `errSilent` sentinel for silent exits, following the same pattern as `private/pkg/bandeps/cmd/bandeps/main.go`. The top-level `wrapError` in `cmd/buf/buf.go` already bypasses its `Failure: ` prefix when `err.Error() == ""`.
- Placed under `beta` per the design discussion; promote to `buf registry cargo` once we've shipped to early users.