### PR TITLE
Skip dependabot pushes to BSR

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -18,3 +18,6 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
+          # Dependabot runs do not have access to a BUF_TOKEN.
+          push: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
+          archive: ${{ github.event_name == 'delete' && github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
Skips dependabot pushes to buf.build. These are no longer skipped in CI by the action as github provides way to give secrets to dependabot. However, this isn't useful for us, so skip them in CI.