### PR TITLE
Update LSP to use new language spec URL

### DIFF
--- a/private/buf/buflsp/completion.go
+++ b/private/buf/buflsp/completion.go
@@ -953,7 +953,7 @@ func predeclaredTypeKeywords() iter.Seq[keyword.Keyword] {
 
 // mapKeyTypeKeywords returns keywords for valid map key types.
 // Map keys can only be integral types, bool, or string (not floating point or bytes).
-// See https://protobuf.com/docs/language-spec#maps
+// See https://buf.build/docs/reference/protobuf-language-spec/#maps
 func mapKeyTypeKeywords() iter.Seq[keyword.Keyword] {
 	return func(yield func(keyword.Keyword) bool) {
 		_ = yield(keyword.Int32) &&
@@ -2000,7 +2000,7 @@ func completionItemsForFieldNumber(
 // Enum values are _any_ int32 value, but we make the assumption here that the user is using the
 // "typical" incrementing from 0 approach and suggest the next available positive int32 value.
 //
-// Ref: https://protobuf.com/docs/language-spec#enum-values
+// Ref: https://buf.build/docs/reference/protobuf-language-spec/#enum-values
 func completionItemsForEnumNumber(
 	file *file,
 	parentDef ast.DeclDef,

--- a/private/buf/buflsp/hover_test.go
+++ b/private/buf/buflsp/hover_test.go
@@ -168,7 +168,7 @@ func TestHover(t *testing.T) {
 			protoFile:        "testdata/completion/map_test.proto",
 			line:             16, // Line with "map<int32, string> field0 = 10;"
 			character:        3,  // On "map" keyword
-			expectedContains: "language-spec#maps",
+			expectedContains: "https://buf.build/docs/reference/protobuf-language-spec/#maps",
 		},
 		{
 			name:          "hover_on_message_after_import_with_trailing_comment",

--- a/private/buf/buflsp/symbol.go
+++ b/private/buf/buflsp/symbol.go
@@ -39,6 +39,8 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
+const protobufLanguageSpecURL = "https://buf.build/docs/reference/protobuf-language-spec/"
+
 // symbol represents a named symbol inside of a [file].
 //
 // For each symbol, we keep track of the location [source.Span] and file [*file] of the
@@ -316,8 +318,9 @@ func (s *symbol) FormatDocs() string {
 				comments,
 				"",
 				fmt.Sprintf(
-					"`%s` is a Protobuf builtin. [Learn more on protobuf.com.](https://protobuf.com/docs/language-spec#%s)",
+					"`%s` is a Protobuf builtin. [Learn more in the Protobuf Language Specification.](%s#%s)",
 					builtin.predeclared,
+					protobufLanguageSpecURL,
 					anchor,
 				),
 			)
@@ -332,8 +335,9 @@ func (s *symbol) FormatDocs() string {
 				comments,
 				"",
 				fmt.Sprintf(
-					"`%s` is a Protobuf keyword. [Learn more on protobuf.com.](https://protobuf.com/docs/language-spec#%s)",
+					"`%s` is a Protobuf keyword. [Learn more in the Protobuf Language Specification.](%s#%s)",
 					kwBuiltin.name,
+					protobufLanguageSpecURL,
 					kwBuiltin.anchor,
 				),
 			)


### PR DESCRIPTION
While redirects on protobuf.com work, update the LSP to link to the new home for the Protobuf specification.