### PR TITLE
Upgrade protocompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- No changes yet.
+- Fix `buf format` dropping comments next to commas or semicolons in message literals.
 
 ## [v1.72.0] - 2026-07-17
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/otelconnect v0.9.0
-	github.com/bufbuild/protocompile v0.14.2-0.20260716165721-bb5762d29672
+	github.com/bufbuild/protocompile v0.14.2-0.20260721215534-273ab18aaede
 	github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b
 	github.com/cli/browser v1.3.0
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
-github.com/bufbuild/protocompile v0.14.2-0.20260716165721-bb5762d29672 h1:6xykiXQPoF/hhOjAhwiHQ0kgcAvrDZw0Tjl1VQkpu5c=
-github.com/bufbuild/protocompile v0.14.2-0.20260716165721-bb5762d29672/go.mod h1:jPUiZUFWc8E3Kc2Y4SRlGAdjde4amGkHY0BUACNS43E=
+github.com/bufbuild/protocompile v0.14.2-0.20260721215534-273ab18aaede h1:eQm2wzIoBCGSL0Mrlt8ZS2blkGkBubFibjb1VwaS3Gg=
+github.com/bufbuild/protocompile v0.14.2-0.20260721215534-273ab18aaede/go.mod h1:N/HDKSkwgQFrJyi/HMZF4WyRVBQDPzRzvXnhF2BPW2s=
 github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b h1:b7wvo9ZhjLzCp7tGbOUMvgtYTnd33zGSAmMxcdxMnhQ=
 github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b/go.mod h1:c5D8gWRIZ2HLWO3gXYTtUfw/hbJyD8xikv2ooPxnklQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/private/buf/bufformat/testdata/proto3/all/v1/all.golden
+++ b/private/buf/bufformat/testdata/proto3/all/v1/all.golden
@@ -92,6 +92,7 @@ message One {
     // oneof-field comment 2
     custom.Thing custom_field = 11; // oneof-option-field-inline comment 4
   }
+  // oneof-inline-comment
 
   int64 integer_field = 12 [
     (custom.repeated_field_option) = 1,


### PR DESCRIPTION
This upgrades protocompile to bring in the fix for `buf format`. Adds a CHANGELOG entry.