### PR TITLE
Fix webhook create/list output to use protojson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix `buf beta registry webhook create` and `buf beta registry webhook list` to emit proto JSON output.
 
 ## [v1.71.0] - 2026-06-16
 

--- a/cmd/buf/internal/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/cmd/buf/internal/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -25,8 +25,8 @@ import (
 	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
+	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -135,7 +135,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	webhookJSON, err := protojson.MarshalOptions{Multiline: true, Indent: "\t"}.Marshal(resp.Msg)
+	webhookJSON, err := protoencoding.NewJSONMarshaler(nil, protoencoding.JSONMarshalerWithIndent()).Marshal(resp.Msg)
 	if err != nil {
 		return err
 	}

--- a/cmd/buf/internal/command/beta/registry/webhook/webhookcreate/webhookcreate.go
+++ b/cmd/buf/internal/command/beta/registry/webhook/webhookcreate/webhookcreate.go
@@ -16,7 +16,6 @@ package webhookcreate
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"buf.build/go/app/appcmd"
@@ -27,6 +26,7 @@ import (
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/spf13/pflag"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -135,7 +135,7 @@ func run(
 	if err != nil {
 		return err
 	}
-	webhookJSON, err := json.MarshalIndent(resp.Msg.GetWebhook(), "", "\t")
+	webhookJSON, err := protojson.MarshalOptions{Multiline: true, Indent: "\t"}.Marshal(resp.Msg)
 	if err != nil {
 		return err
 	}

--- a/cmd/buf/internal/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/cmd/buf/internal/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -24,8 +24,8 @@ import (
 	"github.com/bufbuild/buf/private/gen/proto/connect/buf/alpha/registry/v1alpha1/registryv1alpha1connect"
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
+	"github.com/bufbuild/buf/private/pkg/protoencoding"
 	"github.com/spf13/pflag"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -117,7 +117,7 @@ func run(
 		_, _ = container.Stdout().Write([]byte("[]"))
 		return nil
 	}
-	webhooksJSON, err := protojson.MarshalOptions{Multiline: true, Indent: "\t"}.Marshal(resp.Msg)
+	webhooksJSON, err := protoencoding.NewJSONMarshaler(nil, protoencoding.JSONMarshalerWithIndent()).Marshal(resp.Msg)
 	if err != nil {
 		return err
 	}

--- a/cmd/buf/internal/command/beta/registry/webhook/webhooklist/webhooklist.go
+++ b/cmd/buf/internal/command/beta/registry/webhook/webhooklist/webhooklist.go
@@ -16,7 +16,6 @@ package webhooklist
 
 import (
 	"context"
-	"encoding/json"
 
 	"buf.build/go/app/appcmd"
 	"buf.build/go/app/appext"
@@ -26,6 +25,7 @@ import (
 	registryv1alpha1 "github.com/bufbuild/buf/private/gen/proto/go/buf/alpha/registry/v1alpha1"
 	"github.com/bufbuild/buf/private/pkg/connectclient"
 	"github.com/spf13/pflag"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -117,7 +117,7 @@ func run(
 		_, _ = container.Stdout().Write([]byte("[]"))
 		return nil
 	}
-	webhooksJSON, err := json.MarshalIndent(resp.Msg.GetWebhooks(), "", "\t")
+	webhooksJSON, err := protojson.MarshalOptions{Multiline: true, Indent: "\t"}.Marshal(resp.Msg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix `buf beta registry webhook create` and `buf beta registry webhook list` printing empty objects (`{}` / `[{}]`) instead of actual webhook data.

Root cause: both commands used `encoding/json` to marshal proto-generated structs. Proto structs store field data in unexported fields, invisible to `encoding/json`, so all fields silently serialize as zero values. Fix is to replace `encoding/json.MarshalIndent` with `protojson.MarshalOptions{Multiline: true, Indent: "\t"}.Marshal`, which uses the protobuf reflection API and correctly reads proto field values.

Note: the `create` output shape changes from a bare `{...}` to `{"webhook": {...}}` to match the RPC response structure. 