### PR TITLE
ci: build VERSION from env vars instead of interpolating into the shell

### DIFF
--- a/.github/workflows/build-and-draft-release.yaml
+++ b/.github/workflows/build-and-draft-release.yaml
@@ -16,8 +16,11 @@ jobs:
     steps:
       - name: Set VERSION variable
         # The head ref looks like release/v1.0.0, and we need to trim the string up to the `/v`.
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          VERSION="${{ github.event.inputs.version || github.head_ref}}"
+          VERSION="${INPUT_VERSION:-$HEAD_REF}"
           echo "VERSION=${VERSION##*/v}" >> $GITHUB_ENV
       - name: Get GitHub app token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
Hi, and thanks for buf.

In `.github/workflows/build-and-draft-release.yaml`, the version is assembled by interpolating two values into the shell:

```yaml
run: |
  VERSION="${{ github.event.inputs.version || github.head_ref}}"
  echo "VERSION=${VERSION##*/v}" >> $GITHUB_ENV
```

Actions expands `${{ ... }}` into the script text before bash runs, so both arrive as script rather than as values. Git allows `$`, `(`, `)` and backticks in branch names, the `workflow_dispatch` input is free text, and `$(...)` executes inside double quotes.

The job's guard is real and I want to credit it rather than talk around it:

```yaml
if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release')) }}
```

So a maintainer has to merge the PR, and the branch has to start with `release`. But everything after that prefix is unconstrained, which is what leaves the gap — and the step immediately after this one mints a GitHub App token.

The change binds both to environment variables and keeps the existing precedence:

```yaml
env:
  INPUT_VERSION: ${{ github.event.inputs.version }}
  HEAD_REF: ${{ github.head_ref }}
run: |
  VERSION="${INPUT_VERSION:-$HEAD_REF}"
  echo "VERSION=${VERSION##*/v}" >> $GITHUB_ENV
```

`${INPUT_VERSION:-$HEAD_REF}` reproduces the `||` fallback — the dispatch input wins when set and non-empty, otherwise the head ref — and the `${VERSION##*/v}` trim is untouched, so `release/v1.0.0` still yields `1.0.0`.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its `if:` condition myself.
