### PR TITLE
Validate UUID assert not nil

### DIFF
--- a/private/pkg/uuidutil/uuidutil.go
+++ b/private/pkg/uuidutil/uuidutil.go
@@ -58,19 +58,25 @@ func FromDashless(dashless string) (uuid.UUID, error) {
 // Validate determines if the given UUID string is valid and not [uuid.Nil].
 func Validate(s string) error {
 	id, err := FromString(s)
+	if err != nil {
+		return err
+	}
 	if id == uuid.Nil {
 		return fmt.Errorf("must not be nil: %s", id)
 	}
-	return err
+	return nil
 }
 
 // ValidateDashless validates the dashless uuid is valid and not [uuid.Nil].
 func ValidateDashless(dashless string) error {
 	id, err := FromDashless(dashless)
+	if err != nil {
+		return err
+	}
 	if id == uuid.Nil {
 		return fmt.Errorf("must not be nil: %s", id)
 	}
-	return err
+	return nil
 }
 
 // FromStringSlice returns a slice of uuids from the string slice.

--- a/private/pkg/uuidutil/uuidutil.go
+++ b/private/pkg/uuidutil/uuidutil.go
@@ -62,7 +62,7 @@ func Validate(s string) error {
 		return err
 	}
 	if id == uuid.Nil {
-		return fmt.Errorf("must not be nil: %s", id)
+		return fmt.Errorf("must not be nil: %s", s)
 	}
 	return nil
 }
@@ -74,7 +74,7 @@ func ValidateDashless(dashless string) error {
 		return err
 	}
 	if id == uuid.Nil {
-		return fmt.Errorf("must not be nil: %s", id)
+		return fmt.Errorf("must not be nil: %s", dashless)
 	}
 	return nil
 }

--- a/private/pkg/uuidutil/uuidutil.go
+++ b/private/pkg/uuidutil/uuidutil.go
@@ -55,15 +55,21 @@ func FromDashless(dashless string) (uuid.UUID, error) {
 	return FromString(dashless[0:8] + "-" + dashless[8:12] + "-" + dashless[12:16] + "-" + dashless[16:20] + "-" + dashless[20:])
 }
 
-// Validate determines if the given UUID string is valid.
+// Validate determines if the given UUID string is valid and not [uuid.Nil].
 func Validate(s string) error {
-	_, err := FromString(s)
+	id, err := FromString(s)
+	if id == uuid.Nil {
+		return fmt.Errorf("must not be nil: %s", id)
+	}
 	return err
 }
 
-// ValidateDashless validates the dashless uuid is valid.
+// ValidateDashless validates the dashless uuid is valid and not [uuid.Nil].
 func ValidateDashless(dashless string) error {
-	_, err := FromDashless(dashless)
+	id, err := FromDashless(dashless)
+	if id == uuid.Nil {
+		return fmt.Errorf("must not be nil: %s", id)
+	}
 	return err
 }
 

--- a/private/pkg/uuidutil/uuidutil_test.go
+++ b/private/pkg/uuidutil/uuidutil_test.go
@@ -17,6 +17,7 @@ package uuidutil
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +65,18 @@ func TestValidateDashlessFailsWithUUID(t *testing.T) {
 	require.NoError(t, err)
 	err = ValidateDashless(id.String())
 	require.Error(t, err)
+}
+
+func TestValidateFailsWithNil(t *testing.T) {
+	t.Parallel()
+	err := Validate(uuid.Nil.String())
+	require.ErrorContains(t, err, "must not be nil")
+}
+
+func TestValidateDashlessFailsWithNil(t *testing.T) {
+	t.Parallel()
+	err := ValidateDashless(ToDashless(uuid.Nil))
+	require.ErrorContains(t, err, "must not be nil")
 }
 
 func TestFromStringSliceFailsWithDashless(t *testing.T) {


### PR DESCRIPTION
This ensures no `uuid.UUID` taken as `00000000-0000-0000-0000-000000000000` is marked valid. Parsing a UUID allows for `uuid.Nil` but should not be when validating.