### PR TITLE
Fix Buf CI action runs

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -8,8 +8,9 @@ permissions:
   contents: read
   pull-requests: write
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Serialize pushes and archives, cancel previous.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   buf:
     runs-on: ubuntu-latest
@@ -18,6 +19,6 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          # Dependabot runs do not have access to a BUF_TOKEN.
-          push: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
-          archive: ${{ github.event_name == 'delete' && github.actor != 'dependabot[bot]' }}
+          # Neither dependabot runs nor forks have access to a BUF_TOKEN.
+          push: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' && !github.event.repository.fork }}
+          archive: ${{ github.event_name == 'delete' && github.actor != 'dependabot[bot]' && !github.event.repository.fork }}


### PR DESCRIPTION
This includes two small fixes for buf CI. Applies skip on push and archive for fork repositories. Corrects the concurrency setting so a delete event, from a PR merging, doesn't block a push event. For example see https://github.com/bufbuild/buf/commit/847e40874efa8e0f56a34b17abfe7dabaebef704  and its delete event https://github.com/bufbuild/buf/actions/runs/32162887366/job/95795625222 that succeed, but failed the main branch push.