### PR TITLE
Fix symbols re-exported via `import public` not being found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 - Fix `buf format` dropping comments next to commas or semicolons in message literals.
+- Fix compilation failing to resolve symbols re-exported through `import public` when the
+  re-exporting file also reaches those symbols through a non-public import.
 
 ## [v1.72.0] - 2026-07-17
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	connectrpc.com/connect v1.20.0
 	connectrpc.com/grpcreflect v1.3.0
 	connectrpc.com/otelconnect v0.9.0
-	github.com/bufbuild/protocompile v0.14.2-0.20260723175035-caf54d45c839
+	github.com/bufbuild/protocompile v0.14.2-0.20260804015511-0bf9b3f60f22
 	github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b
 	github.com/cli/browser v1.3.0
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
-github.com/bufbuild/protocompile v0.14.2-0.20260723175035-caf54d45c839 h1:5/Q/uIeoovxoRDNN1AioigMPlAhUlBc/J8ZlvlDV7BQ=
-github.com/bufbuild/protocompile v0.14.2-0.20260723175035-caf54d45c839/go.mod h1:N/HDKSkwgQFrJyi/HMZF4WyRVBQDPzRzvXnhF2BPW2s=
+github.com/bufbuild/protocompile v0.14.2-0.20260804015511-0bf9b3f60f22 h1:gry9ksYwSZrcZiizgjQec6PwGVEsNnH02AZnsQILGrM=
+github.com/bufbuild/protocompile v0.14.2-0.20260804015511-0bf9b3f60f22/go.mod h1:N/HDKSkwgQFrJyi/HMZF4WyRVBQDPzRzvXnhF2BPW2s=
 github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b h1:b7wvo9ZhjLzCp7tGbOUMvgtYTnd33zGSAmMxcdxMnhQ=
 github.com/bufbuild/protoplugin v0.0.0-20260414125817-25d1d281b46b/go.mod h1:c5D8gWRIZ2HLWO3gXYTtUfw/hbJyD8xikv2ooPxnklQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/private/bufpkg/bufimage/build_image_test.go
+++ b/private/bufpkg/bufimage/build_image_test.go
@@ -230,6 +230,17 @@ func TestCompareTrailingComments(t *testing.T) {
 	testCompare(t, "trailingcomments")
 }
 
+func TestComparePublicImports(t *testing.T) {
+	// https://github.com/bufbuild/buf/issues/4633
+	//
+	// A file is re-exported by its importer if it is reachable by following
+	// `import public` declarations only. Whether such a path exists must not
+	// depend on the order in which the importer declares its imports, nor on
+	// whether the importer also imports the file non-publicly.
+	t.Parallel()
+	testCompare(t, "publicimports")
+}
+
 func TestCustomOptionsError1(t *testing.T) {
 	t.Parallel()
 	testFileAnnotations(

--- a/private/bufpkg/bufimage/testdata/publicimports/consumer_diamond.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/consumer_diamond.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package publicimports;
+
+// This is the shape from https://github.com/bufbuild/buf/issues/4633. Leaf is
+// nameable here because diamond.proto re-exports leaf.proto, transitively via
+// public_leaf.proto.
+import "diamond.proto";
+
+message ConsumerDiamond {
+  Leaf leaf = 1;
+}

--- a/private/bufpkg/bufimage/testdata/publicimports/consumer_shadowed.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/consumer_shadowed.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package publicimports;
+
+// Leaf is nameable here because shadowed.proto re-exports leaf.proto, even
+// though shadowed.proto's own import of leaf.proto is not public.
+import "shadowed.proto";
+
+message ConsumerShadowed {
+  Leaf leaf = 1;
+}

--- a/private/bufpkg/bufimage/testdata/publicimports/diamond.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/diamond.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package publicimports;
+
+// Both of these are public imports, and both of them reach leaf.proto, but
+// only public_leaf.proto reaches it publicly. Declaring the non-public path
+// first must not stop diamond.proto from re-exporting leaf.proto.
+import public "plain_leaf.proto";
+import public "public_leaf.proto";

--- a/private/bufpkg/bufimage/testdata/publicimports/leaf.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/leaf.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package publicimports;
+
+message Leaf {}

--- a/private/bufpkg/bufimage/testdata/publicimports/plain_leaf.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/plain_leaf.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package publicimports;
+
+import "leaf.proto";
+
+message PlainLeaf {
+  Leaf leaf = 1;
+}

--- a/private/bufpkg/bufimage/testdata/publicimports/public_leaf.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/public_leaf.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package publicimports;
+
+import public "leaf.proto";

--- a/private/bufpkg/bufimage/testdata/publicimports/shadowed.proto
+++ b/private/bufpkg/bufimage/testdata/publicimports/shadowed.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package publicimports;
+
+// leaf.proto is imported non-publicly here, but it is also re-exported by
+// public_leaf.proto, so shadowed.proto re-exports it too.
+import "leaf.proto";
+import public "public_leaf.proto";
+
+message Shadowed {
+  Leaf leaf = 1;
+}


### PR DESCRIPTION
Fixes #4633.

Since v1.68.0, which switched `buf build` to the new compiler, a symbol re-exported through `import public` is not always found by importers. `protoc` and v1.67.0 accept the same files.

From the reporter's repro:

```protobuf
// a.proto
import "b.proto";
message A { google.protobuf.Timestamp ts = 1; }

// b.proto
import public "act.proto";                      // imports timestamp.proto non-publicly
import public "c.proto";                        // imports timestamp.proto publicly

// c.proto
import public "google/protobuf/timestamp.proto";
```

```
proto/a.proto:5:3:cannot find `google.protobuf.Timestamp` in this scope
```

Nothing to do with well-known types; swapping the order of `b.proto`'s two imports makes it compile.

## Root cause

In protocompile, `imports.Recurse` classified each transitive import by looking only at whichever direct import happened to pull it in first, so a file reachable through several direct imports with differing public-ness could be misclassified. Public direct imports are ordered first specifically so the public path wins, but that does not disambiguate when *both* direct imports are public: `act.proto` is visited first, reaches `timestamp.proto` non-publicly, and `timestamp.proto` lands in the trailing non-public segment, so `b.proto` stops re-exporting it.

A second, related shape was also broken: a plain `import` of a file that is *also* re-exported by a public import. That file has to stay in a direct segment, and `Transitive()` derived public-ness purely from the segment offsets, so it could not represent the case at all.

Fixed in bufbuild/protocompile#754, which classifies every transitive import up front over all direct imports and records public-ness on the import rather than deriving it from segment offsets. This matches `protoc`'s `DescriptorBuilder::RecordPublicDependencies`, which is a closure over `public_dependency` edges and therefore order-independent.

## Testing

`TestComparePublicImports` builds `testdata/publicimports` and diffs the resulting `FileDescriptorSet` against real `protoc`. It covers both shapes independently (each has its own consumer file, so one working mechanism cannot mask the other breaking), and both fail before the protocompile fix:

```
testdata/publicimports/consumer_diamond.proto:11:3:cannot find `Leaf` in this scope
testdata/publicimports/consumer_shadowed.proto:10:3:cannot find `Leaf` in this scope
```

Beyond that, the fix was validated by differential fuzzing against `protoc`: 700 random import DAGs of up to 12 files, each file referencing every symbol `protoc`'s rule says is visible (zero rejections), plus 838 pairwise accept/reject probes agreeing with `protoc` in both directions. The same fuzzer flags the bug on an unpatched build within ~30 seeds.

## Note

`go.mod` currently pins protocompile to the branch commit for bufbuild/protocompile#754. Needs a re-pin to `main` once that merges.