### PR TITLE
Export invalid filter type error returned by FilterImage

### DIFF
--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -41,7 +41,7 @@ var (
 
 	// ErrImageFilterTypeInvalid is returned from FilterImage when
 	// a specified type is invalid.
-	ErrImageFilterTypeInvalid = errors.New("invalid type filter")
+	ErrImageFilterTypeInvalid = errors.New("invalid filter type")
 
 	// ErrImageFilterTypeIsImport is returned from FilterImage when
 	// a specified type name is declared in a module dependency.

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil.go
@@ -39,6 +39,10 @@ var (
 	// a specified type cannot be found in an image.
 	ErrImageFilterTypeNotFound = errors.New("not found")
 
+	// ErrImageFilterTypeInvalid is returned from FilterImage when
+	// a specified type is invalid.
+	ErrImageFilterTypeInvalid = errors.New("invalid type filter")
+
 	// ErrImageFilterTypeIsImport is returned from FilterImage when
 	// a specified type name is declared in a module dependency.
 	ErrImageFilterTypeIsImport = errors.New("type declared in imported module")

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -511,6 +511,15 @@ func TestTypesFromMainModule(t *testing.T) {
 	_, err = FilterImage(image, WithIncludeTypes("nonexisting"))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrImageFilterTypeNotFound)
+
+	_, err = FilterImage(image, WithIncludeTypes("invalid-include"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrImageFilterTypeInvalid)
+
+	_, err = FilterImage(image, WithExcludeTypes("invalid-exclude"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrImageFilterTypeInvalid)
+
 }
 
 func TestMutateInPlace(t *testing.T) {

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -374,9 +374,9 @@ func TestPackages(t *testing.T) {
 		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/packages", bufimage.WithExcludeSourceCodeInfo())
 		require.NoError(t, err)
 		_, err = FilterImage(image, WithIncludeTypes("foo.**.bar"))
-		require.ErrorContains(t, err, "invalid type filter: include type \"foo.**.bar\": the only supported wildcard is \".**\" and it must come at the end")
+		require.ErrorContains(t, err, "invalid filter type: include type \"foo.**.bar\": the only supported wildcard is \".**\" and it must come at the end")
 		_, err = FilterImage(image, WithExcludeTypes("foo.*"))
-		require.ErrorContains(t, err, "invalid type filter: exclude type \"foo.*\": the only supported wildcard is \".**\" and it must come at the end")
+		require.ErrorContains(t, err, "invalid filter type: exclude type \"foo.*\": the only supported wildcard is \".**\" and it must come at the end")
 	})
 }
 

--- a/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
+++ b/private/bufpkg/bufimage/bufimageutil/bufimageutil_test.go
@@ -374,9 +374,9 @@ func TestPackages(t *testing.T) {
 		_, image, err := getImage(ctx, slogtestext.NewLogger(t), "testdata/packages", bufimage.WithExcludeSourceCodeInfo())
 		require.NoError(t, err)
 		_, err = FilterImage(image, WithIncludeTypes("foo.**.bar"))
-		require.ErrorContains(t, err, "invalid include type \"foo.**.bar\": the only supported wildcard is \".**\" and it must come at the end")
+		require.ErrorContains(t, err, "invalid type filter: include type \"foo.**.bar\": the only supported wildcard is \".**\" and it must come at the end")
 		_, err = FilterImage(image, WithExcludeTypes("foo.*"))
-		require.ErrorContains(t, err, "invalid exclude type \"foo.*\": the only supported wildcard is \".**\" and it must come at the end")
+		require.ErrorContains(t, err, "invalid type filter: exclude type \"foo.*\": the only supported wildcard is \".**\" and it must come at the end")
 	})
 }
 
@@ -519,7 +519,6 @@ func TestTypesFromMainModule(t *testing.T) {
 	_, err = FilterImage(image, WithExcludeTypes("invalid-exclude"))
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrImageFilterTypeInvalid)
-
 }
 
 func TestMutateInPlace(t *testing.T) {

--- a/private/bufpkg/bufimage/bufimageutil/image_filter.go
+++ b/private/bufpkg/bufimage/bufimageutil/image_filter.go
@@ -42,9 +42,9 @@ func isValidFilterTypeName(name string) bool {
 // message also clarifies that the only supported wildcard is a trailing ".**".
 func invalidFilterTypeError(kind, typeName string) error {
 	if strings.Contains(typeName, "*") {
-		return fmt.Errorf("invalid %s type %q: the only supported wildcard is %q and it must come at the end", kind, typeName, ".**")
+		return fmt.Errorf("%w: %s type %q: the only supported wildcard is %q and it must come at the end", ErrImageFilterTypeInvalid, kind, typeName, ".**")
 	}
-	return fmt.Errorf("invalid %s type %q", kind, typeName)
+	return fmt.Errorf("%w: %s type %q", ErrImageFilterTypeInvalid, kind, typeName)
 }
 
 // filterImage filters the Image for the given options.


### PR DESCRIPTION
This is so that other bufbuild repos calling `FilterImage` can check for this sentinel error