### PR TITLE
Update private/pkg/cas API

### DIFF
--- a/private/bufpkg/bufmodule/bufmoduleapi/convert.go
+++ b/private/bufpkg/bufmodule/bufmoduleapi/convert.go
@@ -71,7 +71,7 @@ func V1ProtoToDigest(protoDigest *modulev1.Digest) (bufmodule.Digest, error) {
 	if err != nil {
 		return nil, err
 	}
-	casDigest, err := cas.NewDigest(protoDigest.Value)
+	casDigest, err := cas.NewDigest(cas.DigestTypeShake256, protoDigest.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func V1Beta1ProtoToDigest(protoDigest *modulev1beta1.Digest) (bufmodule.Digest, 
 	if err != nil {
 		return nil, err
 	}
-	casDigest, err := cas.NewDigest(protoDigest.Value)
+	casDigest, err := cas.NewDigest(cas.DigestTypeShake256, protoDigest.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufmodule/digest.go
+++ b/private/bufpkg/bufmodule/digest.go
@@ -165,7 +165,7 @@ func ParseDigest(s string) (Digest, error) {
 	}
 	switch digestType {
 	case DigestTypeB4, DigestTypeB5:
-		casDigest, err := cas.NewDigest(value)
+		casDigest, err := cas.NewDigest(cas.DigestTypeShake256, value)
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +240,7 @@ func getB4Digest(
 		storage.FilterReadBucket(bucketWithStorageMatcherApplied, getStorageMatcher(ctx, bucketWithStorageMatcherApplied)),
 		"",
 		func(readObject storage.ReadObject) error {
-			digest, err := cas.NewDigestForContent(readObject)
+			digest, err := cas.NewDigestForContent(cas.DigestTypeShake256, readObject)
 			if err != nil {
 				return err
 			}
@@ -262,7 +262,7 @@ func getB4Digest(
 			// We may not have object data for one of these files, this is valid.
 			continue
 		}
-		digest, err := cas.NewDigestForContent(bytes.NewReader(objectData.Data()))
+		digest, err := cas.NewDigestForContent(cas.DigestTypeShake256, bytes.NewReader(objectData.Data()))
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +361,7 @@ func getB5DigestForBucketAndDepDigests(
 	// Now, place the file digest first, then the sorted dependency digests afterwards.
 	digestStrings := append([]string{filesDigest.String()}, depDigestStrings...)
 	// Join these strings together with newlines, and make a new shake256 digest.
-	digestOfDigests, err := cas.NewDigestForContent(strings.NewReader(strings.Join(digestStrings, "\n")))
+	digestOfDigests, err := cas.NewDigestForContent(cas.DigestTypeShake256, strings.NewReader(strings.Join(digestStrings, "\n")))
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufplugin/bufpluginapi/convert.go
+++ b/private/bufpkg/bufplugin/bufpluginapi/convert.go
@@ -37,7 +37,7 @@ func V1Beta1ProtoToDigest(protoDigest *pluginv1beta1.Digest) (bufplugin.Digest, 
 	if err != nil {
 		return nil, err
 	}
-	casDigest, err := cas.NewDigest(protoDigest.Value)
+	casDigest, err := cas.NewDigest(cas.DigestTypeShake256, protoDigest.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufplugin/digest.go
+++ b/private/bufpkg/bufplugin/digest.go
@@ -152,7 +152,7 @@ func ParseDigest(s string) (Digest, error) {
 	}
 	switch digestType {
 	case DigestTypeP1:
-		casDigest, err := cas.NewDigest(value)
+		casDigest, err := cas.NewDigest(cas.DigestTypeShake256, value)
 		if err != nil {
 			return nil, err
 		}

--- a/private/bufpkg/bufplugin/plugin.go
+++ b/private/bufpkg/bufplugin/plugin.go
@@ -309,7 +309,7 @@ func newGetDigestFuncForPluginAndDigestType(plugin *plugin, digestType DigestTyp
 		if err != nil {
 			return nil, err
 		}
-		casDigest, err := cas.NewDigestForContent(bytes.NewReader(data))
+		casDigest, err := cas.NewDigestForContent(cas.DigestTypeShake256, bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}

--- a/private/bufpkg/bufplugin/plugin_data.go
+++ b/private/bufpkg/bufplugin/plugin_data.go
@@ -81,6 +81,7 @@ func newPluginData(
 			return err
 		}
 		casDigest, err := cas.NewDigestForContent(
+			cas.DigestTypeShake256,
 			bytes.NewReader(pluginData),
 		)
 		if err != nil {

--- a/private/bufpkg/bufpolicy/bufpolicyapi/convert.go
+++ b/private/bufpkg/bufpolicy/bufpolicyapi/convert.go
@@ -40,7 +40,7 @@ func V1Beta1ProtoToDigest(protoDigest *policyv1beta1.Digest) (bufpolicy.Digest, 
 	if err != nil {
 		return nil, err
 	}
-	casDigest, err := cas.NewDigest(protoDigest.Value)
+	casDigest, err := cas.NewDigest(cas.DigestTypeShake256, protoDigest.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/private/bufpkg/bufpolicy/bufpolicystore/buf_policy_store.go
+++ b/private/bufpkg/bufpolicy/bufpolicystore/buf_policy_store.go
@@ -127,7 +127,7 @@ func (p *policyDataStore) getPolicyDataForPolicyKey(
 			return nil, err
 		}
 		// Validate the digest, before parsing the config.
-		casDigest, err := cas.NewDigestForContent(bytes.NewReader(data))
+		casDigest, err := cas.NewDigestForContent(cas.DigestTypeShake256, bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}

--- a/private/bufpkg/bufpolicy/digest.go
+++ b/private/bufpkg/bufpolicy/digest.go
@@ -152,7 +152,7 @@ func ParseDigest(s string) (Digest, error) {
 	}
 	switch digestType {
 	case DigestTypeO1:
-		casDigest, err := cas.NewDigest(value)
+		casDigest, err := cas.NewDigest(cas.DigestTypeShake256, value)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func getO1Digest(policyConfig PolicyConfig) (Digest, error) {
 	if err != nil {
 		return nil, err
 	}
-	casDigest, err := cas.NewDigestForContent(bytes.NewReader(policyDataJSON))
+	casDigest, err := cas.NewDigestForContent(cas.DigestTypeShake256, bytes.NewReader(policyDataJSON))
 	if err != nil {
 		return nil, err
 	}

--- a/private/pkg/cas/blob.go
+++ b/private/pkg/cas/blob.go
@@ -26,7 +26,7 @@ type Blob interface {
 	//
 	// Always non-nil.
 	//
-	// NewDigestForContent(bytes.NewReader(blob.Content())) should always match this value.
+	// NewDigestForContent(blob.Digest().Type(), bytes.NewReader(blob.Content())) should always match this value.
 	Digest() Digest
 	// Content returns the content of the Blob.
 	//
@@ -41,14 +41,14 @@ type Blob interface {
 // NewBlobForContent returns a new Blob for the content as read from the Reader.
 //
 // The reader is read until io.EOF.
-func NewBlobForContent(reader io.Reader, options ...BlobOption) (Blob, error) {
+func NewBlobForContent(digestType DigestType, reader io.Reader, options ...BlobOption) (Blob, error) {
 	blobOptions := newBlobOptions()
 	for _, option := range options {
 		option(blobOptions)
 	}
 	buffer := bytes.NewBuffer(nil)
 	teeReader := io.TeeReader(reader, buffer)
-	digest, err := NewDigestForContent(teeReader, DigestWithDigestType(blobOptions.digestType))
+	digest, err := NewDigestForContent(digestType, teeReader)
 	if err != nil {
 		return nil, err
 	}
@@ -67,15 +67,6 @@ type BlobOption func(*blobOptions)
 func BlobWithKnownDigest(knownDigest Digest) BlobOption {
 	return func(blobOptions *blobOptions) {
 		blobOptions.knownDigest = knownDigest
-	}
-}
-
-// BlobWithDigestType returns a new BlobOption sets the DigestType to be used.
-//
-// The default is DigestTypeShake256.
-func BlobWithDigestType(digestType DigestType) BlobOption {
-	return func(blobOptions *blobOptions) {
-		blobOptions.digestType = digestType
 	}
 }
 
@@ -105,7 +96,6 @@ func (*blob) isBlob() {}
 
 type blobOptions struct {
 	knownDigest Digest
-	digestType  DigestType
 }
 
 func newBlobOptions() *blobOptions {

--- a/private/pkg/cas/blob_set_test.go
+++ b/private/pkg/cas/blob_set_test.go
@@ -53,7 +53,7 @@ func testNewBlobs(t *testing.T, size int, digestType DigestType) []Blob {
 	var blobs []Blob
 	for i := range size {
 		content := fmt.Sprintf("some file content %d", i)
-		blob, err := NewBlobForContent(strings.NewReader(content), BlobWithDigestType(digestType))
+		blob, err := NewBlobForContent(digestType, strings.NewReader(content))
 		require.NoError(t, err)
 		blobs = append(blobs, blob)
 	}

--- a/private/pkg/cas/blob_test.go
+++ b/private/pkg/cas/blob_test.go
@@ -25,9 +25,10 @@ import (
 func TestNewBlobForContent(t *testing.T) {
 	t.Parallel()
 	content := "some file content"
-	digest, err := NewDigestForContent(strings.NewReader(content))
+	digest, err := NewDigestForContent(DigestTypeShake256, strings.NewReader(content))
 	require.NoError(t, err)
 	blob, err := NewBlobForContent(
+		DigestTypeShake256,
 		strings.NewReader(content),
 		BlobWithKnownDigest(digest),
 	)
@@ -36,9 +37,10 @@ func TestNewBlobForContent(t *testing.T) {
 	assert.Equal(t, []byte(content), blob.Content())
 
 	differentContent := "some different file content"
-	differentDigest, err := NewDigestForContent(strings.NewReader(differentContent))
+	differentDigest, err := NewDigestForContent(DigestTypeShake256, strings.NewReader(differentContent))
 	require.NoError(t, err)
 	_, err = NewBlobForContent(
+		DigestTypeShake256,
 		strings.NewReader(content),
 		BlobWithKnownDigest(differentDigest),
 	)

--- a/private/pkg/cas/digest.go
+++ b/private/pkg/cas/digest.go
@@ -30,10 +30,11 @@ import (
 
 const (
 	// DigestTypeShake256 represents the shake256 digest type.
-	//
-	// This is both the default and the only currently-known value for DigestType.
 	DigestTypeShake256 DigestType = iota + 1
 	// DigestTypeSha256 represents the sha256 digest type.
+	//
+	// SHA-256 Digest string values are bare hex so that SHA-256 manifests use the
+	// same digest spelling as standard checksum files.
 	DigestTypeSha256
 
 	sha256DigestLength = 32
@@ -86,7 +87,7 @@ func ParseDigestType(s string) (DigestType, error) {
 //
 // It consists of a DigestType and a digest value.
 type Digest interface {
-	// String() prints typeString:hexValue.
+	// String prints typeString:hexValue for typed digests, or bare hex for SHA-256.
 	fmt.Stringer
 
 	// Type returns the type of digest.
@@ -102,29 +103,12 @@ type Digest interface {
 	isDigest()
 }
 
-// NewDigest returns a new Digest for the value.
-func NewDigest(value []byte, options ...DigestOption) (Digest, error) {
-	digestOptions := newDigestOptions()
-	for _, option := range options {
-		option(digestOptions)
+// NewDigest returns a new Digest for the already-computed digest value.
+func NewDigest(digestType DigestType, value []byte) (Digest, error) {
+	if err := validateDigestParameters(digestType, value); err != nil {
+		return nil, err
 	}
-	if digestOptions.digestType == 0 {
-		digestOptions.digestType = DigestTypeShake256
-	}
-	switch digestOptions.digestType {
-	case DigestTypeShake256:
-		shake256Digest, err := shake256.NewDigest(value)
-		if err != nil {
-			return nil, err
-		}
-		return newDigest(DigestTypeShake256, shake256Digest.Value()), nil
-	case DigestTypeSha256:
-		sha256Digest := sha256.Sum256(value)
-		return newDigest(DigestTypeSha256, sha256Digest[:]), nil
-	default:
-		// This is a system error.
-		return nil, syserror.Newf("unknown DigestType: %v", digestOptions.digestType)
-	}
+	return newDigest(digestType, bytes.Clone(value)), nil
 }
 
 // NewDigestForContent creates a new Digest based on the given content read from the Reader.
@@ -132,15 +116,8 @@ func NewDigest(value []byte, options ...DigestOption) (Digest, error) {
 // A valid Digest is returned, even in the case of empty content.
 //
 // The Reader is read until io.EOF.
-func NewDigestForContent(reader io.Reader, options ...DigestOption) (Digest, error) {
-	digestOptions := newDigestOptions()
-	for _, option := range options {
-		option(digestOptions)
-	}
-	if digestOptions.digestType == 0 {
-		digestOptions.digestType = DigestTypeShake256
-	}
-	switch digestOptions.digestType {
+func NewDigestForContent(digestType DigestType, reader io.Reader) (Digest, error) {
+	switch digestType {
 	case DigestTypeShake256:
 		shake256Digest, err := shake256.NewDigestForContent(reader)
 		if err != nil {
@@ -155,26 +132,15 @@ func NewDigestForContent(reader io.Reader, options ...DigestOption) (Digest, err
 		return newDigest(DigestTypeSha256, hash.Sum(nil)[:]), nil
 	default:
 		// This is a system error.
-		return nil, syserror.Newf("unknown DigestType: %v", digestOptions.digestType)
-	}
-}
-
-// DigestOption is an option for a new Digest.
-type DigestOption func(*digestOptions)
-
-// DigestWithDigestType returns a new DigestOption that specifies the DigestType to be used.
-//
-// The default is DigestTypeShake256.
-func DigestWithDigestType(digestType DigestType) DigestOption {
-	return func(digestOptions *digestOptions) {
-		digestOptions.digestType = digestType
+		return nil, syserror.Newf("unknown DigestType: %v", digestType)
 	}
 }
 
 // ParseDigest parses a Digest from its string representation.
 //
-// A Digest string is of the form typeString:hexValue.
-// The string is expected to be non-empty, If not, an error is returned.
+// A SHA-256 Digest string is of the form hexValue. All other Digest strings are
+// of the form typeString:hexValue. The string is expected to be non-empty. If
+// not, an error is returned.
 //
 // This reverses Digest.String().
 //
@@ -186,11 +152,22 @@ func ParseDigest(s string) (Digest, error) {
 	}
 	digestTypeString, hexValue, ok := strings.Cut(s, ":")
 	if !ok {
-		return nil, newParseError(
-			"digest",
-			s,
-			errors.New(`must in the form "digest_type:digest_hex_value"`),
-		)
+		value, err := hex.DecodeString(s)
+		if err != nil {
+			return nil, newParseError(
+				"digest",
+				s,
+				errors.New(`could not parse hex: must be in the form "digest_hex_value" or "digest_type:digest_hex_value"`),
+			)
+		}
+		if err := validateDigestParameters(DigestTypeSha256, value); err != nil {
+			return nil, newParseError(
+				"digest",
+				s,
+				err,
+			)
+		}
+		return newDigest(DigestTypeSha256, value), nil
 	}
 	digestType, err := ParseDigestType(digestTypeString)
 	if err != nil {
@@ -198,6 +175,13 @@ func ParseDigest(s string) (Digest, error) {
 			"digest",
 			s,
 			err,
+		)
+	}
+	if digestType == DigestTypeSha256 {
+		return nil, newParseError(
+			"digest",
+			s,
+			errors.New(`sha256 digests must be in the form "digest_hex_value"`),
 		)
 	}
 	value, err := hex.DecodeString(hexValue)
@@ -241,17 +225,13 @@ func DigestEqual(a Digest, b Digest) bool {
 type digest struct {
 	digestType DigestType
 	value      []byte
-	// Cache as we call String pretty often.
-	// We could do this lazily but not worth it.
-	stringValue string
 }
 
 // validation should occur outside of this function.
 func newDigest(digestType DigestType, value []byte) *digest {
 	return &digest{
-		digestType:  digestType,
-		value:       value,
-		stringValue: digestType.String() + ":" + hex.EncodeToString(value),
+		digestType: digestType,
+		value:      value,
 	}
 }
 
@@ -264,18 +244,14 @@ func (d *digest) Value() []byte {
 }
 
 func (d *digest) String() string {
-	return d.stringValue
+	valueString := hex.EncodeToString(d.value)
+	if d.digestType == DigestTypeSha256 {
+		return valueString
+	}
+	return d.digestType.String() + ":" + valueString
 }
 
 func (*digest) isDigest() {}
-
-type digestOptions struct {
-	digestType DigestType
-}
-
-func newDigestOptions() *digestOptions {
-	return &digestOptions{}
-}
 
 func validateDigestParameters(digestType DigestType, value []byte) error {
 	switch digestType {

--- a/private/pkg/cas/digest_test.go
+++ b/private/pkg/cas/digest_test.go
@@ -41,31 +41,46 @@ var buftestingDirPath = filepath.Join(
 
 func TestNewDigestForContent(t *testing.T) {
 	t.Parallel()
-	digest, err := cas.NewDigestForContent(bytes.NewBuffer(nil))
+	digest, err := cas.NewDigestForContent(cas.DigestTypeShake256, bytes.NewBuffer(nil))
 	require.NoError(t, err)
 	assert.Equal(t, cas.DigestTypeShake256, digest.Type())
 	assert.NotEmpty(t, digest.Value())
+	assert.Contains(t, digest.String(), ":")
 
-	digest, err = cas.NewDigestForContent(strings.NewReader("some content"))
+	digest, err = cas.NewDigestForContent(cas.DigestTypeShake256, strings.NewReader("some content"))
 	require.NoError(t, err)
 	assert.Equal(t, cas.DigestTypeShake256, digest.Type())
 	assert.NotEmpty(t, digest.Value())
+	assert.Contains(t, digest.String(), ":")
 
-	digest, err = cas.NewDigestForContent(bytes.NewBuffer(nil), cas.DigestWithDigestType(cas.DigestTypeSha256))
+	digest, err = cas.NewDigestForContent(cas.DigestTypeSha256, bytes.NewBuffer(nil))
 	require.NoError(t, err)
 	assert.Equal(t, cas.DigestTypeSha256, digest.Type())
 	assert.NotEmpty(t, digest.Value())
+	assert.NotContains(t, digest.String(), ":")
 
-	digest, err = cas.NewDigestForContent(strings.NewReader("some content"), cas.DigestWithDigestType(cas.DigestTypeSha256))
+	digest, err = cas.NewDigestForContent(cas.DigestTypeSha256, strings.NewReader("some content"))
 	require.NoError(t, err)
 	assert.Equal(t, cas.DigestTypeSha256, digest.Type())
 	assert.NotEmpty(t, digest.Value())
+	assert.NotContains(t, digest.String(), ":")
 
 	// failing digesting content
 	expectedErr := errors.New("testing error")
-	digest, err = cas.NewDigestForContent(iotest.ErrReader(expectedErr))
+	digest, err = cas.NewDigestForContent(cas.DigestTypeShake256, iotest.ErrReader(expectedErr))
 	assert.ErrorIs(t, err, expectedErr)
 	assert.Nil(t, digest)
+}
+
+func TestParseDigest(t *testing.T) {
+	t.Parallel()
+	for _, digestType := range cas.AllDigestTypes {
+		digest, err := cas.NewDigestForContent(digestType, strings.NewReader("some content"))
+		require.NoError(t, err)
+		parsedDigest, err := cas.ParseDigest(digest.String())
+		require.NoError(t, err)
+		assert.True(t, cas.DigestEqual(digest, parsedDigest))
+	}
 }
 
 func TestParseDigestError(t *testing.T) {
@@ -76,25 +91,28 @@ func TestParseDigestError(t *testing.T) {
 	testParseDigestError(t, "shake256:_", true)
 	testParseDigestError(t, "sha256 foo", true)
 	testParseDigestError(t, "sha256:_", true)
-	validDigest, err := cas.NewDigestForContent(bytes.NewBuffer(nil))
+	validDigest, err := cas.NewDigestForContent(cas.DigestTypeShake256, bytes.NewBuffer(nil))
 	require.NoError(t, err)
 	validDigestHex := hex.EncodeToString(validDigest.Value())
 	testParseDigestError(t, fmt.Sprintf("%s:%s", validDigest.Type(), validDigestHex[:10]), true)
 	testParseDigestError(t, fmt.Sprintf("md5:%s", validDigestHex), true)
+	validSHA256Digest, err := cas.NewDigestForContent(cas.DigestTypeSha256, bytes.NewBuffer(nil))
+	require.NoError(t, err)
+	testParseDigestError(t, fmt.Sprintf("sha256:%s", validSHA256Digest.String()), true)
 }
 
 func TestDigestEqual(t *testing.T) {
 	t.Parallel()
 	fileContent := "one line\nanother line\nyet another one\n"
-	d1, err := cas.NewDigestForContent(strings.NewReader(fileContent))
+	d1, err := cas.NewDigestForContent(cas.DigestTypeShake256, strings.NewReader(fileContent))
 	require.NoError(t, err)
-	d2, err := cas.NewDigestForContent(strings.NewReader(fileContent))
+	d2, err := cas.NewDigestForContent(cas.DigestTypeShake256, strings.NewReader(fileContent))
 	require.NoError(t, err)
-	d3, err := cas.NewDigestForContent(strings.NewReader(fileContent + "foo"))
+	d3, err := cas.NewDigestForContent(cas.DigestTypeShake256, strings.NewReader(fileContent+"foo"))
 	require.NoError(t, err)
-	d4, err := cas.NewDigestForContent(strings.NewReader(fileContent), cas.DigestWithDigestType(cas.DigestTypeSha256))
+	d4, err := cas.NewDigestForContent(cas.DigestTypeSha256, strings.NewReader(fileContent))
 	require.NoError(t, err)
-	d5, err := cas.NewDigestForContent(strings.NewReader(fileContent), cas.DigestWithDigestType(cas.DigestTypeSha256))
+	d5, err := cas.NewDigestForContent(cas.DigestTypeSha256, strings.NewReader(fileContent))
 	require.NoError(t, err)
 	assert.True(t, cas.DigestEqual(d1, d2))
 	assert.True(t, cas.DigestEqual(d4, d5))

--- a/private/pkg/cas/file_set.go
+++ b/private/pkg/cas/file_set.go
@@ -74,7 +74,7 @@ func NewFileSet(manifest Manifest, blobSet BlobSet) (FileSet, error) {
 }
 
 // NewFileSetForBucket returns a new FileSet for the given ReadBucket.
-func NewFileSetForBucket(ctx context.Context, bucket storage.ReadBucket) (FileSet, error) {
+func NewFileSetForBucket(ctx context.Context, bucket storage.ReadBucket, digestType DigestType) (FileSet, error) {
 	var fileNodes []FileNode
 	var blobs []Blob
 	if err := storage.WalkReadObjects(
@@ -82,7 +82,7 @@ func NewFileSetForBucket(ctx context.Context, bucket storage.ReadBucket) (FileSe
 		bucket,
 		"",
 		func(readObject storage.ReadObject) error {
-			blob, err := NewBlobForContent(readObject)
+			blob, err := NewBlobForContent(digestType, readObject)
 			if err != nil {
 				return fmt.Errorf("error creating Blob for file %q: %w", readObject.Path(), err)
 			}

--- a/private/pkg/cas/manifest.go
+++ b/private/pkg/cas/manifest.go
@@ -35,6 +35,10 @@ type Manifest interface {
 	//	shake256:3b353aa5aacd11015e8577f16e2c4e7a242ce773d8e3a16806795bb94f76e601b0db9bf42d5e1907fda63303e1fa1c65f1c175ecc025a3ef29c3456ad237ad84  buf.md
 	//	shake256:7c88a20cf931702d042a4ddee3fde5de84814544411f1c62dbf435b1b81a12a8866a070baabcf8b5a0d31675af361ccb2d93ddada4cdcc11bab7ea3d8d7c4667  buf.yaml
 	//	shake256:9db25155eafd19b36882cff129daac575baa67ee44d1cb1fd3894342b28c72b83eb21aa595b806e9cb5344759bc8308200c5af98e4329aa83014dde99afa903a  pet/v1/pet.proto
+	//
+	// A SHA-256 encoded manifest uses bare checksum-style digest values:
+	//
+	//	e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  buf.yaml
 	fmt.Stringer
 
 	// FileNodes returns the set of FileNodes that make up the Manifest.
@@ -114,15 +118,15 @@ func ParseManifest(s string) (Manifest, error) {
 // ManifestToBlob converts the string representation of the given Manifest into a Blob.
 //
 // The Manifest is assumed to be non-nil.
-func ManifestToBlob(manifest Manifest) (Blob, error) {
-	return NewBlobForContent(strings.NewReader(manifest.String()))
+func ManifestToBlob(manifest Manifest, digestType DigestType) (Blob, error) {
+	return NewBlobForContent(digestType, strings.NewReader(manifest.String()))
 }
 
 // ManifestToDigest converts the string representation of the given Manifest into a Digest.
 //
 // The Manifest is assumed to be non-nil.
 func ManifestToDigest(manifest Manifest, digestType DigestType) (Digest, error) {
-	return NewDigestForContent(strings.NewReader(manifest.String()), DigestWithDigestType(digestType))
+	return NewDigestForContent(digestType, strings.NewReader(manifest.String()))
 }
 
 // BlobToManifest converts the given Blob representing the string representation of a Manifest into a Manifest.

--- a/private/pkg/cas/manifest_test.go
+++ b/private/pkg/cas/manifest_test.go
@@ -33,7 +33,7 @@ func TestManifest(t *testing.T) {
 			var digests []Digest
 			var fileNodes []FileNode
 			for i := range 10 {
-				digest, err := NewDigestForContent(strings.NewReader(fmt.Sprintf("content%d", i)), DigestWithDigestType(digestType))
+				digest, err := NewDigestForContent(digestType, strings.NewReader(fmt.Sprintf("content%d", i)))
 				require.NoError(t, err)
 				digests = append(digests, digest)
 				fileNode, err := NewFileNode(fmt.Sprintf("%d", i), digest)

--- a/private/pkg/cas/storage.go
+++ b/private/pkg/cas/storage.go
@@ -30,7 +30,7 @@ func BucketToDigest(ctx context.Context, bucket storage.ReadBucket, digestType D
 		bucket,
 		"",
 		func(readObject storage.ReadObject) error {
-			digest, err := NewDigestForContent(readObject, DigestWithDigestType(digestType))
+			digest, err := NewDigestForContent(digestType, readObject)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- Make `DigestType` a required parameter so that we no longer default to shake256.
- Do not prefix digests with `sha256:` for sha256 digests, either in string form or in manifests. This matches what GNU utilities expect and is what other digesters do for sha256.
