### PR TITLE
Fix LSP panic on imports within external files

### DIFF
--- a/private/buf/buflsp/file.go
+++ b/private/buf/buflsp/file.go
@@ -878,9 +878,21 @@ func (f *file) importToSymbol(imp ir.Import) *symbol {
 		file: f,
 		span: imp.Decl.ImportPath().Span(),
 		kind: &imported{
-			file: f.workspace.PathToFile()[imp.File.Path()],
+			file: f.importedFile(imp),
 		},
 	}
+}
+
+func (f *file) importedFile(imp ir.Import) *file {
+	path := imp.File.Path()
+	if imported, ok := f.workspace.PathToFile()[path]; ok {
+		return imported
+	}
+	sourceFile, ok := f.lsp.opener.Get()[path]
+	if !ok {
+		return nil
+	}
+	return f.Manager().Get(FilePathToURI(sourceFile.Path()))
 }
 
 // messageToSymbols takes an [ir.MessageValue] and returns the symbols parsed from it.

--- a/private/buf/buflsp/hover_test.go
+++ b/private/buf/buflsp/hover_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bufbuild/buf/private/buf/buflsp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lsp.dev/protocol"
@@ -308,7 +309,8 @@ func TestHoverImportInDependencyFile(t *testing.T) {
 	}, &hover)
 	require.NoError(t, hoverErr)
 	require.NotNil(t, hover, "expected hover to be non-nil")
-	assert.Contains(t, hover.Contents.Value, "google/protobuf/source_context.proto")
+	expectedImportPath := filepath.Join(filepath.Dir(dependencyURI.Filename()), "source_context.proto")
+	assert.Contains(t, hover.Contents.Value, expectedImportPath)
 
 	// Go to definition on the same import must resolve to the imported file
 	// rather than panicking or pointing at nothing.
@@ -326,5 +328,5 @@ func TestHoverImportInDependencyFile(t *testing.T) {
 	}, &dependencyLocations)
 	require.NoError(t, definitionErr)
 	require.Len(t, dependencyLocations, 1)
-	assert.Contains(t, string(dependencyLocations[0].URI), "google/protobuf/source_context.proto")
+	assert.Equal(t, buflsp.FilePathToURI(expectedImportPath), dependencyLocations[0].URI)
 }

--- a/private/buf/buflsp/hover_test.go
+++ b/private/buf/buflsp/hover_test.go
@@ -15,7 +15,9 @@
 package buflsp_test
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -245,4 +247,84 @@ func TestHover(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHoverImportInDependencyFile hovers an import inside a file that the editor
+// reached by following an import out of the workspace.
+func TestHoverImportInDependencyFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	protoPath, err := filepath.Abs("testdata/hover_dependency/main.proto")
+	require.NoError(t, err)
+	clientJSONConn, testURI := setupLSPServer(t, protoPath)
+
+	// Follow the import to the well-known type.
+	var locations []protocol.Location
+	_, definitionErr := clientJSONConn.Call(ctx, protocol.MethodTextDocumentDefinition, protocol.DefinitionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: testURI,
+			},
+			Position: protocol.Position{
+				Line:      6, // Line with `import "google/protobuf/api.proto";`
+				Character: 12,
+			},
+		},
+	}, &locations)
+	require.NoError(t, definitionErr)
+	require.Len(t, locations, 1)
+	dependencyURI := locations[0].URI
+	require.Contains(t, string(dependencyURI), "google/protobuf/api.proto")
+
+	// Locate the first import in the dependency, which is
+	// google/protobuf/source_context.proto. The line is found rather than hardcoded
+	// so the test survives a well-known type update.
+	dependencyText, err := os.ReadFile(dependencyURI.Filename())
+	require.NoError(t, err)
+	var importLine uint32
+	var foundImport bool
+	for line := range strings.SplitSeq(string(dependencyText), "\n") {
+		if strings.HasPrefix(line, "import ") {
+			foundImport = true
+			break
+		}
+		importLine++
+	}
+	require.True(t, foundImport, "expected an import in %s", dependencyURI.Filename())
+
+	var hover *protocol.Hover
+	_, hoverErr := clientJSONConn.Call(ctx, protocol.MethodTextDocumentHover, protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: dependencyURI,
+			},
+			Position: protocol.Position{
+				Line:      importLine,
+				Character: 12,
+			},
+		},
+	}, &hover)
+	require.NoError(t, hoverErr)
+	require.NotNil(t, hover, "expected hover to be non-nil")
+	assert.Contains(t, hover.Contents.Value, "google/protobuf/source_context.proto")
+
+	// Go to definition on the same import must resolve to the imported file
+	// rather than panicking or pointing at nothing.
+	var dependencyLocations []protocol.Location
+	_, definitionErr = clientJSONConn.Call(ctx, protocol.MethodTextDocumentDefinition, protocol.DefinitionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{
+				URI: dependencyURI,
+			},
+			Position: protocol.Position{
+				Line:      importLine,
+				Character: 12,
+			},
+		},
+	}, &dependencyLocations)
+	require.NoError(t, definitionErr)
+	require.Len(t, dependencyLocations, 1)
+	assert.Contains(t, string(dependencyLocations[0].URI), "google/protobuf/source_context.proto")
 }

--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -120,6 +120,14 @@ func (s *symbol) IsBuiltIn() bool {
 // Definition returns the location of the definition of the symbol.
 func (s *symbol) Definition() protocol.Location {
 	if imported, ok := s.kind.(*imported); ok {
+		if imported.file == nil {
+			// The import could not be resolved to a tracked file, so there is nowhere to jump
+			// to. Fall back to the import declaration itself.
+			return protocol.Location{
+				URI:   s.file.uri,
+				Range: s.Range(),
+			}
+		}
 		return protocol.Location{
 			URI: imported.file.uri,
 		}
@@ -267,7 +275,7 @@ func (s *symbol) LogValue() slog.Value {
 		slog.Any("start", loc(s.span.StartLoc())),
 		slog.Any("end", loc(s.span.EndLoc())),
 	}
-	if imported, ok := s.kind.(*imported); ok {
+	if imported, ok := s.kind.(*imported); ok && imported.file != nil {
 		attrs = append(attrs, slog.String("imported", imported.file.uri.Filename()))
 	} else if s.def != nil {
 		attrs = append(attrs,
@@ -287,6 +295,9 @@ func (s *symbol) FormatDocs() string {
 	switch s.kind.(type) {
 	case *imported:
 		imported, _ := s.kind.(*imported)
+		if imported.file == nil || imported.file.file == nil {
+			return ""
+		}
 		// Show the path to the file on disk, which is similar to how other LSP clients treat hovering
 		// on an import file.
 		return imported.file.file.Path()

--- a/private/buf/buflsp/testdata/hover_dependency/buf.yaml
+++ b/private/buf/buflsp/testdata/hover_dependency/buf.yaml
@@ -1,0 +1,8 @@
+version: v2
+modules:
+  - path: .
+lint:
+  use:
+    - STANDARD
+  except:
+    - PACKAGE_DIRECTORY_MATCH

--- a/private/buf/buflsp/testdata/hover_dependency/main.proto
+++ b/private/buf/buflsp/testdata/hover_dependency/main.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package hoverdependency.v1;
+
+// google/protobuf/api.proto is a well-known type that itself has imports, which
+// lets us exercise hovering an import from inside a dependency file.
+import "google/protobuf/api.proto";
+
+message ApiHolder {
+  google.protobuf.Api api = 1;
+}


### PR DESCRIPTION
Currently, performing a hover or go to definition on an import within a file outside the workspace (like a WKT) panics. Fix path resolution to fall back to using the LSP opener if the file isn't found in the workspace. Update a few places to guard against a nil file.