### PR TITLE
Fix IMPORT_UNUSED when descriptor.proto is in the dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix `buf beta registry webhook create` and `buf beta registry webhook list` to emit proto JSON output.
 - Fix HTTPS Basic authentication for remote inputs to use `BUF_INPUT_HTTPS_USERNAME` for the username.
+- Fix `IMPORT_USED` lint rule silently reporting no unused imports when
+  `google/protobuf/descriptor.proto` is in the transitive dependency graph.
 
 ## [v1.71.0] - 2026-06-16
 

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -192,7 +192,7 @@ func TestRunImportUsedDescriptor(t *testing.T) {
 	testLint(
 		t,
 		"import_used_descriptor",
-		bufanalysistesting.NewFileAnnotation(t, "a.proto", 10, 1, 10, 42, "IMPORT_USED"),
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 6, 1, 6, 42, "IMPORT_USED"),
 	)
 }
 

--- a/private/bufpkg/bufcheck/lint_test.go
+++ b/private/bufpkg/bufcheck/lint_test.go
@@ -184,6 +184,18 @@ func TestRunImportUsed(t *testing.T) {
 	)
 }
 
+func TestRunImportUsedDescriptor(t *testing.T) {
+	t.Parallel()
+	// A used import of google/protobuf/descriptor.proto places it in the
+	// transitive dependency graph. Its presence must not suppress detection of
+	// other unused imports.
+	testLint(
+		t,
+		"import_used_descriptor",
+		bufanalysistesting.NewFileAnnotation(t, "a.proto", 10, 1, 10, 42, "IMPORT_USED"),
+	)
+}
+
 func TestRunImportUsedLeadingDot(t *testing.T) {
 	t.Parallel()
 	// Leading-dot fully-qualified type references (e.g. .shared.location.v1.USAddress)

--- a/private/bufpkg/bufcheck/testdata/lint/import_used_descriptor/a.proto
+++ b/private/bufpkg/bufcheck/testdata/lint/import_used_descriptor/a.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package a;
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/timestamp.proto";
+
+extend google.protobuf.FileOptions {
+  string a_file_option = 50000;
+}
+
+message A {
+  string name = 1;
+}

--- a/private/bufpkg/bufcheck/testdata/lint/import_used_descriptor/buf.yaml
+++ b/private/bufpkg/bufcheck/testdata/lint/import_used_descriptor/buf.yaml
@@ -1,0 +1,4 @@
+version: v1
+lint:
+  use:
+    - IMPORT_USED

--- a/private/bufpkg/bufimage/build_image.go
+++ b/private/bufpkg/bufimage/build_image.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 
 	descriptorv1 "buf.build/gen/go/bufbuild/protodescriptor/protocolbuffers/go/buf/descriptor/v1"
 	"buf.build/go/standard/xlog/xslog"
@@ -51,6 +50,12 @@ var compileFDPOptions = func() fdp.Options {
 	opts.Apply(fdp.IncludeSourceCodeInfo(true), fdp.GenerateExtraOptionLocations(true))
 	return opts
 }()
+
+// bufDescriptorResolver resolves Buf's descriptor extensions, notably
+// [descriptorv1.E_BufSourceCodeInfoExtension] carrying unused-import info.
+var bufDescriptorResolver = protoencoding.NewLazyResolver(
+	protodesc.ToFileDescriptorProto(descriptorv1.File_buf_descriptor_v1_descriptor_proto),
+)
 
 func buildImage(
 	ctx context.Context,
@@ -292,27 +297,13 @@ func resolverForFDS(fds *descriptorpb.FileDescriptorSet) (*descriptorpb.FileDesc
 	if err := protoencoding.NewWireUnmarshaler(nil).Unmarshal(descriptorSetBytes, normalizedFDS); err != nil {
 		return nil, nil, err
 	}
-	// Include Buf's descriptor proto alongside the compiled files so that
-	// ReparseExtensions can recognise [descriptorv1.E_BufSourceCodeInfoExtension]
-	// and convert unknown fields to typed extensions.
-	//
-	// We only prepend the buf descriptor proto when the compiled files do not already
-	// contain google/protobuf/descriptor.proto. When a vendored descriptor.proto is
-	// present in the compiled output, its FileDescriptorSet definition lacks extension
-	// ranges for the buf extension (field 536000000). protodesc.NewFiles validates
-	// that extension field numbers fall within declared extension ranges when the
-	// containing message is resolved (non-placeholder). Adding the buf descriptor
-	// proto alongside the vendored descriptor.proto causes this validation to fail.
-	var resolverFiles []*descriptorpb.FileDescriptorProto
-	if !slices.ContainsFunc(normalizedFDS.File, func(file *descriptorpb.FileDescriptorProto) bool {
-		return file.GetName() == "google/protobuf/descriptor.proto"
-	}) {
-		resolverFiles = []*descriptorpb.FileDescriptorProto{
-			protodesc.ToFileDescriptorProto(descriptorv1.File_buf_descriptor_v1_descriptor_proto),
-		}
-	}
-	resolverFiles = append(resolverFiles, normalizedFDS.File...)
-	resolver := protoencoding.NewLazyResolver(resolverFiles...)
+	// The file graph is built only from the compiled files, so it matches the
+	// input exactly (including any vendored google/protobuf/descriptor.proto).
+	// Buf's descriptor extensions are supplied by a fallback resolver consulted
+	// only when the file graph cannot resolve a descriptor, so ReparseExtensions
+	// can recognise them without altering the graph.
+	fileResolver := protoencoding.NewLazyResolver(normalizedFDS.File...)
+	resolver := protoencoding.CombineResolvers(fileResolver, bufDescriptorResolver)
 	for _, fileDescriptor := range normalizedFDS.File {
 		if err := protoencoding.ReparseExtensions(resolver, fileDescriptor.ProtoReflect()); err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Fixes `IMPORT_UNUSED` lint when the modules dependency graph included `google/protobuf/descriptor.proto` excluding Buf's `SourceCodeInfoExtension` resolving. Now extensions are resolved through a combined resolver which fallbacks when resolving. Reparsing now recognizes the extension without ever altering the graph. Added a regression test. 

Fixes https://github.com/bufbuild/buf/issues/4598