### PR TITLE
Fix HTTPS Basic auth for env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix `buf beta registry webhook create` and `buf beta registry webhook list` to emit proto JSON output.
+- Fix HTTPS Basic authentication for remote inputs to use `BUF_INPUT_HTTPS_USERNAME` for the username.
 
 ## [v1.71.0] - 2026-06-16
 

--- a/private/buf/bufcli/env.go
+++ b/private/buf/bufcli/env.go
@@ -56,7 +56,7 @@ var (
 		httpauth.NewNetrcAuthenticator(),
 		// must keep this for legacy purposes
 		httpauth.NewEnvAuthenticator(
-			inputHTTPSPasswordEnvKey,
+			inputHTTPSUsernameEnvKey,
 			inputHTTPSPasswordEnvKey,
 		),
 	)

--- a/private/buf/bufcli/env_test.go
+++ b/private/buf/bufcli/env_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020-2026 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bufcli
+
+import (
+	"net/http"
+	"testing"
+
+	"buf.build/go/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultHTTPAuthenticatorUsesUsernameAndPassword(t *testing.T) {
+	t.Parallel()
+	envContainer := app.NewEnvContainer(map[string]string{
+		// Point HOME at an empty dir so the netrc authenticator finds no
+		// machine and falls through to the env authenticator under test.
+		"HOME":                   t.TempDir(),
+		inputHTTPSUsernameEnvKey: "username",
+		inputHTTPSPasswordEnvKey: "password",
+	})
+	request, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	ok, err := defaultHTTPAuthenticator.SetAuth(envContainer, request)
+	require.NoError(t, err)
+	require.True(t, ok)
+	username, password, ok := request.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "username", username)
+	assert.Equal(t, "password", password)
+}

--- a/private/buf/bufcli/env_test.go
+++ b/private/buf/bufcli/env_test.go
@@ -25,10 +25,13 @@ import (
 
 func TestDefaultHTTPAuthenticatorUsesUsernameAndPassword(t *testing.T) {
 	t.Parallel()
+	// Point the home dir at an empty dir so the netrc authenticator finds no
+	// machine and falls through to the env authenticator under test. HOME is
+	// used on unix and USERPROFILE on windows.
+	emptyDir := t.TempDir()
 	envContainer := app.NewEnvContainer(map[string]string{
-		// Point HOME at an empty dir so the netrc authenticator finds no
-		// machine and falls through to the env authenticator under test.
-		"HOME":                   t.TempDir(),
+		"HOME":                   emptyDir,
+		"USERPROFILE":            emptyDir,
 		inputHTTPSUsernameEnvKey: "username",
 		inputHTTPSPasswordEnvKey: "password",
 	})


### PR DESCRIPTION
The default HTTP env authenticator was wired with `BUF_INPUT_HTTPS_PASSWORD` for both username and password. This corrects the username to use the env variable `BUF_INPUT_HTTPS_USERNAME`.

Close #4597