### PR TITLE
Fix license badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Buf
 
-[![License](https://img.shields.io/github/license/bufbuild/buf?color=blue)](https://github.com/bufbuild/buf/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/bufbuild/buf?color=blue&v=1)](https://github.com/bufbuild/buf/blob/main/LICENSE)
 [![Release](https://img.shields.io/github/v/release/bufbuild/buf?include_prereleases)](https://github.com/bufbuild/buf/releases)
 [![CI](https://github.com/bufbuild/buf/workflows/ci/badge.svg)](https://github.com/bufbuild/buf/actions?workflow=ci)
 [![Docker](https://img.shields.io/docker/pulls/bufbuild/buf)](https://hub.docker.com/r/bufbuild/buf)


### PR DESCRIPTION
The current license badge is showing a cached "Unable to select next GitHub token from pool". Make a small change to the shields.io link to invalidate the cache to show the proper license badge.