### PR TITLE
Stop setting java_multiple_files for edition 2024 sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   dependencies, including well-known types.
 - Fix `buf format` non-idempotent trailing comment formatting.
 - Update built-in Well-Known Types to Protobuf v35.1.
+- Fix managed mode setting `java_multiple_files` on Edition 2024 files, which is not
+  allowed and causes code generation to fail.
 
 ## [v1.72.0] - 2026-07-17
 

--- a/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
+++ b/private/bufpkg/bufimage/bufimagemodify/bufimagemodify_test.go
@@ -486,6 +486,33 @@ func TestModifyImageFile(
 			},
 		},
 		{
+			description: "java_multiple_files",
+			dirPathToFullName: map[string]string{
+				filepath.Join("testdata", "foo"):      "buf.build/acme/foo",
+				filepath.Join("testdata", "editions"): "buf.build/acme/editions",
+			},
+			config: bufconfig.NewGenerateManagedConfig(
+				true,
+				[]bufconfig.ManagedDisableRule{},
+				[]bufconfig.ManagedOverrideRule{},
+			),
+			modifyFunc: modifyJavaMultipleFiles,
+			filePathToExpectedOptions: map[string]*descriptorpb.FileOptions{
+				"foo_empty/with_package.proto": {
+					JavaMultipleFiles: new(true),
+				},
+				"edition_2023/a.proto": {
+					JavaMultipleFiles: new(true),
+				},
+				// Removed in edition 2024, where it is the default behavior.
+				"edition_2024/a.proto": nil,
+			},
+			filePathToExpectedMarkedLocationPaths: map[string][][]int32{
+				"foo_empty/with_package.proto": {javaMultipleFilesPath},
+				"edition_2023/a.proto":         {javaMultipleFilesPath},
+			},
+		},
+		{
 			description: "objc_class_prefix",
 			dirPathToFullName: map[string]string{
 				filepath.Join("testdata", "foo"): "buf.build/acme/foo",

--- a/private/bufpkg/bufimage/bufimagemodify/file_option.go
+++ b/private/bufpkg/bufimage/bufimagemodify/file_option.go
@@ -433,6 +433,11 @@ func modifyJavaMultipleFiles(
 	config bufconfig.GenerateManagedConfig,
 	options ...ModifyOption,
 ) error {
+	// The option was removed in edition 2024, where its behavior became the
+	// default. The latest protoc plugins reject any file that still sets it.
+	if imageFile.FileDescriptorProto().GetEdition() >= descriptorpb.Edition_EDITION_2024 {
+		return nil
+	}
 	modifyOptions := newModifyOptions()
 	for _, option := range options {
 		option(modifyOptions)

--- a/private/bufpkg/bufimage/bufimagemodify/testdata/editions/edition_2023/a.proto
+++ b/private/bufpkg/bufimage/bufimagemodify/testdata/editions/edition_2023/a.proto
@@ -1,0 +1,3 @@
+edition = "2023";
+
+package editions.v2023;

--- a/private/bufpkg/bufimage/bufimagemodify/testdata/editions/edition_2024/a.proto
+++ b/private/bufpkg/bufimage/bufimagemodify/testdata/editions/edition_2024/a.proto
@@ -1,0 +1,3 @@
+edition = "2024";
+
+package editions.v2024;


### PR DESCRIPTION
Setting `java_multiple_files = true` on an edition 2024 or later proto file causes generation to fail. Update managed mode to skip setting this.