### PR TITLE
Disable automatic Git maintenance in cloner

### DIFF
--- a/private/pkg/git/cloner.go
+++ b/private/pkg/git/cloner.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,21 @@ type cloner struct {
 	logger            *slog.Logger
 	storageosProvider storageos.Provider
 	options           ClonerOptions
+}
+
+// gitConfigNoAutoMaintenanceArgs prevents background Git tasks from racing with
+// storage.Copy over files in the cloned .git directory.
+var gitConfigNoAutoMaintenanceArgs = []string{
+	"-c",
+	"maintenance.auto=false",
+	"-c",
+	"maintenance.autoDetach=false",
+	"-c",
+	"gc.auto=0",
+	"-c",
+	"gc.autoDetach=false",
+	"-c",
+	"fetch.writeCommitGraph=false",
 }
 
 func newCloner(
@@ -118,15 +134,15 @@ func (c *cloner) CloneToBucket(
 		return newGitCommandError(err, buffer)
 	}
 
-	var gitConfigAuthArgs []string
+	gitConfigArgs := slices.Clone(gitConfigNoAutoMaintenanceArgs)
 	if strings.HasPrefix(url, "https://") {
-		// These extraArgs MUST be first, as the -c flag potentially produced
-		// is only a flag on the parent git command, not on git fetch.
+		// These extraArgs MUST be before the sub-command, as the -c flag potentially
+		// produced is only a flag on the parent git command, not on git fetch.
 		extraArgs, err := c.getArgsForHTTPSCommand(envContainer)
 		if err != nil {
 			return err
 		}
-		gitConfigAuthArgs = append(gitConfigAuthArgs, extraArgs...)
+		gitConfigArgs = append(gitConfigArgs, extraArgs...)
 	}
 
 	if strings.HasPrefix(url, "ssh://") {
@@ -138,7 +154,7 @@ func (c *cloner) CloneToBucket(
 
 	// Build the args for the fetch command.
 	fetchArgs := []string{}
-	fetchArgs = append(fetchArgs, gitConfigAuthArgs...)
+	fetchArgs = append(fetchArgs, gitConfigArgs...)
 	fetchArgs = append(
 		fetchArgs,
 		"fetch",
@@ -191,7 +207,7 @@ func (c *cloner) CloneToBucket(
 		if err := xexec.Run(
 			ctx,
 			"git",
-			xexec.WithArgs(append(gitConfigAuthArgs, "sparse-checkout", "set", options.SubDir)...),
+			xexec.WithArgs(append(gitConfigArgs, "sparse-checkout", "set", options.SubDir)...),
 			xexec.WithEnv(app.Environ(envContainer)),
 			xexec.WithStderr(buffer),
 			xexec.WithDir(baseDir.Path()),
@@ -206,7 +222,7 @@ func (c *cloner) CloneToBucket(
 	if err := xexec.Run(
 		ctx,
 		"git",
-		xexec.WithArgs(append(gitConfigAuthArgs, "checkout", "--force", "FETCH_HEAD")...),
+		xexec.WithArgs(append(gitConfigArgs, "checkout", "--force", "FETCH_HEAD")...),
 		xexec.WithEnv(app.Environ(envContainer)),
 		xexec.WithStderr(buffer),
 		xexec.WithDir(baseDir.Path()),
@@ -220,7 +236,7 @@ func (c *cloner) CloneToBucket(
 		if err := xexec.Run(
 			ctx,
 			"git",
-			xexec.WithArgs(append(gitConfigAuthArgs, "checkout", "--force", checkoutRef)...),
+			xexec.WithArgs(append(gitConfigArgs, "checkout", "--force", checkoutRef)...),
 			xexec.WithEnv(app.Environ(envContainer)),
 			xexec.WithStderr(buffer),
 			xexec.WithDir(baseDir.Path()),
@@ -235,7 +251,7 @@ func (c *cloner) CloneToBucket(
 			ctx,
 			"git",
 			xexec.WithArgs(append(
-				gitConfigAuthArgs,
+				gitConfigArgs,
 				"submodule",
 				"update",
 				"--init",

--- a/private/pkg/git/git_test.go
+++ b/private/pkg/git/git_test.go
@@ -16,6 +16,7 @@ package git
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -24,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -68,6 +70,51 @@ func TestGitCloner(t *testing.T) {
 		content, err = storage.ReadPath(ctx, readBucket, "submodule/sub.proto")
 		require.NoError(t, err)
 		assert.Equal(t, "// submodule", string(content))
+	})
+
+	t.Run("auto_maintenance_disabled", func(t *testing.T) {
+		t.Parallel()
+
+		tracePath := filepath.Join(t.TempDir(), "git-trace.json")
+		readBucketForName(ctx, t, workDir, readBucketForNameOptions{
+			recurseSubmodules: true,
+			envOverrides: map[string]string{
+				"GIT_TRACE2_EVENT": tracePath,
+			},
+		})
+
+		traceData, err := os.ReadFile(tracePath)
+		require.NoError(t, err)
+
+		var gitArgvs [][]string
+		for line := range strings.SplitSeq(string(traceData), "\n") {
+			if line == "" {
+				continue
+			}
+			var event struct {
+				Event string   `json:"event"`
+				Argv  []string `json:"argv"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(line), &event))
+			if event.Event == "start" && len(event.Argv) > 0 {
+				gitArgvs = append(gitArgvs, event.Argv)
+			}
+		}
+
+		for _, subcommand := range []string{"fetch", "checkout", "submodule"} {
+			var found bool
+			for _, argv := range gitArgvs {
+				subcommandIndex := slices.Index(argv, subcommand)
+				if subcommandIndex < 0 {
+					continue
+				}
+				require.GreaterOrEqual(t, subcommandIndex, len(gitConfigNoAutoMaintenanceArgs))
+				assert.Equal(t, gitConfigNoAutoMaintenanceArgs, argv[subcommandIndex-len(gitConfigNoAutoMaintenanceArgs):subcommandIndex])
+				found = true
+				break
+			}
+			require.Truef(t, found, "missing git %q invocation", subcommand)
+		}
 	})
 
 	t.Run("main", func(t *testing.T) {


### PR DESCRIPTION
# What

This disables Git's automatic maintenance while the git cloner is preparing a temporary checkout for `CloneToBucket`.

The cloner now passes these config overrides to the Git commands that operate on the temporary clone:

```text
-c maintenance.auto=false
-c maintenance.autoDetach=false
-c gc.auto=0
-c gc.autoDetach=false
-c fetch.writeCommitGraph=false
```

The regression test checks the actual Git argv via `GIT_TRACE2_EVENT`, so it pins down that these options are passed before `fetch`, `checkout`, and `submodule`.

# Why

I ran into this through `bufbuild/buf-breaking-action@v1` on GitHub Actions. The action failed while cloning the `against` input with missing files under `.git`:

```text
Failure: could not clone https://github.com/winor30/buf-breaking-repro.git: stat .git/objects/bitmap-ref-tips_4VcgMk: file does not exist                                                                                                                                                                                      stat .git/info/refs_9E0SyG: file does not exist
```

That run was on `ubuntu-24.04` with Git 2.54.0.

The cloner creates a temporary Git repository, runs `fetch`/`checkout`/optional submodule commands, and then copies the result into a storage bucket. In the affected path, `.git` files can be part of that copy. If Git kicks off automatic maintenance or GC around the same time, it can create and remove temporary files under `.git` while `storage.Copy` is walking the directory. That leaves `storage.Copy` with a path it saw during the walk, but can no longer stat/open.
I verified the race with a local reproducer that puts a small `git` wrapper at the front of `PATH`. The wrapper delegates to the real Git binary, but after `git fetch` it simulates background Git maintenance by creating files under `.git/buf-copy-race` and deleting them while `CloneToBucket` is copying the checkout.

On `main`, cloning with no matcher fails in the same way:

```text
CloneToBucket error: stat .git/buf-copy-race/file-0: file does not exist
```

On this branch, the same reproducer passes because the maintenance-simulating path is not started.