### PR TITLE
Support recursive glob (.**) in bufimageutil type filters

### DIFF
--- a/cmd/buf/internal/command/build/build.go
+++ b/cmd/buf/internal/command/build/build.go
@@ -132,7 +132,7 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Types,
 		typeFlagName,
 		nil,
-		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types",
+		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. A type name may end with \".**\" to recursively include the named element and everything nested beneath it, such as a package and all of its sub-packages",
 	)
 }
 

--- a/cmd/buf/internal/command/generate/generate.go
+++ b/cmd/buf/internal/command/generate/generate.go
@@ -487,19 +487,19 @@ func (f *flags) Bind(flagSet *pflag.FlagSet) {
 		&f.Types,
 		typeFlagName,
 		nil,
-		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
+		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. A type name may end with \".**\" to recursively include the named element and everything nested beneath it, such as a package and all of its sub-packages. Flag usage overrides buf.gen.yaml",
 	)
 	flagSet.StringSliceVar(
 		&f.TypesDeprecated,
 		typeDeprecatedFlagName,
 		nil,
-		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. Flag usage overrides buf.gen.yaml",
+		"The types (package, message, enum, extension, service, method) that should be included in this image. When specified, the resulting image will only include descriptors to describe the requested types. A type name may end with \".**\" to recursively include the named element and everything nested beneath it, such as a package and all of its sub-packages. Flag usage overrides buf.gen.yaml",
 	)
 	flagSet.StringSliceVar(
 		&f.ExcludeTypes,
 		excludeTypeFlagName,
 		nil,
-		"The types (package, message, enum, extension, service, method) that should be excluded from this image. When specified, the resulting image will omit descriptors for the specified types and remove any references to them, such as fields typed to an excluded message or enum, or custom options tied to an excluded extension. The image is first filtered by the included types, then further reduced by the excluded. Flag usage overrides buf.gen.yaml",
+		"The types (package, message, enum, extension, service, method) that should be excluded from this image. When specified, the resulting image will omit descriptors for the specified types and remove any references to them, such as fields typed to an excluded message or enum, or custom options tied to an excluded extension. A type name may end with \".**\" to recursively exclude the named element and everything nested beneath it, such as a package and all of its sub-packages. The image is first filtered by the included types, then further reduced by the excluded. Flag usage overrides buf.gen.yaml",
 	)
 	_ = flagSet.MarkDeprecated(typeDeprecatedFlagName, fmt.Sprintf("use --%s instead", typeFlagName))
 	_ = flagSet.MarkHidden(typeDeprecatedFlagName)

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -107,6 +107,11 @@ func WithAllowIncludeOfImportedType() ImageFilterOption {
 // For example, "google.protobuf.Any" or "buf.validate". Types may be nested,
 // and can be any package, message, enum, extension, service or method name.
 //
+// A name ending in ".**" is a recursive glob that matches the named element and
+// every symbol nested beneath it. For example, "acme.foo.**" matches the package
+// "acme.foo", all of its sub-packages, and all of their types; "acme.Foo.**"
+// matches the message "acme.Foo" and all of its nested types.
+//
 // If the type does not exist in the image, an error wrapping
 // [ErrImageFilterTypeNotFound] will be returned.
 func WithIncludeTypes(typeNames ...string) ImageFilterOption {
@@ -127,7 +132,14 @@ func WithIncludeTypes(typeNames ...string) ImageFilterOption {
 // For example, "google.protobuf.Any" or "buf.validate". Types may be nested,
 // and can be any package, message, enum, extension, service or method name.
 //
-// If the  type does not exist in the image, an error wrapping
+// A name ending in ".**" is a recursive glob that matches the named element and
+// every symbol nested beneath it. For a package, this additionally excludes all
+// of its sub-packages; without the glob, only the named package's own types are
+// excluded. Note that, even without the glob suffix, excluding a message always
+// excludes any nested types, too. This is because we can't realistically preserve
+// the nested types if we've excluded their container.
+//
+// If the type does not exist in the image, an error wrapping
 // [ErrImageFilterTypeNotFound] will be returned.
 func WithExcludeTypes(typeNames ...string) ImageFilterOption {
 	return func(opts *imageFilterOptions) {
@@ -345,6 +357,7 @@ func (t *transitiveClosure) hasOption(
 
 func (t *transitiveClosure) includeType(
 	typeName protoreflect.FullName,
+	recursive bool,
 	imageIndex *imageIndex,
 	options *imageFilterOptions,
 ) error {
@@ -372,6 +385,12 @@ func (t *transitiveClosure) includeType(
 		if err := t.addElement(descriptorInfo.element, "", false, imageIndex, options); err != nil {
 			return fmt.Errorf("inclusion of type %q: %w", typeName, err)
 		}
+		if recursive {
+			// Auto-include any symbol nested beneath the named element.
+			if err := t.includeChildElements(descriptorInfo.element, imageIndex, options); err != nil {
+				return fmt.Errorf("inclusion of type %q: %w", typeName, err)
+			}
+		}
 		return nil
 	}
 	// It could be a package name
@@ -381,9 +400,14 @@ func (t *transitiveClosure) includeType(
 		return fmt.Errorf("inclusion of type %q: %w", typeName, ErrImageFilterTypeNotFound)
 	}
 	if !options.allowImportedTypes {
-		// if package includes only imported files, then reject
+		// If the package contains only imported files, then reject. For a
+		// recursive glob, sub-packages count toward this check too.
+		packageFiles := pkg.files
+		if recursive {
+			packageFiles = appendPackageFiles(nil, pkg)
+		}
 		onlyImported := true
-		for _, file := range pkg.files {
+		for _, file := range packageFiles {
 			if !file.IsImport() {
 				onlyImported = false
 				break
@@ -393,16 +417,89 @@ func (t *transitiveClosure) includeType(
 			return fmt.Errorf("inclusion of type %q: %w", typeName, ErrImageFilterTypeIsImport)
 		}
 	}
+	return t.includePackage(pkg, recursive, true, imageIndex, options)
+}
+
+// includePackage adds the files of the given package to the closure, recursing
+// into sub-packages when recursive is set.
+//
+// The top-level (named) package is an error if it has been excluded: including
+// and excluding the same package expand to the same set and cancel out, exactly
+// as for a non-recursive package include. Sub-packages reached only via the
+// recursive glob are instead skipped when excluded, so that e.g. including
+// "a.b.**" while excluding "a.b.c" succeeds.
+func (t *transitiveClosure) includePackage(
+	pkg *packageInfo,
+	recursive bool,
+	isTopLevel bool,
+	imageIndex *imageIndex,
+	options *imageFilterOptions,
+) error {
 	for _, file := range pkg.files {
 		fileDescriptor := file.FileDescriptorProto()
 		if mode := t.elements[fileDescriptor]; mode == inclusionModeExcluded {
-			return fmt.Errorf("inclusion of excluded package %q", typeName)
+			if !isTopLevel {
+				continue
+			}
+			return fmt.Errorf("inclusion of excluded package %q", pkg.fullName)
 		}
 		if err := t.addElement(fileDescriptor, "", false, imageIndex, options); err != nil {
-			return fmt.Errorf("inclusion of type %q: %w", typeName, err)
+			return fmt.Errorf("inclusion of type %q: %w", pkg.fullName, err)
+		}
+	}
+	if !recursive {
+		return nil
+	}
+	for _, subPackage := range pkg.subPackages {
+		if err := t.includePackage(subPackage, recursive, false, imageIndex, options); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// includeChildElements recursively adds the symbols nested beneath the given
+// element to the closure. Only messages have such children: their nested
+// messages and enums. Other element kinds have nothing to expand.
+func (t *transitiveClosure) includeChildElements(
+	descriptor namedDescriptor,
+	imageIndex *imageIndex,
+	options *imageFilterOptions,
+) error {
+	message, ok := descriptor.(*descriptorpb.DescriptorProto)
+	if !ok {
+		return nil
+	}
+	for _, nestedMessage := range message.GetNestedType() {
+		if mode := t.elements[nestedMessage]; mode == inclusionModeExcluded {
+			continue
+		}
+		if err := t.addElement(nestedMessage, "", false, imageIndex, options); err != nil {
+			return err
+		}
+		if err := t.includeChildElements(nestedMessage, imageIndex, options); err != nil {
+			return err
+		}
+	}
+	for _, nestedEnum := range message.GetEnumType() {
+		if mode := t.elements[nestedEnum]; mode == inclusionModeExcluded {
+			continue
+		}
+		if err := t.addElement(nestedEnum, "", false, imageIndex, options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// appendPackageFiles appends the files of the given package and all of its
+// sub-packages, recursively, to files.
+func appendPackageFiles(files []bufimage.ImageFile, pkg *packageInfo) []bufimage.ImageFile {
+	files = append(files, pkg.files...)
+	for _, subPackage := range pkg.subPackages {
+		files = appendPackageFiles(files, subPackage)
+	}
+	return files
 }
 
 func (t *transitiveClosure) addImport(fromPath, toPath string) {
@@ -611,11 +708,15 @@ func (t *transitiveClosure) addElement(
 
 func (t *transitiveClosure) excludeType(
 	typeName protoreflect.FullName,
+	recursive bool,
 	imageIndex *imageIndex,
 	options *imageFilterOptions,
 ) error {
 	descriptorInfo, ok := imageIndex.ByName[typeName]
 	if ok {
+		// excludeElement recurses into all nested elements: a symbol cannot be
+		// removed while keeping the types nested within it. The recursive glob
+		// therefore has no additional effect for a named element.
 		return t.excludeElement(descriptorInfo.element, imageIndex, options)
 	}
 	// It could be a package name
@@ -624,8 +725,13 @@ func (t *transitiveClosure) excludeType(
 		// but it's not...
 		return fmt.Errorf("exclusion of type %q: %w", typeName, ErrImageFilterTypeNotFound)
 	}
-	// Exclude the package and all of its files.
-	for _, file := range pkg.files {
+	// Exclude the named package's own files. For a recursive glob, also exclude
+	// all of its sub-packages.
+	packageFiles := pkg.files
+	if recursive {
+		packageFiles = appendPackageFiles(nil, pkg)
+	}
+	for _, file := range packageFiles {
 		fileDescriptor := file.FileDescriptorProto()
 		if err := t.excludeElement(fileDescriptor, imageIndex, options); err != nil {
 			return err

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -42,6 +42,11 @@ var (
 	// ErrImageFilterTypeIsImport is returned from FilterImage when
 	// a specified type name is declared in a module dependency.
 	ErrImageFilterTypeIsImport = errors.New("type declared in imported module")
+
+	// ErrImageFilterTypeExcluded is returned from FilterImage when a type is
+	// named for inclusion but it (or all of the types it expands to) has also
+	// been excluded, so the include and exclude filters contradict each other.
+	ErrImageFilterTypeExcluded = errors.New("type excluded by filter")
 )
 
 // FreeMessageRangeStrings gets the free MessageRange strings for the target files.
@@ -369,7 +374,7 @@ func (t *transitiveClosure) includeType(
 		}
 		// Check if the type is already excluded.
 		if mode := t.elements[descriptorInfo.element]; mode == inclusionModeExcluded {
-			return fmt.Errorf("inclusion of excluded type %q", typeName)
+			return fmt.Errorf("inclusion of type %q: %w", typeName, ErrImageFilterTypeExcluded)
 		}
 		// If an extension field, check if the extendee is excluded.
 		if field, ok := descriptorInfo.element.(*descriptorpb.FieldDescriptorProto); ok && field.Extendee != nil {
@@ -379,7 +384,7 @@ func (t *transitiveClosure) includeType(
 				return fmt.Errorf("missing %q", extendeeName)
 			}
 			if mode := t.elements[extendeeInfo.element]; mode == inclusionModeExcluded {
-				return fmt.Errorf("cannot include extension field %q as the extendee type %q is excluded", typeName, extendeeName)
+				return fmt.Errorf("cannot include extension field %q as its extendee type %q is %w", typeName, extendeeName, ErrImageFilterTypeExcluded)
 			}
 		}
 		if err := t.addElement(descriptorInfo.element, "", false, imageIndex, options); err != nil {
@@ -399,13 +404,22 @@ func (t *transitiveClosure) includeType(
 		// but it's not...
 		return fmt.Errorf("inclusion of type %q: %w", typeName, ErrImageFilterTypeNotFound)
 	}
+	// Determine the files in scope: the package's own files, plus all
+	// sub-package files for a recursive glob.
+	packageFiles := pkg.files
+	if recursive {
+		packageFiles = appendPackageFiles(nil, pkg)
+	}
+	if len(packageFiles) == 0 {
+		// The named package declares no types of its own. This commonly happens
+		// with a version-prefix namespace such as "acme.order" whose types all
+		// live in sub-packages (acme.order.v1, ...); point the caller at the
+		// recursive glob that would include them.
+		return fmt.Errorf("inclusion of type %q: package contains no types directly; did you mean %q?", typeName, string(typeName)+".**")
+	}
 	if !options.allowImportedTypes {
-		// If the package contains only imported files, then reject. For a
-		// recursive glob, sub-packages count toward this check too.
-		packageFiles := pkg.files
-		if recursive {
-			packageFiles = appendPackageFiles(nil, pkg)
-		}
+		// If the package (including its sub-packages, for a recursive glob)
+		// contains only imported files, then reject.
 		onlyImported := true
 		for _, file := range packageFiles {
 			if !file.IsImport() {
@@ -417,50 +431,57 @@ func (t *transitiveClosure) includeType(
 			return fmt.Errorf("inclusion of type %q: %w", typeName, ErrImageFilterTypeIsImport)
 		}
 	}
-	return t.includePackage(pkg, recursive, true, imageIndex, options)
-}
-
-// includePackage adds the files of the given package to the closure, recursing
-// into sub-packages when recursive is set.
-//
-// The top-level (named) package is an error if it has been excluded: including
-// and excluding the same package expand to the same set and cancel out, exactly
-// as for a non-recursive package include. Sub-packages reached only via the
-// recursive glob are instead skipped when excluded, so that e.g. including
-// "a.b.**" while excluding "a.b.c" succeeds.
-func (t *transitiveClosure) includePackage(
-	pkg *packageInfo,
-	recursive bool,
-	isTopLevel bool,
-	imageIndex *imageIndex,
-	options *imageFilterOptions,
-) error {
-	for _, file := range pkg.files {
-		fileDescriptor := file.FileDescriptorProto()
-		if mode := t.elements[fileDescriptor]; mode == inclusionModeExcluded {
-			if !isTopLevel {
-				continue
-			}
-			return fmt.Errorf("inclusion of excluded package %q", pkg.fullName)
-		}
-		if err := t.addElement(fileDescriptor, "", false, imageIndex, options); err != nil {
-			return fmt.Errorf("inclusion of type %q: %w", pkg.fullName, err)
-		}
+	included, err := t.includePackage(pkg, recursive, imageIndex, options)
+	if err != nil {
+		return err
 	}
-	if !recursive {
-		return nil
-	}
-	for _, subPackage := range pkg.subPackages {
-		if err := t.includePackage(subPackage, recursive, false, imageIndex, options); err != nil {
-			return err
-		}
+	if included == 0 {
+		// Every file in scope was excluded, so the include and exclude filters
+		// cancel out (e.g. including "a.b.**" while a.b and all its sub-packages
+		// are excluded).
+		return fmt.Errorf("inclusion of type %q: %w", typeName, ErrImageFilterTypeExcluded)
 	}
 	return nil
 }
 
+// includePackage adds the non-excluded files of the given package to the
+// closure, recursing into sub-packages when recursive is set, and returns the
+// number of files it included. Excluded files are skipped; the caller treats a
+// zero count as a contradiction between the include and exclude filters.
+func (t *transitiveClosure) includePackage(
+	pkg *packageInfo,
+	recursive bool,
+	imageIndex *imageIndex,
+	options *imageFilterOptions,
+) (int, error) {
+	included := 0
+	for _, file := range pkg.files {
+		fileDescriptor := file.FileDescriptorProto()
+		if mode := t.elements[fileDescriptor]; mode == inclusionModeExcluded {
+			continue
+		}
+		if err := t.addElement(fileDescriptor, "", false, imageIndex, options); err != nil {
+			return included, fmt.Errorf("inclusion of package %q: %w", pkg.fullName, err)
+		}
+		included++
+	}
+	if recursive {
+		for _, subPackage := range pkg.subPackages {
+			subIncluded, err := t.includePackage(subPackage, recursive, imageIndex, options)
+			if err != nil {
+				return included, err
+			}
+			included += subIncluded
+		}
+	}
+	return included, nil
+}
+
 // includeChildElements recursively adds the symbols nested beneath the given
 // element to the closure. Only messages have such children: their nested
-// messages and enums. Other element kinds have nothing to expand.
+// messages, enums, and extensions. Other element kinds have nothing to expand
+// (a service's methods and an enum's values are always included with their
+// parent).
 func (t *transitiveClosure) includeChildElements(
 	descriptor namedDescriptor,
 	imageIndex *imageIndex,
@@ -486,6 +507,14 @@ func (t *transitiveClosure) includeChildElements(
 			continue
 		}
 		if err := t.addElement(nestedEnum, "", false, imageIndex, options); err != nil {
+			return err
+		}
+	}
+	for _, nestedExtension := range message.GetExtension() {
+		if mode := t.elements[nestedExtension]; mode == inclusionModeExcluded {
+			continue
+		}
+		if err := t.addElement(nestedExtension, "", false, imageIndex, options); err != nil {
 			return err
 		}
 	}
@@ -643,11 +672,11 @@ func (t *transitiveClosure) addElement(
 		}
 		if inputMode := t.elements[inputInfo.element]; inputMode == inclusionModeExcluded {
 			// The input is excluded, it's an error to include the method.
-			return fmt.Errorf("cannot include method %q as the input type %q is excluded", descriptorInfo.fullName, inputInfo.fullName)
+			return fmt.Errorf("cannot include method %q as its input type %q is %w", descriptorInfo.fullName, inputInfo.fullName, ErrImageFilterTypeExcluded)
 		}
 		if outputMode := t.elements[outputInfo.element]; outputMode == inclusionModeExcluded {
 			// The output is excluded, it's an error to include the method.
-			return fmt.Errorf("cannot include method %q as the output type %q is excluded", descriptorInfo.fullName, outputInfo.fullName)
+			return fmt.Errorf("cannot include method %q as its output type %q is %w", descriptorInfo.fullName, outputInfo.fullName, ErrImageFilterTypeExcluded)
 		}
 		if err := t.addElement(inputInfo.element, descriptorInfo.file.Path(), false, imageIndex, opts); err != nil {
 			return err

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -142,6 +142,17 @@ func TestNesting(t *testing.T) {
 		t.Parallel()
 		runDiffTest(t, "testdata/nesting", "message.txtar", WithIncludeTypes("pkg.Foo"))
 	})
+	t.Run("recursive_message", func(t *testing.T) {
+		t.Parallel()
+		// "pkg.Foo.**" additionally pulls in the otherwise-unreferenced nested
+		// types pkg.Foo.NestedButNotUsed and pkg.Foo.NestedFoo.NestedNestedFoo.
+		runDiffTest(t, "testdata/nesting", "message.recursive.txtar", WithIncludeTypes("pkg.Foo.**"))
+	})
+	t.Run("recursive_message_with_exclude", func(t *testing.T) {
+		t.Parallel()
+		// An explicitly excluded nested type is skipped by the recursive glob.
+		runDiffTest(t, "testdata/nesting", "message.recursive-exclude.txtar", WithIncludeTypes("pkg.Foo.**"), WithExcludeTypes("pkg.Foo.NestedButNotUsed"))
+	})
 	t.Run("recursenested", func(t *testing.T) {
 		t.Parallel()
 		runDiffTest(t, "testdata/nesting", "recursenested.txtar", WithIncludeTypes("pkg.Foo.NestedFoo.NestedNestedFoo"))
@@ -321,6 +332,31 @@ func TestPackages(t *testing.T) {
 	runDiffTest(t, "testdata/packages", "foo.txtar", WithIncludeTypes("foo"))
 	runDiffTest(t, "testdata/packages", "foo.bar.txtar", WithIncludeTypes("foo.bar"))
 	runDiffTest(t, "testdata/packages", "foo.bar.baz.txtar", WithIncludeTypes("foo.bar.baz"))
+	// "foo.**" includes package foo and all of its sub-packages (foo.bar and
+	// foo.bar.baz), in contrast to "foo" which includes only package foo.
+	runDiffTest(t, "testdata/packages", "foo.recursive.txtar", WithIncludeTypes("foo.**"))
+	// Excluding a package without the glob is not recursive: excluding "foo.bar"
+	// drops only foo.bar's own types, leaving its sub-package foo.bar.baz (and
+	// package foo) intact.
+	runDiffTest(t, "testdata/packages", "foo.bar.exclude.txtar", WithExcludeTypes("foo.bar"))
+	// "foo.bar.**" is recursive, so it additionally drops foo.bar.baz.
+	runDiffTest(t, "testdata/packages", "foo.bar.recursive-exclude.txtar", WithExcludeTypes("foo.bar.**"))
+	// Excluding "foo.bar.**" drops foo.bar and foo.bar.baz; the excluded
+	// sub-packages are skipped by the "foo.**" include rather than treated as an
+	// error, leaving only package foo.
+	runDiffTest(t, "testdata/packages", "foo.recursive-exclude.txtar", WithIncludeTypes("foo.**"), WithExcludeTypes("foo.bar.**"))
+
+	// Including a recursive glob while excluding the same top-level package
+	// cancel out, so this is an error just as including and excluding the same
+	// package directly would be.
+	t.Run("recursive_include_excludes_self", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/packages", bufimage.WithExcludeSourceCodeInfo())
+		require.NoError(t, err)
+		_, err = FilterImage(image, WithIncludeTypes("foo.bar.**"), WithExcludeTypes("foo.bar"))
+		require.ErrorContains(t, err, "inclusion of excluded package \"foo.bar\"")
+	})
 }
 
 func TestAny(t *testing.T) {

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -131,8 +131,8 @@ func TestTypes(t *testing.T) {
 		_, image, err := getImage(t.Context(), slogtestext.NewLogger(t), "testdata/options", bufimage.WithExcludeSourceCodeInfo())
 		require.NoError(t, err)
 		_, err = FilterImage(image, WithIncludeTypes("pkg.extension"), WithExcludeTypes("pkg.Foo"))
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "cannot include extension field \"pkg.extension\" as the extendee type \"pkg.Foo\" is excluded")
+		require.ErrorIs(t, err, ErrImageFilterTypeExcluded)
+		assert.ErrorContains(t, err, "cannot include extension field \"pkg.extension\" as its extendee type \"pkg.Foo\" is")
 	})
 }
 
@@ -194,9 +194,11 @@ func TestNesting(t *testing.T) {
 		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/nesting", bufimage.WithExcludeSourceCodeInfo())
 		require.NoError(t, err)
 		_, err = FilterImage(image, WithIncludeTypes("pkg.Foo.NestedFoo"), WithExcludeTypes("pkg.Foo"))
-		require.ErrorContains(t, err, "inclusion of excluded type \"pkg.Foo.NestedFoo\"")
+		require.ErrorIs(t, err, ErrImageFilterTypeExcluded)
+		require.ErrorContains(t, err, "inclusion of type \"pkg.Foo.NestedFoo\"")
 		_, err = FilterImage(image, WithIncludeTypes("pkg.Foo.NestedButNotUsed"), WithExcludeTypes("pkg.Foo"))
-		require.ErrorContains(t, err, "inclusion of excluded type \"pkg.Foo.NestedButNotUsed\"")
+		require.ErrorIs(t, err, ErrImageFilterTypeExcluded)
+		require.ErrorContains(t, err, "inclusion of type \"pkg.Foo.NestedButNotUsed\"")
 	})
 }
 
@@ -324,6 +326,11 @@ func TestExtensions(t *testing.T) {
 	t.Parallel()
 	runDiffTest(t, "testdata/extensions", "extensions.txtar", WithIncludeTypes("pkg.Foo"))
 	runDiffTest(t, "testdata/extensions", "extensions-excluded.txtar", WithExcludeKnownExtensions(), WithIncludeTypes("pkg.Foo"))
+	// Including a message does not pull in extensions declared inside it, but the
+	// recursive glob does: "other.Embedded.**" additionally includes the nested
+	// extension other.Embedded.from_other_file (and thus its extendee pkg.Foo).
+	runDiffTest(t, "testdata/extensions", "embedded.txtar", WithExcludeKnownExtensions(), WithIncludeTypes("other.Embedded"))
+	runDiffTest(t, "testdata/extensions", "embedded.recursive.txtar", WithExcludeKnownExtensions(), WithIncludeTypes("other.Embedded.**"))
 }
 
 func TestPackages(t *testing.T) {
@@ -346,16 +353,61 @@ func TestPackages(t *testing.T) {
 	// error, leaving only package foo.
 	runDiffTest(t, "testdata/packages", "foo.recursive-exclude.txtar", WithIncludeTypes("foo.**"), WithExcludeTypes("foo.bar.**"))
 
-	// Including a recursive glob while excluding the same top-level package
-	// cancel out, so this is an error just as including and excluding the same
-	// package directly would be.
+	// When a recursive include and an exclude leave nothing behind, the filters
+	// contradict each other and FilterImage reports ErrImageFilterTypeExcluded.
+	// foo.bar.baz has no sub-packages, so including "foo.bar.baz.**" while
+	// excluding "foo.bar.baz" cancels out entirely.
 	t.Run("recursive_include_excludes_self", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/packages", bufimage.WithExcludeSourceCodeInfo())
 		require.NoError(t, err)
-		_, err = FilterImage(image, WithIncludeTypes("foo.bar.**"), WithExcludeTypes("foo.bar"))
-		require.ErrorContains(t, err, "inclusion of excluded package \"foo.bar\"")
+		_, err = FilterImage(image, WithIncludeTypes("foo.bar.baz.**"), WithExcludeTypes("foo.bar.baz"))
+		require.ErrorIs(t, err, ErrImageFilterTypeExcluded)
+		require.ErrorContains(t, err, "inclusion of type \"foo.bar.baz\"")
+	})
+
+	// Reject malformed globs: ".**" is only meaningful as a trailing suffix.
+	t.Run("invalid_glob", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/packages", bufimage.WithExcludeSourceCodeInfo())
+		require.NoError(t, err)
+		_, err = FilterImage(image, WithIncludeTypes("foo.**.bar"))
+		require.ErrorContains(t, err, "invalid include type \"foo.**.bar\": the only supported wildcard is \".**\" and it must come at the end")
+		_, err = FilterImage(image, WithExcludeTypes("foo.*"))
+		require.ErrorContains(t, err, "invalid exclude type \"foo.*\": the only supported wildcard is \".**\" and it must come at the end")
+	})
+}
+
+// TestVersionedPackages covers the common shape where the glob target is a
+// version-prefix namespace (acme.order) that declares no types of its own; all
+// types live in sub-packages (acme.order.v1, acme.order.v2).
+func TestVersionedPackages(t *testing.T) {
+	t.Parallel()
+	// "acme.order.**" includes both versioned sub-packages.
+	runDiffTest(t, "testdata/versioned", "acme.order.recursive.txtar", WithIncludeTypes("acme.order.**"))
+
+	t.Run("no_types_directly", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/versioned", bufimage.WithExcludeSourceCodeInfo())
+		require.NoError(t, err)
+		// "acme.order" itself has no types, so a non-recursive include is an error
+		// that points at the recursive glob.
+		_, err = FilterImage(image, WithIncludeTypes("acme.order"))
+		require.ErrorContains(t, err, "package contains no types directly; did you mean \"acme.order.**\"?")
+	})
+
+	t.Run("recursive_include_all_excluded", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/versioned", bufimage.WithExcludeSourceCodeInfo())
+		require.NoError(t, err)
+		// Excluding every sub-package leaves the recursive include empty.
+		_, err = FilterImage(image, WithIncludeTypes("acme.order.**"), WithExcludeTypes("acme.order.v1", "acme.order.v2"))
+		require.ErrorIs(t, err, ErrImageFilterTypeExcluded)
+		require.ErrorContains(t, err, "inclusion of type \"acme.order\"")
 	})
 }
 

--- a/private/bufpkg/bufimage/bufimageutil/image_filter.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_filter.go
@@ -28,6 +28,25 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
+// isValidFilterTypeName reports whether name (a filter type name with any
+// trailing ".**" recursive glob already removed) is acceptable. The empty
+// string is allowed and denotes the root (no-package) namespace; any other
+// value must be a valid fully-qualified name. This rejects malformed inputs
+// such as "foo.**.bar", where ".**" appears anywhere but the end.
+func isValidFilterTypeName(name string) bool {
+	return name == "" || protoreflect.FullName(name).IsValid()
+}
+
+// invalidFilterTypeError builds the error for a malformed filter type name,
+// where kind is "include" or "exclude". When the name contains an asterisk, the
+// message also clarifies that the only supported wildcard is a trailing ".**".
+func invalidFilterTypeError(kind, typeName string) error {
+	if strings.Contains(typeName, "*") {
+		return fmt.Errorf("invalid %s type %q: the only supported wildcard is %q and it must come at the end", kind, typeName, ".**")
+	}
+	return fmt.Errorf("invalid %s type %q", kind, typeName)
+}
+
 // filterImage filters the Image for the given options.
 func filterImage(image bufimage.Image, options *imageFilterOptions) (bufimage.Image, error) {
 	imageIndex, err := newImageIndexForImage(image, options)
@@ -40,14 +59,20 @@ func filterImage(image bufimage.Image, options *imageFilterOptions) (bufimage.Im
 	// every symbol nested beneath it (e.g. a package and all its sub-packages,
 	// or a message and all its nested types).
 	for excludeType := range options.excludeTypes {
-		excludeType, recursive := strings.CutSuffix(excludeType, ".**")
-		if err := closure.excludeType(protoreflect.FullName(excludeType), recursive, imageIndex, options); err != nil {
+		typeName, recursive := strings.CutSuffix(excludeType, ".**")
+		if !isValidFilterTypeName(typeName) {
+			return nil, invalidFilterTypeError("exclude", excludeType)
+		}
+		if err := closure.excludeType(protoreflect.FullName(typeName), recursive, imageIndex, options); err != nil {
 			return nil, err
 		}
 	}
 	for includeType := range options.includeTypes {
-		includeType, recursive := strings.CutSuffix(includeType, ".**")
-		if err := closure.includeType(protoreflect.FullName(includeType), recursive, imageIndex, options); err != nil {
+		typeName, recursive := strings.CutSuffix(includeType, ".**")
+		if !isValidFilterTypeName(typeName) {
+			return nil, invalidFilterTypeError("include", includeType)
+		}
+		if err := closure.includeType(protoreflect.FullName(typeName), recursive, imageIndex, options); err != nil {
 			return nil, err
 		}
 	}

--- a/private/bufpkg/bufimage/bufimageutil/image_filter.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_filter.go
@@ -35,18 +35,19 @@ func filterImage(image bufimage.Image, options *imageFilterOptions) (bufimage.Im
 		return nil, err
 	}
 	closure := newTransitiveClosure()
-	// All excludes are added first, then includes walk included all non excluded types.
-	// TODO: consider supporting a glob syntax of some kind, to do more advanced pattern
-	//   matching, such as ability to get a package AND all of its sub-packages.
+	// All excludes are added first, then includes walk all non-excluded types.
+	// A trailing ".**" is a recursive glob: it matches the named element and
+	// every symbol nested beneath it (e.g. a package and all its sub-packages,
+	// or a message and all its nested types).
 	for excludeType := range options.excludeTypes {
-		excludeType := protoreflect.FullName(excludeType)
-		if err := closure.excludeType(excludeType, imageIndex, options); err != nil {
+		excludeType, recursive := strings.CutSuffix(excludeType, ".**")
+		if err := closure.excludeType(protoreflect.FullName(excludeType), recursive, imageIndex, options); err != nil {
 			return nil, err
 		}
 	}
 	for includeType := range options.includeTypes {
-		includeType := protoreflect.FullName(includeType)
-		if err := closure.includeType(includeType, imageIndex, options); err != nil {
+		includeType, recursive := strings.CutSuffix(includeType, ".**")
+		if err := closure.includeType(protoreflect.FullName(includeType), recursive, imageIndex, options); err != nil {
 			return nil, err
 		}
 	}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/extensions/embedded.recursive.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/extensions/embedded.recursive.txtar
@@ -1,0 +1,18 @@
+-- a.proto --
+syntax = "proto2";
+package pkg;
+message Foo {
+  optional string a = 1;
+  optional Foo b = 2;
+  extensions 10 to max;
+}
+-- b.proto --
+syntax = "proto2";
+package other;
+import "a.proto";
+message Embedded {
+  optional string foo = 1;
+  extend pkg.Foo {
+    optional Embedded from_other_file = 12;
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/extensions/embedded.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/extensions/embedded.txtar
@@ -1,0 +1,6 @@
+-- b.proto --
+syntax = "proto2";
+package other;
+message Embedded {
+  optional string foo = 1;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/nesting/message.recursive-exclude.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/nesting/message.recursive-exclude.txtar
@@ -1,0 +1,13 @@
+-- a.proto --
+syntax = "proto3";
+package pkg;
+message Foo {
+  string x = 1;
+  NestedFoo nested_foo = 2;
+  message NestedFoo {
+    string nested_x = 1;
+    message NestedNestedFoo {
+      string nested_nested_x = 1;
+    }
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/nesting/message.recursive.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/nesting/message.recursive.txtar
@@ -1,0 +1,16 @@
+-- a.proto --
+syntax = "proto3";
+package pkg;
+message Foo {
+  string x = 1;
+  NestedFoo nested_foo = 2;
+  message NestedButNotUsed {
+    string nested_but_not_used = 1;
+  }
+  message NestedFoo {
+    string nested_x = 1;
+    message NestedNestedFoo {
+      string nested_nested_x = 1;
+    }
+  }
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.bar.exclude.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.bar.exclude.txtar
@@ -1,0 +1,594 @@
+-- baz1.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Bar {
+  map<string, int32> attributes = 1;
+}
+message Foo {
+  Enum en = 1;
+  string name = 2;
+  oneof loc {
+    string address = 3;
+    uint32 zip_code = 4;
+    uint64 other_xref = 5;
+  }
+  enum Enum {
+    VALUE0 = 0;
+    VALUE1 = 1;
+    VALUE2 = 2;
+  }
+}
+service BazService {
+  rpc GetBaz ( Foo ) returns ( Bar );
+}
+-- baz2.proto --
+syntax = "proto3";
+package foo.bar.baz;
+import "options.proto";
+message Empty {
+}
+enum AlmostEmpty {
+  UNSET = 0;
+}
+service NoOp {
+  option (svc_option_str) = "blah";
+  rpc Nothing ( Empty ) returns ( Empty );
+}
+-- foo.proto --
+syntax = "proto3";
+package foo;
+message MessageInFoo {
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message DescriptorProto {
+  optional string name = 1;
+  repeated FieldDescriptorProto field = 2;
+  repeated DescriptorProto nested_type = 3;
+  repeated EnumDescriptorProto enum_type = 4;
+  repeated ExtensionRange extension_range = 5;
+  repeated FieldDescriptorProto extension = 6;
+  optional MessageOptions options = 7;
+  repeated OneofDescriptorProto oneof_decl = 8;
+  repeated ReservedRange reserved_range = 9;
+  repeated string reserved_name = 10;
+  optional SymbolVisibility visibility = 11;
+  message ExtensionRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+    optional ExtensionRangeOptions options = 3;
+  }
+  message ReservedRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+  }
+}
+message EnumDescriptorProto {
+  optional string name = 1;
+  repeated EnumValueDescriptorProto value = 2;
+  optional EnumOptions options = 3;
+  repeated EnumReservedRange reserved_range = 4;
+  repeated string reserved_name = 5;
+  optional SymbolVisibility visibility = 6;
+  message EnumReservedRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+  }
+}
+message EnumOptions {
+  optional bool allow_alias = 2;
+  optional bool deprecated = 3 [default = false];
+  optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
+  optional FeatureSet features = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 5;
+}
+message EnumValueDescriptorProto {
+  optional string name = 1;
+  optional int32 number = 2;
+  optional EnumValueOptions options = 3;
+}
+message EnumValueOptions {
+  optional bool deprecated = 1 [default = false];
+  optional FeatureSet features = 2;
+  optional bool debug_redact = 3 [default = false];
+  optional FieldOptions.FeatureSupport feature_support = 4;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message ExtensionRangeOptions {
+  repeated Declaration declaration = 2 [retention = RETENTION_SOURCE];
+  optional VerificationState verification = 3 [default = UNVERIFIED, retention = RETENTION_SOURCE];
+  optional FeatureSet features = 50;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  message Declaration {
+    optional int32 number = 1;
+    optional string full_name = 2;
+    optional string type = 3;
+    optional bool reserved = 5;
+    optional bool repeated = 6;
+    reserved 4;
+  }
+  enum VerificationState {
+    DECLARATION = 0;
+    UNVERIFIED = 1;
+  }
+  extensions 1000 to max;
+}
+message FeatureSet {
+  optional FieldPresence field_presence = 1 [
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "IMPLICIT", edition: EDITION_PROTO3 },
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_2023 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnumType enum_type = 2 [
+    edition_defaults = { value: "CLOSED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "OPEN", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional RepeatedFieldEncoding repeated_field_encoding = 3 [
+    edition_defaults = { value: "EXPANDED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "PACKED", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional Utf8Validation utf8_validation = 4 [
+    edition_defaults = { value: "NONE", edition: EDITION_LEGACY },
+    edition_defaults = { value: "VERIFY", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional MessageEncoding message_encoding = 5 [
+    edition_defaults = { value: "LENGTH_PREFIXED", edition: EDITION_LEGACY },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional JsonFormat json_format = 6 [
+    edition_defaults = { value: "LEGACY_BEST_EFFORT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "ALLOW", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnforceNamingStyle enforce_naming_style = 7 [
+    edition_defaults = { value: "STYLE_LEGACY", edition: EDITION_LEGACY },
+    edition_defaults = { value: "STYLE2024", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE,
+    targets = TARGET_TYPE_EXTENSION_RANGE,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_ONEOF,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_ENUM_ENTRY,
+    targets = TARGET_TYPE_SERVICE,
+    targets = TARGET_TYPE_METHOD
+  ];
+  optional VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8 [
+    edition_defaults = { value: "EXPORT_ALL", edition: EDITION_LEGACY },
+    edition_defaults = { value: "EXPORT_TOP_LEVEL", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE
+  ];
+  message VisibilityFeature {
+    enum DefaultSymbolVisibility {
+      DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0;
+      EXPORT_ALL = 1;
+      EXPORT_TOP_LEVEL = 2;
+      LOCAL_ALL = 3;
+      STRICT = 4;
+    }
+  }
+  enum EnforceNamingStyle {
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+    STYLE2024 = 1;
+    STYLE_LEGACY = 2;
+  }
+  enum EnumType {
+    ENUM_TYPE_UNKNOWN = 0;
+    OPEN = 1;
+    CLOSED = 2;
+  }
+  enum FieldPresence {
+    FIELD_PRESENCE_UNKNOWN = 0;
+    EXPLICIT = 1;
+    IMPLICIT = 2;
+    LEGACY_REQUIRED = 3;
+  }
+  enum JsonFormat {
+    JSON_FORMAT_UNKNOWN = 0;
+    ALLOW = 1;
+    LEGACY_BEST_EFFORT = 2;
+  }
+  enum MessageEncoding {
+    MESSAGE_ENCODING_UNKNOWN = 0;
+    LENGTH_PREFIXED = 1;
+    DELIMITED = 2;
+  }
+  enum RepeatedFieldEncoding {
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+    PACKED = 1;
+    EXPANDED = 2;
+  }
+  enum Utf8Validation {
+    UTF8_VALIDATION_UNKNOWN = 0;
+    VERIFY = 2;
+    NONE = 3;
+    reserved 1;
+  }
+  extensions 1000 to 9994 [
+    declaration = {
+      number: 1000,
+      full_name: ".pb.cpp",
+      type: ".pb.CppFeatures"
+    },
+    declaration = {
+      number: 1001,
+      full_name: ".pb.java",
+      type: ".pb.JavaFeatures"
+    },
+    declaration = {
+      number: 1002,
+      full_name: ".pb.go",
+      type: ".pb.GoFeatures"
+    },
+    declaration = {
+      number: 1003,
+      full_name: ".pb.python",
+      type: ".pb.PythonFeatures"
+    },
+    declaration = {
+      number: 1100,
+      full_name: ".imp.impress_feature_set",
+      type: ".imp.ImpressFeatureSet"
+    },
+    declaration = {
+      number: 9989,
+      full_name: ".pb.java_mutable",
+      type: ".pb.JavaMutableFeatures"
+    },
+    declaration = {
+      number: 9990,
+      full_name: ".pb.proto1",
+      type: ".pb.Proto1Features"
+    }
+  ];
+  extensions 9995 to 9999, 10000;
+  reserved 999;
+}
+message FeatureSetDefaults {
+  repeated FeatureSetEditionDefault defaults = 1;
+  optional Edition minimum_edition = 4;
+  optional Edition maximum_edition = 5;
+  message FeatureSetEditionDefault {
+    optional Edition edition = 3;
+    optional FeatureSet overridable_features = 4;
+    optional FeatureSet fixed_features = 5;
+    reserved 1, 2;
+    reserved "features";
+  }
+}
+message FieldDescriptorProto {
+  optional string name = 1;
+  optional string extendee = 2;
+  optional int32 number = 3;
+  optional Label label = 4;
+  optional Type type = 5;
+  optional string type_name = 6;
+  optional string default_value = 7;
+  optional FieldOptions options = 8;
+  optional int32 oneof_index = 9;
+  optional string json_name = 10;
+  optional bool proto3_optional = 17;
+  enum Label {
+    LABEL_OPTIONAL = 1;
+    LABEL_REQUIRED = 2;
+    LABEL_REPEATED = 3;
+  }
+  enum Type {
+    TYPE_DOUBLE = 1;
+    TYPE_FLOAT = 2;
+    TYPE_INT64 = 3;
+    TYPE_UINT64 = 4;
+    TYPE_INT32 = 5;
+    TYPE_FIXED64 = 6;
+    TYPE_FIXED32 = 7;
+    TYPE_BOOL = 8;
+    TYPE_STRING = 9;
+    TYPE_GROUP = 10;
+    TYPE_MESSAGE = 11;
+    TYPE_BYTES = 12;
+    TYPE_UINT32 = 13;
+    TYPE_ENUM = 14;
+    TYPE_SFIXED32 = 15;
+    TYPE_SFIXED64 = 16;
+    TYPE_SINT32 = 17;
+    TYPE_SINT64 = 18;
+  }
+}
+message FieldOptions {
+  optional CType ctype = 1 [default = STRING];
+  optional bool packed = 2;
+  optional bool deprecated = 3 [default = false];
+  optional bool lazy = 5 [default = false];
+  optional JSType jstype = 6 [default = JS_NORMAL];
+  optional bool weak = 10 [default = false, deprecated = true];
+  optional bool unverified_lazy = 15 [default = false];
+  optional bool debug_redact = 16 [default = false];
+  optional OptionRetention retention = 17;
+  repeated OptionTargetType targets = 19;
+  repeated EditionDefault edition_defaults = 20;
+  optional FeatureSet features = 21;
+  optional FeatureSupport feature_support = 22;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  message EditionDefault {
+    optional string value = 2;
+    optional Edition edition = 3;
+  }
+  message FeatureSupport {
+    optional Edition edition_introduced = 1;
+    optional Edition edition_deprecated = 2;
+    optional string deprecation_warning = 3;
+    optional Edition edition_removed = 4;
+  }
+  enum CType {
+    STRING = 0;
+    CORD = 1;
+    STRING_PIECE = 2;
+  }
+  enum JSType {
+    JS_NORMAL = 0;
+    JS_STRING = 1;
+    JS_NUMBER = 2;
+  }
+  enum OptionRetention {
+    RETENTION_UNKNOWN = 0;
+    RETENTION_RUNTIME = 1;
+    RETENTION_SOURCE = 2;
+  }
+  enum OptionTargetType {
+    TARGET_TYPE_UNKNOWN = 0;
+    TARGET_TYPE_FILE = 1;
+    TARGET_TYPE_EXTENSION_RANGE = 2;
+    TARGET_TYPE_MESSAGE = 3;
+    TARGET_TYPE_FIELD = 4;
+    TARGET_TYPE_ONEOF = 5;
+    TARGET_TYPE_ENUM = 6;
+    TARGET_TYPE_ENUM_ENTRY = 7;
+    TARGET_TYPE_SERVICE = 8;
+    TARGET_TYPE_METHOD = 9;
+  }
+  extensions 1000 to max;
+  reserved 4, 18;
+}
+message FileDescriptorProto {
+  optional string name = 1;
+  optional string package = 2;
+  repeated string dependency = 3;
+  repeated DescriptorProto message_type = 4;
+  repeated EnumDescriptorProto enum_type = 5;
+  repeated ServiceDescriptorProto service = 6;
+  repeated FieldDescriptorProto extension = 7;
+  optional FileOptions options = 8;
+  optional SourceCodeInfo source_code_info = 9;
+  repeated int32 public_dependency = 10;
+  repeated int32 weak_dependency = 11;
+  optional string syntax = 12;
+  optional Edition edition = 14;
+  repeated string option_dependency = 15;
+}
+message FileDescriptorSet {
+  repeated FileDescriptorProto file = 1;
+  extensions 536000000 [
+    declaration = {
+      number: 536000000,
+      full_name: ".buf.descriptor.v1.buf_file_descriptor_set_extension",
+      type: ".buf.descriptor.v1.FileDescriptorSetExtension"
+    }
+  ];
+}
+message FileOptions {
+  optional string java_package = 1;
+  optional string java_outer_classname = 8;
+  optional OptimizeMode optimize_for = 9 [default = SPEED];
+  optional bool java_multiple_files = 10 [default = false];
+  optional string go_package = 11;
+  optional bool cc_generic_services = 16 [default = false];
+  optional bool java_generic_services = 17 [default = false];
+  optional bool py_generic_services = 18 [default = false];
+  optional bool java_generate_equals_and_hash = 20 [deprecated = true];
+  optional bool deprecated = 23 [default = false];
+  optional bool java_string_check_utf8 = 27 [default = false];
+  optional bool cc_enable_arenas = 31 [default = true];
+  optional string objc_class_prefix = 36;
+  optional string csharp_namespace = 37;
+  optional string swift_prefix = 39;
+  optional string php_class_prefix = 40;
+  optional string php_namespace = 41;
+  optional string php_metadata_namespace = 44;
+  optional string ruby_package = 45;
+  optional FeatureSet features = 50;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  enum OptimizeMode {
+    SPEED = 1;
+    CODE_SIZE = 2;
+    LITE_RUNTIME = 3;
+  }
+  extensions 1000 to max;
+  reserved 38, 42;
+  reserved "php_generic_services";
+}
+message GeneratedCodeInfo {
+  repeated Annotation annotation = 1;
+  message Annotation {
+    repeated int32 path = 1 [packed = true];
+    optional string source_file = 2;
+    optional int32 begin = 3;
+    optional int32 end = 4;
+    optional Semantic semantic = 5;
+    enum Semantic {
+      NONE = 0;
+      SET = 1;
+      ALIAS = 2;
+    }
+  }
+}
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
+  optional FeatureSet features = 12;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message MethodDescriptorProto {
+  optional string name = 1;
+  optional string input_type = 2;
+  optional string output_type = 3;
+  optional MethodOptions options = 4;
+  optional bool client_streaming = 5 [default = false];
+  optional bool server_streaming = 6 [default = false];
+}
+message MethodOptions {
+  optional bool deprecated = 33 [default = false];
+  optional IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
+  optional FeatureSet features = 35;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  enum IdempotencyLevel {
+    IDEMPOTENCY_UNKNOWN = 0;
+    NO_SIDE_EFFECTS = 1;
+    IDEMPOTENT = 2;
+  }
+  extensions 1000 to max;
+}
+message OneofDescriptorProto {
+  optional string name = 1;
+  optional OneofOptions options = 2;
+}
+message OneofOptions {
+  optional FeatureSet features = 1;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message ServiceDescriptorProto {
+  optional string name = 1;
+  repeated MethodDescriptorProto method = 2;
+  optional ServiceOptions options = 3;
+  reserved 4;
+  reserved "stream";
+}
+message ServiceOptions {
+  optional bool deprecated = 33 [default = false];
+  optional FeatureSet features = 34;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message SourceCodeInfo {
+  repeated Location location = 1;
+  message Location {
+    repeated int32 path = 1 [packed = true];
+    repeated int32 span = 2 [packed = true];
+    optional string leading_comments = 3;
+    optional string trailing_comments = 4;
+    repeated string leading_detached_comments = 6;
+  }
+  extensions 536000000 [
+    declaration = {
+      number: 536000000,
+      full_name: ".buf.descriptor.v1.buf_source_code_info_extension",
+      type: ".buf.descriptor.v1.SourceCodeInfoExtension"
+    }
+  ];
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}
+enum Edition {
+  EDITION_UNKNOWN = 0;
+  EDITION_1_TEST_ONLY = 1;
+  EDITION_2_TEST_ONLY = 2;
+  EDITION_LEGACY = 900;
+  EDITION_PROTO2 = 998;
+  EDITION_PROTO3 = 999;
+  EDITION_2023 = 1000;
+  EDITION_2024 = 1001;
+  EDITION_UNSTABLE = 9999;
+  EDITION_99997_TEST_ONLY = 99997;
+  EDITION_99998_TEST_ONLY = 99998;
+  EDITION_99999_TEST_ONLY = 99999;
+  EDITION_MAX = 2147483647;
+}
+enum SymbolVisibility {
+  VISIBILITY_UNSET = 0;
+  VISIBILITY_LOCAL = 1;
+  VISIBILITY_EXPORT = 2;
+}
+-- nopackage.proto --
+syntax = "proto3";
+import "google/protobuf/descriptor.proto";
+import "options.proto";
+option (file_option_str) = "foo";
+message Foo {
+  option (msg_option_str) = "foo";
+  oneof x {
+    string bar = 1;
+    string baz = 2;
+  }
+}
+extend google.protobuf.ExtensionRangeOptions {
+  int64 rand = 30000;
+}
+-- options.proto --
+syntax = "proto3";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.FileOptions {
+  string file_option_str = 30000;
+}
+extend google.protobuf.MessageOptions {
+  string msg_option_str = 30000;
+}
+extend google.protobuf.ServiceOptions {
+  string svc_option_str = 30000;
+}
+-- other.proto --
+syntax = "proto3";
+package other;

--- a/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.bar.recursive-exclude.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.bar.recursive-exclude.txtar
@@ -1,0 +1,558 @@
+-- foo.proto --
+syntax = "proto3";
+package foo;
+message MessageInFoo {
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message DescriptorProto {
+  optional string name = 1;
+  repeated FieldDescriptorProto field = 2;
+  repeated DescriptorProto nested_type = 3;
+  repeated EnumDescriptorProto enum_type = 4;
+  repeated ExtensionRange extension_range = 5;
+  repeated FieldDescriptorProto extension = 6;
+  optional MessageOptions options = 7;
+  repeated OneofDescriptorProto oneof_decl = 8;
+  repeated ReservedRange reserved_range = 9;
+  repeated string reserved_name = 10;
+  optional SymbolVisibility visibility = 11;
+  message ExtensionRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+    optional ExtensionRangeOptions options = 3;
+  }
+  message ReservedRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+  }
+}
+message EnumDescriptorProto {
+  optional string name = 1;
+  repeated EnumValueDescriptorProto value = 2;
+  optional EnumOptions options = 3;
+  repeated EnumReservedRange reserved_range = 4;
+  repeated string reserved_name = 5;
+  optional SymbolVisibility visibility = 6;
+  message EnumReservedRange {
+    optional int32 start = 1;
+    optional int32 end = 2;
+  }
+}
+message EnumOptions {
+  optional bool allow_alias = 2;
+  optional bool deprecated = 3 [default = false];
+  optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
+  optional FeatureSet features = 7;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 5;
+}
+message EnumValueDescriptorProto {
+  optional string name = 1;
+  optional int32 number = 2;
+  optional EnumValueOptions options = 3;
+}
+message EnumValueOptions {
+  optional bool deprecated = 1 [default = false];
+  optional FeatureSet features = 2;
+  optional bool debug_redact = 3 [default = false];
+  optional FieldOptions.FeatureSupport feature_support = 4;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message ExtensionRangeOptions {
+  repeated Declaration declaration = 2 [retention = RETENTION_SOURCE];
+  optional VerificationState verification = 3 [default = UNVERIFIED, retention = RETENTION_SOURCE];
+  optional FeatureSet features = 50;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  message Declaration {
+    optional int32 number = 1;
+    optional string full_name = 2;
+    optional string type = 3;
+    optional bool reserved = 5;
+    optional bool repeated = 6;
+    reserved 4;
+  }
+  enum VerificationState {
+    DECLARATION = 0;
+    UNVERIFIED = 1;
+  }
+  extensions 1000 to max;
+}
+message FeatureSet {
+  optional FieldPresence field_presence = 1 [
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "IMPLICIT", edition: EDITION_PROTO3 },
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_2023 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnumType enum_type = 2 [
+    edition_defaults = { value: "CLOSED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "OPEN", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional RepeatedFieldEncoding repeated_field_encoding = 3 [
+    edition_defaults = { value: "EXPANDED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "PACKED", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional Utf8Validation utf8_validation = 4 [
+    edition_defaults = { value: "NONE", edition: EDITION_LEGACY },
+    edition_defaults = { value: "VERIFY", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional MessageEncoding message_encoding = 5 [
+    edition_defaults = { value: "LENGTH_PREFIXED", edition: EDITION_LEGACY },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional JsonFormat json_format = 6 [
+    edition_defaults = { value: "LEGACY_BEST_EFFORT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "ALLOW", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnforceNamingStyle enforce_naming_style = 7 [
+    edition_defaults = { value: "STYLE_LEGACY", edition: EDITION_LEGACY },
+    edition_defaults = { value: "STYLE2024", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE,
+    targets = TARGET_TYPE_EXTENSION_RANGE,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_ONEOF,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_ENUM_ENTRY,
+    targets = TARGET_TYPE_SERVICE,
+    targets = TARGET_TYPE_METHOD
+  ];
+  optional VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8 [
+    edition_defaults = { value: "EXPORT_ALL", edition: EDITION_LEGACY },
+    edition_defaults = { value: "EXPORT_TOP_LEVEL", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE
+  ];
+  message VisibilityFeature {
+    enum DefaultSymbolVisibility {
+      DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0;
+      EXPORT_ALL = 1;
+      EXPORT_TOP_LEVEL = 2;
+      LOCAL_ALL = 3;
+      STRICT = 4;
+    }
+  }
+  enum EnforceNamingStyle {
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+    STYLE2024 = 1;
+    STYLE_LEGACY = 2;
+  }
+  enum EnumType {
+    ENUM_TYPE_UNKNOWN = 0;
+    OPEN = 1;
+    CLOSED = 2;
+  }
+  enum FieldPresence {
+    FIELD_PRESENCE_UNKNOWN = 0;
+    EXPLICIT = 1;
+    IMPLICIT = 2;
+    LEGACY_REQUIRED = 3;
+  }
+  enum JsonFormat {
+    JSON_FORMAT_UNKNOWN = 0;
+    ALLOW = 1;
+    LEGACY_BEST_EFFORT = 2;
+  }
+  enum MessageEncoding {
+    MESSAGE_ENCODING_UNKNOWN = 0;
+    LENGTH_PREFIXED = 1;
+    DELIMITED = 2;
+  }
+  enum RepeatedFieldEncoding {
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+    PACKED = 1;
+    EXPANDED = 2;
+  }
+  enum Utf8Validation {
+    UTF8_VALIDATION_UNKNOWN = 0;
+    VERIFY = 2;
+    NONE = 3;
+    reserved 1;
+  }
+  extensions 1000 to 9994 [
+    declaration = {
+      number: 1000,
+      full_name: ".pb.cpp",
+      type: ".pb.CppFeatures"
+    },
+    declaration = {
+      number: 1001,
+      full_name: ".pb.java",
+      type: ".pb.JavaFeatures"
+    },
+    declaration = {
+      number: 1002,
+      full_name: ".pb.go",
+      type: ".pb.GoFeatures"
+    },
+    declaration = {
+      number: 1003,
+      full_name: ".pb.python",
+      type: ".pb.PythonFeatures"
+    },
+    declaration = {
+      number: 1100,
+      full_name: ".imp.impress_feature_set",
+      type: ".imp.ImpressFeatureSet"
+    },
+    declaration = {
+      number: 9989,
+      full_name: ".pb.java_mutable",
+      type: ".pb.JavaMutableFeatures"
+    },
+    declaration = {
+      number: 9990,
+      full_name: ".pb.proto1",
+      type: ".pb.Proto1Features"
+    }
+  ];
+  extensions 9995 to 9999, 10000;
+  reserved 999;
+}
+message FeatureSetDefaults {
+  repeated FeatureSetEditionDefault defaults = 1;
+  optional Edition minimum_edition = 4;
+  optional Edition maximum_edition = 5;
+  message FeatureSetEditionDefault {
+    optional Edition edition = 3;
+    optional FeatureSet overridable_features = 4;
+    optional FeatureSet fixed_features = 5;
+    reserved 1, 2;
+    reserved "features";
+  }
+}
+message FieldDescriptorProto {
+  optional string name = 1;
+  optional string extendee = 2;
+  optional int32 number = 3;
+  optional Label label = 4;
+  optional Type type = 5;
+  optional string type_name = 6;
+  optional string default_value = 7;
+  optional FieldOptions options = 8;
+  optional int32 oneof_index = 9;
+  optional string json_name = 10;
+  optional bool proto3_optional = 17;
+  enum Label {
+    LABEL_OPTIONAL = 1;
+    LABEL_REQUIRED = 2;
+    LABEL_REPEATED = 3;
+  }
+  enum Type {
+    TYPE_DOUBLE = 1;
+    TYPE_FLOAT = 2;
+    TYPE_INT64 = 3;
+    TYPE_UINT64 = 4;
+    TYPE_INT32 = 5;
+    TYPE_FIXED64 = 6;
+    TYPE_FIXED32 = 7;
+    TYPE_BOOL = 8;
+    TYPE_STRING = 9;
+    TYPE_GROUP = 10;
+    TYPE_MESSAGE = 11;
+    TYPE_BYTES = 12;
+    TYPE_UINT32 = 13;
+    TYPE_ENUM = 14;
+    TYPE_SFIXED32 = 15;
+    TYPE_SFIXED64 = 16;
+    TYPE_SINT32 = 17;
+    TYPE_SINT64 = 18;
+  }
+}
+message FieldOptions {
+  optional CType ctype = 1 [default = STRING];
+  optional bool packed = 2;
+  optional bool deprecated = 3 [default = false];
+  optional bool lazy = 5 [default = false];
+  optional JSType jstype = 6 [default = JS_NORMAL];
+  optional bool weak = 10 [default = false, deprecated = true];
+  optional bool unverified_lazy = 15 [default = false];
+  optional bool debug_redact = 16 [default = false];
+  optional OptionRetention retention = 17;
+  repeated OptionTargetType targets = 19;
+  repeated EditionDefault edition_defaults = 20;
+  optional FeatureSet features = 21;
+  optional FeatureSupport feature_support = 22;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  message EditionDefault {
+    optional string value = 2;
+    optional Edition edition = 3;
+  }
+  message FeatureSupport {
+    optional Edition edition_introduced = 1;
+    optional Edition edition_deprecated = 2;
+    optional string deprecation_warning = 3;
+    optional Edition edition_removed = 4;
+  }
+  enum CType {
+    STRING = 0;
+    CORD = 1;
+    STRING_PIECE = 2;
+  }
+  enum JSType {
+    JS_NORMAL = 0;
+    JS_STRING = 1;
+    JS_NUMBER = 2;
+  }
+  enum OptionRetention {
+    RETENTION_UNKNOWN = 0;
+    RETENTION_RUNTIME = 1;
+    RETENTION_SOURCE = 2;
+  }
+  enum OptionTargetType {
+    TARGET_TYPE_UNKNOWN = 0;
+    TARGET_TYPE_FILE = 1;
+    TARGET_TYPE_EXTENSION_RANGE = 2;
+    TARGET_TYPE_MESSAGE = 3;
+    TARGET_TYPE_FIELD = 4;
+    TARGET_TYPE_ONEOF = 5;
+    TARGET_TYPE_ENUM = 6;
+    TARGET_TYPE_ENUM_ENTRY = 7;
+    TARGET_TYPE_SERVICE = 8;
+    TARGET_TYPE_METHOD = 9;
+  }
+  extensions 1000 to max;
+  reserved 4, 18;
+}
+message FileDescriptorProto {
+  optional string name = 1;
+  optional string package = 2;
+  repeated string dependency = 3;
+  repeated DescriptorProto message_type = 4;
+  repeated EnumDescriptorProto enum_type = 5;
+  repeated ServiceDescriptorProto service = 6;
+  repeated FieldDescriptorProto extension = 7;
+  optional FileOptions options = 8;
+  optional SourceCodeInfo source_code_info = 9;
+  repeated int32 public_dependency = 10;
+  repeated int32 weak_dependency = 11;
+  optional string syntax = 12;
+  optional Edition edition = 14;
+  repeated string option_dependency = 15;
+}
+message FileDescriptorSet {
+  repeated FileDescriptorProto file = 1;
+  extensions 536000000 [
+    declaration = {
+      number: 536000000,
+      full_name: ".buf.descriptor.v1.buf_file_descriptor_set_extension",
+      type: ".buf.descriptor.v1.FileDescriptorSetExtension"
+    }
+  ];
+}
+message FileOptions {
+  optional string java_package = 1;
+  optional string java_outer_classname = 8;
+  optional OptimizeMode optimize_for = 9 [default = SPEED];
+  optional bool java_multiple_files = 10 [default = false];
+  optional string go_package = 11;
+  optional bool cc_generic_services = 16 [default = false];
+  optional bool java_generic_services = 17 [default = false];
+  optional bool py_generic_services = 18 [default = false];
+  optional bool java_generate_equals_and_hash = 20 [deprecated = true];
+  optional bool deprecated = 23 [default = false];
+  optional bool java_string_check_utf8 = 27 [default = false];
+  optional bool cc_enable_arenas = 31 [default = true];
+  optional string objc_class_prefix = 36;
+  optional string csharp_namespace = 37;
+  optional string swift_prefix = 39;
+  optional string php_class_prefix = 40;
+  optional string php_namespace = 41;
+  optional string php_metadata_namespace = 44;
+  optional string ruby_package = 45;
+  optional FeatureSet features = 50;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  enum OptimizeMode {
+    SPEED = 1;
+    CODE_SIZE = 2;
+    LITE_RUNTIME = 3;
+  }
+  extensions 1000 to max;
+  reserved 38, 42;
+  reserved "php_generic_services";
+}
+message GeneratedCodeInfo {
+  repeated Annotation annotation = 1;
+  message Annotation {
+    repeated int32 path = 1 [packed = true];
+    optional string source_file = 2;
+    optional int32 begin = 3;
+    optional int32 end = 4;
+    optional Semantic semantic = 5;
+    enum Semantic {
+      NONE = 0;
+      SET = 1;
+      ALIAS = 2;
+    }
+  }
+}
+message MessageOptions {
+  optional bool message_set_wire_format = 1 [default = false];
+  optional bool no_standard_descriptor_accessor = 2 [default = false];
+  optional bool deprecated = 3 [default = false];
+  optional bool map_entry = 7;
+  optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
+  optional FeatureSet features = 12;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+  reserved 4, 5, 6, 8, 9;
+}
+message MethodDescriptorProto {
+  optional string name = 1;
+  optional string input_type = 2;
+  optional string output_type = 3;
+  optional MethodOptions options = 4;
+  optional bool client_streaming = 5 [default = false];
+  optional bool server_streaming = 6 [default = false];
+}
+message MethodOptions {
+  optional bool deprecated = 33 [default = false];
+  optional IdempotencyLevel idempotency_level = 34 [default = IDEMPOTENCY_UNKNOWN];
+  optional FeatureSet features = 35;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  enum IdempotencyLevel {
+    IDEMPOTENCY_UNKNOWN = 0;
+    NO_SIDE_EFFECTS = 1;
+    IDEMPOTENT = 2;
+  }
+  extensions 1000 to max;
+}
+message OneofDescriptorProto {
+  optional string name = 1;
+  optional OneofOptions options = 2;
+}
+message OneofOptions {
+  optional FeatureSet features = 1;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message ServiceDescriptorProto {
+  optional string name = 1;
+  repeated MethodDescriptorProto method = 2;
+  optional ServiceOptions options = 3;
+  reserved 4;
+  reserved "stream";
+}
+message ServiceOptions {
+  optional bool deprecated = 33 [default = false];
+  optional FeatureSet features = 34;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message SourceCodeInfo {
+  repeated Location location = 1;
+  message Location {
+    repeated int32 path = 1 [packed = true];
+    repeated int32 span = 2 [packed = true];
+    optional string leading_comments = 3;
+    optional string trailing_comments = 4;
+    repeated string leading_detached_comments = 6;
+  }
+  extensions 536000000 [
+    declaration = {
+      number: 536000000,
+      full_name: ".buf.descriptor.v1.buf_source_code_info_extension",
+      type: ".buf.descriptor.v1.SourceCodeInfoExtension"
+    }
+  ];
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}
+enum Edition {
+  EDITION_UNKNOWN = 0;
+  EDITION_1_TEST_ONLY = 1;
+  EDITION_2_TEST_ONLY = 2;
+  EDITION_LEGACY = 900;
+  EDITION_PROTO2 = 998;
+  EDITION_PROTO3 = 999;
+  EDITION_2023 = 1000;
+  EDITION_2024 = 1001;
+  EDITION_UNSTABLE = 9999;
+  EDITION_99997_TEST_ONLY = 99997;
+  EDITION_99998_TEST_ONLY = 99998;
+  EDITION_99999_TEST_ONLY = 99999;
+  EDITION_MAX = 2147483647;
+}
+enum SymbolVisibility {
+  VISIBILITY_UNSET = 0;
+  VISIBILITY_LOCAL = 1;
+  VISIBILITY_EXPORT = 2;
+}
+-- nopackage.proto --
+syntax = "proto3";
+import "google/protobuf/descriptor.proto";
+import "options.proto";
+option (file_option_str) = "foo";
+message Foo {
+  option (msg_option_str) = "foo";
+  oneof x {
+    string bar = 1;
+    string baz = 2;
+  }
+}
+extend google.protobuf.ExtensionRangeOptions {
+  int64 rand = 30000;
+}
+-- options.proto --
+syntax = "proto3";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.FileOptions {
+  string file_option_str = 30000;
+}
+extend google.protobuf.MessageOptions {
+  string msg_option_str = 30000;
+}
+extend google.protobuf.ServiceOptions {
+  string svc_option_str = 30000;
+}
+-- other.proto --
+syntax = "proto3";
+package other;

--- a/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.recursive-exclude.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.recursive-exclude.txtar
@@ -1,0 +1,5 @@
+-- foo.proto --
+syntax = "proto3";
+package foo;
+message MessageInFoo {
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.recursive.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/packages/foo.recursive.txtar
@@ -1,0 +1,245 @@
+-- bar.proto --
+syntax = "proto3";
+package foo.bar;
+message MessageInBar {
+}
+enum EnumInBar {
+  UNSET = 0;
+}
+service ServiceInBar {
+  rpc Bar ( MessageInBar ) returns ( MessageInBar );
+}
+-- baz1.proto --
+syntax = "proto3";
+package foo.bar.baz;
+message Bar {
+  map<string, int32> attributes = 1;
+}
+message Foo {
+  Enum en = 1;
+  string name = 2;
+  oneof loc {
+    string address = 3;
+    uint32 zip_code = 4;
+    uint64 other_xref = 5;
+  }
+  enum Enum {
+    VALUE0 = 0;
+    VALUE1 = 1;
+    VALUE2 = 2;
+  }
+}
+service BazService {
+  rpc GetBaz ( Foo ) returns ( Bar );
+}
+-- baz2.proto --
+syntax = "proto3";
+package foo.bar.baz;
+import "options.proto";
+message Empty {
+}
+enum AlmostEmpty {
+  UNSET = 0;
+}
+service NoOp {
+  option (svc_option_str) = "blah";
+  rpc Nothing ( Empty ) returns ( Empty );
+}
+-- foo.proto --
+syntax = "proto3";
+package foo;
+message MessageInFoo {
+}
+-- google/protobuf/descriptor.proto --
+syntax = "proto2";
+package google.protobuf;
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Protobuf.Reflection";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
+option java_outer_classname = "DescriptorProtos";
+option java_package = "com.google.protobuf";
+option objc_class_prefix = "GPB";
+option optimize_for = SPEED;
+message FeatureSet {
+  optional FieldPresence field_presence = 1 [
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "IMPLICIT", edition: EDITION_PROTO3 },
+    edition_defaults = { value: "EXPLICIT", edition: EDITION_2023 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnumType enum_type = 2 [
+    edition_defaults = { value: "CLOSED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "OPEN", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional RepeatedFieldEncoding repeated_field_encoding = 3 [
+    edition_defaults = { value: "EXPANDED", edition: EDITION_LEGACY },
+    edition_defaults = { value: "PACKED", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional Utf8Validation utf8_validation = 4 [
+    edition_defaults = { value: "NONE", edition: EDITION_LEGACY },
+    edition_defaults = { value: "VERIFY", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional MessageEncoding message_encoding = 5 [
+    edition_defaults = { value: "LENGTH_PREFIXED", edition: EDITION_LEGACY },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional JsonFormat json_format = 6 [
+    edition_defaults = { value: "LEGACY_BEST_EFFORT", edition: EDITION_LEGACY },
+    edition_defaults = { value: "ALLOW", edition: EDITION_PROTO3 },
+    feature_support = { edition_introduced: EDITION_2023 },
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE
+  ];
+  optional EnforceNamingStyle enforce_naming_style = 7 [
+    edition_defaults = { value: "STYLE_LEGACY", edition: EDITION_LEGACY },
+    edition_defaults = { value: "STYLE2024", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE,
+    targets = TARGET_TYPE_EXTENSION_RANGE,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_ONEOF,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_ENUM_ENTRY,
+    targets = TARGET_TYPE_SERVICE,
+    targets = TARGET_TYPE_METHOD
+  ];
+  optional VisibilityFeature.DefaultSymbolVisibility default_symbol_visibility = 8 [
+    edition_defaults = { value: "EXPORT_ALL", edition: EDITION_LEGACY },
+    edition_defaults = { value: "EXPORT_TOP_LEVEL", edition: EDITION_2024 },
+    feature_support = { edition_introduced: EDITION_2024 },
+    retention = RETENTION_SOURCE,
+    targets = TARGET_TYPE_FILE
+  ];
+  message VisibilityFeature {
+    enum DefaultSymbolVisibility {
+      DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = 0;
+      EXPORT_ALL = 1;
+      EXPORT_TOP_LEVEL = 2;
+      LOCAL_ALL = 3;
+      STRICT = 4;
+    }
+  }
+  enum EnforceNamingStyle {
+    ENFORCE_NAMING_STYLE_UNKNOWN = 0;
+    STYLE2024 = 1;
+    STYLE_LEGACY = 2;
+  }
+  enum EnumType {
+    ENUM_TYPE_UNKNOWN = 0;
+    OPEN = 1;
+    CLOSED = 2;
+  }
+  enum FieldPresence {
+    FIELD_PRESENCE_UNKNOWN = 0;
+    EXPLICIT = 1;
+    IMPLICIT = 2;
+    LEGACY_REQUIRED = 3;
+  }
+  enum JsonFormat {
+    JSON_FORMAT_UNKNOWN = 0;
+    ALLOW = 1;
+    LEGACY_BEST_EFFORT = 2;
+  }
+  enum MessageEncoding {
+    MESSAGE_ENCODING_UNKNOWN = 0;
+    LENGTH_PREFIXED = 1;
+    DELIMITED = 2;
+  }
+  enum RepeatedFieldEncoding {
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+    PACKED = 1;
+    EXPANDED = 2;
+  }
+  enum Utf8Validation {
+    UTF8_VALIDATION_UNKNOWN = 0;
+    VERIFY = 2;
+    NONE = 3;
+    reserved 1;
+  }
+  extensions 1000 to 9994 [
+    declaration = {
+      number: 1000,
+      full_name: ".pb.cpp",
+      type: ".pb.CppFeatures"
+    },
+    declaration = {
+      number: 1001,
+      full_name: ".pb.java",
+      type: ".pb.JavaFeatures"
+    },
+    declaration = {
+      number: 1002,
+      full_name: ".pb.go",
+      type: ".pb.GoFeatures"
+    },
+    declaration = {
+      number: 1003,
+      full_name: ".pb.python",
+      type: ".pb.PythonFeatures"
+    },
+    declaration = {
+      number: 1100,
+      full_name: ".imp.impress_feature_set",
+      type: ".imp.ImpressFeatureSet"
+    },
+    declaration = {
+      number: 9989,
+      full_name: ".pb.java_mutable",
+      type: ".pb.JavaMutableFeatures"
+    },
+    declaration = {
+      number: 9990,
+      full_name: ".pb.proto1",
+      type: ".pb.Proto1Features"
+    }
+  ];
+  extensions 9995 to 9999, 10000;
+  reserved 999;
+}
+message ServiceOptions {
+  optional bool deprecated = 33 [default = false];
+  optional FeatureSet features = 34;
+  repeated UninterpretedOption uninterpreted_option = 999;
+  extensions 1000 to max;
+}
+message UninterpretedOption {
+  repeated NamePart name = 2;
+  optional string identifier_value = 3;
+  optional uint64 positive_int_value = 4;
+  optional int64 negative_int_value = 5;
+  optional double double_value = 6;
+  optional bytes string_value = 7;
+  optional string aggregate_value = 8;
+  message NamePart {
+    required string name_part = 1;
+    required bool is_extension = 2;
+  }
+}
+-- options.proto --
+syntax = "proto3";
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.ServiceOptions {
+  string svc_option_str = 30000;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/versioned/acme.order.recursive.txtar
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/versioned/acme.order.recursive.txtar
@@ -1,0 +1,13 @@
+-- acme/order/v1/order.proto --
+syntax = "proto3";
+package acme.order.v1;
+message Order {
+  string id = 1;
+}
+-- acme/order/v2/order.proto --
+syntax = "proto3";
+package acme.order.v2;
+message Order {
+  string id = 1;
+  string customer_id = 2;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/versioned/acme/order/v1/order.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/versioned/acme/order/v1/order.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package acme.order.v1;
+
+message Order {
+  string id = 1;
+}

--- a/private/bufpkg/bufimage/bufimageutil/testdata/versioned/acme/order/v2/order.proto
+++ b/private/bufpkg/bufimage/bufimageutil/testdata/versioned/acme/order/v2/order.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package acme.order.v2;
+
+message Order {
+  string id = 1;
+  string customer_id = 2;
+}


### PR DESCRIPTION
A trailing ".**" on an include or exclude type name now matches the named element and every symbol nested beneath it: a package and all its sub-packages and types, or a message and all its nested types.

(Note that exclusion was already recursive if the root type was a message that contain nested types: we can't realistically keep the nested types if we remove their container.)

This addresses a long-standing TODO since the question of whether including a type should include its children/descendants definitely came up when this functionality was first implemented.
